### PR TITLE
fix: explain unknown agent discovery failures

### DIFF
--- a/src/agents/agent-refinements.ts
+++ b/src/agents/agent-refinements.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { discoverAgents, resolveAgentName, type AgentConfig } from "./agents.ts";
+import { discoverAgents, formatUnknownAgentError, resolveAgentName, unknownAgentDiagnosticContext, type AgentConfig } from "./agents.ts";
 import { getProjectSubagentsDir } from "../shared/artifacts.ts";
 import type { Details, JsonSchemaObject, SingleResult, SubagentState } from "../shared/types.ts";
 
@@ -536,10 +536,10 @@ function guidanceFromProposal(proposal: RefinementProposal): string {
 }
 
 function resolveOneAgent(cwd: string, agentName: string): { ok: true; agent: AgentConfig } | { ok: false; error: string } {
-	const agents = discoverAgents(cwd, "both").agents;
-	const resolved = resolveAgentName(agentName, agents);
+	const discovered = discoverAgents(cwd, "both");
+	const resolved = resolveAgentName(agentName, discovered.agents);
 	if (resolved.error) return { ok: false, error: resolved.error };
-	if (!resolved.agent) return { ok: false, error: `Unknown agent: ${agentName}` };
+	if (!resolved.agent) return { ok: false, error: formatUnknownAgentError(agentName, unknownAgentDiagnosticContext(discovered)) };
 	return { ok: true, agent: resolved.agent };
 }
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -263,12 +263,70 @@ export function findBlockingAgentDiagnostic(name: string, agent: AgentConfig | r
 	return !agents.length || (match && agentDefinitionPriority(match) > highestPriority) ? match : undefined;
 }
 
-interface AgentDiscoveryResult {
+export type AgentDefinitionDirectoryState = "absent" | "empty" | "candidates" | "unreadable" | "not-directory";
+
+/** A definition directory actually inspected during one agent-discovery operation. */
+export interface AgentDefinitionDirectoryReport {
+	source: AgentSource;
+	path: string;
+	state: AgentDefinitionDirectoryState;
+	candidateCount?: number;
+}
+
+/**
+ * Filesystem provenance for a failed agent resolution. Context is created from
+ * the discovery result that supplied the effective agents; callers must not
+ * pair arbitrary agent arrays with these directory reports.
+ */
+export interface UnknownAgentDiagnosticContext {
+	cwd: string;
+	scope: AgentScope;
+	directories: readonly AgentDefinitionDirectoryReport[];
+	agents: readonly AgentConfig[];
+}
+
+export interface AgentDiscoveryResult {
 	agents: AgentConfig[];
 	agentDiagnostics?: AgentDiscoveryDiagnostic[];
 	projectAgentsDir: string | null;
+	cwd: string;
+	scope: AgentScope;
+	directories: readonly AgentDefinitionDirectoryReport[];
 	modelScope?: ModelScopeConfig;
 	maxThinking?: ThinkingLevel;
+}
+
+/** Create formatter input from the exact discovery operation used for resolution. */
+export function unknownAgentDiagnosticContext(discovered: Pick<AgentDiscoveryResult, "cwd" | "scope" | "directories" | "agents">): UnknownAgentDiagnosticContext {
+	return {
+		cwd: discovered.cwd,
+		scope: discovered.scope,
+		directories: discovered.directories,
+		agents: discovered.agents,
+	};
+}
+
+/** Render local discovery evidence without exposing filesystem error details. */
+export function formatUnknownAgentError(name: string, context: UnknownAgentDiagnosticContext, prefix = "Unknown agent"): string {
+	const directories = context.directories.map((directory) => {
+		const state = directory.state === "candidates"
+			? `${directory.candidateCount ?? 0} candidate${directory.candidateCount === 1 ? "" : "s"}`
+			: directory.state === "empty" ? "present but empty"
+				: directory.state === "not-directory" ? "not a directory"
+					: directory.state;
+		return `- ${directory.source}: ${directory.path} (${state})`;
+	});
+	const agents = [...context.agents]
+		.sort((left, right) => left.name.localeCompare(right.name) || left.source.localeCompare(right.source))
+		.map((agent) => `- ${agent.name} (${agent.source})`);
+	return [
+		`${prefix}: ${name}`,
+		`Effective cwd: ${path.resolve(context.cwd)}`,
+		"Consulted agent-definition directories:",
+		...(directories.length ? directories : ["- (none)"]),
+		"Discovered agents:",
+		...(agents.length ? agents : ["- (none)"]),
+	].join("\n");
 }
 
 function getUserChainDir(): string {
@@ -1629,6 +1687,60 @@ function listFilesRecursive(dir: string, predicate: (fileName: string) => boolea
 	return files;
 }
 
+export interface AgentDefinitionInspection {
+	files: string[];
+	state: AgentDefinitionDirectoryState;
+}
+
+/** Narrow filesystem seam so unavailable paths can be tested without permissions. */
+export interface AgentDefinitionInspectionFs {
+	existsSync(filePath: string): boolean;
+	statSync(filePath: string): { isDirectory(): boolean };
+	readdirSync(dir: string): fs.Dirent[];
+}
+
+const DEFAULT_AGENT_DEFINITION_INSPECTION_FS: AgentDefinitionInspectionFs = {
+	existsSync: fs.existsSync,
+	statSync: fs.statSync,
+	readdirSync: (dir) => fs.readdirSync(dir, { withFileTypes: true }),
+};
+
+/**
+ * Inspect one agent-definition directory while retaining traversal failure
+ * state. A nested unreadable directory makes the whole inspection unavailable,
+ * preventing a partial traversal from being reported as empty or complete.
+ */
+export function inspectAgentDefinitionDirectory(dir: string, operations: AgentDefinitionInspectionFs = DEFAULT_AGENT_DEFINITION_INSPECTION_FS): AgentDefinitionInspection {
+	const root = path.resolve(dir);
+	try {
+		if (!operations.existsSync(root)) return { files: [], state: "absent" };
+		if (!operations.statSync(root).isDirectory()) return { files: [], state: "not-directory" };
+	} catch {
+		return { files: [], state: "unreadable" };
+	}
+	const files: string[] = [];
+	let unreadable = false;
+	const visit = (current: string): void => {
+		let entries: fs.Dirent[];
+		try {
+			entries = operations.readdirSync(current).sort((a, b) => a.name.localeCompare(b.name));
+		} catch {
+			unreadable = true;
+			return;
+		}
+		for (const entry of entries) {
+			const filePath = path.join(current, entry.name);
+			if (entry.isDirectory()) {
+				if (!shouldPruneDiscoveryDir(root, filePath, entry.name)) visit(filePath);
+				continue;
+			}
+			if ((entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith(".md") && !entry.name.endsWith(".chain.md") && !isLegacyAgentSkillPath(root, filePath)) files.push(filePath);
+		}
+	};
+	visit(root);
+	return { files, state: unreadable ? "unreadable" : files.length ? "candidates" : "empty" };
+}
+
 function isLegacyAgentSkillPath(rootDir: string, filePath: string): boolean {
 	const relative = path.relative(rootDir, filePath);
 	const parts = relative.split(path.sep).map((part) => part.toLowerCase());
@@ -1734,9 +1846,9 @@ interface AgentDefinitionFile {
 	content: string;
 }
 
-function readAgentDefinitionFiles(dir: string): AgentDefinitionFile[] {
+function readAgentDefinitionFiles(dir: string, inspection = inspectAgentDefinitionDirectory(dir)): AgentDefinitionFile[] {
 	const files: AgentDefinitionFile[] = [];
-	for (const filePath of listFilesRecursive(dir, (fileName) => fileName.endsWith(".md") && !fileName.endsWith(".chain.md"))) {
+	for (const filePath of inspection.files) {
 		if (isLegacyAgentSkillPath(dir, filePath)) {
 			continue;
 		}
@@ -1956,8 +2068,17 @@ function loadAgentsFromDefinitionFiles(files: AgentDefinitionFile[], source: Age
 	return { agents, diagnostics };
 }
 
-function loadAgentsFromDir(dir: string, source: AgentSource, discoveryPriority?: number, packageSource?: Omit<PackageSubagentPath, "dir">): { agents: AgentConfig[]; diagnostics: AgentDiscoveryDiagnostic[] } {
-	return loadAgentsFromDefinitionFiles(readAgentDefinitionFiles(dir), source, discoveryPriority, packageSource);
+function loadAgentsFromDir(dir: string, source: AgentSource, discoveryPriority?: number, packageSource?: Omit<PackageSubagentPath, "dir">, inspection = inspectAgentDefinitionDirectory(dir)): { agents: AgentConfig[]; diagnostics: AgentDiscoveryDiagnostic[] } {
+	return loadAgentsFromDefinitionFiles(readAgentDefinitionFiles(dir, inspection), source, discoveryPriority, packageSource);
+}
+
+function reportAgentDefinitionDirectory(source: AgentSource, dir: string, inspection: AgentDefinitionInspection): AgentDefinitionDirectoryReport {
+	return {
+		source,
+		path: path.resolve(dir),
+		state: inspection.state,
+		...(inspection.state === "candidates" ? { candidateCount: inspection.files.length } : {}),
+	};
 }
 
 function loadChainsFromDir(dir: string, source: AgentSource): { chains: ChainConfig[]; diagnostics: ChainDiscoveryDiagnostic[] } {
@@ -1994,20 +2115,18 @@ function isDirectory(p: string): boolean {
 	}
 }
 
-function resolveNearestProjectAgentDirs(cwd: string): { readDirs: string[]; preferredDir: string | null } {
+function resolveNearestProjectAgentDirs(cwd: string): { readDirs: string[]; candidateDirs: string[]; preferredDir: string | null } {
 	const projectRoot = findConfiguredProjectRoot(cwd);
-	if (!projectRoot) return { readDirs: [], preferredDir: null };
+	if (!projectRoot) return { readDirs: [], candidateDirs: [], preferredDir: null };
 
 	const legacyDir = path.join(projectRoot, ".agents");
 	const preferredDir = path.join(getProjectConfigDir(projectRoot), "agents");
+	const candidateDirs = [legacyDir, preferredDir];
 	const readDirs: string[] = [];
 	if (isDirectory(legacyDir)) readDirs.push(legacyDir);
 	if (isDirectory(preferredDir)) readDirs.push(preferredDir);
 
-	return {
-		readDirs,
-		preferredDir,
-	};
+	return { readDirs, candidateDirs, preferredDir };
 }
 
 function resolveNearestProjectChainDirs(cwd: string): { readDirs: string[]; preferredDir: string | null } {
@@ -2021,7 +2140,9 @@ function resolveNearestProjectChainDirs(cwd: string): { readDirs: string[]; pref
 	};
 }
 const BUILTIN_AGENTS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "agents");
-const BUILTIN_AGENT_DEFINITION_FILES = readAgentDefinitionFiles(BUILTIN_AGENTS_DIR);
+// Candidate files and inspection state must describe the same cached builtin scan.
+const BUILTIN_AGENT_DEFINITION_INSPECTION = inspectAgentDefinitionDirectory(BUILTIN_AGENTS_DIR);
+const BUILTIN_AGENT_DEFINITION_FILES = readAgentDefinitionFiles(BUILTIN_AGENTS_DIR, BUILTIN_AGENT_DEFINITION_INSPECTION);
 
 export const EXTRA_AGENT_DIRS_ENV = "PI_SUBAGENT_EXTRA_AGENT_DIRS";
 
@@ -2040,11 +2161,12 @@ function extraUserAgentDirs(): string[] {
 }
 
 export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
+	const effectiveCwd = path.resolve(cwd);
 	const userDirOld = path.join(getAgentDir(), "agents");
 	const userDirNew = path.join(os.homedir(), ".agents");
-	const { readDirs: projectAgentDirs, preferredDir: projectAgentsDir } = resolveNearestProjectAgentDirs(cwd);
+	const { readDirs: projectAgentDirs, candidateDirs: projectCandidateDirs, preferredDir: projectAgentsDir } = resolveNearestProjectAgentDirs(effectiveCwd);
 	const userSettingsPath = getUserAgentSettingsPath();
-	const projectSettingsPath = getProjectAgentSettingsPath(cwd);
+	const projectSettingsPath = getProjectAgentSettingsPath(effectiveCwd);
 	const userSettings = scope === "project" ? EMPTY_SUBAGENT_SETTINGS : readSubagentSettings(userSettingsPath);
 	const projectSettings = scope === "user" ? EMPTY_SUBAGENT_SETTINGS : readSubagentSettings(projectSettingsPath);
 	const defaultProvider = resolveSubagentDefaultProvider(userSettings, projectSettings, projectSettingsPath);
@@ -2053,65 +2175,60 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
 	const maxThinking = resolveSubagentMaxThinking(userSettings, projectSettings, projectSettingsPath);
 	const defaultExtensions = resolveSubagentDefaultExtensions(userSettings, projectSettings, projectSettingsPath);
 	const modelScope = projectSettings.modelScope ?? userSettings.modelScope;
-	const packageSubagentPaths = collectPackageSubagentPaths(cwd, {
+	const packageSubagentPaths = collectPackageSubagentPaths(effectiveCwd, {
 		includeUser: scope !== "project",
 		includeProject: scope !== "user",
 	});
+	const directories: AgentDefinitionDirectoryReport[] = [reportAgentDefinitionDirectory("builtin", BUILTIN_AGENTS_DIR, BUILTIN_AGENT_DEFINITION_INSPECTION)];
 
 	const builtinLoaded = loadAgentsFromDefinitionFiles(BUILTIN_AGENT_DEFINITION_FILES, "builtin");
 	const builtinAgents = applyBuiltinOverrides(
 		applySubagentDefaults(builtinLoaded.agents, defaultModel, defaultProvider, defaultThinking, defaultExtensions),
-		userSettings,
-		projectSettings,
-		userSettingsPath,
-		projectSettingsPath,
+		userSettings, projectSettings, userSettingsPath, projectSettingsPath,
 	);
 
-	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), userDirOld, userDirNew]
-		.map((dir, discoveryPriority) => loadAgentsFromDir(dir, "user", discoveryPriority));
+	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), userDirOld, userDirNew].map((dir, discoveryPriority) => {
+		const inspection = inspectAgentDefinitionDirectory(dir);
+		directories.push(reportAgentDefinitionDirectory("user", dir, inspection));
+		return loadAgentsFromDir(dir, "user", discoveryPriority, undefined, inspection);
+	});
 	const userAgents = applyCustomAgentOverrides(
 		applySubagentDefaults(userLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions),
-		userSettings,
-		projectSettings,
-		userSettingsPath,
-		projectSettingsPath,
+		userSettings, projectSettings, userSettingsPath, projectSettingsPath,
 	);
 
-	const projectLoaded = scope === "user" ? [] : projectAgentDirs.map((dir) => loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : 0));
+	// Report both legacy and preferred project definition paths only after the
+	// existing configured-root resolver found a root; never synthesize cwd paths.
+	const projectInspections = scope === "user" ? new Map<string, AgentDefinitionInspection>() : new Map(projectCandidateDirs.map((dir) => [dir, inspectAgentDefinitionDirectory(dir)]));
+	if (scope !== "user") for (const dir of projectCandidateDirs) directories.push(reportAgentDefinitionDirectory("project", dir, projectInspections.get(dir)!));
+	const projectLoaded = scope === "user" ? [] : projectAgentDirs.map((dir) => loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : 0, undefined, projectInspections.get(dir)!));
 	const projectAgents = applyCustomAgentOverrides(
 		applySubagentDefaults(projectLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions),
-		userSettings,
-		projectSettings,
-		userSettingsPath,
-		projectSettingsPath,
-	);
-	const packageLoaded = packageSubagentPaths.agents.map((entry, index) => loadAgentsFromDir(entry.dir, "package", packageSubagentPaths.agents.length - index, entry));
-	const packageMap = new Map<string, AgentConfig>();
-	for (const loaded of packageLoaded) {
-		for (const agent of loaded.agents) {
-			if (!packageMap.has(agent.name)) packageMap.set(agent.name, agent);
-		}
-	}
-	const packageAgents = applyCustomAgentOverrides(
-		applySubagentDefaults(Array.from(packageMap.values()), defaultModel, defaultProvider, defaultThinking, defaultExtensions),
-		userSettings,
-		projectSettings,
-		userSettingsPath,
-		projectSettingsPath,
-	);
-	const agents = applySubagentMaxThinking(
-		mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents, packageAgents)
-			.filter((agent) => agent.disabled !== true),
-		maxThinking,
+		userSettings, projectSettings, userSettingsPath, projectSettingsPath,
 	);
 
+	const packageLoaded = packageSubagentPaths.agents.map((entry, index) => {
+		const inspection = inspectAgentDefinitionDirectory(entry.dir);
+		directories.push(reportAgentDefinitionDirectory("package", entry.dir, inspection));
+		return loadAgentsFromDir(entry.dir, "package", packageSubagentPaths.agents.length - index, entry, inspection);
+	});
+	const packageMap = new Map<string, AgentConfig>();
+	for (const loaded of packageLoaded) for (const agent of loaded.agents) if (!packageMap.has(agent.name)) packageMap.set(agent.name, agent);
+	const packageAgents = applyCustomAgentOverrides(
+		applySubagentDefaults(Array.from(packageMap.values()), defaultModel, defaultProvider, defaultThinking, defaultExtensions),
+		userSettings, projectSettings, userSettingsPath, projectSettingsPath,
+	);
+	const agents = applySubagentMaxThinking(
+		mergeAgentsForScope(scope, userAgents, projectAgents, builtinAgents, packageAgents).filter((agent) => agent.disabled !== true),
+		maxThinking,
+	);
 	const agentDiagnostics = [
 		...builtinLoaded.diagnostics,
 		...userLoaded.flatMap((loaded) => loaded.diagnostics),
 		...projectLoaded.flatMap((loaded) => loaded.diagnostics),
 		...packageLoaded.flatMap((loaded) => loaded.diagnostics),
 	];
-	return { agents, agentDiagnostics, projectAgentsDir, ...(modelScope !== undefined ? { modelScope } : {}), ...(maxThinking !== undefined ? { maxThinking } : {}) };
+	return { agents, agentDiagnostics, projectAgentsDir, cwd: effectiveCwd, scope, directories, ...(modelScope !== undefined ? { modelScope } : {}), ...(maxThinking !== undefined ? { maxThinking } : {}) };
 }
 
 export function discoverAgentsAll(cwd: string): {

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { discoverAgents, discoverAgentsAll, findBlockingAgentDiagnostic, resolveAgentName, type AgentConfig, type AgentScope, type AgentSource } from "../agents/agents.ts";
+import { discoverAgents, discoverAgentsAll, findBlockingAgentDiagnostic, formatUnknownAgentError, resolveAgentName, unknownAgentDiagnosticContext, type AgentConfig, type AgentScope, type AgentSource } from "../agents/agents.ts";
 import { resolveExecutionAgentScope } from "../agents/agent-scope.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../agents/agent-memory.ts";
@@ -251,7 +251,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		return { ok: false, code: "ambiguous_agent", message: resolvedAgent.error, diagnostics };
 	}
 	if (!resolvedAgent.agent) {
-		return { ok: false, code: "missing_agent", message: `Unknown agent: ${input.agent}`, diagnostics };
+		return { ok: false, code: "missing_agent", message: formatUnknownAgentError(input.agent, unknownAgentDiagnosticContext(discovered)), diagnostics };
 	}
 	const agent = resolvedAgent.agent;
 	let extensionBindings: ExtensionBindings | undefined;

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -10,7 +10,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { AgentConfig } from "../../agents/agents.ts";
+import { discoverAgents, formatUnknownAgentError, unknownAgentDiagnosticContext, type AgentConfig, type UnknownAgentDiagnosticContext } from "../../agents/agents.ts";
 import { appendAgentRefinementOverlay } from "../../agents/agent-refinements.ts";
 import { writePrivateAtomicJson } from "../../shared/atomic-json.ts";
 import { currentCompletionOwnerId } from "../../shared/completion-owner.ts";
@@ -153,6 +153,8 @@ interface AsyncChainParams {
 	attachRoot?: ImportedAsyncRoot & { agent: string; outputName?: string; label?: string };
 	resultMode?: SubagentRunMode;
 	agents: AgentConfig[];
+	/** Original discovery provenance, retained by normal callers for unknown-agent diagnostics. */
+	unknownAgentDiagnosticContext?: UnknownAgentDiagnosticContext;
 	ctx: AsyncExecutionContext;
 	availableModels?: AvailableModelInfo[];
 	cwd?: string;
@@ -285,6 +287,8 @@ export interface AsyncRunnerStepBuildParams {
 	attachRoot?: ImportedAsyncRoot & { agent: string; outputName?: string; label?: string };
 	resultMode?: SubagentRunMode;
 	agents: AgentConfig[];
+	/** Exact discovery provenance for failed resolution; omission triggers defensive fallback discovery. */
+	unknownAgentDiagnosticContext?: UnknownAgentDiagnosticContext;
 	ctx: AsyncExecutionContext;
 	availableModels?: AvailableModelInfo[];
 	cwd?: string;
@@ -749,6 +753,8 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 	}
 	const workflowGraph = buildWorkflowGraphSnapshot({ runId: id, mode: resultMode, steps: graphChain });
 
+	const diagnosticContext = params.unknownAgentDiagnosticContext
+		?? unknownAgentDiagnosticContext(discoverAgents(path.resolve(runnerCwd), "both"));
 	for (const s of chain) {
 		const stepAgents = isParallelStep(s)
 			? s.parallel.map((t) => t.agent)
@@ -756,9 +762,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 				? [s.parallel.agent]
 				: [(s as SequentialStep).agent];
 		for (const agentName of stepAgents) {
-			if (!agents.find((x) => x.name === agentName)) {
-				return { error: `Unknown agent: ${agentName}` };
-			}
+			if (!agents.find((x) => x.name === agentName)) return { error: formatUnknownAgentError(agentName, diagnosticContext) };
 		}
 	}
 
@@ -1180,6 +1184,7 @@ export function executeAsyncChain(
 		attachRoot: params.attachRoot,
 		resultMode,
 		agents,
+		unknownAgentDiagnosticContext: params.unknownAgentDiagnosticContext,
 		ctx,
 		availableModels: params.availableModels,
 		cwd,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -6,7 +6,7 @@ import { spawn } from "node:child_process";
 import { existsSync, unlinkSync } from "node:fs";
 import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
-import type { AgentConfig } from "../../agents/agents.ts";
+import { discoverAgents, formatUnknownAgentError, unknownAgentDiagnosticContext, type AgentConfig } from "../../agents/agents.ts";
 import { appendAgentRefinementOverlay } from "../../agents/agent-refinements.ts";
 import { alignForkedSessionCwd } from "../../shared/fork-context.ts";
 import {
@@ -1672,6 +1672,8 @@ async function runSyncCompletionInner(
 	};
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
+		const diagnosticContext = options.unknownAgentDiagnosticContext
+			?? unknownAgentDiagnosticContext(discoverAgents(path.resolve(options.cwd ?? runtimeCwd), "both"));
 		return redactResultPrompt(withRunContext({
 			index: options.index ?? 0,
 			agent: agentName,
@@ -1679,7 +1681,7 @@ async function runSyncCompletionInner(
 			exitCode: 1,
 			messages: [],
 			usage: emptyUsage(),
-			error: `Unknown agent: ${agentName}`,
+			error: formatUnknownAgentError(agentName, diagnosticContext),
 		}, options.context));
 	}
 	options = {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { findBlockingAgentDiagnostic, resolveAgentName, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope } from "../../agents/agents.ts";
+import { discoverAgents, findBlockingAgentDiagnostic, formatUnknownAgentError, resolveAgentName, unknownAgentDiagnosticContext, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope, type UnknownAgentDiagnosticContext } from "../../agents/agents.ts";
 import { getArtifactsDir, getChainRunsDir, getProjectArtifactPackagingWarning, getProjectSubagentsDir } from "../../shared/artifacts.ts";
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { createCapacityResilientJsonWriter } from "../../shared/capacity-resilient-json.ts";
@@ -403,7 +403,7 @@ interface ExecutorDeps {
 	tempArtifactsDir: string;
 	getSubagentSessionRoot: (parentSessionFile: string | null) => string;
 	expandTilde: (p: string) => string;
-	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[]; agentDiagnostics?: AgentDiscoveryDiagnostic[]; modelScope?: ModelScopeConfig; maxThinking?: AgentConfig["maxThinking"] };
+	discoverAgents: (cwd: string, scope: AgentScope) => { agents: AgentConfig[]; agentDiagnostics?: AgentDiscoveryDiagnostic[]; modelScope?: ModelScopeConfig; maxThinking?: AgentConfig["maxThinking"]; cwd?: string; scope?: AgentScope; directories?: UnknownAgentDiagnosticContext["directories"] };
 	allowMutatingManagementActions?: boolean;
 	activateSupervisorTransport?: () => void;
 	refreshResultDelivery?: () => void;
@@ -421,6 +421,8 @@ interface ExecutionContextData {
 	signal: AbortSignal;
 	onUpdate?: (r: AgentToolResult<Details>) => void;
 	agents: AgentConfig[];
+	/** Exact filesystem discovery provenance retained through defensive execution backstops. */
+	unknownAgentDiagnosticContext: UnknownAgentDiagnosticContext;
 	/** Discovered agent definitions before per-run bridge injection. */
 	recoveryAgents: AgentConfig[];
 	runId: string;
@@ -1271,6 +1273,7 @@ function appendStepToAsyncChain(input: {
 		agents,
 		ctx: asyncCtx,
 		availableModels: input.ctx.modelRegistry.getAvailable().map(toModelInfo),
+		unknownAgentDiagnosticContext: diagnosticContextFromDiscovery(discoveredForAppend, input.requestCwd, scope),
 		cwd: status.cwd ?? input.requestCwd,
 		chainSkills,
 		dynamicFanoutMaxItems: input.deps.config.chain?.dynamicFanout?.maxItems,
@@ -1766,6 +1769,7 @@ async function resumeAsyncRun(input: {
 	const scope: AgentScope = resolveExecutionAgentScope(input.params.agentScope);
 	const discovered = input.deps.discoverAgents(effectiveCwd, scope);
 	const discoveredAgents = discovered.agents;
+	const unknownAgentDiagnosticContext = diagnosticContextFromDiscovery(discovered, effectiveCwd, scope);
 	const modelScope = discovered.modelScope;
 	const sessionName = resolveIntercomSessionTarget(input.deps.pi.getSessionName(), input.ctx.sessionManager.getSessionId());
 	const recoveryDescriptor = "recoveryDescriptor" in target ? target.recoveryDescriptor : undefined;
@@ -1793,7 +1797,7 @@ async function resumeAsyncRun(input: {
 	} : undefined);
 	if (!baseAgentConfig) {
 		return {
-			content: [{ type: "text", text: `Unknown agent for resume: ${target.agent}` }],
+			content: [{ type: "text", text: formatUnknownAgentError(target.agent, unknownAgentDiagnosticContext, "Unknown agent for resume") }],
 			isError: true,
 			details: { mode: "management", results: [] },
 		};
@@ -1874,6 +1878,7 @@ async function resumeAsyncRun(input: {
 				label: `Attached ${target.runId}`,
 			},
 			agents,
+			unknownAgentDiagnosticContext,
 			ctx: compactOptional<Parameters<typeof executeAsyncSingle>[1]["ctx"]>({
 				pi: input.deps.pi,
 				cwd: input.requestCwd,
@@ -2269,19 +2274,28 @@ async function maybeBuildForegroundIntercomReceipt(input: {
 	};
 }
 
-function canonicalizeAgentName(name: string, agents: AgentConfig[], diagnostics?: AgentDiscoveryDiagnostic[]): { name?: string; error?: string } {
+function diagnosticContextFromDiscovery(
+	discovered: { agents: AgentConfig[]; cwd?: string; scope?: AgentScope; directories?: UnknownAgentDiagnosticContext["directories"] },
+	cwd: string,
+	scope: AgentScope,
+): UnknownAgentDiagnosticContext {
+	if (discovered.cwd && discovered.scope && discovered.directories) return unknownAgentDiagnosticContext({ ...discovered, cwd: discovered.cwd, scope: discovered.scope, directories: discovered.directories });
+	return unknownAgentDiagnosticContext(discoverAgents(path.resolve(cwd), scope));
+}
+
+function canonicalizeAgentName(name: string, agents: AgentConfig[], diagnostics: AgentDiscoveryDiagnostic[] | undefined, context: UnknownAgentDiagnosticContext): { name?: string; error?: string } {
 	const resolved = resolveAgentName(name, agents);
 	const candidates = resolved.error ? agents.filter((agent) => resolveAgentName(name, [agent]).agent) : resolved.agent;
 	const diagnostic = findBlockingAgentDiagnostic(name, candidates, diagnostics);
 	if (diagnostic) return { error: `Agent '${name}' has invalid configuration: ${diagnostic.error}` };
 	if (resolved.error) return { error: resolved.error };
-	if (!resolved.agent) return { error: `Unknown agent: ${name}` };
+	if (!resolved.agent) return { error: formatUnknownAgentError(name, context) };
 	return { name: resolved.agent.name };
 }
 
-function canonicalizeExecutionParams(params: SubagentParamsLike, agents: AgentConfig[], diagnostics?: AgentDiscoveryDiagnostic[]): { params?: SubagentParamsLike; error?: string } {
+function canonicalizeExecutionParams(params: SubagentParamsLike, agents: AgentConfig[], diagnostics: AgentDiscoveryDiagnostic[] | undefined, context: UnknownAgentDiagnosticContext): { params?: SubagentParamsLike; error?: string } {
 	const resolve = (name: string, location?: string): { name?: string; error?: string } => {
-		const result = canonicalizeAgentName(name, agents, diagnostics);
+		const result = canonicalizeAgentName(name, agents, diagnostics, context);
 		return result.error && location ? { error: `${result.error} (${location})` } : result;
 	};
 	if (params.agent) {
@@ -2349,6 +2363,7 @@ function validateExecutionInput(
 	hasTasks: boolean,
 	hasSingle: boolean,
 	allowClarifyTaskPrompt: boolean,
+	context: UnknownAgentDiagnosticContext,
 ): AgentToolResult<Details> | null {
 	if (Number(hasChain) + Number(hasTasks) + Number(hasSingle) !== 1) {
 		return {
@@ -2374,7 +2389,7 @@ function validateExecutionInput(
 
 	if (hasSingle && params.agent && !agents.find((agent) => agent.name === params.agent)) {
 		return {
-			content: [{ type: "text", text: `Unknown agent: ${params.agent}` }],
+			content: [{ type: "text", text: formatUnknownAgentError(params.agent, context) }],
 			isError: true,
 			details: { mode: "single" as const, results: [] },
 		};
@@ -2385,7 +2400,7 @@ function validateExecutionInput(
 			const task = params.tasks[i]!;
 			if (!agents.find((agent) => agent.name === task.agent)) {
 				return {
-					content: [{ type: "text", text: `Unknown agent: ${task.agent} (task ${i + 1})` }],
+					content: [{ type: "text", text: `${formatUnknownAgentError(task.agent, context)} (task ${i + 1})` }],
 					isError: true,
 					details: { mode: "parallel" as const, results: [] },
 				};
@@ -2430,7 +2445,7 @@ function validateExecutionInput(
 			for (const agentName of stepAgents) {
 				if (!agents.find((a) => a.name === agentName)) {
 					return {
-						content: [{ type: "text", text: `Unknown agent: ${agentName} (step ${i + 1})` }],
+						content: [{ type: "text", text: `${formatUnknownAgentError(agentName, context)} (step ${i + 1})` }],
 						isError: true,
 						details: { mode: "chain" as const, results: [] },
 					};
@@ -3141,6 +3156,7 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		intercomBridge,
 		nestedRoute,
 		contextPolicy,
+		unknownAgentDiagnosticContext,
 	} = data;
 	const hasChain = (params.chain?.length ?? 0) > 0;
 	const hasTasks = (params.tasks?.length ?? 0) > 0;
@@ -3179,7 +3195,7 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		const a = agents.find((x) => x.name === params.agent);
 		if (!a) {
 			return {
-				content: [{ type: "text", text: `Unknown agent: ${params.agent}` }],
+				content: [{ type: "text", text: formatUnknownAgentError(params.agent!, unknownAgentDiagnosticContext) }],
 				isError: true,
 				details: { mode: "single" as const, results: [] },
 			};
@@ -3545,7 +3561,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const agentConfig = agents.find((a) => a.name === params.agent);
 	if (!agentConfig) {
 		return {
-			content: [{ type: "text", text: `Unknown agent: ${params.agent}` }],
+			content: [{ type: "text", text: formatUnknownAgentError(params.agent!, data.unknownAgentDiagnosticContext) }],
 			isError: true,
 			details: { mode: "single", results: [] },
 		};
@@ -3678,6 +3694,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			llmIntentArbiter: createTaskMutationArbiter(ctx),
 			...workflowForegroundSteeringLaunchOptions(foregroundControl, 0),
 			context: data.contextPolicy.contextForAgent(params.agent!),
+			unknownAgentDiagnosticContext: data.unknownAgentDiagnosticContext,
 			runFanoutBudget: params.runFanoutAdmitted ? data.runFanoutBudget : { ...data.runFanoutBudget, parentPath: `${data.runFanoutBudget.parentPath ? `${data.runFanoutBudget.parentPath}/` : ""}single` },
 			cwd: singleCwd,
 			signal,
@@ -5727,7 +5744,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const parentSessionFile = ctx.sessionManager.getSessionFile() ?? null;
 		const discovered = deps.discoverAgents(effectiveCwd, scope);
 		const discoveredAgents = discovered.agents;
-		const canonicalParams = canonicalizeExecutionParams(effectiveParams, discoveredAgents, discovered.agentDiagnostics);
+		const unknownAgentDiagnosticContext = diagnosticContextFromDiscovery(discovered, effectiveCwd, scope);
+		const canonicalParams = canonicalizeExecutionParams(effectiveParams, discoveredAgents, discovered.agentDiagnostics, unknownAgentDiagnosticContext);
 		if (canonicalParams.error) return buildRequestedModeError(effectiveParams, canonicalParams.error);
 		effectiveParams = canonicalParams.params!;
 		const modelScope = discovered.modelScope;
@@ -5776,6 +5794,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			hasTasks,
 			hasSingle,
 			allowClarifyTaskPrompt,
+			unknownAgentDiagnosticContext,
 		);
 		if (validationError) return validationError;
 
@@ -6032,6 +6051,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			signal,
 			onUpdate: onUpdateWithContext,
 			agents,
+			unknownAgentDiagnosticContext,
 			recoveryAgents: discoveredAgents,
 			runId,
 			shareEnabled,

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -5,7 +5,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentConfig } from "../agents/agents.ts";
+import { discoverAgents, formatUnknownAgentError, unknownAgentDiagnosticContext, type AgentConfig, type AgentScope, type UnknownAgentDiagnosticContext } from "../agents/agents.ts";
 import { normalizeSkillInput } from "../agents/skills.ts";
 import { CHAIN_RUNS_DIR, type AcceptanceInput, type AgentContract, type ChainGateLayer, type JsonSchemaObject, type OutputMode, type ToolBudgetConfig } from "./types.ts";
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -411,16 +411,24 @@ export function buildChainInstructions(
  * Resolve behaviors for all tasks in a parallel step.
  * Creates namespaced output paths to avoid collisions.
  */
+/** Exact discovery context, or explicit input for defensive fallback discovery. */
+export type ParallelBehaviorDiagnostics = UnknownAgentDiagnosticContext | { cwd: string; scope?: AgentScope };
+
 export function resolveParallelBehaviors(
 	tasks: ParallelTaskItem[],
 	agentConfigs: AgentConfig[],
 	stepIndex: number,
 	chainSkills?: string[],
+	diagnostics?: ParallelBehaviorDiagnostics,
 ): ResolvedStepBehavior[] {
 	return tasks.map((task, taskIndex) => {
 		const config = agentConfigs.find((a) => a.name === task.agent);
 		if (!config) {
-			throw new Error(`Unknown agent: ${task.agent}`);
+			if (!diagnostics) throw new Error("resolveParallelBehaviors requires unknown-agent diagnostic context or fallback discovery input.");
+			const context = "directories" in diagnostics
+				? diagnostics
+				: unknownAgentDiagnosticContext(discoverAgents(path.resolve(diagnostics.cwd), diagnostics.scope ?? "both"));
+			throw new Error(formatUnknownAgentError(task.agent, context));
 		}
 
 		// Build subdirectory path for this parallel task

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2013,6 +2013,8 @@ export interface SubagentChildStatusEvent {
 // ============================================================================
 
 export interface RunSyncOptions {
+	/** Exact discovery provenance for an unknown-agent error; omission uses defensive fallback discovery. */
+	unknownAgentDiagnosticContext?: import("../agents/agents.ts").UnknownAgentDiagnosticContext;
 	/** Opt-in global permission rules; missing tools remain allowed. */
 	permissions?: import("../runs/shared/permissions.ts").PermissionConfig;
 	/** Session id of the direct parent session for permission-system ask forwarding. */

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { keyText, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth, type Component, type KeyId, type TUI } from "@earendil-works/pi-tui";
-import { BUILTIN_AGENT_NAMES, discoverAgents, discoverAgentsAll, findBlockingAgentDiagnostic, resolveAgentName, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope } from "../agents/agents.ts";
+import { BUILTIN_AGENT_NAMES, discoverAgents, discoverAgentsAll, findBlockingAgentDiagnostic, formatUnknownAgentError, resolveAgentName, unknownAgentDiagnosticContext, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope, type UnknownAgentDiagnosticContext } from "../agents/agents.ts";
 import { listRuntimeAgentConfigs, mergeRuntimeAgents } from "../agents/runtime-agent-registry.ts";
 import { resolveExistingReadPaths } from "../shared/settings.ts";
 import {
@@ -109,9 +109,9 @@ const extractExecutionFlags = (rawArgs: string): { args: string; bg: boolean; fo
 	return { args, bg, fork };
 };
 
-function discoverSlashAgents(pi: ExtensionAPI, cwd: string, scope: AgentScope): { agents: AgentConfig[]; agentDiagnostics?: AgentDiscoveryDiagnostic[] } {
+function discoverSlashAgents(pi: ExtensionAPI, cwd: string, scope: AgentScope): { agents: AgentConfig[]; agentDiagnostics?: AgentDiscoveryDiagnostic[]; unknownAgentDiagnosticContext: UnknownAgentDiagnosticContext } {
 	const discovered = discoverAgents(cwd, scope);
-	if (listRuntimeAgentConfigs(pi).length === 0) return discovered;
+	if (listRuntimeAgentConfigs(pi).length === 0) return { ...discovered, unknownAgentDiagnosticContext: unknownAgentDiagnosticContext(discovered) };
 	const all = discoverAgentsAll(cwd);
 	const configuredAgents: AgentConfig[] = [
 		...all.builtin,
@@ -119,7 +119,8 @@ function discoverSlashAgents(pi: ExtensionAPI, cwd: string, scope: AgentScope): 
 		...(scope !== "project" ? all.user : []),
 		...(scope !== "user" ? all.project : []),
 	];
-	return mergeRuntimeAgents(pi, discovered, configuredAgents);
+	const merged = mergeRuntimeAgents(pi, discovered, configuredAgents);
+	return { ...merged, unknownAgentDiagnosticContext: { ...unknownAgentDiagnosticContext(discovered), agents: merged.agents } };
 }
 
 const makeAgentCompletions = (pi: ExtensionAPI, state: SubagentState) => (prefix: string) => {
@@ -694,7 +695,7 @@ export function registerSlashCommands(
 				: resolvedAgent.agent;
 			const diagnostic = findBlockingAgentDiagnostic(agentName, candidates, discovered.agentDiagnostics);
 			if (diagnostic || resolvedAgent.error || !resolvedAgent.agent) {
-				ctx.ui.notify(diagnostic ? `Agent '${agentName}' has invalid configuration: ${diagnostic.error}` : resolvedAgent.error ?? `Unknown agent: ${agentName}`, "error");
+				ctx.ui.notify(diagnostic ? `Agent '${agentName}' has invalid configuration: ${diagnostic.error}` : resolvedAgent.error ?? formatUnknownAgentError(agentName, discovered.unknownAgentDiagnosticContext), "error");
 				return;
 			}
 

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -470,7 +470,11 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		removeTempDir(tempDir);
 	});
 
-	function makeAsyncExecutor(agents: ReturnType<typeof makeAgent>[], config: Record<string, unknown> = {}) {
+	function makeAsyncExecutor(
+		agents: ReturnType<typeof makeAgent>[],
+		config: Record<string, unknown> = {},
+		discoverOverride?: (cwd: string) => { agents: ReturnType<typeof makeAgent>[]; cwd?: string; scope?: "user" | "project" | "both"; directories?: Array<{ source: "builtin" | "package" | "user" | "project" | "runtime"; path: string; state: "absent" | "empty" | "candidates" | "unreadable" | "not-directory"; candidateCount?: number }> },
+	) {
 		return createSubagentExecutor!({
 			pi: { events: createEventBus(), getSessionName: () => undefined },
 			state: { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
@@ -479,7 +483,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			tempArtifactsDir: tempDir,
 			getSubagentSessionRoot: () => tempDir,
 			expandTilde: (p: string) => p,
-			discoverAgents: () => ({ agents }),
+			discoverAgents: (cwd: string) => discoverOverride ? discoverOverride(cwd) : ({ agents }),
 		});
 	}
 
@@ -4538,6 +4542,91 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.ok(result.details.asyncId);
 		const payload = await readAsyncPayload(result.details.asyncId);
 		assert.equal(payload.results[0]?.model, "gateway/parent-model");
+	});
+
+	it("reports the retained discovery context when a resumed target agent is missing", { skip: !createSubagentExecutor ? "executor not available" : undefined }, async () => {
+		const runId = `resume-missing-agent-${Date.now().toString(36)}`;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		const sessionFile = path.join(tempDir, "missing-agent-session.jsonl");
+		const visible = makeAgent("visible");
+		visible.source = "project";
+		const evidenceDir = path.join(tempDir, "request-discovery", "agents");
+		try {
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(sessionFile, "", "utf-8");
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId,
+				sessionId: "session-123",
+				mode: "single",
+				state: "complete",
+				startedAt: 100,
+				lastUpdate: 200,
+				cwd: tempDir,
+				sessionFile,
+				steps: [{ agent: "vanished", status: "complete" }],
+			}, null, 2), "utf-8");
+			const executor = makeAsyncExecutor([visible], {}, (cwd) => ({
+				agents: [visible],
+				cwd: path.resolve(cwd),
+				scope: "both",
+				directories: [{ source: "project", path: evidenceDir, state: "empty" }],
+			}));
+			const result = await executor.execute(
+				"resume-missing-agent",
+				{ action: "resume", id: runId, message: "Continue" },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			) as AsyncExecutionResult;
+			assert.equal(result.isError, true);
+			assert.match(result.content[0]?.text ?? "", /^Unknown agent for resume: vanished\nEffective cwd: /);
+			assert.match(result.content[0]?.text ?? "", new RegExp(evidenceDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+			assert.match(result.content[0]?.text ?? "", /visible \(project\)/);
+		} finally {
+			fs.rmSync(asyncDir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the append request discovery context for a missing appended agent", { skip: !createSubagentExecutor ? "executor not available" : undefined }, async () => {
+		const runId = `append-missing-agent-${Date.now().toString(36)}`;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		const visible = makeAgent("visible");
+		visible.source = "project";
+		const evidenceDir = path.join(tempDir, "append-request", "agents");
+		const storedCwd = path.join(tempDir, "stored-run-cwd");
+		try {
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId,
+				sessionId: "session-123",
+				mode: "chain",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				cwd: storedCwd,
+				steps: [{ agent: "visible", status: "running" }],
+			}, null, 2), "utf-8");
+			const executor = makeAsyncExecutor([visible], {}, (cwd) => ({
+				agents: [visible],
+				cwd: path.resolve(cwd),
+				scope: "both",
+				directories: [{ source: "project", path: evidenceDir, state: "empty" }],
+			}));
+			const result = await executor.execute(
+				"append-missing-agent",
+				{ action: "append-step", id: runId, step: { agent: "vanished", task: "Review" } },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			) as AsyncExecutionResult;
+			assert.equal(result.isError, true);
+			assert.match(result.content[0]?.text ?? "", /^Unknown agent: vanished\nEffective cwd: /);
+			assert.match(result.content[0]?.text ?? "", new RegExp(evidenceDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+			assert.match(result.content[0]?.text ?? "", /visible \(project\)/);
+			assert.doesNotMatch(result.content[0]?.text ?? "", new RegExp(storedCwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+		} finally {
+			fs.rmSync(asyncDir, { recursive: true, force: true });
+		}
 	});
 
 	it("background chains inherit the parent session model when no step or agent model is set", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -4591,7 +4591,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const result = await runSync(tempDir, agents, "nonexistent", sentinel, {});
 
 		assert.equal(result.exitCode, 1);
-		assert.ok(result.error?.includes("Unknown agent"));
+		assert.match(result.error ?? "", /^Unknown agent: nonexistent\nEffective cwd: /);
+		assert.match(result.error ?? "", /Consulted agent-definition directories:[\s\S]*Discovered agents:/);
+		assert.doesNotMatch(result.error ?? "", /echo \(project\)/);
 		assert.equal(result.task, "[prompt redacted]");
 		assert.doesNotMatch(JSON.stringify(result), new RegExp(sentinel));
 	});

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -653,6 +653,16 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		assert.equal(sessionManager.flushed, true);
 	});
 
+	it("/run reports discovery evidence for a missing agent", async () => {
+		await withTempProject("pi-slash-missing-agent-", async (root) => {
+			fs.writeFileSync(path.join(root, ".pi", "agents", "worker.md"), "---\nname: worker\ndescription: Worker\n---\n", "utf-8");
+			const run = await captureSlashCommandParams("run", "missing", root);
+			assert.equal(run.params, undefined);
+			assert.match(run.notifications[0] ?? "", /^Unknown agent: missing\nEffective cwd: /);
+			assert.match(run.notifications[0] ?? "", /Consulted agent-definition directories:[\s\S]*worker \(project\)/);
+		});
+	});
+
 	it("/run reports malformed agent configuration", async () => {
 		await withTempProject("pi-slash-invalid-agent-", async (root) => {
 			fs.writeFileSync(path.join(root, ".pi", "agents", "broken.md"), "---\nname: broken\ndescription: Broken\nrunner:\n  type: unknown\n---\nBroken agent.\n");

--- a/test/integration/template-resolution.test.ts
+++ b/test/integration/template-resolution.test.ts
@@ -215,6 +215,14 @@ describe("resolveParallelBehaviors", { skip: !available ? "pi packages not avail
 
 		assert.equal(behaviors[0]?.output, false);
 	});
+
+	it("requires truthful context or explicit fallback for missing parallel agents", () => {
+		assert.throws(() => resolveParallelBehaviors([{ agent: "missing", task: "Review" }], [], 0), /requires unknown-agent diagnostic context/);
+		assert.throws(() => resolveParallelBehaviors(
+			[{ agent: "missing", task: "Review" }], [], 0, undefined,
+			{ cwd: process.cwd(), scope: "both" },
+		), /Unknown agent: missing[\s\S]*Effective cwd:[\s\S]*Consulted agent-definition directories/);
+	});
 });
 
 describe("read-only progress suppression", { skip: !available ? "pi packages not available" : undefined }, () => {

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, it } from "node:test";
 import { handleManagementAction } from "../../src/agents/agent-management.ts";
 import { serializeAgent } from "../../src/agents/agent-serializer.ts";
 import { parseChain, serializeChain } from "../../src/agents/chain-serializer.ts";
-import { discoverAgents, discoverAgentsAll, type AgentConfig } from "../../src/agents/agents.ts";
+import { discoverAgents, discoverAgentsAll, inspectAgentDefinitionDirectory, type AgentConfig } from "../../src/agents/agents.ts";
 import { parseFrontmatter } from "../../src/agents/frontmatter.ts";
 import { buildPiArgs } from "../../src/runs/shared/pi-args.ts";
 import { THINKING_LEVELS } from "../../src/shared/model-info.ts";
@@ -99,6 +99,38 @@ afterEach(() => {
 		if (!dir) continue;
 		fs.rmSync(dir, { recursive: true, force: true });
 	}
+});
+
+describe("agent definition directory inspection", () => {
+	it("distinguishes absent, empty, candidates, unreadable, and non-directory paths", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-inspection-"));
+		tempDirs.push(root);
+		const empty = path.join(root, "empty");
+		const candidates = path.join(root, "candidates");
+		const file = path.join(root, "not-directory");
+		fs.mkdirSync(empty);
+		fs.mkdirSync(candidates);
+		fs.writeFileSync(path.join(candidates, "worker.md"), "---\nname: worker\ndescription: Worker\n---\n", "utf-8");
+		fs.writeFileSync(file, "not a directory", "utf-8");
+		assert.equal(inspectAgentDefinitionDirectory(path.join(root, "absent")).state, "absent");
+		assert.equal(inspectAgentDefinitionDirectory(empty).state, "empty");
+		assert.deepEqual(inspectAgentDefinitionDirectory(candidates), { state: "candidates", files: [path.join(candidates, "worker.md")] });
+		assert.equal(inspectAgentDefinitionDirectory(file).state, "not-directory");
+		assert.equal(inspectAgentDefinitionDirectory(path.join(root, "blocked"), {
+			existsSync: () => true,
+			statSync: () => ({ isDirectory: () => true }),
+			readdirSync: () => { throw new Error("permission denied"); },
+		}).state, "unreadable");
+	});
+
+	it("reports cached builtin and configured project definition paths without synthesizing a root", () => withTempHome(() => {
+		const project = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-report-"));
+		tempDirs.push(project);
+		writeJson(path.join(project, ".pi", "settings.json"), { subagents: { projectRootResolution: "nearest" } });
+		const discovered = discoverAgents(project, "project");
+		assert.ok(discovered.directories.some((entry) => entry.source === "builtin"));
+		assert.deepEqual(discovered.directories.filter((entry) => entry.source === "project").map((entry) => entry.path), [path.join(project, ".agents"), path.join(project, ".pi", "agents")]);
+	}));
 });
 
 describe("folded frontmatter blocks", () => {

--- a/test/unit/agent-refinements.test.ts
+++ b/test/unit/agent-refinements.test.ts
@@ -68,6 +68,24 @@ describe("agent refinements", () => {
 		assert.throws(() => getAgentRefinementPath(tempDir, "../worker"), /cannot be used/);
 	});
 
+	it("reports discovery evidence and does not launch or write for a missing refinement target", async () => {
+		let launched = false;
+		const result = await handleRefinementAction("refine", { agent: "missing" }, {
+			cwd: tempDir,
+			state: state(),
+			signal: new AbortController().signal,
+			launchProposalChild: async () => {
+				launched = true;
+				return { details: { results: [] } };
+			},
+		});
+		assert.equal(result.isError, true);
+		assert.equal(launched, false);
+		assert.match(firstText(result), /^Unknown agent: missing\nEffective cwd: /);
+		assert.match(firstText(result), /Consulted agent-definition directories:[\s\S]*Discovered agents:/);
+		assert.equal(fs.existsSync(getAgentRefinementPath(tempDir, "missing")), false);
+	});
+
 	it("does not launch or write when no bounded evidence exists", async () => {
 		writeProjectAgent();
 		let launched = false;

--- a/test/unit/async-execution.test.ts
+++ b/test/unit/async-execution.test.ts
@@ -27,6 +27,41 @@ const ctx = {
 };
 
 describe("async runner execution", () => {
+	it("uses supplied discovery context for missing async agents", () => {
+		const result = buildAsyncRunnerSteps("missing-agent", {
+			chain: [{ agent: "missing", task: "Do not launch" }],
+			agents: [agent("arbitrary")],
+			unknownAgentDiagnosticContext: {
+				cwd: path.resolve(ctx.cwd),
+				scope: "both",
+				directories: [{ source: "project", path: path.join(ctx.cwd, ".pi", "agents"), state: "empty" }],
+				agents: [agent("discovered")],
+			},
+			ctx,
+			maxSubagentDepth: 1,
+			asyncDir: path.join(process.cwd(), ".tmp-missing-agent"),
+		});
+		assert.ok("error" in result);
+		assert.match(result.error, /^Unknown agent: missing\nEffective cwd: /);
+		assert.match(result.error, /discovered \(project\)/);
+		assert.doesNotMatch(result.error, /arbitrary \(project\)/);
+	});
+
+	it("uses the resolved cwd override for no-context missing-agent fallback discovery", () => {
+		const override = path.join("diagnostic-cwd-override", "nested");
+		const result = buildAsyncRunnerSteps("missing-agent-cwd", {
+			chain: [{ agent: "missing", task: "Do not launch" }],
+			agents: [agent("arbitrary")],
+			ctx,
+			cwd: override,
+			maxSubagentDepth: 1,
+			asyncDir: path.join(process.cwd(), ".tmp-missing-agent-cwd"),
+		});
+		assert.ok("error" in result);
+		assert.ok(result.error.startsWith(`Unknown agent: missing\nEffective cwd: ${path.resolve(ctx.cwd, override)}`));
+		assert.doesNotMatch(result.error, /arbitrary \(project\)/);
+	});
+
 	it("formats interactive yield and headless auto-drain guidance separately", () => {
 		const interactive = formatAsyncStartedMessage("Async: worker [interactive]", true);
 		assert.match(interactive, /interactive session[\s\S]*return control/i);

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -446,7 +446,13 @@ Project prompt.
 `);
 
 		const missingAgent = await resolveSubagentLaunchContract({ agent: "missing", cwd });
-		assert.deepEqual(missingAgent, { ok: false, code: "missing_agent", message: "Unknown agent: missing", diagnostics: [] });
+		assert.equal(missingAgent.ok, false);
+		assert.equal(missingAgent.code, "missing_agent");
+		assert.deepEqual(missingAgent.diagnostics, []);
+		assert.match(missingAgent.message, /^Unknown agent: missing\nEffective cwd: /);
+		assert.match(missingAgent.message, /Consulted agent-definition directories:/);
+		assert.match(missingAgent.message, /project: .*\.pi[\\/]agents \(1 candidate\)/);
+		assert.match(missingAgent.message, /Discovered agents:\n[\s\S]*worker \(project\)/);
 		writeAgent(path.join(cwd, ".pi", "agents", "broken.md"), `---
 name: broken
 description: Broken worker


### PR DESCRIPTION
## Why

`Unknown agent: <name>` did not identify the cwd or discovery inputs used for resolution. When a delegated run started from a worktree without its project agent definitions, checking the main checkout misleadingly showed that the requested agent existed.

## What changed

- retain discovery-owned diagnostic context: effective cwd, scope, consulted agent-definition directories, and effective agents
- distinguish absent, present-but-empty, candidate-containing, unreadable, and non-directory definition paths
- cache builtin definition files and their inspection metadata together
- format missing-agent errors with the effective cwd, directory states, and source-qualified discovered agents
- propagate the original discovery context through preflight, `/run`, refinement, foreground, resume, async, and append-step paths
- define consistent fallback behavior for lower-level APIs that lack original discovery provenance
- preserve invalid-configuration and ambiguous-agent precedence

The human-readable error becomes multiline, but structured contracts remain unchanged: preflight still returns `missing_agent`, foreground result shapes are unchanged, and direct synchronous execution still returns exit code 1 with prompt redaction.

## Example

```text
Unknown agent: fleet-reviewer
Effective cwd: D:\wt\HEDSWE-2808
Consulted agent-definition directories:
- project: D:\wt\HEDSWE-2808\.pi\agents (absent)
- project: D:\wt\HEDSWE-2808\.agents (present but empty)
Discovered agents:
- worker (builtin)
```

(The exact directory list reflects the configured scope and project-root resolution.)

## Verification

- `npm run typecheck`
- focused discovery/preflight/refinement/async tests: 6 passed
- focused resume/append-step/`/run`/sync/settings-helper tests: 5 passed
- full `npm test`: 2,484 passed, 32 skipped; 3 unrelated Windows symlink-creation tests could not run because this environment lacks symlink privilege (`EPERM`)
- `git diff --check`
- one OpenAI delivery-plan review incorporated
- Anthropic architecture review completed via authenticated Claude CLI after the Relay-managed Anthropic OAuth token was rejected; one documentation correction incorporated

## Scope

- Standalone change against `main`
- No dependency on the unrelated HEDSWE-3060 connection-fallback PR
- No persisted-state or discovery-precedence changes

Downstream report: HEDSWE-3059
