### PR TITLE
fix: preserve errors and artifacts for resumed workflow children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Follow symlinked directories during agent discovery without revisiting recursive links. Thanks to [@robsdudeson](https://github.com/robsdudeson) for #1505 and #1510.
 - Explain unknown-agent failures with the effective cwd and discovery inputs. Thanks to [@genkikadomatsu](https://github.com/genkikadomatsu) for #1511.
 - Retry fallback models for transient provider connection failures. Thanks to [@genkikadomatsu](https://github.com/genkikadomatsu) for #1508.
+- Preserve typed errors, partial output, and transcript/artifact metadata when foreground workflow children resume. See #1513.
 - Bypass repository fsmonitor hooks when collecting mutation evidence. Thanks to [@jpriverar](https://github.com/jpriverar) for #1497.
 - Avoid the fatal Node `ReadFileUtf8` retention path. Thanks to [@pgoodjohn](https://github.com/pgoodjohn) for #1501.
 - Preserve bounded async child failure context after compaction, including missing file-only output, instead of leaving failed run summaries empty. See #1495.

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { resultFilePath } from "./result-files.ts";
-import type { AcceptanceLedger, AsyncStatus, CostSummary, ModelAttempt } from "../../shared/types.ts";
+import type { AcceptanceLedger, ArtifactPaths, AsyncStatus, CostSummary, ModelAttempt } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 
 export interface ImportedAsyncRoot {
@@ -27,6 +27,10 @@ export interface ImportedAsyncRootResult {
 	structuredOutputPath?: string;
 	structuredOutputSchemaPath?: string;
 	acceptance?: AcceptanceLedger;
+	artifactPaths?: ArtifactPaths;
+	outputSaveError?: string;
+	transcriptPath?: string;
+	transcriptError?: string;
 	timedOut?: boolean;
 	stopped?: boolean;
 }
@@ -56,6 +60,10 @@ interface AsyncResultFile {
 		structuredOutputPath?: string;
 		structuredOutputSchemaPath?: string;
 		acceptance?: AcceptanceLedger;
+		artifactPaths?: ArtifactPaths;
+		outputSaveError?: string;
+		transcriptPath?: string;
+		transcriptError?: string;
 	}>;
 }
 
@@ -118,6 +126,7 @@ function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, 
 		...(step?.structuredOutputPath ? { structuredOutputPath: step.structuredOutputPath } : {}),
 		...(step?.structuredOutputSchemaPath ? { structuredOutputSchemaPath: step.structuredOutputSchemaPath } : {}),
 		...(step?.acceptance ? { acceptance: step.acceptance } : {}),
+		...(step?.transcriptPath ? { transcriptPath: step.transcriptPath } : {}),
 	};
 }
 
@@ -136,6 +145,7 @@ function outputFromTimeout(root: ImportedAsyncRoot, status: AsyncStatus | null, 
 		...(step?.modelAttempts ? { modelAttempts: step.modelAttempts } : {}),
 		...(step?.contextOverflow ? { contextOverflow: true } : {}),
 		...(step?.totalCost ? { totalCost: step.totalCost } : {}),
+		...(step?.transcriptPath ? { transcriptPath: step.transcriptPath } : {}),
 	};
 }
 
@@ -168,6 +178,10 @@ function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null
 		...(child?.structuredOutputPath ?? step?.structuredOutputPath ? { structuredOutputPath: child?.structuredOutputPath ?? step?.structuredOutputPath } : {}),
 		...(child?.structuredOutputSchemaPath ?? step?.structuredOutputSchemaPath ? { structuredOutputSchemaPath: child?.structuredOutputSchemaPath ?? step?.structuredOutputSchemaPath } : {}),
 		...(child?.acceptance ?? step?.acceptance ? { acceptance: child?.acceptance ?? step?.acceptance } : {}),
+		...(child?.artifactPaths ? { artifactPaths: child.artifactPaths } : {}),
+		...(child?.outputSaveError ? { outputSaveError: child.outputSaveError } : {}),
+		...(child?.transcriptPath ?? step?.transcriptPath ? { transcriptPath: child?.transcriptPath ?? step?.transcriptPath } : {}),
+		...(child?.transcriptError ? { transcriptError: child.transcriptError } : {}),
 	};
 }
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2107,9 +2107,13 @@ async function resumeAsyncRun(input: {
 			...(completed.structuredOutputPath ? { structuredOutputPath: completed.structuredOutputPath } : {}),
 			...(completed.structuredOutputSchemaPath ? { structuredOutputSchemaPath: completed.structuredOutputSchemaPath } : {}),
 			...(completed.acceptance ? { acceptance: completed.acceptance } : {}),
+			...(completed.artifactPaths ? { artifactPaths: completed.artifactPaths } : {}),
+			...(completed.outputSaveError ? { outputSaveError: completed.outputSaveError } : {}),
+			...(completed.transcriptPath ? { transcriptPath: completed.transcriptPath } : {}),
+			...(completed.transcriptError ? { transcriptError: completed.transcriptError } : {}),
 		};
 		return {
-			content: [{ type: "text", text: completed.output || completed.error || `Revived ${target.source} subagent ${revivedId} completed without output.` }],
+			content: [{ type: "text", text: completed.success ? completed.output || completed.error || `Revived ${target.source} subagent ${revivedId} completed without output.` : completed.error || completed.output || `Revived ${target.source} subagent ${revivedId} completed without output.` }],
 			...(completed.success ? {} : { isError: true }),
 			details: {
 				...result.details,
@@ -3126,9 +3130,13 @@ async function waitForWorkflowAsyncSingleResult(
 		...(completed.structuredOutputPath ? { structuredOutputPath: completed.structuredOutputPath } : {}),
 		...(completed.structuredOutputSchemaPath ? { structuredOutputSchemaPath: completed.structuredOutputSchemaPath } : {}),
 		...(completed.acceptance ? { acceptance: completed.acceptance } : {}),
+		...(completed.artifactPaths ? { artifactPaths: completed.artifactPaths } : {}),
+		...(completed.outputSaveError ? { outputSaveError: completed.outputSaveError } : {}),
+		...(completed.transcriptPath ? { transcriptPath: completed.transcriptPath } : {}),
+		...(completed.transcriptError ? { transcriptError: completed.transcriptError } : {}),
 	});
 	return {
-		content: [{ type: "text", text: completed.output || completed.error || `Async workflow child ${options.runId} completed without output.` }],
+		content: [{ type: "text", text: completed.success ? completed.output || completed.error || `Async workflow child ${options.runId} completed without output.` : completed.error || completed.output || `Async workflow child ${options.runId} completed without output.` }],
 		...(completed.success ? {} : { isError: true }),
 		details: {
 			...launchResult.details,
@@ -3991,6 +3999,10 @@ function workflowChildResult(
 	const output = result.details.results.length === 1 && result.details.results[0]?.finalOutput !== undefined
 		? result.details.results[0].finalOutput
 		: receiptOutput;
+	const childError = result.details.results.map((child) => child.error).find((error): error is string => Boolean(error));
+	const failureError = childError && receiptOutput && receiptOutput !== childError
+		? `${childError}\n\n${receiptOutput}`
+		: childError || receiptOutput || output || "Child run failed.";
 	const detached = result.details.results.some((child) => child.detached);
 	const interrupted = result.details.results.some((child) => child.interrupted);
 	const stopped = result.details.results.some((child) => child.stopped);
@@ -4039,7 +4051,7 @@ function workflowChildResult(
 		...(resolvedAgents.length === 1 ? { agent: resolvedAgents[0] } : {}),
 		...(runId ? { runId } : {}),
 		output,
-		...(!ok ? { error: receiptOutput || output || "Child run failed." } : {}),
+		...(!ok ? { error: failureError } : {}),
 		...(detached ? { detached: true } : {}),
 		...(interrupted ? { interrupted: true } : {}),
 		...(stopped ? { stopped: true } : {}),

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -4225,6 +4225,43 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.readFileSync(configuredOutput, "utf-8"), "resumed report");
 	});
 
+	it("preserves failed foreground resume errors and transcript metadata", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([makeAgent("echo")]);
+		mockPi.onCall({ output: "first report" });
+		const firstResult = await executor.execute(
+			"workflow-resume-failure-first",
+			{ async: false, workflowScript: `return runs.run("first", { agent: "echo", task: "First" });` },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(firstResult.isError, undefined, firstResult.content[0]?.text ?? "workflow failed");
+		const first = firstResult.details.workflow?.value as { runId?: string };
+		assert.ok(first.runId);
+
+		const partialOutput = "I’ll re-read the current implementation before changing it.";
+		mockPi.onCall({ output: partialOutput });
+		const resumedResult = await executor.execute(
+			"workflow-resume-failure-resumed",
+			{ async: false, workflowScript: `return runs.run("resumed", { resume: ${JSON.stringify(first.runId)}, task: "Implement the approved file changes" });` },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(resumedResult.isError, true);
+		const resumedText = resumedResult.content.map((part) => part.type === "text" ? part.text : "").join("\n");
+		assert.match(resumedText, /Subagent completed without making edits for an implementation task/);
+		assert.doesNotMatch(resumedText, new RegExp(`^${escapeRegExp(partialOutput)}`));
+		const child = resumedResult.details.results[0];
+		assert.equal(child?.finalOutput, partialOutput);
+		assert.match(child?.error ?? "", /Subagent completed without making edits for an implementation task/);
+		assert.ok(child?.transcriptPath);
+		assert.equal(child?.transcriptPath, child?.artifactPaths?.transcriptPath);
+		assert.ok(child?.artifactPaths?.outputPath);
+		assert.match(fs.readFileSync(child.transcriptPath, "utf-8"), /first|re-read|implementation/i);
+	});
+
 	it("fails closed on an invalid explicit foreground resume output schema", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "first result" });
 		const result = await makeExecutor([makeAgent("echo")]).execute(


### PR DESCRIPTION
Fixes #1513.

Failed foreground retained-resume children now preserve their typed error before normal output text, while keeping partial output, transcript metadata, and artifact metadata available for inspection. Completion guard behavior stays unchanged.

Validation:
- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/chain-root-attachment.test.ts`
- `git diff --check`

Fresh exact-head review found no issues.
