### PR TITLE
feat: add one-use workflow child permit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Resolve package subagents from bare HTTP(S) Git URLs stored in Pi settings. Thanks to [@trancikk](https://github.com/trancikk) for #1452.
 
 ### Added
+- Add a package-internal one-use permit for one exact native child in a foreground `workflowScript`. Thanks to [@maroffo](https://github.com/maroffo) for #1494.
 - Add configured pruned fork sessions with budgeted transcript-overflow summaries, stable child-visible recovery refs, and private validated recovery sidecars while preserving normal fork links and safety behavior.
 - Load `workflowScript` from `workflowScriptPath` for execution, offline validation, and schedule creation. Thanks to [@elecnix](https://github.com/elecnix) for #1464.
 - Add offline `workflowScript` syntax and structural validation through the public subagent tool. Thanks to [@elecnix](https://github.com/elecnix) for #1462.

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -106,6 +106,7 @@ import { appendTurnBudgetSystemPrompt, formatTurnBudgetOutput, initialTurnBudget
 import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
 import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { agentDefinitionDigest, launchBindingDigest } from "../../shared/launch-contract.ts";
+import { consumeWorkflowChildPermit } from "../../shared/workflow-child-permit.ts";
 import { createBoundedByteTail, createBoundedLineReader, formatProtocolOutputLimit, MAX_CHILD_STDERR_BYTES, PI_AGGREGATE_EVENT_PROJECTOR, projectChildLifecycle, type ChildLifecycleAction, type ChildLifecycleState, type ProtocolOutputLimit } from "../shared/child-protocol.ts";
 import {
 	acceptChildWatchdogEvent,
@@ -540,8 +541,27 @@ async function runSingleAttempt(
 	let toolAvailabilityError: string | undefined;
 	let abortedBySignal = options.signal?.aborted === true;
 
+	const spawnSpec = getPiSpawnCommand(args);
+	if (options.workflowChildPermitLaunch) {
+		const permitError = consumeWorkflowChildPermit(options.workflowChildPermitLaunch.permit, {
+			workflowRunId: options.workflowChildPermitLaunch.workflowRunId,
+			childKey: options.workflowChildPermitLaunch.childKey,
+			agent: agent.name,
+			launchContractDigest,
+			context: options.context ?? "fresh",
+			runner: "pi",
+		});
+		if (permitError) {
+			cleanupTempDir(tempDir);
+			result.exitCode = 1;
+			result.error = permitError;
+			result.finalOutput = permitError;
+			progress.status = "failed";
+			progress.error = permitError;
+			return result;
+		}
+	}
 	const exitCode = await new Promise<number>((resolve) => {
-		const spawnSpec = getPiSpawnCommand(args);
 		const proc = spawn(spawnSpec.command, spawnSpec.args, {
 			cwd: options.cwd ?? runtimeCwd,
 			env: spawnEnv,
@@ -1810,6 +1830,18 @@ async function runSyncCompletionInner(
 		agent.modelProvider ?? options.preferredModelProvider,
 		{ scope: options.modelScope, primaryModelFromParent: options.modelOverrideFromParent },
 	);
+	if (options.workflowChildPermitLaunch && candidates.length > 1) {
+		const error = "Workflow child permit does not support model fallback.";
+		return redactResultPrompt(withRunContext({
+			index: options.index ?? 0,
+			agent: agent.name,
+			task,
+			exitCode: 1,
+			messages: [],
+			usage: emptyUsage(),
+			error,
+		}, options.context));
+	}
 	try {
 		for (const candidate of candidates) {
 			const model = applyThinkingSuffix(candidate, options.thinkingOverride ?? agent.thinking, options.thinkingOverride !== undefined);
@@ -1943,6 +1975,7 @@ async function runSyncCompletionInner(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
+			if (options.workflowChildPermitLaunch && !attemptSucceeded) break modelAttemptsLoop;
 			// Preserve the legacy intercom handoff contract: once this logical run has
 			// been handed to a supervisor, terminating that attempt must not launch a
 			// startup retry or model fallback. Explicit user detach retains fallback.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -128,6 +128,7 @@ import { previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, Wo
 import { buildWorkflowReceipt, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
 import { workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { resolveWorkflowChatProgress, type WorkflowChatProgressProjection } from "../../workflows/chat-progress.ts";
+import { claimWorkflowChildPermit, validateWorkflowChildPermitRoot, type WorkflowChildPermit, type WorkflowChildPermitContext } from "../../shared/workflow-child-permit.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
@@ -458,6 +459,7 @@ interface ExecutionContextData {
 	runFanoutBudget: RunFanoutBudgetDescriptor;
 	topLevelAsyncCapacityEligible: boolean;
 	activeAsyncCapacity?: ActiveAsyncCapacityHandle;
+	workflowChildPermitLaunch?: WorkflowChildPermitContext;
 }
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
@@ -3741,6 +3743,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			agentContract: params.agentContract,
 			acceptance: params.acceptance,
 			acceptanceContext: { mode: "single" },
+			workflowChildPermitLaunch: data.workflowChildPermitLaunch,
 			onEffectivePrompt: foregroundControl ? (prompt) => updateLiveEffectivePrompt(foregroundControl, 0, prompt) : undefined,
 			onDetachReady: (detach) => {
 				detachForeground = detach;
@@ -4375,6 +4378,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 	const delegatedThinkingOverrides = new WeakMap<object, AgentConfig["thinking"]>();
 	const delegatedZeroToolBudgets = new WeakSet<object>();
 	const delegatedExecutions = new WeakSet<object>();
+	const workflowPermitContexts = new WeakMap<object, { root: WorkflowChildPermit } | { child: WorkflowChildPermitContext }>();
 	const warnedArtifactPackageDirs = new Set<string>();
 	const scheduledOwnerExecutors = new Map<string, ReturnType<typeof createSubagentExecutor>>();
 	const execute = async (
@@ -4398,6 +4402,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const delegatedThinkingOverride = delegatedThinkingOverrides.get(params);
 		const allowZeroToolBudget = delegatedZeroToolBudgets.has(params);
 		const delegatedExecution = delegatedExecutions.has(params);
+		const workflowPermitContext = workflowPermitContexts.get(params);
+		const delegatedWorkflowPermit = workflowPermitContext && "root" in workflowPermitContext ? workflowPermitContext.root : undefined;
+		const workflowChildPermitLaunch = workflowPermitContext && "child" in workflowPermitContext ? workflowPermitContext.child : undefined;
 		if (!preserveActiveSession) deps.state.baseCwd = ctx.cwd;
 		deps.state.foregroundRuns ??= new Map();
 		deps.state.foregroundControls ??= new Map();
@@ -4408,6 +4415,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const normalizedAction = typeof requestParams.action === "string" ? requestParams.action.trim() : requestParams.action;
 		if (normalizedAction === "resume" && requestParams.extensionBindings !== undefined) return buildRequestedModeError(requestParams, "extensionBindings is not supported with action='resume'; resume uses the original retained child binding.");
 		if (requestParams.workflowScript !== undefined && normalizedAction === undefined) {
+			if (delegatedWorkflowPermit) {
+				const permitError = validateWorkflowChildPermitRoot(delegatedWorkflowPermit, _id);
+				if (permitError) return buildRequestedModeError(requestParams, permitError);
+				if (requestParams.async !== false) return buildRequestedModeError(requestParams, "Workflow child permit supports foreground workflow roots only; set async:false.");
+			}
 			const workflowParentModel = parentModelOverride !== undefined
 				? parentModelOverride
 				: (() => {
@@ -5002,6 +5014,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			try {
 				const workflow = await runWorkflowScript({
 					script: requestParams.workflowScript,
+					...(delegatedWorkflowPermit ? { oneUsePermit: { claim: (key: string) => claimWorkflowChildPermit(delegatedWorkflowPermit, _id, key) } } : {}),
 					timeoutMs: timeout,
 					signal,
 					...(workflowState ? { state: workflowState } : {}),
@@ -5022,6 +5035,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						sendWorkflowProgress();
 					},
 					launch: async (key, childParams, workflowSignal, admission) => {
+						if (delegatedWorkflowPermit && admission.batch) throw new Error("Workflow child permit does not support runs.all.");
+						if (delegatedWorkflowPermit && childParams.resume !== undefined) throw new Error("Workflow child permit does not support retained resume.");
+						if (delegatedWorkflowPermit && childParams.async === true) throw new Error("Workflow child permit supports one foreground child only.");
 						if (workflowUsageBudget.budget && childParams.async === true) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, "workflow usageBudget does not support async runs.run launches."), childParams, deps.state);
 						const budgetState = usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults));
 						if (budgetState?.exhausted) return workflowChildResult(key, buildRequestedModeError(childParams as SubagentParamsLike, usageBudgetExceededMessage(budgetState)), childParams, deps.state);
@@ -5040,6 +5056,15 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								missionBinding,
 								deps.asyncByDefault,
 							);
+							if (delegatedWorkflowPermit) {
+								if (childRequest.async !== false) throw new Error("Workflow child permit supports one foreground child only.");
+								const childCwd = resolveRequestedCwd(workflowCwd, childRequest.cwd);
+								const childAgent = typeof childRequest.agent === "string"
+									? resolveAgentName(childRequest.agent, deps.discoverAgents(childCwd, resolveExecutionAgentScope(childRequest.agentScope)).agents).agent
+									: undefined;
+								if (childAgent?.runner?.type === "external-cli" || childAgent?.runner?.type === "external-job") throw new Error("Workflow child permit supports native Pi children only.");
+								workflowPermitContexts.set(childRequest, { child: { permit: delegatedWorkflowPermit, workflowRunId: _id, childKey: key } });
+							}
 							workflowLaunchObservers.set(childRequest, (launch) => recordMissionWorkflowChild(missionBinding, _id, key, {
 								status: "running",
 								agent: launch.agent,
@@ -6096,6 +6121,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			runFanoutBudget,
 			topLevelAsyncCapacityEligible,
 			activeAsyncCapacity,
+			workflowChildPermitLaunch,
 		});
 
 		const foregroundDescription = selectedAgentNames.length === 1
@@ -6364,13 +6390,17 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const privateParams = delegatedParams as SubagentParamsLike & {
 			delegatedThinkingOverride?: AgentConfig["thinking"];
 			delegatedAllowZeroToolBudget?: true;
+			delegatedWorkflowPermit?: WorkflowChildPermit;
 		};
 		const thinkingOverride = privateParams.delegatedThinkingOverride;
 		const allowZeroToolBudget = privateParams.delegatedAllowZeroToolBudget === true;
+		const workflowPermit = privateParams.delegatedWorkflowPermit;
 		delete privateParams.delegatedThinkingOverride;
 		delete privateParams.delegatedAllowZeroToolBudget;
+		delete privateParams.delegatedWorkflowPermit;
 		if (thinkingOverride !== undefined) delegatedThinkingOverrides.set(delegatedParams, thinkingOverride);
 		if (allowZeroToolBudget) delegatedZeroToolBudgets.add(delegatedParams);
+		if (workflowPermit) workflowPermitContexts.set(delegatedParams, { root: workflowPermit });
 		delegatedExecutions.add(delegatedParams);
 		return execute(id, delegatedParams, signal, onUpdate, ctx);
 	};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -14,6 +14,7 @@ import type { AuthorityPolicyConfig } from "../policy/authority.ts";
 import type { ThinkingLevel } from "./model-info.ts";
 import type { GlobalMissionIndexRecord, MissionRecord, MissionStoreConfig } from "../missions/types.ts";
 import type { ExtensionBindings } from "../runs/shared/extension-bindings.ts";
+import type { WorkflowChildPermitContext } from "./workflow-child-permit.ts";
 
 // ============================================================================
 // Basic Types
@@ -2081,6 +2082,8 @@ export interface RunSyncOptions {
 	thinkingOverride?: AgentConfig["thinking"];
 	thinkingCeiling?: ThinkingLevel;
 	extensionBindings?: ExtensionBindings;
+	/** Package-internal one-use authorization for one foreground workflow child. */
+	workflowChildPermitLaunch?: WorkflowChildPermitContext;
 	/** Registry models available for heuristic bare-model resolution */
 	availableModels?: Array<{ provider: string; id: string; fullId: string }>;
 	/** Current parent-session provider to prefer for ambiguous bare model ids */

--- a/src/shared/workflow-child-permit.ts
+++ b/src/shared/workflow-child-permit.ts
@@ -1,0 +1,116 @@
+import { stableJsonDigest } from "./launch-contract.ts";
+
+export interface WorkflowChildPermitInput {
+	issuerPackage: string;
+	workflowRunId: string;
+	childKey: string;
+	agent: string;
+	launchContractDigest: string;
+	context: "fresh" | "fork";
+}
+
+export interface WorkflowChildPermitLaunch {
+	workflowRunId: string;
+	childKey: string;
+	agent: string;
+	launchContractDigest: string;
+	context: "fresh" | "fork";
+	runner: "pi";
+}
+
+export interface WorkflowChildPermitContext {
+	permit: WorkflowChildPermit;
+	workflowRunId: string;
+	childKey: string;
+}
+
+export interface WorkflowChildPermit {
+	readonly __workflowChildPermit: unique symbol;
+}
+
+interface WorkflowChildPermitRecord {
+	issuerPackage: string;
+	workflowRunId: string;
+	childKey: string;
+	agent: string;
+	expectedProjectionDigest: string;
+	state: "available" | "claimed" | "consumed";
+}
+
+const records = new WeakMap<object, WorkflowChildPermitRecord>();
+
+function projectionDigest(input: Omit<WorkflowChildPermitLaunch, "workflowRunId">): string {
+	return stableJsonDigest({
+		version: 1,
+		childKey: input.childKey,
+		agent: input.agent,
+		launchContractDigest: input.launchContractDigest,
+		context: input.context,
+		runner: input.runner,
+	});
+}
+
+function required(value: string, label: string): string {
+	if (!value.trim() || value !== value.trim()) throw new Error(`${label} must be a non-empty trimmed string.`);
+	return value;
+}
+
+/** Package-internal first-slice permit. It is opaque, in-memory, and not serializable. */
+export function createWorkflowChildPermit(input: WorkflowChildPermitInput): WorkflowChildPermit {
+	const permit = Object.freeze(Object.create(null)) as WorkflowChildPermit;
+	const record: WorkflowChildPermitRecord = {
+		issuerPackage: required(input.issuerPackage, "issuerPackage"),
+		workflowRunId: required(input.workflowRunId, "workflowRunId"),
+		childKey: required(input.childKey, "childKey"),
+		agent: required(input.agent, "agent"),
+		expectedProjectionDigest: projectionDigest({
+			childKey: input.childKey,
+			agent: input.agent,
+			launchContractDigest: required(input.launchContractDigest, "launchContractDigest"),
+			context: input.context,
+			runner: "pi",
+		}),
+		state: "available",
+	};
+	records.set(permit as object, record);
+	return permit;
+}
+
+export function validateWorkflowChildPermitRoot(permit: WorkflowChildPermit, workflowRunId: string): string | undefined {
+	const record = records.get(permit as object);
+	if (!record) return "Workflow child permit is invalid.";
+	if (record.state !== "available") return "Workflow child permit is already consumed.";
+	if (record.workflowRunId !== workflowRunId) return "Workflow child permit does not match this workflow root.";
+	return undefined;
+}
+
+/** Claim the first distinct launch attempt before validating its model-authored shape. */
+export function claimWorkflowChildPermit(permit: WorkflowChildPermit, workflowRunId: string, childKey: string): string | undefined {
+	const record = records.get(permit as object);
+	if (!record) return "Workflow child permit is invalid.";
+	if (record.state !== "available") return "Workflow child permit is already consumed.";
+	if (record.workflowRunId !== workflowRunId) return "Workflow child permit does not match this workflow root.";
+	record.state = record.childKey === childKey ? "claimed" : "consumed";
+	if (record.childKey !== childKey) return "Workflow child permit child key mismatch.";
+	return undefined;
+}
+
+/** Verify and permanently consume the permit before the one native process spawn. */
+export function consumeWorkflowChildPermit(permit: WorkflowChildPermit, launch: WorkflowChildPermitLaunch): string | undefined {
+	const record = records.get(permit as object);
+	if (!record) return "Workflow child permit is invalid.";
+	if (record.state === "available") return "Workflow child permit launch was not claimed.";
+	if (record.state === "consumed") return "Workflow child permit is already consumed.";
+	if (record.workflowRunId !== launch.workflowRunId) return "Workflow child permit does not match this workflow root.";
+	record.state = "consumed";
+	if (record.childKey !== launch.childKey) return "Workflow child permit child key mismatch.";
+	if (record.agent !== launch.agent) return "Workflow child permit agent mismatch.";
+	if (launch.runner !== "pi") return "Workflow child permit supports native Pi children only.";
+	if (record.expectedProjectionDigest !== projectionDigest(launch)) return "Workflow child permit does not match the final launch projection.";
+	return undefined;
+}
+
+export function workflowChildPermitConsumed(permit: WorkflowChildPermit): boolean {
+	const state = records.get(permit as object)?.state;
+	return state === "claimed" || state === "consumed";
+}

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -734,10 +734,12 @@ export class WorkflowScriptError extends Error {
 
 export interface RunWorkflowScriptOptions {
 	script: string;
+	/** Host-only first-slice admission context. It is never sent to the workflow worker. */
+	oneUsePermit?: { claim: (key: string) => string | undefined };
 	timeoutMs?: number;
 	signal?: AbortSignal;
 	admit?: (calls: Array<{ key: string; params: Record<string, unknown> }>) => void | Promise<void>;
-	launch: (key: string, params: Record<string, unknown>, signal: AbortSignal, admission: { admitted: boolean }) => Promise<WorkflowScriptChildResult>;
+	launch: (key: string, params: Record<string, unknown>, signal: AbortSignal, admission: { admitted: boolean; batch: boolean }) => Promise<WorkflowScriptChildResult>;
 	resolveResume?: (reference: WorkflowReceiptResumeReference, signal: AbortSignal) => string | WorkflowResolvedResumeReference | Promise<string | WorkflowResolvedResumeReference>;
 	status: (keyOrRunId: string, signal: AbortSignal) => Promise<WorkflowScriptChildResult>;
 	steer?: (key: string, message: string, options: WorkflowSteerOptions, signal: AbortSignal) => Promise<WorkflowSteerResult>;
@@ -1381,6 +1383,31 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			}
 			const params = message.args.params;
 			if (!isRecord(params)) return respond(Promise.reject(new Error(`runs.run('${key}', params) requires a params object.`)));
+			const collectFailure = message.args.collectFailure === true;
+			const callObserved = observedRunCalls.delete(message.callId);
+			const deliver = (promise: Promise<WorkflowScriptChildResult>) => collectFailure
+				? promise
+				: promise.then((result) => {
+					if (!result.ok && !result.stopped) {
+						const childError = new Error(result.detached ? `Run '${key}' detached: ${result.error ?? result.output}` : `Run '${key}' failed: ${result.error ?? result.output}`) as Error & { workflowErrorKind?: "detached-child" };
+						if (result.detached) childError.workflowErrorKind = "detached-child";
+						throw childError;
+					}
+					return result;
+				});
+			const fingerprint = stableJson(params);
+			const existing = launches.get(key);
+			if (existing) {
+				if (existing.fingerprint !== fingerprint) return respond(Promise.reject(new Error(`Duplicate workflow key '${key}' used with incompatible launch params.`)));
+				if (callObserved) existing.observed = true;
+				trace.push({ operation: "run", key, state: "reused", ...workflowStringMetadata(params) });
+				traceChanged();
+				return respond(deliver(existing.promise), `runs.run('${key}') result`);
+			}
+			const permitError = options.oneUsePermit?.claim(key);
+			if (permitError) return respond(Promise.reject(new Error(permitError)));
+			if (options.oneUsePermit && message.args.batch !== undefined) return respond(Promise.reject(new Error("Workflow child permit does not support runs.all.")));
+			if (options.oneUsePermit && params.resume !== undefined) return respond(Promise.reject(new Error("Workflow child permit does not support retained resume.")));
 			if (params.action !== undefined) return respond(Promise.reject(new Error(`runs.run('${key}') accepts execution params only; management action is not allowed.`)));
 			if (params.workflowScript !== undefined) return respond(Promise.reject(new Error(`runs.run('${key}') cannot start a nested workflow script.`)));
 			if (params.tasks !== undefined || params.chain !== undefined || params.parallel !== undefined || params.concurrency !== undefined || params.chainDir !== undefined) {
@@ -1411,28 +1438,6 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (params.resume !== undefined && (typeof params.task !== "string" || !params.task.trim())) {
 				return respond(Promise.reject(new Error(`runs.run('${key}') resume requires a non-empty task follow-up.`)));
 			}
-			const collectFailure = message.args.collectFailure === true;
-			const callObserved = observedRunCalls.delete(message.callId);
-			const deliver = (promise: Promise<WorkflowScriptChildResult>) => collectFailure
-				? promise
-				: promise.then((result) => {
-					if (!result.ok && !result.stopped) {
-						const childError = new Error(result.detached ? `Run '${key}' detached: ${result.error ?? result.output}` : `Run '${key}' failed: ${result.error ?? result.output}`) as Error & { workflowErrorKind?: "detached-child" };
-						if (result.detached) childError.workflowErrorKind = "detached-child";
-						throw childError;
-					}
-					return result;
-				});
-			const fingerprint = stableJson(params);
-			const existing = launches.get(key);
-			if (existing) {
-				if (existing.fingerprint !== fingerprint) return respond(Promise.reject(new Error(`Duplicate workflow key '${key}' used with incompatible launch params.`)));
-				if (callObserved) existing.observed = true;
-				trace.push({ operation: "run", key, state: "reused", ...workflowStringMetadata(params) });
-				traceChanged();
-				return respond(deliver(existing.promise), `runs.run('${key}') result`);
-			}
-
 			const startedAt = Date.now();
 			const batch = isRecord(message.args.batch) && typeof message.args.batch.id === "string" && Array.isArray(message.args.batch.calls)
 				? { id: message.args.batch.id, calls: message.args.batch.calls.filter((call): call is { key: string; params: Record<string, unknown> } => isRecord(call) && typeof call.key === "string" && isRecord(call.params)) }
@@ -1482,7 +1487,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 					if (resolvedResumeLineage.at(-1) !== resolvedResumeId) resolvedResumeLineage.push(resolvedResumeId!);
 				}
 				const launchParams = resolvedResumeId ? { ...params, resume: resolvedResumeId } : params;
-				return options.launch(key, launchParams, childSignal, { admitted: true });
+				return options.launch(key, launchParams, childSignal, { admitted: true, batch: batch !== undefined });
 			}).then((result) => {
 				let normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
 				if (resolvedResumeLineage?.length && normalized.runId) {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -64,6 +64,7 @@ import { missionStatePath } from "../../src/missions/workflow-state.ts";
 import { discardPreservedWorktrees } from "../../src/runs/shared/parallel-handoff.ts";
 import { resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
 import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
+import { createWorkflowChildPermit, workflowChildPermitConsumed } from "../../src/shared/workflow-child-permit.ts";
 
 interface ModelAttempt {
 	success?: boolean;
@@ -514,6 +515,83 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
 		assert.doesNotMatch(readCallArgs().join("\n"), /This path is authoritative for this run/);
+	});
+
+	it("consumes one exact host-only workflow child permit before spawn", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([makeAgent("echo"), makeAgent("other"), makeAgent("external", { runner: { type: "external-cli", command: "external" } })]);
+		const ctx = makeMinimalCtx(tempDir);
+		const script = `return runs.run("main", { agent: "echo", task: "Exact task", acceptance: false });`;
+		mockPi.onCall({ output: "projection probe" });
+		const probe = await executor.execute("probe", { async: false, workflowScript: script }, new AbortController().signal, undefined, ctx);
+		const launchContractDigest = (probe.details as { results?: Array<{ launchContractDigest?: string }> }).results?.[0]?.launchContractDigest;
+		assert.ok(launchContractDigest);
+
+		const permitFor = (workflowRunId: string, overrides: Partial<Parameters<typeof createWorkflowChildPermit>[0]> = {}) => createWorkflowChildPermit({
+			issuerPackage: "permit-secret-package",
+			workflowRunId,
+			childKey: "main",
+			agent: "echo",
+			launchContractDigest,
+			context: "fresh",
+			...overrides,
+		});
+		const run = (id: string, workflowScript: string, permit: ReturnType<typeof permitFor>, async = false) => executor.executeDelegated(
+			id,
+			{ async, workflowScript, delegatedWorkflowPermit: permit },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		mockPi.onCall({ output: "permitted child" });
+		const permit = permitFor("permitted");
+		const allowed = await run("permitted", script, permit);
+		assert.equal(allowed.isError, undefined, allowed.content[0]?.text ?? "permitted workflow failed");
+		assert.equal(workflowChildPermitConsumed(permit), true);
+		assert.equal(mockPi.callCount(), 2);
+		assert.doesNotMatch(JSON.stringify(allowed), /permit-secret-package|__workflowChildPermit/);
+
+		const reused = await run("permitted", script, permit);
+		assert.equal(reused.isError, true);
+		assert.match(reused.content[0]?.text ?? "", /already consumed/);
+		assert.equal(mockPi.callCount(), 2);
+
+		mockPi.onCall({ stderr: "spawned child failed", exitCode: 1 });
+		const failedPermit = permitFor("spawn-failure");
+		const spawnFailure = await run("spawn-failure", script, failedPermit);
+		assert.equal(spawnFailure.isError, true);
+		assert.equal(workflowChildPermitConsumed(failedPermit), true);
+		assert.equal(mockPi.callCount(), 3, "a consumed permit must not start a retry");
+
+		const denied = [
+			await run("wrong-key", `return runs.run("other", { agent: "echo", task: "Exact task", acceptance: false });`, permitFor("wrong-key")),
+			await run("wrong-agent", `return runs.run("main", { agent: "other", task: "Exact task", acceptance: false });`, permitFor("wrong-agent")),
+			await run("wrong-task", `return runs.run("main", { agent: "echo", task: "Changed task", acceptance: false });`, permitFor("wrong-task")),
+			await run("runs-all", `return runs.all([{ key: "main", agent: "echo", task: "Exact task", acceptance: false }]);`, permitFor("runs-all")),
+			await run("resume", `return runs.run("main", { resume: "retained-run", task: "Continue" });`, permitFor("resume")),
+			await run("external", `return runs.run("main", { agent: "external", task: "Exact task", async: false });`, permitFor("external")),
+			await run("async-root", script, permitFor("async-root"), true),
+		];
+		const denialText = denied.map((result) => result.content[0]?.text ?? "").join("\n");
+		assert.match(denialText, /child key mismatch.*agent mismatch.*final launch projection.*runs\.all.*retained resume.*native Pi children.*foreground workflow roots/s);
+		const wrongThenRightPermit = permitFor("wrong-then-right");
+		const wrongThenRight = await run("wrong-then-right", `
+			try { await runs.run("other", { agent: "echo", task: "Exact task", acceptance: false }); } catch {}
+			return runs.run("main", { agent: "echo", task: "Exact task", acceptance: false });
+		`, wrongThenRightPermit);
+		assert.equal(wrongThenRight.isError, true);
+		assert.match(wrongThenRight.content[0]?.text ?? "", /already consumed/);
+		assert.equal(workflowChildPermitConsumed(wrongThenRightPermit), true);
+		assert.equal(mockPi.callCount(), 3, "wrong-then-right must not spawn");
+		const fallback = await makeExecutor([makeAgent("echo", { model: "mock/primary", fallbackModels: ["mock/backup"] })]).executeDelegated(
+			"fallback",
+			{ async: false, workflowScript: script, delegatedWorkflowPermit: permitFor("fallback") },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.match(fallback.content[0]?.text ?? "", /does not support model fallback/);
+		assert.equal(mockPi.callCount(), 3);
 	});
 
 	it("resolves workflow child profile context from its agent default", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {


### PR DESCRIPTION
Implements the accepted internal-only first slice for #1494.

This adds a package-private one-use permit for one exact native child spawn from a foreground `workflowScript` root. The permit is host-only and in-memory. It is not serialized into workflow state, status, receipts, artifacts, transcripts, environment, or model-visible params.

The final permit comparison still happens at the resolved launch-plan point before native spawn. The permit now also claims or consumes on the first distinct `runs.run` attempt, so a wrong child attempt cannot be followed by the expected child in the same root.

Validation:
- focused permit integration test passed
- `test/unit/scripted-workflow.test.ts` passed
- `npm run typecheck` passed
- `git diff --check origin/main..HEAD` passed
- fresh security/API review returned no issues

Fixes #1494.