### PR TITLE
chore: deslop unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Reclaim failed async capacity slots after a configurable abandoned timeout when the runner PID is gone, while preserving honest unknown process-proof diagnostics. Thanks to [@rafafortes](https://github.com/rafafortes) for #1472.
+- Reject non-string workflow-child summary identifiers when reading receipt metadata.
 - Resolve the `advisor` builtin alias through the bundled `oracle` definition in model listings. Thanks to [@smileBeda](https://github.com/smileBeda) for #1502.
 - Clarify terminal keyed workflow-resume failures when `workflow-receipt.json` is unavailable, including direct child-run recovery from status and event logs (#1512).
 - Follow symlinked directories during agent discovery without revisiting recursive links. Thanks to [@robsdudeson](https://github.com/robsdudeson) for #1505 and #1510.
@@ -27,6 +28,9 @@
 - Preview runtime-recorded workflow child sessions in Fleet and inspect without trusting sibling transcripts. Thanks to [@JHa13y](https://github.com/JHa13y) for #1441.
 - Keep inline workflow children resumable from their foreground runs without mistaking a missing async directory for lost state. Thanks to [@lancegui](https://github.com/lancegui) for #1442.
 - Resolve package subagents from bare HTTP(S) Git URLs stored in Pi settings. Thanks to [@trancikk](https://github.com/trancikk) for #1452.
+- Make workflow validation and return serialization failures easier to recover from with no-child-launch diagnostics, portable rewrite guidance, workflow ids, and completed-child output references (#1432, #1434).
+- Report child processes that exit during tool execution as mid-tool failures instead of cold starts, even when earlier assistant text exists. Thanks to [@cyzlmh](https://github.com/cyzlmh) for #1437.
+- Keep unaddressable legacy result aliases and overlong public result filenames from blocking canonical hashed or pending fallbacks. Thanks to [@LeonardBode](https://github.com/LeonardBode) for #1440.
 
 ### Added
 - Add a package-internal one-use permit for one exact native child in a foreground `workflowScript`. Thanks to [@maroffo](https://github.com/maroffo) for #1494.
@@ -42,11 +46,6 @@
 - Add code-owned `codex-exec` read-only and `codex-exec-writer` workspace-writing profiles with bounded JSONL terminal proof, final-message artifacts, and opt-in mode-specific smoke evidence.
 - External CLI runs now publish code-owned capability limits and compact workflow receipt metadata for adapter identity, artifacts, handoff mode, supervisor support, and resumability.
 - External one-shot runners now support bounded parser hooks and logs, environment allowlists, cached launch preflight, coalesced parser progress, and process-tree cleanup.
-
-### Fixed
-- Make workflow validation and return serialization failures easier to recover from with no-child-launch diagnostics, portable rewrite guidance, workflow ids, and completed-child output references (#1432, #1434).
-- Report child processes that exit during tool execution as mid-tool failures instead of cold starts, even when earlier assistant text exists. Thanks to [@cyzlmh](https://github.com/cyzlmh) for #1437.
-- Keep unaddressable legacy result aliases and overlong public result filenames from blocking canonical hashed or pending fallbacks. Thanks to [@LeonardBode](https://github.com/LeonardBode) for #1440.
 
 ## [0.56.0] - 2026-08-23
 

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -33,7 +33,7 @@ import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/m
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import { resolveTurnBudgetConfig } from "../runs/shared/turn-budget.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
-import { validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
+import { CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL, isCodeOwnedExternalCliAdapterId, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import type { AcceptanceInput, Details, ExtensionConfig, ToolBudgetConfig } from "../shared/types.ts";
 import { getProjectConfigDir } from "../shared/utils.ts";
 import { capabilityCeilingAgentRestrictionSources, isAgentAllowedByCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
@@ -379,17 +379,17 @@ function applyAgentConfig(target: AgentConfig, cfg: Record<string, unknown>): st
 			if (runner.type === "pi" && Object.keys(runner).every((key) => key === "type")) target.runner = { type: "pi" };
 			else if (runner.type === "external-cli" && typeof runner.command === "string" && runner.command.trim()
 				&& (runner.args === undefined || (Array.isArray(runner.args) && runner.args.every((arg) => typeof arg === "string")))
-				&& (runner.adapter === undefined || runner.adapter === "codex-exec" || runner.adapter === "codex-exec-writer" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "cursor-agent" || runner.adapter === "cursor-agent-writer")
+				&& (runner.adapter === undefined || isCodeOwnedExternalCliAdapterId(runner.adapter))
 				&& (runner.adapter === undefined || runner.args === undefined || runner.args.length === 0)
 				&& (runner.promptDelivery === undefined || runner.promptDelivery === "stdin")
 				&& Object.keys(runner).every((key) => ["type", "adapter", "command", "args", "promptDelivery"].includes(key))) {
 				const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
-				target.runner = { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "codex-exec-writer" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "cursor-agent" || runner.adapter === "cursor-agent-writer" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
+				target.runner = { type: "external-cli", ...(isCodeOwnedExternalCliAdapterId(runner.adapter) ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(runnerArgs?.length ? { args: runnerArgs } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" } : {}) };
 			} else if (runner.type === "external-job" && typeof runner.provider === "string" && runner.provider.trim() === runner.provider && runner.provider
 				&& (runner.options === undefined || (runner.options && typeof runner.options === "object" && !Array.isArray(runner.options) && isJsonSerializable(runner.options)))
 				&& Object.keys(runner).every((key) => ["type", "provider", "options"].includes(key))) {
 				target.runner = { type: "external-job", provider: runner.provider, ...(runner.options ? { options: runner.options as Record<string, unknown> } : {}) };
-			} else return "config.runner must be { type: 'pi' }, { type: 'external-cli', adapter?: 'codex-exec' | 'codex-exec-writer' | 'claude-code' | 'claude-code-writer' | 'cursor-agent' | 'cursor-agent-writer', command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.";
+			} else return `config.runner must be { type: 'pi' }, { type: 'external-cli', adapter?: ${CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL}, command: string, args?: string[], promptDelivery?: 'stdin' }, or { type: 'external-job', provider: string, options?: object }.`;
 		} else return "config.runner must be an object, false, or empty string when provided.";
 	}
 	if (hasKey(cfg, "model")) {

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -9,7 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
-import { parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
+import { CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL, isCodeOwnedExternalCliAdapterId, parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
@@ -1841,7 +1841,7 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) {
 		throw new Error(`Agent '${agentName}' external-cli runner args must be an array of strings.`);
 	}
-	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "codex-exec-writer" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer" && runner.adapter !== "cursor-agent" && runner.adapter !== "cursor-agent-writer") throw new Error(`Agent '${agentName}' external-cli runner adapter must be 'codex-exec', 'codex-exec-writer', 'claude-code', 'claude-code-writer', 'cursor-agent', or 'cursor-agent-writer'.`);
+	if (runner.adapter !== undefined && !isCodeOwnedExternalCliAdapterId(runner.adapter)) throw new Error(`Agent '${agentName}' external-cli runner adapter must be ${CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL}.`);
 	if (runner.adapter !== undefined && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Agent '${agentName}' ${runner.adapter} adapter owns its argv; runner args are not supported.`);
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") {
 		throw new Error(`Agent '${agentName}' external-cli runner promptDelivery must be 'stdin'.`);
@@ -1853,7 +1853,7 @@ function parseAgentRunnerFrontmatter(raw: string | undefined, agentName: string)
 	const runnerArgs = Array.isArray(runner.args) ? runner.args.filter((arg): arg is string => typeof arg === "string") : undefined;
 	return {
 		type: "external-cli",
-		...(runner.adapter === "codex-exec" || runner.adapter === "codex-exec-writer" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "cursor-agent" || runner.adapter === "cursor-agent-writer" ? { adapter: runner.adapter } : {}),
+		...(isCodeOwnedExternalCliAdapterId(runner.adapter) ? { adapter: runner.adapter } : {}),
 		command: runner.command.trim(),
 		...(runnerArgs?.length ? { args: runnerArgs } : {}),
 		...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}),

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig, TurnBudgetConfig } from "../shared/types.ts";
-import { parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
+import { CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL, isCodeOwnedExternalCliAdapterId, parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
@@ -170,7 +170,7 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	if (runner.type !== "external-cli") throw new Error("Runtime agent definition runner.type must be 'pi', 'external-cli', or 'external-job'.");
 	if (typeof runner.command !== "string" || !runner.command.trim()) throw new Error("Runtime agent definition external-cli runner requires a non-empty command string.");
 	if (runner.args !== undefined && (!Array.isArray(runner.args) || runner.args.some((arg) => typeof arg !== "string"))) throw new Error("Runtime agent definition external-cli runner args must be an array of strings.");
-	if (runner.adapter !== undefined && runner.adapter !== "codex-exec" && runner.adapter !== "codex-exec-writer" && runner.adapter !== "claude-code" && runner.adapter !== "claude-code-writer" && runner.adapter !== "cursor-agent" && runner.adapter !== "cursor-agent-writer") throw new Error("Runtime agent definition external-cli runner adapter must be 'codex-exec', 'codex-exec-writer', 'claude-code', 'claude-code-writer', 'cursor-agent', or 'cursor-agent-writer'.");
+	if (runner.adapter !== undefined && !isCodeOwnedExternalCliAdapterId(runner.adapter)) throw new Error(`Runtime agent definition external-cli runner adapter must be ${CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL}.`);
 	if (runner.adapter !== undefined && Array.isArray(runner.args) && runner.args.length > 0) throw new Error(`Runtime agent definition ${runner.adapter} adapter owns its argv; runner args are not supported.`);
 	if (runner.promptDelivery !== undefined && runner.promptDelivery !== "stdin") throw new Error("Runtime agent definition external-cli runner promptDelivery must be 'stdin'.");
 	const capabilities = parseExternalCliCapabilityNarrowing(runner.capabilities, "Runtime agent definition external-cli runner capabilities");
@@ -178,7 +178,7 @@ function validateRunner(value: unknown): AgentRunnerConfig | undefined {
 	const unknown = Object.keys(runner).filter((key) => !supported.has(key));
 	if (unknown.length > 0) throw new Error(`Runtime agent definition external-cli runner has unsupported fields: ${unknown.join(", ")}.`);
 	const args = runner.args as string[] | undefined;
-	return { type: "external-cli", ...(runner.adapter === "codex-exec" || runner.adapter === "codex-exec-writer" || runner.adapter === "claude-code" || runner.adapter === "claude-code-writer" || runner.adapter === "cursor-agent" || runner.adapter === "cursor-agent-writer" ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
+	return { type: "external-cli", ...(isCodeOwnedExternalCliAdapterId(runner.adapter) ? { adapter: runner.adapter } : {}), command: runner.command.trim(), ...(args?.length ? { args } : {}), ...(runner.promptDelivery ? { promptDelivery: "stdin" as const } : {}), ...(capabilities ? { capabilities } : {}) };
 }
 
 function validateTurnBudget(value: unknown): TurnBudgetConfig | undefined {

--- a/src/runs/shared/claude-code-adapter.ts
+++ b/src/runs/shared/claude-code-adapter.ts
@@ -1,4 +1,4 @@
-import type { ExternalCliParser, ExternalCliParserProgress, ExternalCliParserTerminal } from "./external-cli-runner.ts";
+import { parseExternalCliJsonlEvent, type ExternalCliParser, type ExternalCliParserProgress, type ExternalCliParserTerminal } from "./external-cli-runner.ts";
 import type { ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
 
 const MAX_EVENT_TYPE_LENGTH = 128;
@@ -59,12 +59,7 @@ export function createClaudeCodeJsonlParser(): ExternalCliParser {
 	let terminal: ExternalCliParserTerminal | undefined;
 	return {
 		parseLine(line): ExternalCliParserProgress {
-			let value: unknown;
-			try { value = JSON.parse(line) as unknown; }
-			catch (error) { throw new Error(`Claude Code emitted malformed JSONL: ${error instanceof Error ? error.message : String(error)}`); }
-			if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Claude Code emitted a JSONL event that is not an object.");
-			const event = value as Record<string, unknown>;
-			if (typeof event.type !== "string" || !event.type || event.type.length > MAX_EVENT_TYPE_LENGTH) throw new Error("Claude Code emitted a JSONL event with an invalid type.");
+			const event = parseExternalCliJsonlEvent(line, "Claude Code", MAX_EVENT_TYPE_LENGTH);
 			if (terminal && event.type === "result") throw new Error("Claude Code emitted a duplicate terminal result.");
 			eventCount += 1;
 			if (!terminal && event.type === "result") {

--- a/src/runs/shared/codex-exec-adapter.ts
+++ b/src/runs/shared/codex-exec-adapter.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExternalCliParser, ExternalCliParserProgress, ExternalCliParserTerminal } from "./external-cli-runner.ts";
+import { parseExternalCliJsonlEvent, type ExternalCliParser, type ExternalCliParserProgress, type ExternalCliParserTerminal } from "./external-cli-runner.ts";
 import type { ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
 
 const MAX_FINAL_MESSAGE_BYTES = 1024 * 1024;
@@ -41,12 +41,7 @@ export function createCodexExecJsonlParser(finalMessagePath: string): ExternalCl
 	let terminal: ExternalCliParserTerminal | undefined;
 	return {
 		parseLine(line): ExternalCliParserProgress {
-			let value: unknown;
-			try { value = JSON.parse(line) as unknown; }
-			catch (error) { throw new Error(`Codex exec emitted malformed JSONL: ${error instanceof Error ? error.message : String(error)}`); }
-			if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Codex exec emitted a JSONL event that is not an object.");
-			const event = value as Record<string, unknown>;
-			if (typeof event.type !== "string" || !event.type || event.type.length > MAX_EVENT_TYPE_LENGTH) throw new Error("Codex exec emitted a JSONL event with an invalid type.");
+			const event = parseExternalCliJsonlEvent(line, "Codex exec", MAX_EVENT_TYPE_LENGTH);
 			if (terminal) throw new Error("Codex exec emitted an event after its terminal state.");
 			eventCount += 1;
 			if (event.type === "turn.completed") terminal = { state: "completed" };

--- a/src/runs/shared/cursor-agent-adapter.ts
+++ b/src/runs/shared/cursor-agent-adapter.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { ExternalCliParser, ExternalCliParserProgress, ExternalCliParserTerminal } from "./external-cli-runner.ts";
+import { parseExternalCliJsonlEvent, type ExternalCliParser, type ExternalCliParserProgress, type ExternalCliParserTerminal } from "./external-cli-runner.ts";
 import type { ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
 
 const MAX_EVENT_TYPE_LENGTH = 128;
@@ -36,12 +36,7 @@ export function createCursorAgentJsonlParser(): ExternalCliParser {
 	let terminal: ExternalCliParserTerminal | undefined;
 	return {
 		parseLine(line): ExternalCliParserProgress {
-			let value: unknown;
-			try { value = JSON.parse(line) as unknown; }
-			catch (error) { throw new Error(`Cursor Agent emitted malformed JSONL: ${error instanceof Error ? error.message : String(error)}`); }
-			if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Cursor Agent emitted a JSONL event that is not an object.");
-			const event = value as Record<string, unknown>;
-			if (typeof event.type !== "string" || !event.type || event.type.length > MAX_EVENT_TYPE_LENGTH) throw new Error("Cursor Agent emitted a JSONL event with an invalid type.");
+			const event = parseExternalCliJsonlEvent(line, "Cursor Agent", MAX_EVENT_TYPE_LENGTH);
 			if (terminal) throw new Error("Cursor Agent emitted an event after its terminal state.");
 			eventCount += 1;
 			if (event.type === "error") terminal = { state: "failed", error: terminalError(event) };

--- a/src/runs/shared/external-cli-contract.ts
+++ b/src/runs/shared/external-cli-contract.ts
@@ -22,6 +22,29 @@ const PROMPT_FILE_UNSUPPORTED = {
 	resume: "The one-shot prompt-file adapter does not retain a durable external session identity.",
 } as const;
 
+export const CODE_OWNED_EXTERNAL_CLI_ADAPTER_IDS = [
+	"codex-exec",
+	"codex-exec-writer",
+	"claude-code",
+	"claude-code-writer",
+	"cursor-agent",
+	"cursor-agent-writer",
+] as const;
+export type CodeOwnedExternalCliAdapterId = typeof CODE_OWNED_EXTERNAL_CLI_ADAPTER_IDS[number];
+
+const CODE_OWNED_EXTERNAL_CLI_ADAPTER_ID_SET = new Set<string>(CODE_OWNED_EXTERNAL_CLI_ADAPTER_IDS);
+export const CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL = CODE_OWNED_EXTERNAL_CLI_ADAPTER_IDS.map((id) => `'${id}'`).join(", ");
+
+export function isCodeOwnedExternalCliAdapterId(value: unknown): value is CodeOwnedExternalCliAdapterId {
+	return typeof value === "string" && CODE_OWNED_EXTERNAL_CLI_ADAPTER_ID_SET.has(value);
+}
+
+const RESERVED_READ_ONLY_ADAPTERS = [
+	{ name: "claude-code", writer: "claude-code-writer", access: "file-write" },
+	{ name: "codex-exec", writer: "codex-exec-writer", access: "workspace-write" },
+	{ name: "cursor-agent", writer: "cursor-agent-writer", access: "workspace-write" },
+] as const;
+
 export function validateCodeOwnedProfileRunner(
 	agent: {
 		name: string;
@@ -31,14 +54,10 @@ export function validateCodeOwnedProfileRunner(
 	},
 ): string | undefined {
 	const selectionNames = [agent.name, ...(agent.localName ? [agent.localName] : []), ...(agent.aliases ?? [])];
-	if (selectionNames.includes("claude-code") && !(agent.runner?.type === "external-cli" && agent.runner.adapter === "claude-code")) {
-		return "Selection name 'claude-code' is reserved for the read-only 'claude-code' adapter. Use 'claude-code-writer' for explicit file-write access.";
-	}
-	if (selectionNames.includes("codex-exec") && !(agent.runner?.type === "external-cli" && agent.runner.adapter === "codex-exec")) {
-		return "Selection name 'codex-exec' is reserved for the read-only 'codex-exec' adapter. Use 'codex-exec-writer' for explicit workspace-write access.";
-	}
-	if (selectionNames.includes("cursor-agent") && !(agent.runner?.type === "external-cli" && agent.runner.adapter === "cursor-agent")) {
-		return "Selection name 'cursor-agent' is reserved for the read-only 'cursor-agent' adapter. Use 'cursor-agent-writer' for explicit workspace-write access.";
+	for (const adapter of RESERVED_READ_ONLY_ADAPTERS) {
+		if (selectionNames.includes(adapter.name) && !(agent.runner?.type === "external-cli" && agent.runner.adapter === adapter.name)) {
+			return `Selection name '${adapter.name}' is reserved for the read-only '${adapter.name}' adapter. Use '${adapter.writer}' for explicit ${adapter.access} access.`;
+		}
 	}
 	return undefined;
 }
@@ -56,7 +75,7 @@ export function parseExternalCliCapabilityNarrowing(value: unknown, label: strin
 }
 
 export function resolveExternalCliRunnerStatus(input: {
-	adapter?: "codex-exec" | "codex-exec-writer" | "claude-code" | "claude-code-writer" | "cursor-agent" | "cursor-agent-writer";
+	adapter?: CodeOwnedExternalCliAdapterId;
 	command: string;
 	args?: string[];
 	promptDelivery?: "stdin";
@@ -120,7 +139,7 @@ export function normalizeExternalCliRunnerStatus(value: unknown): ExternalCliRun
 			nonResumableReason: PROMPT_FILE_UNSUPPORTED.resume,
 		};
 	}
-	const adapter = adapterId === "codex-exec" || adapterId === "codex-exec-writer" || adapterId === "claude-code" || adapterId === "claude-code-writer" || adapterId === "cursor-agent" || adapterId === "cursor-agent-writer" ? adapterId : undefined;
+	const adapter = isCodeOwnedExternalCliAdapterId(adapterId) ? adapterId : undefined;
 	return resolveExternalCliRunnerStatus({ ...(adapter ? { adapter } : {}), command: input.command, ...(args ? { args } : {}), ...(promptDelivery ? { promptDelivery } : {}) });
 }
 

--- a/src/runs/shared/external-cli-runner.ts
+++ b/src/runs/shared/external-cli-runner.ts
@@ -46,6 +46,19 @@ export interface ExternalCliParser {
 	finish(): ExternalCliParserTerminal | undefined;
 }
 
+export function parseExternalCliJsonlEvent(line: string, label: string, maxTypeLength: number): Record<string, unknown> {
+	let value: unknown;
+	try {
+		value = JSON.parse(line) as unknown;
+	} catch (error) {
+		throw new Error(`${label} emitted malformed JSONL: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} emitted a JSONL event that is not an object.`);
+	const event = value as Record<string, unknown>;
+	if (typeof event.type !== "string" || !event.type || event.type.length > maxTypeLength) throw new Error(`${label} emitted a JSONL event with an invalid type.`);
+	return event;
+}
+
 export interface ExternalCliRunResult {
 	output: string;
 	exitCode: number | null;

--- a/src/workflows/workflow-child-summary.ts
+++ b/src/workflows/workflow-child-summary.ts
@@ -111,5 +111,7 @@ export function parseWorkflowChildSummary(value: unknown): WorkflowChildSummaryV
 		return { childId: child.childId, state, ...(child.runId ? { runId: child.runId as string } : {}), ...(child.agent ? { agent: child.agent as string } : {}), ...(child.model ? { model: child.model as string } : {}), ...(child.thinking ? { thinking: child.thinking as string } : {}) };
 	});
 	if (new Set(children.map((child) => child.childId)).size !== children.length) throw new Error("workflowChildren has duplicate childId values.");
-	return { version: 1, parentToolCallId: requiredId(String(input.parentToolCallId ?? ""), "parentToolCallId"), workflowRunId: requiredId(String(input.workflowRunId ?? ""), "workflowRunId"), inventoryComplete: input.inventoryComplete, workflowState, children };
+	if (typeof input.parentToolCallId !== "string") throw new Error("workflowChildren.parentToolCallId is invalid.");
+	if (typeof input.workflowRunId !== "string") throw new Error("workflowChildren.workflowRunId is invalid.");
+	return { version: 1, parentToolCallId: requiredId(input.parentToolCallId, "parentToolCallId"), workflowRunId: requiredId(input.workflowRunId, "workflowRunId"), inventoryComplete: input.inventoryComplete, workflowState, children };
 }

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -147,6 +147,18 @@ describe("workflow receipts", () => {
 		assert.throws(() => buildWorkflowReceipt({ workflowRunId: "workflow-1", state: "complete", children: [], workflowChildren: summary }), /does not match its receipt/);
 	});
 
+	it("rejects non-string workflow-child summary identifiers", () => {
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-1");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		writeWorkflowReceipt(asyncDir, {
+			...buildWorkflowReceipt({ workflowRunId: "workflow-1", state: "complete", children: [] }),
+			workflowChildren: { version: 1, parentToolCallId: 123, workflowRunId: true, inventoryComplete: true, workflowState: "completed", children: [] } as never,
+		});
+
+		assert.throws(() => readWorkflowReceipt(asyncRoot, "workflow-1"), /workflowChildren\.parentToolCallId is invalid/);
+	});
+
 	it("adds bounded external adapter metadata without raw output or handoff content", () => {
 		const runner = resolveExternalCliRunnerStatus({ command: "review-cli" });
 		const externalAdapter = externalCliReceiptMetadata({


### PR DESCRIPTION
## Summary

This deslop pass tightens the unreleased adapter and workflow summary changes before release.

It merges the duplicate `[Unreleased]` changelog `Fixed` headings, rejects non-string workflow-child summary identifiers at the receipt boundary, and removes repeated adapter JSONL parsing plus repeated code-owned adapter id checks.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-receipt.test.ts test/unit/codex-exec-adapter.test.ts test/unit/claude-code-adapter.test.ts test/unit/cursor-agent-adapter.test.ts test/unit/agent-frontmatter.test.ts test/unit/agent-management.test.ts test/unit/runtime-agent-registration.test.ts`
- `npm run test:all`
- `npm run typecheck`
- `git diff --check`
- Fresh exact-head review: no issues found
