### PR TITLE
fix: preserve delegated output defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Preserve agent frontmatter output defaults for prompt-template delegated leaves. Thanks to [@ashlineldridge](https://github.com/ashlineldridge) for #1521.
 - Reclaim failed async capacity slots after a configurable abandoned timeout when the runner PID is gone, while preserving honest unknown process-proof diagnostics. Thanks to [@rafafortes](https://github.com/rafafortes) for #1472.
 - Reject non-string workflow-child summary identifiers when reading receipt metadata.
 - Resolve the `advisor` builtin alias through the bundled `oracle` definition in model listings. Thanks to [@smileBeda](https://github.com/smileBeda) for #1502.

--- a/src/slash/delegation-adapters.ts
+++ b/src/slash/delegation-adapters.ts
@@ -298,7 +298,6 @@ export function toSubagentDelegationExecutionParams(request: SubagentDelegationR
 		enforceHardTurnLimit: true,
 		toolBudget: request.toolBudget,
 		skill: request.skill,
-		output: false,
 		...(request.result.kind === "structured" ? { outputSchema: request.result.schema } : {}),
 		acceptance: false,
 		artifacts: request.artifacts,

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -65,6 +65,7 @@ import { discardPreservedWorktrees } from "../../src/runs/shared/parallel-handof
 import { resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
 import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
 import { createWorkflowChildPermit, workflowChildPermitConsumed } from "../../src/shared/workflow-child-permit.ts";
+import { toSubagentDelegationExecutionParams } from "../../src/slash/delegation-adapters.ts";
 
 interface ModelAttempt {
 	success?: boolean;
@@ -501,6 +502,45 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(configuredTask, new RegExp(escapeRegExp(configuredPath)));
 		assert.match(configuredTask, /This path is authoritative for this run/);
 		assert.equal(fs.readFileSync(configuredPath, "utf-8"), "Agent report");
+	});
+
+	it("preserves agent output defaults for structured prompt-template delegation", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const configuredPath = path.join(tempDir, "delegated-agent-report.md");
+		mockPi.onCall({
+			stdoutRaw: [
+				{ type: "tool_execution_start", toolName: "structured_output", args: { value: { ok: true } } },
+				{ type: "tool_result_end", message: { role: "toolResult", toolName: "structured_output", content: [{ type: "text", text: "Structured output captured." }] } },
+				{ type: "tool_execution_end", toolName: "structured_output" },
+			].map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+			structuredOutputCapture: { ok: true },
+		});
+		const executor = makeExecutor([makeAgent("echo", { output: configuredPath, outputMode: "file-only" })]);
+		const request: SubagentDelegationRequest = {
+			requestId: "delegated-output-default",
+			ownerRunId: "owner-1",
+			nodeId: "node-1",
+			agent: "echo",
+			task: "Return structured data",
+			context: "fresh",
+			cwd: tempDir,
+			model: "mock/model",
+			result: { kind: "structured", schema: { type: "object", required: ["ok"], properties: { ok: { type: "boolean" } } } },
+		};
+
+		const result = await executor.executeDelegated(
+			request.requestId,
+			toSubagentDelegationExecutionParams(request),
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "delegated execution failed");
+		const child = result.details?.results?.[0];
+		assert.equal(child?.savedOutputPath, configuredPath);
+		assert.equal(child?.outputMode, "file-only");
+		assert.deepEqual(child?.structuredOutput, { ok: true });
+		assert.deepEqual(JSON.parse(fs.readFileSync(configuredPath, "utf-8")), { ok: true });
 	});
 
 	it("does not inject a workflow child output without an aggregate or explicit output", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -189,7 +189,6 @@ describe("public subagent delegation contract", () => {
 			enforceHardTurnLimit: true,
 			toolBudget: { soft: 3, hard: 5, block: "*" },
 			skill: ["review"],
-			output: false,
 			acceptance: false,
 			artifacts: true,
 			delegatedThinkingOverride: "high",


### PR DESCRIPTION
Fixes #1521.

This preserves agent frontmatter `output` and `outputMode` defaults for prompt-template delegated leaves. The public delegation request still cannot set `output`; the bridge now leaves it omitted so the existing single-agent executor resolves the selected agent default.

Validation:
- `node --experimental-strip-types --test test/unit/delegation-api.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review: no issues found.
