### PR TITLE
docs: update stale model examples

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -255,7 +255,7 @@ tools: read, grep, find, ls, bash, mcp:chrome-devtools
 extensions:
 subagentOnlyExtensions: ./tools/child-only-search.ts
 model: claude-haiku-4-5
-fallbackModels: openai/gpt-5-mini, anthropic/claude-sonnet-4
+fallbackModels: openai-codex/gpt-5.6-luna:low, anthropic/claude-sonnet-4
 thinking: high
 systemPromptMode: replace
 inheritProjectContext: false
@@ -286,7 +286,7 @@ tools:
   - read
   - mcp:github/search_repositories
 fallbackModels:
-  - openai/gpt-5-mini
+  - openai-codex/gpt-5.6-luna:low
   - anthropic/claude-sonnet-4
 ```
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -51,7 +51,7 @@ For a persistent role override with a backup model for provider failures:
       "reviewer": {
         "model": "anthropic/claude-sonnet-4",
         "thinking": "high",
-        "fallbackModels": ["openai/gpt-5-mini"]
+        "fallbackModels": ["openai-codex/gpt-5.6-luna:low"]
       }
     }
   }
@@ -182,9 +182,9 @@ To keep subagents inside a budget or compliance profile, enforce a model scope. 
     "modelScope": {
       "enforce": true,
       "strict": true,
-      "allow": ["inherit", "openai/gpt-5-*"],
+      "allow": ["inherit", "openai/gpt-5-*", "openai-codex/gpt-5.6-*"],
       "agents": {
-        "worker": { "allow": ["openai/gpt-5-mini"] },
+        "worker": { "allow": ["openai-codex/gpt-5.6-luna"] },
         "reviewer": { "allow": ["inherit"] }
       }
     }

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -161,7 +161,7 @@ Agent definitions are not loaded into context by default. Management actions let
   inheritProjectContext: false,
   inheritSkills: false,
   model: "anthropic/claude-sonnet-4",
-  fallbackModels: ["openai/gpt-5-mini", "anthropic/claude-haiku-4-5"],
+  fallbackModels: ["openai-codex/gpt-5.6-luna:low", "anthropic/claude-haiku-4-5"],
   tools: "read, bash, mcp:github/search_repositories",
   extensions: "",
   skills: "parallel-scout",

--- a/skills/pi-subagents/references/prompting-and-roles.md
+++ b/skills/pi-subagents/references/prompting-and-roles.md
@@ -230,7 +230,7 @@ Direct settings example:
       "reviewer": {
         "model": "anthropic/claude-sonnet-4",
         "thinking": "high",
-        "fallbackModels": ["openai/gpt-5-mini"],
+        "fallbackModels": ["openai-codex/gpt-5.6-luna:low"],
         "acceptanceRole": "read-only"
       }
     }


### PR DESCRIPTION
## Summary

Updates the stale user-facing `openai/gpt-5-mini` model examples to `openai-codex/gpt-5.6-luna:low`.

Closes #1523.

## Validation

- `git diff --check`
- Fresh docs review: `/Users/nicobailon/.pi/agent/memory/extensions-subagent/lane-reports/issue-1523-review.md`