### PR TITLE
feat: add runtime agent registration event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Add process-local event registration so independent Pi extensions can register runtime agents through the installed owner. Thanks to [@fmoda3](https://github.com/fmoda3) for #1533.
+
 ### Fixed
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.
 - Fail native child launches before spawn when the requested local working directory is missing or not a directory, with the requested and resolved paths in the error.

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -58,6 +58,45 @@ The DTO intentionally never exposes run, async, or tool IDs. Clients must ignore
 
 `pi.events` is in-process only. It does not reach separate Pi processes or child subagents; use the file lifecycle artifacts or `pi-intercom` for cross-process coordination.
 
+## Runtime agent registration from independent extensions
+
+An independently installed Pi extension can register an agent with the installed `pi-subagents` owner through the process-local `pi-subagents:runtime-agent-register:v1` event. Emit after extension setup, such as during `session_start`. Event delivery is synchronous, so the owner writes the result onto the request before `emit()` returns.
+
+```typescript
+const request: {
+  version: 1;
+  name: string;
+  definition: {
+    description: string;
+    systemPrompt: string;
+    tools?: readonly string[];
+  };
+  result?:
+    | { ok: true; registration: { dispose(): void } }
+    | { ok: false; error: Error };
+} = {
+  version: 1,
+  name: "runtime-probe-agent",
+  definition: {
+    description: "Agent registered by an independent extension",
+    systemPrompt: "Return the words runtime probe.",
+    tools: [],
+  },
+};
+
+pi.events.emit("pi-subagents:runtime-agent-register:v1", request);
+if (!request.result) throw new Error("pi-subagents is not installed or not ready");
+if (!request.result.ok) throw request.result.error;
+const registration = request.result.registration;
+// Call registration.dispose() during your extension cleanup.
+```
+
+If `pi-subagents` is a resolvable dependency of the consumer package, `pi-subagents/agents` exports `RUNTIME_AGENT_REGISTER_EVENT`, the request/result types, and `registerAgentViaEvents()` for the same contract. A separately installed Pi package is not automatically a Node dependency of another package. In that case, use the event contract directly instead of a runtime import. A type-only development dependency is optional.
+
+The installed owner applies the existing runtime-agent validation, collision checks, limits, runtime source metadata, and cleanup. If more than one owner listens, the first handler that writes `request.result` wins. Unsupported versions, malformed requests, and registration failures return `{ ok: false, error }`. No result means no compatible owner handled the event.
+
+This contract is process-local. It does not register agents in child processes or other Pi processes, and it does not change package discovery or package resolution.
+
 ## External jobs in FleetView
 
 Use `pi-subagents/external-runs` to publish display-only current-session jobs owned by another extension:

--- a/src/agents/runtime-agent-events.ts
+++ b/src/agents/runtime-agent-events.ts
@@ -1,0 +1,70 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerRuntimeAgent, type RuntimeAgentDefinition, type RuntimeAgentRegistration } from "./runtime-agent-registry.ts";
+
+export const RUNTIME_AGENT_REGISTER_EVENT = "pi-subagents:runtime-agent-register:v1";
+export const RUNTIME_AGENT_REGISTER_VERSION = 1;
+
+export type RuntimeAgentRegistrationResult =
+	| { ok: true; registration: RuntimeAgentRegistration }
+	| { ok: false; error: Error };
+
+export interface RuntimeAgentRegistrationRequest {
+	version: 1;
+	name: string;
+	definition: RuntimeAgentDefinition;
+	result?: RuntimeAgentRegistrationResult;
+}
+
+export interface RegisterRuntimeAgentViaEventsInput {
+	pi: Pick<ExtensionAPI, "events">;
+	name: string;
+	definition: RuntimeAgentDefinition;
+}
+
+function errorFrom(value: unknown): Error {
+	return value instanceof Error ? value : new Error(String(value));
+}
+
+/** Register through the installed pi-subagents owner in this Pi process. */
+export function registerAgentViaEvents(input: RegisterRuntimeAgentViaEventsInput): RuntimeAgentRegistration {
+	const request: RuntimeAgentRegistrationRequest = {
+		version: RUNTIME_AGENT_REGISTER_VERSION,
+		name: input.name,
+		definition: input.definition,
+	};
+	input.pi.events.emit(RUNTIME_AGENT_REGISTER_EVENT, request);
+	const result = request.result as unknown;
+	if (result === undefined) {
+		throw new Error("pi-subagents is not installed, not ready, or does not support runtime agent event registration.");
+	}
+	if (result && typeof result === "object" && !Array.isArray(result)) {
+		const candidate = result as Record<string, unknown>;
+		if (candidate.ok === true && candidate.registration && typeof candidate.registration === "object" && typeof (candidate.registration as { dispose?: unknown }).dispose === "function") {
+			return candidate.registration as RuntimeAgentRegistration;
+		}
+		if (candidate.ok === false && candidate.error instanceof Error) throw candidate.error;
+	}
+	throw new Error("pi-subagents returned a malformed runtime agent registration result.");
+}
+
+/** Install the process-local registration listener for the owning pi-subagents runtime. */
+export function registerRuntimeAgentEventListener(pi: ExtensionAPI): () => void {
+	return pi.events.on(RUNTIME_AGENT_REGISTER_EVENT, (rawRequest) => {
+		if (!rawRequest || typeof rawRequest !== "object" || Array.isArray(rawRequest)) return;
+		const request = rawRequest as Record<string, unknown>;
+		if (request.result !== undefined) return;
+		try {
+			if (request.version !== RUNTIME_AGENT_REGISTER_VERSION) {
+				throw new Error(`Unsupported runtime agent registration event version '${String(request.version)}'.`);
+			}
+			const registration = registerRuntimeAgent({
+				pi,
+				name: request.name as string,
+				definition: request.definition as RuntimeAgentDefinition,
+			});
+			request.result = { ok: true, registration } satisfies RuntimeAgentRegistrationResult;
+		} catch (error) {
+			request.result = { ok: false, error: errorFrom(error) } satisfies RuntimeAgentRegistrationResult;
+		}
+	});
+}

--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -1,4 +1,12 @@
 import { registerRuntimeAgent, type RegisterRuntimeAgentInput, type RuntimeAgentDefinition, type RuntimeAgentRegistration } from "../agents/runtime-agent-registry.ts";
+export {
+	RUNTIME_AGENT_REGISTER_EVENT,
+	RUNTIME_AGENT_REGISTER_VERSION,
+	registerAgentViaEvents,
+	type RegisterRuntimeAgentViaEventsInput,
+	type RuntimeAgentRegistrationRequest,
+	type RuntimeAgentRegistrationResult,
+} from "../agents/runtime-agent-events.ts";
 
 export type { RegisterRuntimeAgentInput, RuntimeAgentDefinition, RuntimeAgentRegistration };
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -21,6 +21,7 @@ import { keyText, type ExtensionAPI, type ExtensionContext, type ToolDefinition 
 import { Box, Container, Spacer, Text, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
 import { discoverAgents, discoverAgentsAll, type AgentConfig, type AgentScope } from "../agents/agents.ts";
 import { clearRuntimeAgentsForPi, listRuntimeAgentConfigs, mergeRuntimeAgents } from "../agents/runtime-agent-registry.ts";
+import { registerRuntimeAgentEventListener } from "../agents/runtime-agent-events.ts";
 import { ensureAccessibleDir } from "../shared/accessible-dir.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
@@ -794,6 +795,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		fleetStatus?.refresh();
 	};
 	const eventUnsubscribes = [
+		registerRuntimeAgentEventListener(pi),
 		pi.events.on(SUBAGENT_ASYNC_STARTED_EVENT, asyncStartedHandler),
 		pi.events.on(SUBAGENT_ASYNC_COMPLETE_EVENT, asyncCompleteHandler),
 		pi.events.on(SUBAGENT_PROCESS_TERMINAL_EVENT, () => {

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -116,6 +116,10 @@ test("published extension APIs use supported package entrypoints", async () => {
 		"./shared-types": "./src/api/shared-types.ts",
 		"./project-panes": "./src/api/project-panes.ts",
 	});
+	const agents = await import("pi-subagents/agents");
+	assert.equal(agents.RUNTIME_AGENT_REGISTER_EVENT, "pi-subagents:runtime-agent-register:v1");
+	assert.equal(agents.RUNTIME_AGENT_REGISTER_VERSION, 1);
+	assert.equal(typeof agents.registerAgentViaEvents, "function");
 	const backgroundWork = await import("pi-subagents/background-work");
 	assert.equal(backgroundWork.BACKGROUND_WORK_PROTOCOL_VERSION, 1);
 	assert.equal(backgroundWork.BACKGROUND_WORK_REGISTRY_KEY, "pi-subagents.background-work.v1");

--- a/test/unit/runtime-agent-registration.test.ts
+++ b/test/unit/runtime-agent-registration.test.ts
@@ -4,7 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { registerAgent } from "../../src/api/agents.ts";
+import { RUNTIME_AGENT_REGISTER_EVENT, registerAgent, registerAgentViaEvents, type RuntimeAgentRegistrationRequest } from "../../src/api/agents.ts";
+import { registerRuntimeAgentEventListener } from "../../src/agents/runtime-agent-events.ts";
 import { handleList } from "../../src/agents/agent-management.ts";
 import { discoverAgents, discoverAgentsAll } from "../../src/agents/agents.ts";
 import { clearRuntimeAgentsForPi, mergeRuntimeAgents } from "../../src/agents/runtime-agent-registry.ts";
@@ -22,6 +23,25 @@ function makePi(): ExtensionAPI {
 		on() {},
 		registerTool() {},
 	} as unknown as ExtensionAPI;
+}
+
+function makeEventBus(): ExtensionAPI["events"] {
+	const handlers = new Map<string, Set<(data: unknown) => void>>();
+	return {
+		emit(channel, data) {
+			for (const handler of handlers.get(channel) ?? []) handler(data);
+		},
+		on(channel, handler) {
+			const listeners = handlers.get(channel) ?? new Set();
+			listeners.add(handler);
+			handlers.set(channel, listeners);
+			return () => listeners.delete(handler);
+		},
+	};
+}
+
+function makePiWithEvents(events: ExtensionAPI["events"]): ExtensionAPI {
+	return { on() {}, registerTool() {}, events } as unknown as ExtensionAPI;
 }
 
 function writeProjectAgent(name: string, aliases: string[] = []): void {
@@ -81,6 +101,83 @@ describe("runtime agent registration", () => {
 		registration.dispose();
 		assert.equal(mergeRuntimeAgents(pi, discoverAgents(tempProject, "both")).agents.some((candidate) => candidate.name === "runtime-helper"), false);
 		registration.dispose();
+	});
+
+	it("registers through the owner runtime when consumer and owner API objects differ", () => {
+		const events = makeEventBus();
+		const ownerPi = makePiWithEvents(events);
+		const consumerPi = makePiWithEvents(events);
+		const unsubscribe = registerRuntimeAgentEventListener(ownerPi);
+		const registration = registerAgentViaEvents({
+			pi: consumerPi,
+			name: "runtime-event-helper",
+			definition: { description: "Event helper", systemPrompt: "Help through the owner." },
+		});
+
+		assert.equal(mergeRuntimeAgents(ownerPi, discoverAgents(tempProject, "both")).agents.some((agent) => agent.name === "runtime-event-helper"), true);
+		assert.equal(mergeRuntimeAgents(consumerPi, discoverAgents(tempProject, "both")).agents.some((agent) => agent.name === "runtime-event-helper"), false);
+		assert.throws(
+			() => registerAgentViaEvents({ pi: consumerPi, name: "runtime-event-helper", definition: { description: "Duplicate", systemPrompt: "Duplicate." } }),
+			/collides with runtime agent 'runtime-event-helper'/,
+		);
+
+		registration.dispose();
+		assert.equal(mergeRuntimeAgents(ownerPi, discoverAgents(tempProject, "both")).agents.some((agent) => agent.name === "runtime-event-helper"), false);
+		unsubscribe();
+		clearRuntimeAgentsForPi(ownerPi);
+	});
+
+	it("uses first-handler-wins semantics for duplicate owners", () => {
+		const events = makeEventBus();
+		const firstOwner = makePiWithEvents(events);
+		const secondOwner = makePiWithEvents(events);
+		const consumer = makePiWithEvents(events);
+		const unsubscribeFirst = registerRuntimeAgentEventListener(firstOwner);
+		const unsubscribeSecond = registerRuntimeAgentEventListener(secondOwner);
+
+		const registration = registerAgentViaEvents({
+			pi: consumer,
+			name: "first-owner-agent",
+			definition: { description: "First owner", systemPrompt: "Use the first owner." },
+		});
+		assert.equal(mergeRuntimeAgents(firstOwner, discoverAgents(tempProject, "both")).agents.some((agent) => agent.name === "first-owner-agent"), true);
+		assert.equal(mergeRuntimeAgents(secondOwner, discoverAgents(tempProject, "both")).agents.some((agent) => agent.name === "first-owner-agent"), false);
+
+		registration.dispose();
+		unsubscribeFirst();
+		unsubscribeSecond();
+		clearRuntimeAgentsForPi(firstOwner);
+		clearRuntimeAgentsForPi(secondOwner);
+	});
+
+	it("returns useful event registration errors and detects a missing owner", () => {
+		const events = makeEventBus();
+		const owner = makePiWithEvents(events);
+		const consumer = makePiWithEvents(events);
+		const unsubscribe = registerRuntimeAgentEventListener(owner);
+		const unsupported = { version: 2, name: "bad-version", definition: {} } as unknown as RuntimeAgentRegistrationRequest;
+		events.emit(RUNTIME_AGENT_REGISTER_EVENT, unsupported);
+		assert.equal(unsupported.result?.ok, false);
+		if (unsupported.result?.ok === false) assert.match(unsupported.result.error.message, /Unsupported runtime agent registration event version '2'/);
+
+		const malformed = { version: 1, name: "bad-definition" } as unknown as RuntimeAgentRegistrationRequest;
+		events.emit(RUNTIME_AGENT_REGISTER_EVENT, malformed);
+		assert.equal(malformed.result?.ok, false);
+		if (malformed.result?.ok === false) assert.match(malformed.result.error.message, /definition must be an object/i);
+		unsubscribe();
+		assert.throws(
+			() => registerAgentViaEvents({ pi: consumer, name: "no-owner", definition: { description: "Missing", systemPrompt: "Missing." } }),
+			/not installed, not ready, or does not support/,
+		);
+		const unsubscribeMalformed = events.on(RUNTIME_AGENT_REGISTER_EVENT, (raw) => {
+			(raw as { result?: unknown }).result = {};
+		});
+		assert.throws(
+			() => registerAgentViaEvents({ pi: consumer, name: "malformed-result", definition: { description: "Malformed", systemPrompt: "Malformed." } }),
+			/malformed runtime agent registration result/,
+		);
+		unsubscribeMalformed();
+		clearRuntimeAgentsForPi(owner);
 	});
 
 	it("lists runtime agents for the matching Pi runtime", () => {


### PR DESCRIPTION
## Summary

Adds a process-local runtime-agent registration event so an independent Pi extension can register an agent through the installed `pi-subagents` owner. The direct `registerAgent()` API remains available when `pi-subagents/agents` is a resolvable dependency.

Closes #1533.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/runtime-agent-registration.test.ts test/unit/package-manifest.test.ts`
- `npm run typecheck`
- `git diff --check`