### PR TITLE
fix: deliver results from replaced sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fail native child launches before spawn when the requested local working directory is missing or not a directory, with the requested and resolved paths in the error.
 - Map report paths requested in workflow child tasks to the actual saved child output when workflow output routing overrides them.
 - Let agents declare extension mutation tools so real non-Git or untracked edits satisfy the implementation completion guard. Thanks to [@AlphaGodzilla](https://github.com/AlphaGodzilla) for #1532.
+- Deliver async results from an explicitly replaced predecessor session without accepting unrelated session results. Thanks to [@DresvyanskiyDenis](https://github.com/DresvyanskiyDenis) for #1531.
 
 ## [0.57.0] - 2026-08-26
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -37,6 +37,7 @@ import { getActiveAsyncCapacitySnapshot, resolveAbandonedSlotReleaseAfterMs, res
 import { cleanupResultIndexes, missionObserverResultCandidateFiles } from "../runs/background/result-files.ts";
 import { ASYNC_RETENTION_DELAY_MS, cleanupAsyncRetention } from "../runs/background/async-retention.ts";
 import { createResultWatcher } from "../runs/background/result-watcher.ts";
+import { createResultDeliveryOwnership } from "../runs/background/result-delivery-ownership.ts";
 import { createScheduledRunManager } from "../runs/background/scheduled-runs.ts";
 import { registerSlashCommands } from "../slash/slash-commands.ts";
 import { registerPromptTemplateDelegationBridge } from "../slash/prompt-template-bridge.ts";
@@ -466,7 +467,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const supervisorChannel = createNativeSupervisorChannel(pi, state);
 	const waitSubscriptionManager = createWaitSubscriptionManager(pi, state);
 	const mainWatchdog = registerMainWatchdog(pi);
-	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch });
+	const resultDeliveryOwnership = createResultDeliveryOwnership(state);
+	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch, ownership: resultDeliveryOwnership });
 	const fleetStatus = fleetViewEnabled
 		? new SubagentFleetStatus(state, async (itemKey) => {
 			const ctx = state.lastUiContext;
@@ -528,6 +530,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		10 * 60 * 1000,
 		{
 			notifier: completionNotifier,
+			ownership: resultDeliveryOwnership,
 			observeCompletion: (result) => scheduledRunManager.handleAsyncCompletion(result),
 			observedCompletionRunIds: () => scheduledRunManager.observedCompletionRunIds(),
 			hasDeliveryDemand: hasResultDeliveryDemand,
@@ -535,7 +538,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			resultScanLogging: config.resultScanLogging,
 		},
 	);
-	const { startResultWatcher, primeExistingResults, stopResultWatcher } = resultWatcher;
+	const { startResultWatcher, transitionResultDelivery, primeExistingResults, stopResultWatcher } = resultWatcher;
 	refreshResultDelivery = resultWatcher.refreshResultDelivery;
 	const asyncRetentionAbort = new AbortController();
 	const asyncRetentionTimer = setTimeout(async () => {
@@ -853,11 +856,14 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		);
 	};
 
-	const resetSessionState = (ctx: ExtensionContext, recovering: boolean) => {
+	const resetSessionState = (ctx: ExtensionContext, recovering: boolean, previousSessionFile?: string) => {
 		state.widgetsSuspended = false;
 		state.baseCwd = ctx.cwd;
 		goalTurnId = 0;
+		const previousRuntimeSessionId = state.currentSessionId;
+		resultDeliveryOwnership.claimPredecessor(previousSessionFile, previousRuntimeSessionId);
 		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
+		transitionResultDelivery();
 		state.parentSessionFile = ctx.sessionManager.getSessionFile();
 		state.trustedSessionFileRoot = state.parentSessionFile ? path.join(getAgentDir(), "sessions") : undefined;
 		state.trustedSessionRoots = [...new Set([
@@ -934,6 +940,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			clearTimeout(asyncRetentionTimer);
 			asyncRetentionAbort.abort();
 			stopResultWatcher();
+			resultDeliveryOwnership.clear();
 			completionNotifier.dispose();
 			mainWatchdog.dispose();
 			scheduledRunManager.stop();
@@ -1034,7 +1041,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", (event, ctx) => {
 		installRuntime(ctx);
 		const recovering = event.reason === "startup" || event.reason === "reload" || event.reason === "resume";
-		resetSessionState(ctx, recovering);
+		resetSessionState(ctx, recovering, event.previousSessionFile);
 		herdrStatusBridge.sessionStarted({
 			hasUI: ctx.hasUI === true,
 			runs: activeHerdrRuns(),

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -16,6 +16,7 @@ import {
 } from "./completion-batcher.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT, type ParallelHandoffReference, type ScheduleOrigin, type SubagentState } from "../../shared/types.ts";
 import { isUnexplainedProcessSignal } from "../shared/process-signal.ts";
+import type { ResultDeliveryOwnership } from "./result-delivery-ownership.ts";
 
 export interface SubagentNotifyDetails {
 	agent: string;
@@ -91,6 +92,7 @@ export interface RegisterSubagentNotifyOptions {
 	batchConfig?: CompletionBatchConfig;
 	timers?: NotifyTimerApi;
 	now?: () => number;
+	ownership?: Pick<ResultDeliveryOwnership, "owns">;
 }
 
 export interface CompletionNotifier {
@@ -228,6 +230,8 @@ export function formatGroupedCompletion(details: SubagentNotifyDetails[]): strin
 interface PendingCompletion {
 	key: string;
 	details: SubagentNotifyDetails;
+	sessionId: string;
+	completionOwnerId: unknown;
 	triggerTurn: boolean;
 	resolve(accepted: boolean): void;
 }
@@ -335,6 +339,10 @@ export default function registerSubagentNotify(
 	const batchConfig = resolveCompletionBatchConfig(options.batchConfig);
 	const batchers = new Map<string, CompletionBatcher<PendingCompletion>>();
 	let disposed = false;
+	const ownsResult = options.ownership?.owns
+		?? ((sessionId: string, completionOwnerId: unknown) => sessionId === state.currentSessionId
+			&& typeof completionOwnerId === "string"
+			&& completionOwnerId === state.completionOwnerId);
 
 	const settle = (items: PendingCompletion[], accepted: boolean) => {
 		for (const item of items) {
@@ -343,7 +351,18 @@ export default function registerSubagentNotify(
 			item.resolve(accepted);
 		}
 	};
-	const emit = (items: PendingCompletion[]) => settle(items, sendCompletion(pi, items));
+	const emit = (items: PendingCompletion[]) => {
+		const accepted: PendingCompletion[] = [];
+		const rejected: PendingCompletion[] = [];
+		for (const item of items) {
+			const owned = item.details.source === "foreground"
+				? item.sessionId === state.currentSessionId
+				: ownsResult(item.sessionId, item.completionOwnerId);
+			(owned ? accepted : rejected).push(item);
+		}
+		settle(rejected, false);
+		settle(accepted, sendCompletion(pi, accepted));
+	};
 	const getBatcher = (result: CompletionNotification) => {
 		const key = completionBatchKey(result);
 		let batcher = batchers.get(key);
@@ -360,8 +379,10 @@ export default function registerSubagentNotify(
 	};
 
 	const deliver = (result: CompletionNotification): Promise<boolean> => {
-		if (disposed || typeof result.sessionId !== "string" || result.sessionId !== state.currentSessionId) return Promise.resolve(false);
-		if (result.source !== "foreground" && (!state.completionOwnerId || result.completionOwnerId !== state.completionOwnerId)) return Promise.resolve(false);
+		if (disposed || typeof result.sessionId !== "string") return Promise.resolve(false);
+		if (result.source === "foreground") {
+			if (result.sessionId !== state.currentSessionId) return Promise.resolve(false);
+		} else if (!ownsResult(result.sessionId, result.completionOwnerId)) return Promise.resolve(false);
 		if (result.intercomDelivered === true) return Promise.resolve(true);
 		const key = buildCompletionKey(result, "notify");
 		const seenAt = seen.get(key);
@@ -376,6 +397,8 @@ export default function registerSubagentNotify(
 		const item: PendingCompletion = {
 			key,
 			details,
+			sessionId: result.sessionId,
+			completionOwnerId: result.completionOwnerId,
 			triggerTurn: result.triggerTurn !== false,
 			resolve,
 		};

--- a/src/runs/background/result-delivery-ownership.ts
+++ b/src/runs/background/result-delivery-ownership.ts
@@ -1,0 +1,45 @@
+import type { SubagentState } from "../../shared/types.ts";
+
+const MAX_CLAIMED_PREDECESSOR_SESSIONS = 8;
+
+type ResultDeliveryState = Pick<SubagentState, "currentSessionId" | "completionOwnerId">;
+
+export interface ResultDeliveryOwnership {
+	owns(sessionId: string, completionOwnerId: unknown): boolean;
+	claimedSessionIds(): readonly string[];
+	claimPredecessor(previousSessionFile: string | undefined, previousRuntimeSessionId: string | null): boolean;
+	clear(): void;
+}
+
+export function createResultDeliveryOwnership(state: ResultDeliveryState): ResultDeliveryOwnership {
+	const claimed = new Map<string, string>();
+
+	const currentOwner = (): string | undefined => typeof state.completionOwnerId === "string" && state.completionOwnerId
+		? state.completionOwnerId
+		: undefined;
+
+	return {
+		owns(sessionId, completionOwnerId) {
+			const owner = currentOwner();
+			if (!owner || completionOwnerId !== owner) return false;
+			return sessionId === state.currentSessionId || claimed.get(sessionId) === owner;
+		},
+		claimedSessionIds() {
+			const owner = currentOwner();
+			if (!owner) return [];
+			return [...claimed].flatMap(([sessionId, claimedOwner]) => claimedOwner === owner ? [sessionId] : []);
+		},
+		claimPredecessor(previousSessionFile, previousRuntimeSessionId) {
+			const owner = currentOwner();
+			if (!owner || !previousSessionFile || !previousRuntimeSessionId) return false;
+			if (previousSessionFile !== previousRuntimeSessionId || state.currentSessionId !== previousRuntimeSessionId) return false;
+			claimed.delete(previousRuntimeSessionId);
+			claimed.set(previousRuntimeSessionId, owner);
+			while (claimed.size > MAX_CLAIMED_PREDECESSOR_SESSIONS) claimed.delete(claimed.keys().next().value!);
+			return true;
+		},
+		clear() {
+			claimed.clear();
+		},
+	};
+}

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -25,6 +25,7 @@ import { recordWaitCompletion } from "./wait-completions.ts";
 import { MISSION_BINDING_FILE, syncMissionFromAsyncCompletion } from "../../missions/lifecycle.ts";
 import { missionObserverResultCandidateFiles, promotePendingResultFile, removeMissionObserverIndex, removeResultIndex, resultCandidateFilesForSession, resultPayloadPathForIndexedRun, resultPayloadPathForMissionObserverRun, resultPayloadPathForSessionRun, writeAsyncResultFile, writeResultIndexForData } from "./result-files.ts";
 import type { CompletionNotifier, CompletionNotification } from "./notify.ts";
+import type { ResultDeliveryOwnership } from "./result-delivery-ownership.ts";
 
 const WATCHER_RESTART_DELAY_MS = 3000;
 const POLL_INTERVAL_MS = 3000;
@@ -60,6 +61,8 @@ type ResultWatcherDeps = {
 	/** Control how slow result-index scans are logged. Defaults to \"activity\". */
 	resultScanLogging?: "all" | "activity" | "off";
 	platform?: NodeJS.Platform;
+	/** Shared current/predecessor session ownership used by the notifier. */
+	ownership?: Pick<ResultDeliveryOwnership, "owns" | "claimedSessionIds">;
 };
 
 type ResultFileChild = {
@@ -200,6 +203,7 @@ export function createResultWatcher(
 	deps: ResultWatcherDeps = {},
 ): {
 	startResultWatcher: () => void;
+	transitionResultDelivery: () => void;
 	primeExistingResults: (options?: { triggerTurn?: boolean }) => void;
 	refreshResultDelivery: () => void;
 	stopResultWatcher: () => void;
@@ -218,14 +222,16 @@ export function createResultWatcher(
 	// The sole in-memory ownership lease. It is acquired for one active session
 	// and revoked before the watcher, queues, or callbacks are torn down.
 	let activeSessionId: string | null = null;
+	const ownsResult = deps.ownership?.owns
+		?? ((sessionId: string, completionOwnerId: unknown) => sessionId === state.currentSessionId
+			&& typeof completionOwnerId === "string"
+			&& completionOwnerId === state.completionOwnerId);
+	const claimedSessionIds = () => deps.ownership?.claimedSessionIds() ?? [];
 
 	const ownsCompletion = (sessionId: string, completionOwnerId: unknown, epoch: number) => {
 		if (!deliveryActive || epoch !== deliveryEpoch) return false;
 		if (!activeSessionId && state.currentSessionId) activeSessionId = state.currentSessionId;
-		return activeSessionId === sessionId
-			&& state.currentSessionId === sessionId
-			&& typeof completionOwnerId === "string"
-			&& completionOwnerId === state.completionOwnerId;
+		return activeSessionId === state.currentSessionId && ownsResult(sessionId, completionOwnerId);
 	};
 
 	const scheduleResult = (file: string, triggerTurn: boolean, delayMs = 0) => {
@@ -246,8 +252,11 @@ export function createResultWatcher(
 	const resultPayloadPath = (file: string, observed?: ReadonlySet<string>): string | undefined => {
 		if (file !== path.basename(file) || !file.endsWith(".json")) return undefined;
 		const runId = file.replace(/\.json$/i, "");
-		const sessionResult = state.currentSessionId ? resultPayloadPathForSessionRun(resultsDir, state.currentSessionId, runId) : undefined;
-		if (sessionResult) return sessionResult;
+		for (const sessionId of [state.currentSessionId, ...claimedSessionIds()]) {
+			if (!sessionId) continue;
+			const sessionResult = resultPayloadPathForSessionRun(resultsDir, sessionId, runId);
+			if (sessionResult) return sessionResult;
+		}
 		const observerResult = resultPayloadPathForMissionObserverRun(resultsDir, runId);
 		if (observerResult) return observerResult;
 		if (observed?.has(runId)) {
@@ -308,7 +317,7 @@ export function createResultWatcher(
 		// Missing identity stays on the normal parser path so malformed or legacy
 		// files keep their existing diagnostics and compatibility behavior.
 		if (!identity.sessionId) return true;
-		if (identity.sessionId === state.currentSessionId && identity.completionOwnerId === state.completionOwnerId) return true;
+		if (ownsResult(identity.sessionId, identity.completionOwnerId)) return true;
 		if (identity.asyncDir && fsApi.existsSync(path.join(identity.asyncDir, MISSION_BINDING_FILE))) return true;
 		if (identity.runId && (observed ?? observedRunIds()).has(identity.runId)) return true;
 		return Boolean(deps.observeCompletion && !deps.observedCompletionRunIds);
@@ -621,8 +630,9 @@ export function createResultWatcher(
 	};
 	const indexedResultCandidates = (observed: ReadonlySet<string>): string[] => {
 		const files = new Set<string>();
-		if (state.currentSessionId) {
-			for (const file of resultCandidateFilesForSession(resultsDir, state.currentSessionId)) files.add(file);
+		for (const sessionId of [state.currentSessionId, ...claimedSessionIds()]) {
+			if (!sessionId) continue;
+			for (const file of resultCandidateFilesForSession(resultsDir, sessionId)) files.add(file);
 		}
 		for (const runId of state.asyncJobs.keys()) files.add(`${runId}.json`);
 		for (const file of missionObserverResultCandidateFiles(resultsDir)) files.add(file);
@@ -755,6 +765,13 @@ export function createResultWatcher(
 		}
 	};
 
+	const transitionResultDelivery = () => {
+		deliveryActive = true;
+		activeSessionId = state.currentSessionId;
+		deliveryEpoch += 1;
+		identityCache.clear();
+	};
+
 	const stopResultWatcher = () => {
 		deliveryActive = false;
 		activeSessionId = null;
@@ -769,5 +786,5 @@ export function createResultWatcher(
 		identityCache.clear();
 	};
 
-	return { startResultWatcher, primeExistingResults, stopResultWatcher, refreshResultDelivery: () => { primeExistingResults(); startDemandPolling(); } };
+	return { startResultWatcher, transitionResultDelivery, primeExistingResults, stopResultWatcher, refreshResultDelivery: () => { primeExistingResults(); startDemandPolling(); } };
 }

--- a/test/integration/result-watcher.test.ts
+++ b/test/integration/result-watcher.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { buildCompletionKey } from "../../src/runs/background/completion-dedupe.ts";
 import { createResultWatcher as createRawResultWatcher } from "../../src/runs/background/result-watcher.ts";
+import { createResultDeliveryOwnership } from "../../src/runs/background/result-delivery-ownership.ts";
 import { writeAsyncResultFile, writePendingAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { encodeIndexSegment, MAX_INDEX_SEGMENT_BYTES } from "../../src/runs/background/index-segment.ts";
 import { createScheduledRunManager, scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
@@ -168,6 +169,43 @@ describe("result watcher", () => {
 
 			assert.equal(emitted.filter((entry) => entry.event === "subagent:async-complete").length, 1);
 			assert.equal(fs.existsSync(resultPath), false);
+		} finally {
+			fs.rmSync(resultsDir, { recursive: true, force: true });
+		}
+	});
+
+	it("hands predecessor results to the replacement session without widening ownership", async () => {
+		const resultsDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-result-watcher-transition-"));
+		try {
+			const state = createState();
+			state.currentSessionId = "session-old";
+			const ownership = createResultDeliveryOwnership(state);
+			const delivered: string[] = [];
+			const watcher = createResultWatcher({ events: { on: () => () => {}, emit() {} } }, state, resultsDir, 60_000, {
+				deliverIntercomResults: false,
+				ownership,
+				notifier: { async deliver(result) { delivered.push(result.id!); return true; } },
+			});
+			try {
+				watcher.startResultWatcher();
+				assert.equal(ownership.claimPredecessor("session-old", "session-old"), true);
+				state.currentSessionId = "session-new";
+				watcher.transitionResultDelivery();
+				writeIndexedResult(path.join(resultsDir, "old-run.json"), { id: "old-run", sessionId: "session-old", success: true, summary: "old" });
+				writeIndexedResult(path.join(resultsDir, "new-run.json"), { id: "new-run", sessionId: "session-new", success: true, summary: "new" });
+				writeIndexedResult(path.join(resultsDir, "foreign-run.json"), { id: "foreign-run", sessionId: "session-foreign", success: true, summary: "foreign" });
+				writeAsyncResultFile(path.join(resultsDir, "wrong-owner.json"), { id: "wrong-owner", sessionId: "session-old", completionOwnerId: "other-owner", success: true, summary: "wrong" });
+
+				watcher.primeExistingResults();
+				assert.equal(await waitForPredicate(() => delivered.length === 2), true);
+				assert.deepEqual(delivered.sort(), ["new-run", "old-run"]);
+				assert.equal(fs.existsSync(path.join(resultsDir, "old-run.json")), false);
+				assert.equal(fs.existsSync(path.join(resultsDir, "new-run.json")), false);
+				assert.equal(fs.existsSync(path.join(resultsDir, "foreign-run.json")), true);
+				assert.equal(fs.existsSync(path.join(resultsDir, "wrong-owner.json")), true);
+			} finally {
+				watcher.stopResultWatcher();
+			}
 		} finally {
 			fs.rmSync(resultsDir, { recursive: true, force: true });
 		}

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -995,6 +995,58 @@ describe("subagent extension child mode", () => {
 		}
 	});
 
+	it("claims the explicit predecessor session during session replacement", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-session-transition-"));
+		const configDir = path.join(agentDir, "extensions", "subagent");
+		fs.mkdirSync(configDir, { recursive: true });
+		fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ completionBatch: { enabled: false } }), "utf-8");
+		const script = String.raw`
+			import fs from "node:fs";
+			import path from "node:path";
+			import registerSubagentExtension from "./index.ts";
+			import { currentCompletionOwnerId } from "./src/shared/completion-owner.ts";
+			const handlers = new Map();
+			const listeners = new Map();
+			const events = {
+				on(channel, handler) { let set = listeners.get(channel); if (!set) listeners.set(channel, set = new Set()); set.add(handler); return () => set.delete(handler); },
+				emit(channel, payload) { for (const handler of [...(listeners.get(channel) ?? [])]) handler(payload); },
+			};
+			const sent = [];
+			const pi = new Proxy({
+				events,
+				on(channel, handler) { handlers.set(channel, handler); },
+				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage(message) { sent.push(message); }, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			const sessions = path.join(process.env.PI_CODING_AGENT_DIR, "sessions");
+			fs.mkdirSync(sessions, { recursive: true });
+			const oldSession = path.join(sessions, "old.jsonl");
+			const newSession = path.join(sessions, "new.jsonl");
+			fs.writeFileSync(oldSession, "");
+			fs.writeFileSync(newSession, "");
+			let currentSession = oldSession;
+			const sessionManager = { getSessionId() { return path.basename(currentSession); }, getSessionFile() { return currentSession; }, getEntries() { return []; } };
+			const ctx = { cwd: process.cwd(), hasUI: false, ui: { setWidget() {}, requestRender() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } }, sessionManager, modelRegistry: { getAvailable() { return []; } } };
+			registerSubagentExtension(pi);
+			handlers.get("session_start")({ reason: "startup" }, ctx);
+			currentSession = newSession;
+			handlers.get("session_start")({ reason: "new", previousSessionFile: oldSession }, ctx);
+			const owner = currentCompletionOwnerId();
+			events.emit("subagent:async-complete", { id: "old-owned", agent: "worker", success: true, summary: "old", timestamp: 1, sessionId: oldSession, completionOwnerId: owner });
+			events.emit("subagent:async-complete", { id: "foreign", agent: "worker", success: true, summary: "foreign", timestamp: 2, sessionId: path.join(sessions, "foreign.jsonl"), completionOwnerId: owner });
+			if (sent.length !== 1) throw new Error("expected only the claimed predecessor completion, got " + sent.length);
+			await handlers.get("session_shutdown")({ reason: "quit" });
+		`;
+
+		try {
+			const env = parentToolEnv();
+			env.PI_CODING_AGENT_DIR = agentDir;
+			execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
 	it("registers the main watchdog command and renderer in parent mode", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -10,6 +10,7 @@ import registerSubagentNotify, {
 	type SubagentNotifyDetails,
 } from "../../src/runs/background/notify.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT } from "../../src/shared/types.ts";
+import { createResultDeliveryOwnership } from "../../src/runs/background/result-delivery-ownership.ts";
 
 const COMPLETION_OWNER_ID = "completion-owner-a";
 
@@ -157,6 +158,47 @@ describe("registerSubagentNotify", () => {
 		assert.equal(await notifier.deliver(completionResult({ id: "missing-owner", completionOwnerId: undefined })), false);
 		assert.equal(await notifier.deliver(completionResult({ id: "different-owner", completionOwnerId: "completion-owner-b" })), false);
 		assert.equal(sent.length, 0);
+	});
+
+	it("accepts only explicitly claimed predecessor-session completions", async () => {
+		const events = createEventBus();
+		const sent: unknown[] = [];
+		const pi = { events, sendMessage(message: unknown) { sent.push(message); } };
+		const state = { currentSessionId: "session-old" as string | null, completionOwnerId: COMPLETION_OWNER_ID };
+		const ownership = createResultDeliveryOwnership(state);
+		assert.equal(ownership.claimPredecessor("session-old", "session-old"), true);
+		state.currentSessionId = "session-new";
+		const notifier = registerSubagentNotify(pi as never, state, { batchConfig: { enabled: false }, ownership });
+		try {
+			assert.equal(await notifier.deliver(completionResult({ id: "predecessor", sessionId: "session-old" })), true);
+			assert.equal(await notifier.deliver(completionResult({ id: "foreign", sessionId: "session-foreign" })), false);
+			assert.equal(await notifier.deliver(completionResult({ id: "wrong-owner", sessionId: "session-old", completionOwnerId: "other-owner" })), false);
+			assert.equal(sent.length, 1);
+		} finally {
+			notifier.dispose();
+		}
+	});
+
+	it("rechecks session ownership before emitting a delayed batch", async () => {
+		const clock = createFakeClock();
+		const events = createEventBus();
+		const sent: unknown[] = [];
+		const pi = { events, sendMessage(message: unknown) { sent.push(message); } };
+		const state = { currentSessionId: "session-a" as string | null, completionOwnerId: COMPLETION_OWNER_ID };
+		const notifier = registerSubagentNotify(pi as never, state, {
+			batchConfig: { enabled: true, debounceMs: 150, maxWaitMs: 1000, stragglerDebounceMs: 75, stragglerMaxWaitMs: 400, stragglerWindowMs: 2000 },
+			timers: clock.api,
+			now: clock.now,
+		});
+		try {
+			const pending = notifier.deliver(completionResult({ id: "delayed-unclaimed" }));
+			state.currentSessionId = "session-b";
+			clock.advance(150);
+			assert.equal(await pending, false);
+			assert.equal(sent.length, 0);
+		} finally {
+			notifier.dispose();
+		}
 	});
 
 	it("does not wake the session when background delivery explicitly disables triggerTurn", async () => {

--- a/test/unit/result-delivery-ownership.test.ts
+++ b/test/unit/result-delivery-ownership.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createResultDeliveryOwnership } from "../../src/runs/background/result-delivery-ownership.ts";
+
+const OWNER = "owner-a";
+
+describe("result delivery ownership", () => {
+	it("claims only the directly proven previous runtime session", () => {
+		const state = { currentSessionId: "old" as string | null, completionOwnerId: OWNER };
+		const ownership = createResultDeliveryOwnership(state);
+		assert.equal(ownership.claimPredecessor(undefined, "old"), false);
+		assert.equal(ownership.claimPredecessor("different", "old"), false);
+		assert.equal(ownership.claimPredecessor("old", "different"), false);
+		assert.equal(ownership.claimPredecessor("old", "old"), true);
+		state.currentSessionId = "new";
+		assert.equal(ownership.owns("old", OWNER), true);
+		assert.equal(ownership.owns("new", OWNER), true);
+		assert.equal(ownership.owns("old", "other-owner"), false);
+		assert.equal(ownership.owns("foreign", OWNER), false);
+	});
+
+	it("keeps predecessor claims bounded", () => {
+		const state = { currentSessionId: "session-0" as string | null, completionOwnerId: OWNER };
+		const ownership = createResultDeliveryOwnership(state);
+		for (let index = 0; index < 9; index += 1) {
+			const previous = `session-${index}`;
+			assert.equal(ownership.claimPredecessor(previous, previous), true);
+			state.currentSessionId = `session-${index + 1}`;
+		}
+		assert.deepEqual(ownership.claimedSessionIds(), ["session-1", "session-2", "session-3", "session-4", "session-5", "session-6", "session-7", "session-8"]);
+		assert.equal(ownership.owns("session-0", OWNER), false);
+		assert.equal(ownership.owns("session-8", OWNER), true);
+	});
+});


### PR DESCRIPTION
Fixes #1531.

This adds a bounded result-delivery ownership handoff for explicit session replacement. The watcher and notifier now share the same current-or-claimed-predecessor predicate, so predecessor results can be retried and delivered after replacement without accepting unrelated sessions or mismatched owners.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/result-delivery-ownership.test.ts test/unit/notify.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/integration/result-watcher.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'claims the explicit predecessor session during session replacement' test/unit/index-child-registration.test.ts`
- `npm run typecheck`
- `git diff --check`
