### PR TITLE
fix: publish detached workflow handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add process-local event registration so independent Pi extensions can register runtime agents through the installed owner. Thanks to [@fmoda3](https://github.com/fmoda3) for #1533.
 
 ### Fixed
+- Publish a deterministic terminal handoff with settled child evidence and keyed recovery actions when detached workflow lanes settle. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.
 - Fail native child launches before spawn when the requested local working directory is missing or not a directory, with the requested and resolved paths in the error.
 - Map report paths requested in workflow child tasks to the actual saved child output when workflow output routing overrides them.

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -9,6 +9,8 @@ import {
 	type IntercomEventBus,
 	type SingleResult,
 	type SubagentState,
+	type WorkflowRecoveryAction,
+	type WorkflowTerminalResolution,
 } from "../../shared/types.ts";
 import { updateActiveRunIndex } from "../background/active-run-index.ts";
 import { resultFilePath, writeAsyncResultFile } from "../background/result-files.ts";
@@ -34,19 +36,31 @@ const UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION = "unsupported-continuation: de
 const INTERRUPTED_DETACHED_CHILD = "Interrupted. Waiting for explicit next action.";
 type WorkflowStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
 	outputPathMapping?: { requestedPath: string; savedPath: string };
+	interrupted?: boolean;
 };
+
+function findWorkflowStep(status: AsyncStatus, childRunId: string, workflowKey?: string): WorkflowStatusStep | undefined {
+	return status.steps?.find((candidate) => candidate.runId === childRunId)
+		?? (workflowKey ? status.steps?.find((candidate) => candidate.workflowKey === workflowKey) : undefined) as WorkflowStatusStep | undefined;
+}
 
 export function applyDetachedChildToPausedWorkflow(
 	status: AsyncStatus,
-	input: { childRunId: string; result: Pick<SingleResult, "exitCode" | "error" | "interrupted" | "sessionFile">; workflowKey?: string },
+	input: { childRunId: string; result: Pick<SingleResult, "exitCode" | "error" | "interrupted" | "sessionFile" | "stopped">; workflowKey?: string },
 ): AsyncStatus | undefined {
 	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
 	const next = cloneWorkflowStatus(status);
-	const step = next.steps?.find((candidate) => candidate.runId === input.childRunId)
-		?? (input.workflowKey ? next.steps?.find((candidate) => candidate.workflowKey === input.workflowKey) : undefined);
+	const step = findWorkflowStep(next, input.childRunId, input.workflowKey);
 	if (!step) return undefined;
 	const succeeded = childSucceeded(input.result);
-	const failedSiblingError = next.steps?.find((candidate) => candidate !== step && candidate.status === "failed" && candidate.error)?.error;
+	const failedSiblingError = next.steps?.find((candidate) => {
+		const candidateStep = candidate as WorkflowStatusStep;
+		return candidateStep !== step && candidateStep.status === "failed" && !candidateStep.interrupted && candidateStep.error;
+	})?.error;
+	const interruptedChildError = next.steps?.find((candidate) => {
+		const candidateStep = candidate as WorkflowStatusStep;
+		return candidateStep.status === "failed" && candidateStep.interrupted && candidateStep.error;
+	})?.error;
 	const updatedAt = Date.now();
 	step.status = succeeded ? "completed" : "failed";
 	step.endedAt = updatedAt;
@@ -54,13 +68,24 @@ export function applyDetachedChildToPausedWorkflow(
 	delete step.currentTool;
 	delete step.currentToolStartedAt;
 	if (input.result.sessionFile) step.sessionFile = input.result.sessionFile;
-	if (succeeded) delete step.error;
-	else if (input.result.interrupted) step.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
-	else if (input.result.error) step.error = input.result.error;
+	if (succeeded) {
+		delete step.error;
+		delete step.interrupted;
+	} else if (input.result.interrupted || input.result.stopped) {
+		step.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
+		step.interrupted = true;
+		if (input.result.stopped) step.stopped = true;
+	} else {
+		delete step.interrupted;
+		delete step.stopped;
+		if (input.result.error) step.error = input.result.error;
+	}
 	next.lastUpdate = updatedAt;
 	const promoted = promotePausedWorkflowIfSettled(next);
-	if (promoted?.state === "failed" && input.result.interrupted && !failedSiblingError) promoted.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
+	if (promoted?.state === "failed" && failedSiblingError) promoted.error = failedSiblingError;
+	else if (promoted?.state === "failed" && (input.result.interrupted || input.result.stopped)) promoted.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
 	else if (promoted?.state === "failed" && input.result.error) promoted.error = input.result.error;
+	else if (promoted?.state === "failed" && interruptedChildError) promoted.error = interruptedChildError;
 	const resolved = promoted ?? next;
 	const workflowState = resolved.state === "complete" ? "completed" : resolved.state === "paused" ? "paused" : resolved.state === "stopped" ? "stopped" : "failed";
 	resolved.workflowChildren = workflowChildSummary({ parentToolCallId: resolved.toolCallId ?? resolved.runId, workflowRunId: resolved.runId, workflowState, inventoryComplete: true, trace: resolved.workflow?.trace, steps: resolved.steps });
@@ -86,7 +111,27 @@ export function promotePausedWorkflowIfSettled(status: AsyncStatus): AsyncStatus
 	return next;
 }
 
-function workflowResultChildren(status: AsyncStatus, childRunId: string, result: SingleResult, existingResults: unknown): unknown {
+function workflowResolution(status: AsyncStatus, result: Pick<SingleResult, "interrupted">): WorkflowTerminalResolution | undefined {
+	if (status.state !== "complete" && status.state !== "failed") return undefined;
+	if (status.steps?.some((step) => {
+		const candidate = step as WorkflowStatusStep;
+		return candidate.status === "failed" && !candidate.interrupted;
+	})) return "failed-child";
+	if (result.interrupted || status.steps?.some((step) => {
+		const candidate = step as WorkflowStatusStep;
+		return candidate.status === "stopped" || candidate.stopped || candidate.interrupted || candidate.error === INTERRUPTED_DETACHED_CHILD;
+	})) return "interrupted-child";
+	return "settled-awaiting-resume";
+}
+
+function workflowRecovery(receipt: WorkflowReceipt | undefined): WorkflowRecoveryAction[] {
+	if (!receipt) return [];
+	return Object.values(receipt.entries).flatMap((entry) => entry.resumability.state === "resumable"
+		? [{ key: entry.key, call: "runs.run" as const, resume: { workflowRunId: receipt.workflowRunId, key: entry.key, latest: true as const }, taskRequired: true as const }]
+		: []);
+}
+
+function workflowResultChildren(status: AsyncStatus, childRunId: string, result: SingleResult, existingResults: unknown, receipt?: WorkflowReceipt): unknown {
 	const output = getSingleResultOutput(result);
 	const outputReference = result.savedOutputPath ?? result.outputReference?.path;
 	const outputPathMapping = outputPathMappingFromTask(result.task, outputReference);
@@ -101,6 +146,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 				output,
 				outputState: output.trim() ? "present" : "absent",
 				detached: undefined,
+				...(outputReference ? { outputReference } : {}),
 				...(outputPathMapping ? { outputPathMapping } : {}),
 				...(result.interrupted ? { interrupted: true } : {}),
 				...(result.error ? { error: result.error } : {}),
@@ -114,8 +160,10 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 		success: step.status === "completed" || step.status === "complete",
 		output: step.runId === childRunId ? output : "",
 		outputState: step.runId === childRunId && output.trim() ? "present" : "absent",
+		...(step.runId === childRunId && outputReference ? { outputReference } : step.workflowKey && receipt?.entries[step.workflowKey]?.outputReference ? { outputReference: receipt.entries[step.workflowKey]!.outputReference } : {}),
 		...(step.runId === childRunId && outputPathMapping ? { outputPathMapping } : step.outputPathMapping ? { outputPathMapping: step.outputPathMapping } : {}),
-		...(step.runId === childRunId && result.interrupted ? { interrupted: true } : {}),
+		...(step.interrupted ? { interrupted: true } : {}),
+		...(step.stopped ? { stopped: true } : {}),
 		...(step.error ? { error: step.error } : {}),
 	}));
 }
@@ -135,10 +183,14 @@ function workflowResultOutputPathMappingSummary(results: unknown): string {
 	return mappings.length > 0 ? ` Output path mappings: ${mappings.join("; ")}.` : "";
 }
 
-function publishedWorkflowResult(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, existing?: Record<string, unknown>, receipt?: WorkflowReceipt): Record<string, unknown> {
+function publishedWorkflowResult(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, existing?: Record<string, unknown>, receipt?: WorkflowReceipt, settledStep?: WorkflowStatusStep): Record<string, unknown> {
 	const sessionId = status.sessionId ?? (typeof existing?.sessionId === "string" ? existing.sessionId : undefined);
-	const results = workflowResultChildren(status, childRunId, result, existing?.results);
-	const summary = `${status.state === "complete"
+	const resolution = workflowResolution(status, result);
+	const recovery = workflowRecovery(receipt);
+	const results = workflowResultChildren(status, childRunId, result, existing?.results, receipt);
+	const summary = `${resolution === "settled-awaiting-resume"
+		? `Workflow lanes settled after detached child ${childRunId} finished. JavaScript workflow continuation was not persisted.${recovery.length ? " Use the listed keyed recovery action to continue a child." : " No retained child is resumable."}`
+		: status.state === "complete"
 		? `Workflow completed after detached child ${childRunId} finished.`
 		: status.error ?? (typeof existing?.summary === "string" ? existing.summary : "Workflow failed.")}${workflowResultOutputPathMappingSummary(results)}`;
 	return {
@@ -158,6 +210,7 @@ function publishedWorkflowResult(status: AsyncStatus, childRunId: string, result
 		results,
 		workflow: status.workflow,
 		workflowChildren: status.workflowChildren,
+		...(resolution ? { workflowResolution: resolution, recovery } : {}),
 		reconciledFromDetachedChild: childRunId,
 		...(receipt ? { workflowReceipt: { path: path.join(asyncDir, "workflow-receipt.json"), receipt } } : {}),
 		asyncDir,
@@ -167,7 +220,7 @@ function publishedWorkflowResult(status: AsyncStatus, childRunId: string, result
 	};
 }
 
-function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string): WorkflowReceipt | undefined {
+function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, resolution: WorkflowTerminalResolution | undefined): WorkflowReceipt | undefined {
 	const receiptPath = workflowReceiptPath(DIRS.async, status.runId);
 	if (!fs.existsSync(receiptPath)) return undefined;
 	const receipt = readWorkflowReceipt(DIRS.async, status.runId);
@@ -216,7 +269,13 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 			[key]: updatedEntry,
 		},
 		workflowChildren: status.workflowChildren,
+		...(resolution ? { workflowResolution: resolution } : {}),
 	};
+	if (resolution) next.recovery = workflowRecovery(next);
+	else {
+		delete next.workflowResolution;
+		delete next.recovery;
+	}
 	writeWorkflowReceipt(asyncDir, next);
 	return next;
 }
@@ -250,7 +309,7 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 	if (!next) return false;
 	const outputReference = input.result.savedOutputPath ?? input.result.outputReference?.path;
 	const outputPathMapping = outputPathMappingFromTask(input.result.task, outputReference);
-	const settledStep = next.steps?.find((step) => step.runId === input.childRunId || (input.workflowKey && step.workflowKey === input.workflowKey)) as WorkflowStatusStep | undefined;
+	const settledStep = findWorkflowStep(next, input.childRunId, input.workflowKey);
 	if (settledStep && outputPathMapping) settledStep.outputPathMapping = outputPathMapping;
 	writeAtomicJson(path.join(asyncDir, "status.json"), next);
 	updateActiveRunIndex(asyncDir, next.state, next.toolCallId);
@@ -271,12 +330,13 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 	}
 	let receipt: WorkflowReceipt | undefined;
 	let receiptError: string | undefined;
+	const resolution = workflowResolution(next, input.result);
 	try {
-		receipt = reconcileWorkflowReceipt(next, input.childRunId, input.result, asyncDir);
+		receipt = reconcileWorkflowReceipt(next, input.childRunId, input.result, asyncDir, resolution);
 	} catch (error) {
 		receiptError = `Failed to reconcile async workflow receipt: ${error instanceof Error ? error.message : String(error)}`;
 	}
-	const published = publishedWorkflowResult(next, input.childRunId, input.result, asyncDir, existing, receipt);
+	const published = publishedWorkflowResult(next, input.childRunId, input.result, asyncDir, existing, receipt, settledStep);
 	writeAsyncResultFile(resultPath, published);
 	if (receiptError) {
 		appendDetachedWorkflowEvent(asyncDir, {
@@ -288,11 +348,14 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 		});
 	}
 	if (next.state === "complete" || next.state === "failed") {
+		if (!resolution) throw new Error(`Terminal detached workflow '${input.workflowRunId}' has no resolution classification.`);
 		appendDetachedWorkflowEvent(asyncDir, {
 			ts: Date.now(),
 			runId: input.workflowRunId,
 			type: "subagent.workflow.completed",
 			state: next.state,
+			workflowResolution: resolution,
+			recovery: workflowRecovery(receipt),
 			...(next.error ? { error: next.error } : {}),
 			reconciledFromDetachedChild: input.childRunId,
 		});
@@ -304,6 +367,8 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 			agent: "workflow",
 			success: next.state === "complete",
 			state: next.state,
+			workflowResolution: resolution,
+			recovery: workflowRecovery(receipt),
 			summary: typeof published.summary === "string" ? published.summary : (next.state === "complete" ? "Workflow completed." : next.error),
 			reconciledFromDetachedChild: input.childRunId,
 			...(Array.isArray(published.results) ? { results: published.results } : {}),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -76,6 +76,15 @@ export interface WorkflowGraphSnapshot {
 
 export type WorkflowReceiptState = "complete" | "failed" | "paused" | "stopped";
 
+export type WorkflowTerminalResolution = "settled-awaiting-resume" | "failed-child" | "interrupted-child";
+
+export interface WorkflowRecoveryAction {
+	key: string;
+	call: "runs.run";
+	resume: { workflowRunId: string; key: string; latest: true };
+	taskRequired: true;
+}
+
 export interface WorkflowChildSummaryV1 {
 	version: 1;
 	parentToolCallId: string;
@@ -113,6 +122,8 @@ export interface WorkflowReceipt {
 	createdAt: number;
 	entries: Record<string, WorkflowReceiptEntry>;
 	workflowChildren?: WorkflowChildSummaryV1;
+	workflowResolution?: WorkflowTerminalResolution;
+	recovery?: WorkflowRecoveryAction[];
 }
 
 export interface SavedOutputReference {

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
-import type { ExternalCliReceiptMetadata, WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState } from "../shared/types.ts";
+import type { ExternalCliReceiptMetadata, WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState, WorkflowRecoveryAction, WorkflowTerminalResolution } from "../shared/types.ts";
 import type { WorkflowReceiptResumeReference, WorkflowScriptChildResult } from "./scripted-workflow.ts";
 import { parseWorkflowChildSummary } from "./workflow-child-summary.ts";
 
@@ -194,6 +194,27 @@ function parseEntry(value: unknown, key: string, source: string): WorkflowReceip
 	return value as WorkflowReceiptEntry;
 }
 
+function parseWorkflowResolution(value: unknown, source: string): WorkflowTerminalResolution | undefined {
+	if (value === undefined) return undefined;
+	if (value !== "settled-awaiting-resume" && value !== "failed-child" && value !== "interrupted-child") throw new Error(`Invalid workflow receipt '${source}': workflowResolution is invalid.`);
+	return value;
+}
+
+function parseRecovery(value: unknown, workflowRunId: string, entries: Record<string, WorkflowReceiptEntry>, source: string): WorkflowRecoveryAction[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) throw new Error(`Invalid workflow receipt '${source}': recovery must be an array.`);
+	return value.map((item, index) => {
+		if (!item || typeof item !== "object" || Array.isArray(item)) throw new Error(`Invalid workflow receipt '${source}': recovery[${index}] must be an object.`);
+		const action = item as Record<string, unknown>;
+		const key = action.key;
+		const resume = action.resume;
+		if (typeof key !== "string" || !entries[key] || action.call !== "runs.run" || action.taskRequired !== true || !resume || typeof resume !== "object" || Array.isArray(resume)) throw new Error(`Invalid workflow receipt '${source}': recovery[${index}] is invalid.`);
+		const reference = resume as Record<string, unknown>;
+		if (reference.workflowRunId !== workflowRunId || reference.key !== key || reference.latest !== true || entries[key].resumability.state !== "resumable") throw new Error(`Invalid workflow receipt '${source}': recovery[${index}] does not identify a resumable entry.`);
+		return { key, call: "runs.run", resume: { workflowRunId, key, latest: true }, taskRequired: true };
+	});
+}
+
 export function readWorkflowReceipt(asyncDirRoot: string, workflowRunId: string): WorkflowReceipt {
 	const receiptPath = workflowReceiptPath(asyncDirRoot, workflowRunId);
 	let value: unknown;
@@ -222,7 +243,9 @@ export function readWorkflowReceipt(asyncDirRoot: string, workflowRunId: string)
 	for (const [key, entry] of Object.entries(receipt.entries as Record<string, unknown>)) entries[assertKey(key, "workflow receipt key")] = parseEntry(entry, key, receiptPath);
 	const workflowChildren = parseWorkflowChildSummary(receipt.workflowChildren);
 	if (workflowChildren && workflowChildren.workflowRunId !== workflowRunId) throw new Error(`Workflow receipt '${receiptPath}' is stale: workflowChildren.workflowRunId does not match.`);
-	return { version: 1, workflowRunId, state: receipt.state, createdAt: receipt.createdAt, entries, ...(workflowChildren ? { workflowChildren } : {}) };
+	const workflowResolution = parseWorkflowResolution(receipt.workflowResolution, receiptPath);
+	const recovery = parseRecovery(receipt.recovery, workflowRunId, entries, receiptPath);
+	return { version: 1, workflowRunId, state: receipt.state, createdAt: receipt.createdAt, entries, ...(workflowChildren ? { workflowChildren } : {}), ...(workflowResolution ? { workflowResolution } : {}), ...(recovery ? { recovery } : {}) };
 }
 
 export function resolveWorkflowReceiptResumeEntry(input: {

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -147,10 +147,15 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 	it("publishes a terminal result when the paused result file is already gone", () => {
 		const workflowRunId = "workflow-missing-result";
 		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const childDir = path.join(DIRS.async, "child-1");
 		const requestedPath = path.join(asyncDir, "requested.md");
 		const savedPath = path.join(asyncDir, "saved.md");
+		const sessionFile = path.join(childDir, "session.jsonl");
 		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(childDir, { recursive: true });
 		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(sessionFile, "", "utf-8");
+		fs.writeFileSync(path.join(childDir, "status.json"), JSON.stringify({ runId: "child-1", mode: "single", state: "complete", startedAt: 1, lastUpdate: 2, sessionId: "session-1", steps: [{ agent: "worker", status: "complete", sessionFile }] }), "utf-8");
 		const status = { ...pausedWorkflow("child-1"), runId: workflowRunId, sessionId: "session-1" };
 		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
 		writeWorkflowReceipt(asyncDir, buildWorkflowReceipt({
@@ -175,21 +180,206 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			state,
 			workflowRunId,
 			childRunId: "child-1",
-			result: { index: 0, agent: "worker", task: `Write your findings to exactly this path: ${requestedPath}`, exitCode: 0, savedOutputPath: savedPath, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+			result: { index: 0, agent: "worker", task: `Write your findings to exactly this path: ${requestedPath}`, exitCode: 0, sessionFile, savedOutputPath: savedPath, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
 		}), true);
-		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; summary?: string; error?: string; sessionId?: string; results?: Array<{ outputPathMapping?: unknown }>; workflowReceipt?: { receipt?: { state?: string; entries?: Record<string, { resumability?: { state?: string; reason?: string } }> } } };
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; summary?: string; error?: string; sessionId?: string; workflowResolution?: string; recovery?: unknown[]; results?: Array<{ outputReference?: string; outputPathMapping?: unknown }>; workflowReceipt?: { receipt?: { state?: string; workflowResolution?: string; recovery?: unknown[]; entries?: Record<string, { resumability?: { state?: string; reason?: string } }> } } };
 		assert.equal(published.state, "failed");
 		assert.equal(published.success, false);
 		assert.match(published.error ?? "", /unsupported-continuation/);
+		assert.equal(published.workflowResolution, "settled-awaiting-resume");
+		assert.match(published.summary ?? "", /Workflow lanes settled/);
+		assert.deepEqual(published.recovery, [{ key: "detaches", call: "runs.run", resume: { workflowRunId, key: "detaches", latest: true }, taskRequired: true }]);
 		assert.ok(published.summary?.includes(`Output path mappings: 'detaches': requested ${requestedPath} -> saved ${savedPath}`));
+		assert.equal(published.results?.[0]?.outputReference, savedPath);
 		assert.deepEqual(published.results?.[0]?.outputPathMapping, { requestedPath, savedPath });
 		assert.equal(published.sessionId, "session-1");
 		assert.equal(published.workflowReceipt?.receipt?.state, "failed");
-		assert.equal(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.state, "not-resumable");
-		assert.match(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.reason ?? "", /not found|Status file|too short/);
+		assert.equal(published.workflowReceipt?.receipt?.workflowResolution, "settled-awaiting-resume");
+		assert.deepEqual(published.workflowReceipt?.receipt?.recovery, published.recovery);
+		assert.equal(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.state, "resumable");
 		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
 		assert.match(events, /"type":"subagent.workflow.completed"/);
 		assert.match(events, /"state":"failed"/);
+		assert.match(events, /"workflowResolution":"settled-awaiting-resume"/);
+		assert.match(events, /"call":"runs.run"/);
+	});
+
+	it("classifies interrupted detached settlement without losing child details", () => {
+		const workflowRunId = "workflow-interrupted-handoff";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ ...pausedWorkflow("child-interrupted"), runId: workflowRunId, sessionId: "session-1" }), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-interrupted",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, interrupted: true, error: "operator stopped child", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; error?: string; results?: Array<{ interrupted?: boolean; error?: string }> };
+		assert.equal(published.workflowResolution, "interrupted-child");
+		assert.equal(published.error, "operator stopped child");
+		assert.deepEqual(published.results, [{ workflowKey: "detaches", agent: "worker", runId: "child-interrupted", success: false, output: "", outputState: "absent", interrupted: true, error: "operator stopped child" }]);
+	});
+
+	it("prioritizes a failed sibling over interrupted detached evidence", () => {
+		const workflowRunId = "workflow-failed-sibling-handoff";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const status = { ...pausedWorkflow("child-interrupted"), runId: workflowRunId, sessionId: "session-1" };
+		status.steps!.push({ agent: "worker", workflowKey: "fails", runId: "child-failed", status: "paused", activityState: "needs_attention" });
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+		let emitted: { name: string; payload: { error?: string; summary?: string; workflowResolution?: string } } | undefined;
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-failed",
+			result: { index: 1, agent: "worker", task: "t", exitCode: 1, error: "sibling boom", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), true);
+		const paused = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as { state?: string; error?: string; steps?: Array<{ runId?: string; error?: string }> };
+		assert.equal(paused.state, "paused");
+		assert.equal(paused.error, "Run 'worker' detached for intercom coordination.");
+		assert.equal(paused.steps?.find((step) => step.runId === "child-failed")?.error, "sibling boom");
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-interrupted",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, interrupted: true, error: "operator stopped child", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+			events: { emit: (name, payload) => { emitted = { name, payload: payload as { error?: string; summary?: string; workflowResolution?: string } }; } } as IntercomEventBus,
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; error?: string; results?: Array<{ workflowKey?: string; interrupted?: boolean; error?: string }> };
+		assert.equal(published.workflowResolution, "failed-child");
+		assert.equal(published.error, "sibling boom");
+		assert.deepEqual(published.results?.find((child) => child.workflowKey === "detaches"), { workflowKey: "detaches", agent: "worker", runId: "child-interrupted", success: false, output: "", outputState: "absent", interrupted: true, error: "operator stopped child" });
+		assert.deepEqual(published.results?.find((child) => child.workflowKey === "fails"), { workflowKey: "fails", agent: "worker", runId: "child-failed", success: false, output: "", outputState: "absent", error: "sibling boom" });
+		assert.equal(emitted?.name, "subagent:async-complete");
+		assert.equal(emitted?.payload.summary, "sibling boom");
+		assert.equal(emitted?.payload.workflowResolution, "failed-child");
+		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
+		assert.match(events, /"workflowResolution":"failed-child"/);
+		assert.match(events, /"error":"sibling boom"/);
+		assert.doesNotMatch(events, /"error":"operator stopped child"/);
+	});
+
+	it("preserves a later failed child error after interruption settles first", () => {
+		const workflowRunId = "workflow-interrupted-first-handoff";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const status = { ...pausedWorkflow("child-interrupted"), runId: workflowRunId, sessionId: "session-1" };
+		status.steps!.push({ agent: "worker", workflowKey: "fails", runId: "child-failed", status: "paused", activityState: "needs_attention" });
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-interrupted",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, interrupted: true, error: "operator stopped child" },
+		}), true);
+		const paused = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as { state?: string; steps?: Array<{ runId?: string; error?: string; interrupted?: boolean }> };
+		assert.equal(paused.state, "paused");
+		assert.equal(paused.steps?.find((step) => step.runId === "child-interrupted")?.interrupted, true);
+		assert.equal(paused.steps?.find((step) => step.runId === "child-interrupted")?.error, "operator stopped child");
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-failed",
+			result: { index: 1, agent: "worker", task: "t", exitCode: 1, error: "sibling boom" },
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; error?: string; summary?: string; results?: Array<{ workflowKey?: string; error?: string; interrupted?: boolean }> };
+		assert.equal(published.workflowResolution, "failed-child");
+		assert.equal(published.error, "sibling boom");
+		assert.equal(published.summary, "sibling boom");
+		assert.equal(published.results?.find((child) => child.workflowKey === "detaches")?.error, "operator stopped child");
+		assert.equal(published.results?.find((child) => child.workflowKey === "detaches")?.interrupted, true);
+		assert.equal(published.results?.find((child) => child.workflowKey === "fails")?.error, "sibling boom");
+	});
+
+	it("preserves an interrupted child error after a later sibling succeeds", () => {
+		const workflowRunId = "workflow-interrupted-first-success-final";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const status = { ...pausedWorkflow("child-interrupted"), runId: workflowRunId, sessionId: "session-1" };
+		status.steps!.push({ agent: "worker", workflowKey: "passes", runId: "child-passes", status: "paused", activityState: "needs_attention" });
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-interrupted",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, interrupted: true, error: "operator stopped child" },
+		}), true);
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-passes",
+			result: { index: 1, agent: "worker", task: "t", exitCode: 0 },
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; error?: string; summary?: string; results?: Array<{ workflowKey?: string; error?: string; interrupted?: boolean }> };
+		assert.equal(published.workflowResolution, "interrupted-child");
+		assert.equal(published.error, "operator stopped child");
+		assert.equal(published.summary, "operator stopped child");
+		assert.equal(published.results?.find((child) => child.workflowKey === "detaches")?.error, "operator stopped child");
+		assert.equal(published.results?.find((child) => child.workflowKey === "detaches")?.interrupted, true);
+	});
+
+	it("classifies a stopped detached child as interrupted evidence", () => {
+		const workflowRunId = "workflow-stopped-handoff";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ ...pausedWorkflow("child-stopped"), runId: workflowRunId, sessionId: "session-1" }), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-stopped",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 1, stopped: true, error: "Subagent stopped by user.", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; error?: string; results?: Array<{ workflowKey?: string; error?: string; interrupted?: boolean; stopped?: boolean }> };
+		assert.equal(published.workflowResolution, "interrupted-child");
+		assert.equal(published.error, "Subagent stopped by user.");
+		assert.deepEqual(published.results, [{ workflowKey: "detaches", agent: "worker", runId: "child-stopped", success: false, output: "", outputState: "absent", interrupted: true, stopped: true, error: "Subagent stopped by user." }]);
+	});
+
+	it("classifies an interrupted workflowKey-matched child as interrupted evidence", () => {
+		const workflowRunId = "workflow-key-interrupted-handoff";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const status = { ...pausedWorkflow("persisted-child"), runId: workflowRunId, sessionId: "session-1" };
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "latest-child-run",
+			workflowKey: "detaches",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, interrupted: true, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; error?: string };
+		assert.equal(published.workflowResolution, "interrupted-child");
+		assert.notEqual(published.workflowResolution, "failed-child");
+		assert.equal(published.error, "Interrupted. Waiting for explicit next action.");
+	});
+
+	it("classifies a stopped sibling as interrupted terminal evidence", () => {
+		const workflowRunId = "workflow-stopped-sibling-handoff";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const status = { ...pausedWorkflow("child-final"), runId: workflowRunId, sessionId: "session-1" };
+		status.steps!.push({ agent: "worker", workflowKey: "stopped", runId: "child-stopped", status: "stopped", stopped: true });
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+		assert.equal(reconcileDetachedWorkflowChildCompletion({ state, workflowRunId, childRunId: "child-final", result: { index: 0, agent: "worker", task: "t", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } } }), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; results?: Array<{ workflowKey?: string; stopped?: boolean }> };
+		assert.equal(published.workflowResolution, "interrupted-child");
+		assert.equal(published.results?.find((child) => child.workflowKey === "stopped")?.stopped, true);
 	});
 
 	it("preserves sibling output path mappings when rebuilding from workflow status", () => {
@@ -309,7 +499,9 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			agent: "workflow",
 			success: false,
 			state: "failed",
-			summary: "unsupported-continuation: detached workflow child settled, but JavaScript workflow continuation was not persisted. Resume the workflow explicitly instead of treating the completed child as top-level workflow completion.",
+			workflowResolution: "settled-awaiting-resume",
+			recovery: [],
+			summary: "Workflow lanes settled after detached child child-1 finished. JavaScript workflow continuation was not persisted. No retained child is resumable.",
 			reconciledFromDetachedChild: "child-1",
 			results: [{ workflowKey: "detaches", agent: "worker", runId: "child-1", success: true, output: "", outputState: "absent" }],
 			sessionId: "session-1",
@@ -430,7 +622,9 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			result: { index: 0, agent: "worker", task: "t", exitCode: 0, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
 		}), true);
 		assert.equal(fs.existsSync(path.join(asyncDir, "events.jsonl")), false);
-		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string };
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; workflowResolution?: string; recovery?: unknown };
 		assert.equal(published.state, "paused");
+		assert.equal(published.workflowResolution, undefined);
+		assert.equal(published.recovery, undefined);
 	});
 });

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -216,6 +216,8 @@ describe("workflow receipts", () => {
 		const asyncDir = path.join(asyncRoot, "workflow-1");
 		fs.mkdirSync(asyncDir, { recursive: true });
 		const receipt = buildWorkflowReceipt({ workflowRunId: "workflow-1", state: "complete", children: [child("advisor")] });
+		receipt.workflowResolution = "settled-awaiting-resume";
+		receipt.recovery = [{ key: "advisor", call: "runs.run", resume: { workflowRunId: "workflow-1", key: "advisor", latest: true }, taskRequired: true }];
 		assert.equal(writeWorkflowReceipt(asyncDir, receipt), workflowReceiptPath(asyncRoot, "workflow-1"));
 		assert.deepEqual(readWorkflowReceipt(asyncRoot, "workflow-1"), receipt);
 		let validations = 0;
@@ -229,6 +231,9 @@ describe("workflow receipts", () => {
 		});
 		assert.equal(runId, "run-advisor");
 		assert.equal(validations, 1);
+		const invalid = { ...receipt, recovery: [{ ...receipt.recovery[0], resume: { workflowRunId: "other", key: "advisor", latest: true } }] };
+		fs.writeFileSync(workflowReceiptPath(asyncRoot, "workflow-1"), JSON.stringify(invalid));
+		assert.throws(() => readWorkflowReceipt(asyncRoot, "workflow-1"), /recovery\[0\] does not identify a resumable entry/);
 	});
 
 	it("explains a missing receipt when workflow status or events remain visible", () => {


### PR DESCRIPTION
Fixes #1537.

Parent: #1530.

This publishes deterministic terminal handoff metadata when detached workflow lanes settle. It keeps the existing workflow state enum, adds bounded resolution and recovery metadata, preserves settled child evidence and output path mappings, and exposes keyed resume actions for resumable children.

Non-goals kept out of this PR:
- no persisted JavaScript continuation;
- no automatic resume;
- no budget, preflight, or no-progress logic;
- no watcher/session-delivery changes.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-detach-reconcile.test.ts test/unit/workflow-receipt.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review passed in `lane-reports/issue-1537-review.md`.
