### PR TITLE
fix: resolve package MCP direct tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Classify workflow budget and timeout stops as partial terminal outcomes while preserving settled child evidence. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Show task intent and context-window use in compact in-progress async status rows.
 - Publish a deterministic terminal handoff with settled child evidence and keyed recovery actions when detached workflow lanes settle. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
+- Resolve direct MCP tool selections from Pi package manifests and Agent Plugin configs. Thanks to [@fmoda3](https://github.com/fmoda3) for #1541.
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.
 - Fail native child launches before spawn when the requested local working directory is missing or not a directory, with the requested and resolved paths in the error.
 - Map report paths requested in workflow child tasks to the actual saved child output when workflow output routing overrides them.

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -804,7 +804,7 @@ export function findNearestProjectRoot(cwd: string): string | null {
 	return findProjectRootCandidates(cwd)[0] ?? null;
 }
 
-function findConfiguredProjectRoot(cwd: string): string | null {
+export function findConfiguredProjectRoot(cwd: string): string | null {
 	const candidates = findProjectRootCandidates(cwd);
 	const nearestRoot = candidates[0];
 	if (!nearestRoot) return null;

--- a/src/runs/shared/mcp-config-sources.ts
+++ b/src/runs/shared/mcp-config-sources.ts
@@ -1,0 +1,379 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { findConfiguredProjectRoot } from "../../agents/agents.ts";
+import { getAgentDir, getConfigDirName, getProjectConfigDir } from "../../shared/utils.ts";
+
+const PACKAGE_CONFIG_ROOT = "npm";
+const PACKAGE_GIT_ROOT = "git";
+const PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const PLUGIN_MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
+const PLUGIN_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const PLUGIN_STDIO_FIELDS = new Set(["type", "command", "args", "env", "cwd"]);
+const PLUGIN_HTTP_FIELDS = new Set(["type", "url", "headers"]);
+
+export interface McpServerDefinition {
+	command?: string;
+	args?: string[];
+	socket?: string;
+	env?: Record<string, string>;
+	cwd?: string;
+	url?: string;
+	headers?: Record<string, string>;
+	requestHeadersCommand?: {
+		command: string;
+		args?: string[];
+		env?: Record<string, string>;
+		timeoutMs?: number;
+	};
+	auth?: "oauth" | "bearer" | false;
+	bearerToken?: string;
+	bearerTokenEnv?: string;
+	exposeResources?: boolean;
+	includeTools?: string[];
+	excludeTools?: string[];
+	protocolVersion?: string;
+	directTools?: boolean | string[];
+	httpTransport?: string;
+	pluginDataDir?: string;
+	literalEnv?: boolean;
+}
+
+export function loadPackageMcpServers(cwd: string): Record<string, McpServerDefinition> {
+	const servers: Record<string, McpServerDefinition> = {};
+	const seen = new Set<string>();
+
+	for (const packageRoot of getConfiguredPackageRoots(cwd)) {
+		const manifest = readJson(path.join(packageRoot, "package.json"));
+		if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) continue;
+		const packageName = (manifest as { name?: unknown }).name;
+		if (typeof packageName !== "string" || !packageName) continue;
+		const mcpValue = (manifest as { pi?: { mcp?: unknown } }).pi?.mcp;
+		const configPaths = typeof mcpValue === "string"
+			? [mcpValue]
+			: Array.isArray(mcpValue) && mcpValue.every((value): value is string => typeof value === "string")
+				? mcpValue
+				: [];
+		const packagePrefix = formatName(packageName, "package");
+
+		for (const configPath of configPaths) {
+			const resolvedPath = resolvePackageConfigPath(packageRoot, configPath);
+			if (!resolvedPath) continue;
+			const config = readJson(resolvedPath);
+			if (!config || typeof config !== "object" || Array.isArray(config)) continue;
+			const rawServers = (config as { mcpServers?: unknown }).mcpServers;
+			if (!rawServers || typeof rawServers !== "object" || Array.isArray(rawServers)) continue;
+			for (const [serverName, definition] of Object.entries(rawServers)) {
+				if (!definition || typeof definition !== "object" || Array.isArray(definition)) continue;
+				const normalizedName = `${packagePrefix}__${formatName(serverName, "server")}`;
+				if (seen.has(normalizedName)) continue;
+				seen.add(normalizedName);
+				servers[normalizedName] = definition as McpServerDefinition;
+			}
+		}
+	}
+
+	return servers;
+}
+
+export function loadAgentPluginMcpServers(paths: unknown, cwd: string): Record<string, McpServerDefinition> {
+	const servers: Record<string, McpServerDefinition> = {};
+	if (!Array.isArray(paths)) return servers;
+
+	for (const configuredPath of paths) {
+		if (typeof configuredPath !== "string") continue;
+		const pluginRoot = resolvePluginPath(configuredPath, cwd);
+		const manifest = readJson(path.join(pluginRoot, "plugin.json"));
+		if (!isValidPluginManifest(manifest)) continue;
+		const config = readJson(path.join(pluginRoot, "mcp.json"));
+		if (!isValidPluginConfig(config)) continue;
+		const rawServers = (config as { mcpServers: Record<string, unknown> }).mcpServers;
+
+		for (const [serverName, rawDefinition] of Object.entries(rawServers)) {
+			const definition = translatePluginServer(manifest.name, pluginRoot, serverName, rawDefinition);
+			if (!definition) continue;
+			const normalizedName = `${formatName(manifest.name, "plugin")}__${formatName(serverName, "server")}`;
+			if (Object.hasOwn(servers, normalizedName)) continue;
+			servers[normalizedName] = definition;
+		}
+	}
+
+	return servers;
+}
+
+function getConfiguredPackageRoots(cwd: string): string[] {
+	const roots: string[] = [];
+	const projectConfigDir = findProjectConfigDir(cwd);
+	const sources = [
+		{ path: path.join(projectConfigDir, "settings.json"), baseDir: projectConfigDir },
+		{ path: path.join(getAgentDir(), "settings.json"), baseDir: getAgentDir() },
+	];
+	for (const source of sources) {
+		const settings = readJson(source.path);
+		if (!settings || typeof settings !== "object" || Array.isArray(settings)) continue;
+		const packages = (settings as { packages?: unknown }).packages;
+		if (!Array.isArray(packages)) continue;
+		for (const entry of packages) {
+			const packageSource = typeof entry === "string"
+				? entry
+				: entry && typeof entry === "object" && !Array.isArray(entry) && typeof (entry as { source?: unknown }).source === "string"
+					? (entry as { source: string }).source
+					: undefined;
+			if (!packageSource) continue;
+			const root = resolvePackageRoot(packageSource, source.baseDir);
+			if (root && !roots.includes(root)) roots.push(root);
+		}
+	}
+	return roots;
+}
+
+function findProjectConfigDir(cwd: string): string {
+	const projectRoot = findConfiguredProjectRoot(path.resolve(cwd));
+	return projectRoot ? getProjectConfigDir(projectRoot) : path.join(path.resolve(cwd), getConfigDirName());
+}
+
+function resolvePackageRoot(source: string, baseDir: string): string | undefined {
+	const trimmed = source.trim();
+	if (!trimmed) return undefined;
+	if (trimmed.startsWith("npm:")) {
+		const packageName = parseNpmPackageName(trimmed);
+		return packageName ? resolveContainedPath(path.join(baseDir, PACKAGE_CONFIG_ROOT, "node_modules"), packageName) ?? undefined : undefined;
+	}
+
+	if (trimmed.startsWith("git:") || /^(?:https?:\/\/|ssh:\/\/|git@[^:]+:)/.test(trimmed)) {
+		const parsed = parseGitPackagePath(trimmed.startsWith("git:") ? trimmed : `git:${trimmed}`);
+		return parsed ? path.join(baseDir, PACKAGE_GIT_ROOT, parsed.host, parsed.repoPath) : undefined;
+	}
+
+	const localPath = trimmed.startsWith("file:") ? trimmed.slice(5) : trimmed;
+	if (localPath === "~") return os.homedir();
+	if (localPath.startsWith("~/")) return path.join(os.homedir(), localPath.slice(2));
+	return path.isAbsolute(localPath) ? path.resolve(localPath) : path.resolve(baseDir, localPath);
+}
+
+function parseNpmPackageName(source: string): string | undefined {
+	const spec = source.slice(4).trim();
+	if (!spec) return undefined;
+	const match = spec.match(/^(@?[^@]+(?:\/[^@]+)?)(?:@(.+))?$/);
+	const packageName = match?.[1] ?? spec;
+	return resolveContainedPath("/", packageName) ? packageName : undefined;
+}
+
+function parseGitPackagePath(source: string): { host: string; repoPath: string } | undefined {
+	const spec = source.slice(4).trim();
+	if (!spec) return undefined;
+
+	let host = "";
+	let repoPath = "";
+	const scpLike = spec.match(/^git@([^:]+):(.+)$/);
+	if (scpLike) {
+		host = scpLike[1] ?? "";
+		repoPath = scpLike[2] ?? "";
+	} else if (/^[a-z][a-z0-9+.-]*:\/\//i.test(spec)) {
+		try {
+			const url = new URL(spec);
+			host = url.hostname;
+			repoPath = url.pathname.replace(/^\/+/, "");
+		} catch {
+			return undefined;
+		}
+	} else {
+		const slashIndex = spec.indexOf("/");
+		if (slashIndex < 0) return undefined;
+		host = spec.slice(0, slashIndex);
+		repoPath = spec.slice(slashIndex + 1);
+	}
+
+	const normalizedPath = stripGitRef(repoPath).replace(/\.git$/, "").replace(/^\/+/, "");
+	if (!host || !isSafePackagePath(host) || !isSafePackagePath(normalizedPath) || normalizedPath.split(/[\\/]/).length < 2) {
+		return undefined;
+	}
+	return { host, repoPath: normalizedPath };
+}
+
+function stripGitRef(repoPath: string): string {
+	const atIndex = repoPath.indexOf("@");
+	const hashIndex = repoPath.indexOf("#");
+	const refIndex = [atIndex, hashIndex].filter((index) => index >= 0).sort((a, b) => a - b)[0];
+	return refIndex === undefined ? repoPath : repoPath.slice(0, refIndex);
+}
+
+function isSafePackagePath(value: string): boolean {
+	return value.length > 0
+		&& !path.isAbsolute(value)
+		&& value.split(/[\\/]/).every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+
+function resolvePackageConfigPath(packageRoot: string, configuredPath: string): string | undefined {
+	const lexicalPath = resolveContainedPath(packageRoot, configuredPath);
+	if (!lexicalPath || !fs.existsSync(lexicalPath)) return undefined;
+	try {
+		if (!fs.statSync(lexicalPath).isFile()) return undefined;
+		const packageRealPath = fs.realpathSync(packageRoot);
+		const configRealPath = fs.realpathSync(lexicalPath);
+		return resolveContainedPath(packageRealPath, configRealPath) ?? undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function resolveContainedPath(root: string, value: string): string | undefined {
+	const resolved = path.resolve(root, value);
+	const relative = path.relative(root, resolved);
+	return relative === "" || (!relative.startsWith("..") && !relative.startsWith(path.sep) && !path.isAbsolute(relative))
+		? resolved
+		: undefined;
+}
+
+function resolvePluginPath(configuredPath: string, cwd: string): string {
+	if (configuredPath === "~") return path.resolve(process.env.HOME ?? "", ".");
+	if (configuredPath.startsWith("~/")) return path.resolve(process.env.HOME ?? "", configuredPath.slice(2));
+	return path.isAbsolute(configuredPath) ? path.resolve(configuredPath) : path.resolve(cwd, configuredPath);
+}
+
+function isValidPluginManifest(value: unknown): value is { name: string } {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const manifest = value as { $schema?: unknown; name?: unknown };
+	return manifest.$schema === PLUGIN_SCHEMA
+		&& typeof manifest.name === "string"
+		&& manifest.name.length >= 1
+		&& manifest.name.length <= 64
+		&& PLUGIN_NAME_PATTERN.test(manifest.name);
+}
+
+function isValidPluginConfig(value: unknown): value is { mcpServers: Record<string, unknown> } {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const config = value as Record<string, unknown>;
+	return config.$schema === PLUGIN_MCP_SCHEMA
+		&& Object.keys(config).every((key) => key === "$schema" || key === "mcpServers")
+		&& !!config.mcpServers
+		&& typeof config.mcpServers === "object"
+		&& !Array.isArray(config.mcpServers);
+}
+
+function translatePluginServer(
+	pluginName: string,
+	pluginRoot: string,
+	serverName: string,
+	value: unknown,
+): McpServerDefinition | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const raw = value as Record<string, unknown>;
+	if (raw.type === "stdio") return translatePluginStdioServer(pluginName, pluginRoot, serverName, raw);
+	if (raw.type === "streamable-http" || raw.type === "sse") return translatePluginHttpServer(raw);
+	return undefined;
+}
+
+function translatePluginStdioServer(
+	pluginName: string,
+	pluginRoot: string,
+	serverName: string,
+	raw: Record<string, unknown>,
+): McpServerDefinition | undefined {
+	if ([...Object.keys(raw)].some((key) => !PLUGIN_STDIO_FIELDS.has(key))) return undefined;
+	if (typeof raw.command !== "string" || !raw.command) return undefined;
+	if (!isBareCommand(raw.command) && !raw.command.startsWith("./")) return undefined;
+	const args = stringArray(raw.args);
+	if (raw.args !== undefined && !args) return undefined;
+	const env = stringRecord(raw.env);
+	if (raw.env !== undefined && !env) return undefined;
+	if (env && (Object.hasOwn(env, "PLUGIN_ROOT") || Object.hasOwn(env, "PLUGIN_DATA"))) return undefined;
+
+	const pluginDataDir = path.join(getAgentDir(), "agent-plugin-data", pluginName);
+	const command = raw.command.startsWith("./") ? resolveContainedPath(pluginRoot, raw.command) : raw.command;
+	if (!command) return undefined;
+	const cwd = resolvePluginCwd(raw.cwd, pluginRoot, pluginDataDir);
+	if (!cwd) return undefined;
+
+	return {
+		command,
+		args: (args ?? []).map((value) => expandPluginPlaceholders(value, pluginRoot, pluginDataDir)),
+		env: {
+			...Object.fromEntries(Object.entries(env ?? {}).map(([key, value]) => [key, expandPluginPlaceholders(value, pluginRoot, pluginDataDir)])),
+			PLUGIN_ROOT: pluginRoot,
+			PLUGIN_DATA: pluginDataDir,
+		},
+		cwd,
+		pluginDataDir,
+		literalEnv: true,
+	};
+}
+
+function translatePluginHttpServer(raw: Record<string, unknown>): McpServerDefinition | undefined {
+	if ([...Object.keys(raw)].some((key) => !PLUGIN_HTTP_FIELDS.has(key))) return undefined;
+	if (typeof raw.url !== "string" || !isValidPluginUrl(raw.url)) return undefined;
+	const headers = stringRecord(raw.headers);
+	if (raw.headers !== undefined && !headers) return undefined;
+	if (headers) {
+		const normalized = new Set<string>();
+		for (const key of Object.keys(headers)) {
+			const lower = key.toLowerCase();
+			if (normalized.has(lower)) return undefined;
+			normalized.add(lower);
+		}
+		try {
+			new Headers(headers);
+		} catch {
+			return undefined;
+		}
+	}
+	return { url: raw.url, ...(headers ? { headers } : {}), httpTransport: raw.type as string };
+}
+
+function resolvePluginCwd(value: unknown, pluginRoot: string, pluginDataDir: string): string | undefined {
+	if (value === undefined) return pluginRoot;
+	if (typeof value !== "string") return undefined;
+	if (value.startsWith("./")) return resolveContainedPath(pluginRoot, value);
+	if (value === "${PLUGIN_ROOT}" || value.startsWith("${PLUGIN_ROOT}/")) return resolveContainedPath(pluginRoot, value.replace("${PLUGIN_ROOT}", "."));
+	if (value === "${PLUGIN_DATA}" || value.startsWith("${PLUGIN_DATA}/")) return resolveContainedPath(pluginDataDir, value.replace("${PLUGIN_DATA}", "."));
+	return undefined;
+}
+
+function expandPluginPlaceholders(value: string, pluginRoot: string, pluginDataDir: string): string {
+	return value.replaceAll("${PLUGIN_ROOT}", pluginRoot).replaceAll("${PLUGIN_DATA}", pluginDataDir);
+}
+
+function isBareCommand(command: string): boolean {
+	return !command.includes("/")
+		&& !command.includes("\\")
+		&& !command.includes("${PLUGIN_ROOT}")
+		&& !command.includes("${PLUGIN_DATA}");
+}
+
+function isValidPluginUrl(value: string): boolean {
+	if (value.includes("${") || value.includes("$env:") || value.includes("{env:")) return false;
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return false;
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+	if (url.username || url.password || url.hash) return false;
+	if (url.protocol === "https:") return true;
+	const host = url.hostname.toLowerCase();
+	return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]" || /^127(?:\.\d{1,3}){3}$/.test(host);
+}
+
+function stringArray(value: unknown): string[] | undefined {
+	return Array.isArray(value) && value.every((entry) => typeof entry === "string") ? value : undefined;
+}
+
+function stringRecord(value: unknown): Record<string, string> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const entries = Object.entries(value);
+	if (entries.some(([, entry]) => typeof entry !== "string")) return undefined;
+	return Object.fromEntries(entries) as Record<string, string>;
+}
+
+function formatName(value: string, fallback: string): string {
+	return value.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "") || fallback;
+}
+
+function readJson(filePath: string): unknown | undefined {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	} catch {
+		return undefined;
+	}
+}

--- a/src/runs/shared/mcp-direct-tool-allowlist.ts
+++ b/src/runs/shared/mcp-direct-tool-allowlist.ts
@@ -2,7 +2,9 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { findConfiguredProjectRoot } from "../../agents/agents.ts";
 import { getAgentDir, getProjectConfigDir } from "../../shared/utils.ts";
+import { loadAgentPluginMcpServers, loadPackageMcpServers, type McpServerDefinition } from "./mcp-config-sources.ts";
 
 const CACHE_VERSION = 1;
 const CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -24,29 +26,7 @@ const IMPORT_PATHS = {
 type ToolPrefix = "server" | "none" | "short";
 type ImportKind = keyof typeof IMPORT_PATHS;
 
-interface ServerEntry {
-	command?: string;
-	args?: string[];
-	socket?: string;
-	env?: Record<string, string>;
-	cwd?: string;
-	url?: string;
-	headers?: Record<string, string>;
-	requestHeadersCommand?: {
-		command: string;
-		args?: string[];
-		env?: Record<string, string>;
-		timeoutMs?: number;
-	};
-	auth?: "oauth" | "bearer" | false;
-	bearerToken?: string;
-	bearerTokenEnv?: string;
-	exposeResources?: boolean;
-	includeTools?: string[];
-	excludeTools?: string[];
-	protocolVersion?: string;
-	directTools?: boolean | string[];
-}
+type ServerEntry = McpServerDefinition;
 
 interface McpConfig {
 	mcpServers: Record<string, ServerEntry>;
@@ -54,6 +34,7 @@ interface McpConfig {
 	settings?: {
 		toolPrefix?: ToolPrefix;
 		directTools?: boolean;
+		agentPluginPaths?: unknown;
 	};
 }
 
@@ -111,19 +92,30 @@ function loadMetadataCache(): MetadataCache | null {
 }
 
 function loadMcpConfig(cwd: string): McpConfig {
+	const resolvedCwd = path.resolve(cwd);
+	const projectRoot = findConfiguredProjectRoot(resolvedCwd) ?? resolvedCwd;
 	let config: McpConfig = { mcpServers: {} };
-	for (const sourcePath of getConfigPaths(cwd)) {
+	for (const sourcePath of getConfigPaths(projectRoot)) {
 		const loaded = readConfig(sourcePath);
 		if (!loaded) continue;
-		config = mergeConfigs(config, expandImports(loaded, cwd));
+		config = mergeConfigs(config, expandImports(loaded, projectRoot));
 	}
-	return config;
+
+	const packageServers = loadPackageMcpServers(projectRoot);
+	const pluginServers = loadAgentPluginMcpServers(config.settings?.agentPluginPaths, projectRoot);
+	const packageOnlyServers = Object.fromEntries(
+		Object.entries(packageServers).filter(([name]) => !Object.hasOwn(pluginServers, name)),
+	);
+	return mergeConfigs(
+		{ mcpServers: packageOnlyServers },
+		mergeConfigs({ mcpServers: pluginServers }, config),
+	);
 }
 
-function getConfigPaths(cwd: string): string[] {
+function getConfigPaths(projectRoot: string): string[] {
 	const piGlobalPath = path.join(getAgentDir(), "mcp.json");
-	const projectPath = path.resolve(cwd, ".mcp.json");
-	const projectPiPath = path.resolve(getProjectConfigDir(cwd), "mcp.json");
+	const projectPath = path.resolve(projectRoot, ".mcp.json");
+	const projectPiPath = path.resolve(getProjectConfigDir(projectRoot), "mcp.json");
 	const sources: string[] = [];
 	if (GENERIC_GLOBAL_CONFIG_PATH !== piGlobalPath) sources.push(GENERIC_GLOBAL_CONFIG_PATH);
 	sources.push(piGlobalPath);

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -96,9 +96,10 @@ export function getProjectConfigDir(projectRoot: string): string {
 
 export function getAgentDir(): string {
 	const configured = process.env.PI_CODING_AGENT_DIR;
-	if (configured === "~") return os.homedir();
-	if (configured?.startsWith("~/")) return path.join(os.homedir(), configured.slice(2));
-	return configured || path.join(os.homedir(), getConfigDirName(), "agent");
+	const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+	if (configured === "~") return home;
+	if (configured?.startsWith("~/") || configured?.startsWith("~\\")) return path.join(home, configured.slice(2));
+	return configured || path.join(home, getConfigDirName(), "agent");
 }
 
 const statusCache = new Map<string, { mtime: number; ctime: number; size: number; ino: number; status: AsyncStatus }>();

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1298,6 +1298,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		const fixture = createMcpFixture();
 		process.env.PI_CODING_AGENT_DIR = "~/.pi/agent";
 		process.chdir(fixture.root);
+		fs.mkdirSync(path.join(fixture.projectDir, ".pi"));
 		writeMcpFixture(fixture, {
 			serverName: "project-mcp",
 			configPath: path.join(fixture.projectDir, ".mcp.json"),
@@ -1316,6 +1317,199 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		});
 
 		assert.equal(args[args.indexOf("--tools") + 1], "read,project_mcp_inspect");
+	});
+
+	it("resolves direct MCP tools from Pi package manifests", () => {
+		const fixture = createMcpFixture();
+		const packageRoot = path.join(fixture.agentDir, "npm", "node_modules", "@acme", "tools");
+		const definition = { command: "node", args: ["package-mcp"] };
+		writeJson(path.join(fixture.agentDir, "settings.json"), { packages: ["npm:@acme/tools@1.0.0"] });
+		writeJson(path.join(packageRoot, "package.json"), { name: "@acme/tools", pi: { mcp: "./mcp.json" } });
+		writeJson(path.join(packageRoot, "mcp.json"), { mcpServers: { wiki: definition } });
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"acme_tools__wiki": {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: "read_wiki_structure" }],
+				},
+			},
+		});
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["acme_tools__wiki/read_wiki_structure"],
+			cwd: fixture.projectDir,
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,acme_tools__wiki_read_wiki_structure");
+	});
+
+	it("resolves direct MCP tools from the git-root package when child cwd has an incidental .pi directory", () => {
+		const fixture = createMcpFixture();
+		const nestedCwd = path.join(fixture.projectDir, "packages", "app");
+		const packageRoot = path.join(fixture.projectDir, ".pi", "npm", "node_modules", "@acme", "tools");
+		const definition = { command: "node", args: ["package-mcp"] };
+		fs.mkdirSync(nestedCwd, { recursive: true });
+		fs.mkdirSync(path.join(nestedCwd, ".pi"));
+		fs.mkdirSync(path.join(fixture.projectDir, ".git"));
+		writeJson(path.join(fixture.projectDir, ".pi", "settings.json"), {
+			packages: ["npm:@acme/tools@1.0.0"],
+			subagents: { projectRootResolution: "git-root" },
+		});
+		writeJson(path.join(packageRoot, "package.json"), { name: "@acme/tools", pi: { mcp: "./mcp.json" } });
+		writeJson(path.join(packageRoot, "mcp.json"), { mcpServers: { wiki: definition } });
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"acme_tools__wiki": {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: "read_wiki_structure" }],
+				},
+			},
+		});
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["acme_tools__wiki/read_wiki_structure"],
+			cwd: nestedCwd,
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,acme_tools__wiki_read_wiki_structure");
+	});
+
+	it("resolves direct MCP tools from pinned Git package manifests", () => {
+		const fixture = createMcpFixture();
+		const packageRoot = path.join(fixture.agentDir, "git", "github.com", "acme", "tools");
+		const definition = { command: "node", args: ["git-package-mcp"] };
+		writeJson(path.join(fixture.agentDir, "settings.json"), { packages: ["git:https://github.com/acme/tools.git#main"] });
+		writeJson(path.join(packageRoot, "package.json"), { name: "@acme/tools", pi: { mcp: "./mcp.json" } });
+		writeJson(path.join(packageRoot, "mcp.json"), { mcpServers: { wiki: definition } });
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"acme_tools__wiki": {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: "read_wiki_structure" }],
+				},
+			},
+		});
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["acme_tools__wiki/read_wiki_structure"],
+			cwd: fixture.projectDir,
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,acme_tools__wiki_read_wiki_structure");
+	});
+
+	it("resolves direct MCP tools from Agent Plugin MCP config", () => {
+		const fixture = createMcpFixture();
+		const pluginRoot = path.join(fixture.projectDir, "plugins", "acme-tools");
+		const definition = { url: "https://example.test/mcp", headers: { "X-Tenant": "public" } };
+		fs.mkdirSync(path.join(fixture.projectDir, ".pi"));
+		writeJson(path.join(pluginRoot, "plugin.json"), {
+			$schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+			name: "acme.tools",
+		});
+		writeJson(path.join(pluginRoot, "mcp.json"), {
+			$schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+			mcpServers: { wiki: { type: "streamable-http", ...definition } },
+		});
+		writeJson(path.join(fixture.projectDir, ".mcp.json"), {
+			settings: { agentPluginPaths: ["./plugins/acme-tools"] },
+			mcpServers: {},
+		});
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"acme_tools__wiki": {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: "read_wiki_structure" }],
+				},
+			},
+		});
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["acme_tools__wiki/read_wiki_structure"],
+			cwd: fixture.projectDir,
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,acme_tools__wiki_read_wiki_structure");
+	});
+
+	it("resolves root Agent Plugin MCP tools when child cwd is nested", () => {
+		const fixture = createMcpFixture();
+		const nestedCwd = path.join(fixture.projectDir, "packages", "app");
+		const pluginRoot = path.join(fixture.projectDir, "plugins", "acme-tools");
+		const definition = { url: "https://example.test/mcp", headers: { "X-Tenant": "public" } };
+		fs.mkdirSync(nestedCwd, { recursive: true });
+		fs.mkdirSync(path.join(nestedCwd, ".pi"));
+		fs.mkdirSync(path.join(fixture.projectDir, ".git"));
+		writeJson(path.join(fixture.projectDir, ".pi", "settings.json"), {
+			subagents: { projectRootResolution: "git-root" },
+		});
+		writeJson(path.join(pluginRoot, "plugin.json"), {
+			$schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+			name: "acme.tools",
+		});
+		writeJson(path.join(pluginRoot, "mcp.json"), {
+			$schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+			mcpServers: { wiki: { type: "streamable-http", ...definition } },
+		});
+		writeJson(path.join(fixture.projectDir, ".mcp.json"), {
+			settings: { agentPluginPaths: ["./plugins/acme-tools"] },
+			mcpServers: {},
+		});
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"acme_tools__wiki": {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: "read_wiki_structure" }],
+				},
+			},
+		});
+
+		const { args } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["acme_tools__wiki/read_wiki_structure"],
+			cwd: nestedCwd,
+		});
+
+		assert.equal(args[args.indexOf("--tools") + 1], "read,acme_tools__wiki_read_wiki_structure");
 	});
 
 	it("keeps tool extension paths when explicit extensions are allowlisted", () => {


### PR DESCRIPTION
## Summary

Closes #1541.

Resolve direct MCP tool selections from Pi package manifests and Agent Plugin configs.

Runtime-registered MCP servers remain a separate cross-project follow-up in #1546 because those definitions are in memory and arrive after the child strict allowlist gate.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/pi-args.test.ts`
- `npm run typecheck`
- `git diff --check`

Thanks to [@fmoda3](https://github.com/fmoda3) for the reproduction and source analysis in #1541.
