### PR TITLE
fix: remove false stop attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Classify workflow budget and timeout stops as partial terminal outcomes while preserving settled child evidence. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Show task intent and context-window use in compact in-progress async status rows.
+- Avoid attributing assistant-issued workflow stops to the user.
 - Publish a deterministic terminal handoff with settled child evidence and keyed recovery actions when detached workflow lanes settle. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Resolve direct MCP tool selections from Pi package manifests and Agent Plugin configs. Thanks to [@fmoda3](https://github.com/fmoda3) for #1541.
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -557,7 +557,7 @@ function stopAsyncRun(
 			childId: stoppedChild.id,
 			status: "stopping",
 			ts,
-			reason: "user",
+			reason: "rpc",
 			source: "rpc",
 			asyncDir,
 			stepIndex: stoppedChild.index,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4818,7 +4818,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									version: 1,
 									childId: entry.key,
 									status: "stopped",
-									reason: "user",
+									reason: "subagent-action",
 									source: "async",
 									stepIndex: status.steps?.indexOf(projectedStep),
 									agent: projectedStep.agent,
@@ -5646,7 +5646,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						if (!isStoppableAsyncStatusStep(resolution.child.step)) return { content: [{ type: "text", text: `Child '${paramsWithResolvedCwd.childId}' in async run '${targetRunId}' is ${resolution.child.step.status}; stop only supports pending or running children.` }], isError: true, details: { mode: "management", results: [] } };
 						const stopChild = deps.state.workflowChildStops?.get(targetRunId!);
 						if (!stopChild) return { content: [{ type: "text", text: `Workflow ${targetRunId} child stop is unavailable in this extension runtime.` }], isError: true, details: { mode: "management", results: [] } };
-						if (!stopChild(resolution.child.id)) return { content: [{ type: "text", text: `Child '${paramsWithResolvedCwd.childId}' in workflow ${workflowRunId} is not available to stop.` }], isError: true, details: { mode: "management", results: [] } };
+						if (!stopChild(resolution.child.id, `Workflow child '${resolution.child.id}' stopped.`)) return { content: [{ type: "text", text: `Child '${paramsWithResolvedCwd.childId}' in workflow ${workflowRunId} is not available to stop.` }], isError: true, details: { mode: "management", results: [] } };
 						try {
 							fs.appendFileSync(path.join(asyncJob.asyncDir, "events.jsonl"), `${JSON.stringify({
 								type: "subagent.child-status",
@@ -5655,7 +5655,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								childId: resolution.child.id,
 								status: "stopping",
 								ts: Date.now(),
-								reason: "user",
+								reason: "subagent-action",
 								source: "async",
 								stepIndex: resolution.child.index,
 								agent: resolution.child.step.agent,
@@ -5669,7 +5669,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						}
 						return { content: [{ type: "text", text: `Stop requested for child ${resolution.child.id} in async workflow ${workflowRunId}.` }], details: { mode: "management", results: [] } };
 					}
-					workflowController.abort(new Error("Workflow stopped by user."));
+					workflowController.abort(new Error("Workflow stopped."));
 					return { content: [{ type: "text", text: `Stop requested for async workflow ${targetRunId}.` }], details: { mode: "management", results: [] } };
 				}
 				let resolved: ResolvedSubagentRunId | undefined;

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1655,6 +1655,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		);
 		assert.equal(result.isError, undefined);
 		assert.equal(controller.signal.aborted, true);
+		assert.equal(controller.signal.reason instanceof Error ? controller.signal.reason.message : String(controller.signal.reason), "Workflow stopped.");
 		assert.match(result.content[0]?.text ?? "", /Stop requested for async workflow workflow-stop/);
 	});
 
@@ -1700,10 +1701,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
 		}
 		assert.equal(status.state, "stopped");
-		assert.equal(status.error, "Workflow stopped by user.");
+		assert.equal(status.error, "Workflow stopped.");
 		assert.equal(status.steps?.[0]?.status, "stopped");
 		assert.equal(status.steps?.[0]?.stopped, true);
-		assert.equal(status.steps?.[0]?.error, "Workflow stopped by user.");
+		assert.equal(status.steps?.[0]?.error, "Workflow stopped.");
 		assert.equal(status.workflow?.trace.some((entry) => entry.key === "review" && entry.state === "stopped"), true);
 		assert.equal(status.workflow?.trace.some((entry) => entry.key === "review" && entry.state === "failed"), false);
 
@@ -1725,7 +1726,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as AsyncStatus;
 		assert.equal(status.steps?.[0]?.status, "stopped");
 		assert.equal(status.steps?.[0]?.stopped, true);
-		assert.equal(status.steps?.[0]?.error, "Workflow stopped by user.");
+		assert.equal(status.steps?.[0]?.error, "Workflow stopped.");
 
 		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		fs.rmSync(path.join(DIRS.results, `${workflowRunId}.json`), { force: true });
@@ -1783,6 +1784,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(status.stopped, undefined);
 		assert.equal(status.steps?.find((step) => step.workflowKey === "slow")?.status, "stopped");
 		assert.equal(status.steps?.find((step) => step.workflowKey === "slow")?.stopped, true);
+		assert.equal(status.steps?.find((step) => step.workflowKey === "slow")?.error, "Workflow child 'slow' stopped.");
 		assert.equal(status.steps?.find((step) => step.workflowKey === "fast")?.status, "completed");
 		assert.equal(status.steps?.find((step) => step.workflowKey === "fast")?.stopped, undefined);
 		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { state?: string; stopped?: boolean; results?: Array<{ workflowKey?: string; success?: boolean; stopped?: boolean }> };
@@ -1793,9 +1795,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const childStatusEvents = fs.readFileSync(path.join(started.details.asyncDir, "events.jsonl"), "utf-8")
 			.trim()
 			.split("\n")
-			.map((line) => JSON.parse(line) as { type?: string; childId?: string; status?: string });
+			.map((line) => JSON.parse(line) as { type?: string; childId?: string; status?: string; reason?: string });
 		assert.ok(childStatusEvents.some((event) => event.type === "subagent.child-status" && event.childId === "slow" && event.status === "stopping"));
-		assert.ok(childStatusEvents.some((event) => event.type === "subagent.child-status" && event.childId === "slow" && event.status === "stopped"));
+		const stoppedChildStatus = childStatusEvents.findLast((event) => event.type === "subagent.child-status" && event.childId === "slow" && event.status === "stopped");
+		assert.equal(stoppedChildStatus?.reason, "subagent-action");
 		fs.rmSync(started.details.asyncDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		fs.rmSync(resultPath, { force: true });
 	});

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -779,7 +779,7 @@ describe("subagent extension RPC bridge", () => {
 				childId: "review",
 				status: "stopping",
 				ts: 150,
-				reason: "user",
+				reason: "rpc",
 				source: "rpc",
 				asyncDir,
 				stepIndex: 1,
@@ -835,6 +835,7 @@ describe("subagent extension RPC bridge", () => {
 			assert.equal(childStatus?.runId, "workflow-stop-child");
 			assert.equal(childStatus?.childId, "slow");
 			assert.equal(childStatus?.status, "stopping");
+			assert.equal(childStatus?.reason, "rpc");
 			assert.equal(childStatus?.source, "rpc");
 			assert.equal(childStatus?.workflowKey, "slow");
 


### PR DESCRIPTION
Fixes #1548.

This removes false human-user attribution from workflow stops that are initiated by the subagent tool or RPC. Stop behavior and result settlement are unchanged.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/rpc.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'stops a live async workflow through its controller|persists parent-stopped workflow children as stopped instead of failed|stops one live async workflow child without stopping the parent or sibling' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
