### PR TITLE
Sync Herdr status when restoring active jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Avoid attributing assistant-issued workflow stops to the user.
 - Publish a deterministic terminal handoff with settled child evidence and keyed recovery actions when detached workflow lanes settle. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Resolve direct MCP tool selections from Pi package manifests and Agent Plugin configs. Thanks to [@fmoda3](https://github.com/fmoda3) for #1541.
+- Sync Herdr status after restoring active async jobs, so recovered work appears without waiting for another lifecycle event. Thanks to [@vicocamacho](https://github.com/vicocamacho) for #1553.
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.
 - Fail native child launches before spawn when the requested local working directory is missing or not a directory, with the requested and resolved paths in the error.
 - Map report paths requested in workflow child tasks to the actual saved child output when workflow output routing overrides them.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -812,7 +812,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		if (event.toolName !== "subagent") return;
 		if (!ctx.hasUI) return;
 		state.lastUiContext = ctx;
+		const activeJobCount = state.asyncJobs.size;
 		restoreActiveJobs(ctx);
+		if (state.asyncJobs.size > activeJobCount) herdrStatusBridge.syncRuns();
 		fleetStatus?.setContext(ctx);
 		fleetStatus?.refresh();
 		if (state.asyncJobs.size > 0) {

--- a/src/integrations/herdr-status.ts
+++ b/src/integrations/herdr-status.ts
@@ -59,6 +59,7 @@ export interface HerdrStatusBridge {
 	 * state. Also re-syncs runs that survived a reload/resume.
 	 */
 	sessionStarted(input: { hasUI: boolean; runs: Iterable<HerdrStatusRun> }): void;
+	syncRuns(): void;
 	agentStarted(): void;
 	flush(): Promise<void>;
 	dispose(): void;
@@ -376,6 +377,10 @@ export function registerHerdrStatusBridge(options: HerdrStatusBridgeOptions): He
 			if (!enabled || disposed || hasUI !== true) return;
 			rootSession = true;
 			replaceRuns(restoredRuns);
+		},
+		syncRuns() {
+			if (!enabled || !rootSession || disposed) return;
+			refresh();
 		},
 		async flush() {
 			while (draining || pendingReport) await drainPromise;

--- a/test/unit/herdr-status-bridge.test.ts
+++ b/test/unit/herdr-status-bridge.test.ts
@@ -109,6 +109,27 @@ describe("Herdr status bridge", () => {
 		}]);
 	});
 
+	it("synchronizes runs discovered outside lifecycle events", async () => {
+		const events = new FakeEvents();
+		const commands: string[][] = [];
+		const bridge = registerHerdrStatusBridge({
+			events,
+			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			getRuns: () => [{ id: "restored-run", agent: "worker" }],
+			runHerdr: (args) => commands.push([...args]),
+			refreshMs: 0,
+		});
+		bridge.sessionStarted({ hasUI: true, runs: [] });
+
+		bridge.syncRuns();
+		await bridge.flush();
+
+		assert.equal(commands.length, 1);
+		assert.ok(commands[0]?.includes("summary=⏳ 1 subagent (worker)"));
+
+		bridge.dispose();
+	});
+
 	it("reports an async run as visible and semantically busy", async () => {
 		const events = new FakeEvents();
 		const commands: string[][] = [];
@@ -630,10 +651,15 @@ describe("Herdr status bridge", () => {
 		const events = new FakeEvents();
 		const commands: string[][] = [];
 		const busyEvents: unknown[] = [];
+		let getRunsCalls = 0;
 		events.on("herdr:busy", (payload) => busyEvents.push(payload));
 		const bridge = registerHerdrStatusBridge({
 			events,
 			env: { HERDR_ENV: "1", HERDR_PANE_ID: "w1:p1" },
+			getRuns: () => {
+				getRunsCalls += 1;
+				return [{ id: "run-authoritative", agent: "worker" }];
+			},
 			runHerdr: (args) => commands.push([...args]),
 			refreshMs: 0,
 		});
@@ -646,10 +672,12 @@ describe("Herdr status bridge", () => {
 
 		// A headless parent (print/json mode, or a test harness) must never publish.
 		bridge.sessionStarted({ hasUI: false, runs: [{ id: "run-headless", agent: "worker" }] });
+		bridge.syncRuns();
 		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
 		await bridge.flush();
 		assert.deepEqual(commands, []);
 		assert.deepEqual(busyEvents, []);
+		assert.equal(getRunsCalls, 0);
 
 		// Only the root interactive session owns the pane.
 		bridge.sessionStarted({ hasUI: true, runs: [] });
@@ -665,19 +693,26 @@ describe("Herdr status bridge", () => {
 	it("stays inert outside a Herdr pane", async () => {
 		const events = new FakeEvents();
 		const commands: string[][] = [];
+		let getRunsCalls = 0;
 		const bridge = registerHerdrStatusBridge({
 			events,
 			env: {},
+			getRuns: () => {
+				getRunsCalls += 1;
+				return [{ id: "run-2", agent: "reviewer" }];
+			},
 			runHerdr: (args) => commands.push([...args]),
 			refreshMs: 0,
 		});
 
 		bridge.sessionStarted({ hasUI: true, runs: [{ id: "run-2", agent: "reviewer" }] });
+		bridge.syncRuns();
 		events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: "run-1", agent: "worker" });
 		bridge.agentStarted();
 		bridge.dispose();
 		await bridge.flush();
 
 		assert.deepEqual(commands, []);
+		assert.equal(getRunsCalls, 0);
 	});
 });

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -635,9 +635,13 @@ describe("subagent extension child mode", () => {
 			const handlers = new Map();
 			const events = { on(channel, handler) { eventHandlers.set(channel, handler); return () => {}; }, emit() {} };
 			const widgets = [];
+			const herdrCommands = [];
+			process.env.HERDR_ENV = "1";
+			process.env.HERDR_PANE_ID = "w1:p1";
 			const fakePi = new Proxy({
 				events,
 				on(channel, handler) { handlers.set(channel, handler); },
+				exec(command, args) { herdrCommands.push({ command, args }); return Promise.resolve({ code: 0, stdout: "", stderr: "", killed: false }); },
 				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
 				sendMessage() {}, getSessionName() { return undefined; },
 			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
@@ -663,6 +667,10 @@ describe("subagent extension child mode", () => {
 			handlers.get("tool_result")({ toolName: "subagent" }, ctx);
 			const fleetWidgets = widgets.filter((entry) => entry.key === "subagent-fleet-status");
 			if (!fleetWidgets.some((entry) => typeof entry.value === "function")) throw new Error("management result did not restore active fleet status: " + JSON.stringify(fleetWidgets));
+			if (!herdrCommands.some(({ args }) => args.includes("summary=⏳ 1 subagent"))) throw new Error("management result did not restore Herdr status: " + JSON.stringify(herdrCommands));
+			const herdrCommandCount = herdrCommands.length;
+			handlers.get("tool_result")({ toolName: "subagent" }, ctx);
+			if (herdrCommands.length !== herdrCommandCount) throw new Error("unchanged active jobs redundantly refreshed Herdr status: " + JSON.stringify(herdrCommands));
 			handlers.get("session_shutdown")();
 			fs.rmSync(asyncDir, { recursive: true, force: true });
 		`;


### PR DESCRIPTION
### What this fixes

Herdr can miss a background run restored from the async run index.

restoreActiveJobs adds the run to state.asyncJobs, so FleetView shows it. Herdr does not see an async start event, though, so the pane can look idle while the run is still active.

### How it works

This adds syncRuns to the Herdr status bridge. After a subagent management result, the extension calls it only when restoreActiveJobs adds a run.

The guards stay inside the bridge. Headless sessions and sessions outside Herdr never evaluate getRuns. Repeating the same management action also does not send another Herdr report.