### PR TITLE
fix: fail closed on unresolved MCP direct tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Avoid attributing assistant-issued workflow stops to the user.
 - Publish a deterministic terminal handoff with settled child evidence and keyed recovery actions when detached workflow lanes settle. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Resolve direct MCP tool selections from Pi package manifests and Agent Plugin configs. Thanks to [@fmoda3](https://github.com/fmoda3) for #1541.
+- Fail closed with a launch diagnostic when configured runtime-style MCP direct-tool selectors cannot be resolved.
 - Sync Herdr status after restoring active async jobs, so recovered work appears without waiting for another lifecycle event. Thanks to [@vicocamacho](https://github.com/vicocamacho) for #1553.
 - Report deterministic settlement diagnostics when background children fail before required output handoff.
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.

--- a/src/runs/shared/mcp-direct-tool-allowlist.ts
+++ b/src/runs/shared/mcp-direct-tool-allowlist.ts
@@ -61,17 +61,38 @@ interface MetadataCache {
 
 export interface ResolvedMcpDirectToolSelection { name: string; selector: string }
 
-export function resolveMcpDirectToolSelections(mcpDirectTools: string[] | undefined, cwd = process.cwd()): ResolvedMcpDirectToolSelection[] {
-	if (!mcpDirectTools?.length) return [];
+export interface McpDirectToolResolution {
+	selections: ResolvedMcpDirectToolSelection[];
+	unresolvedSelectors: string[];
+}
 
-	try {
-		const config = loadMcpConfig(cwd);
-		const cache = loadMetadataCache();
-		if (!cache) return [];
-		return resolveDirectToolSelections(config, cache, getToolPrefix(config.settings?.toolPrefix), mcpDirectTools);
-	} catch {
-		return [];
-	}
+function normalizeSelectors(selectors: string[] | undefined): string[] {
+	return [...new Set((selectors ?? []).map((selector) => selector.replace(/\/+$/, "")).filter(Boolean))];
+}
+
+export function resolveMcpDirectToolResolution(mcpDirectTools: string[] | undefined, cwd = process.cwd()): McpDirectToolResolution {
+	const selectors = normalizeSelectors(mcpDirectTools);
+	if (selectors.length === 0) return { selections: [], unresolvedSelectors: [] };
+
+	const config = loadMcpConfig(cwd);
+	validateSelectedServerDefinitions(config, selectors);
+	const cache = loadMetadataCache();
+	if (!cache) return { selections: [], unresolvedSelectors: selectors };
+	const selections = resolveDirectToolSelections(config, cache, getToolPrefix(config.settings?.toolPrefix), selectors);
+	const unresolvedSelectors = selectors.filter((selector) =>
+		selector.includes("/")
+			? !selections.some((selection) => selection.selector === selector)
+			: !selections.some((selection) => selection.selector.startsWith(`${selector}/`)),
+	);
+	return { selections, unresolvedSelectors };
+}
+
+export function resolveMcpDirectToolSelections(mcpDirectTools: string[] | undefined, cwd = process.cwd()): ResolvedMcpDirectToolSelection[] {
+	return resolveMcpDirectToolResolution(mcpDirectTools, cwd).selections;
+}
+
+export function formatUnresolvedMcpDirectToolSelectors(selectors: readonly string[]): string {
+	return `Unresolved MCP direct-tool selectors: ${selectors.join(", ")}. Direct MCP tools require a matching configured server and fresh metadata cache; runtime-registered servers require a host/pi-mcp-adapter handoff before child launch.`;
 }
 
 function loadMetadataCache(): MetadataCache | null {
@@ -260,6 +281,14 @@ function parseSelections(selections: string[]): { servers: Set<string>; tools: M
 		}
 	}
 	return { servers, tools };
+}
+
+function validateSelectedServerDefinitions(config: McpConfig, selectors: string[]): void {
+	const { servers, tools } = parseSelections(selectors);
+	for (const serverName of new Set([...servers, ...tools.keys()])) {
+		const definition = config.mcpServers[serverName];
+		if (definition) computeMcpServerHash(definition);
+	}
 }
 
 function isServerCacheValid(entry: ServerCacheEntry | undefined, definition: ServerEntry): entry is ServerCacheEntry {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -9,7 +9,8 @@ import {
 	type NestedPathEntry,
 } from "./nested-path.ts";
 import {
-	resolveMcpDirectToolSelections,
+	formatUnresolvedMcpDirectToolSelectors,
+	resolveMcpDirectToolResolution,
 	type ResolvedMcpDirectToolSelection,
 } from "./mcp-direct-tool-allowlist.ts";
 import { resolvePiPackageRoot } from "./pi-spawn.ts";
@@ -461,9 +462,13 @@ export function resolvePiLaunchToolPlan(
 					!requestedBuiltinTools.includes(tool) &&
 					(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")),
 			);
-	const resolvedMcpSelections = capabilityCeiling?.denyExtensions
-		? []
-		: resolveMcpDirectToolSelections(input.mcpDirectTools, input.cwd);
+	const mcpResolution = capabilityCeiling?.denyExtensions
+		? { selections: [], unresolvedSelectors: [] }
+		: resolveMcpDirectToolResolution(input.mcpDirectTools, input.cwd);
+	if (mcpResolution.unresolvedSelectors.length > 0) {
+		throw new Error(formatUnresolvedMcpDirectToolSelectors(mcpResolution.unresolvedSelectors));
+	}
+	const resolvedMcpSelections = mcpResolution.selections;
 	const effectiveMcpSelections = resolvedMcpSelections.filter(
 		(selection) => !allowedToolSet || allowedToolSet.has(selection.name),
 	);

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1153,7 +1153,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		}
 	});
 
-	it("fails closed with --no-tools when MCP-only names cannot be resolved", () => {
+	it("fails closed with a deterministic diagnostic when MCP selectors cannot be resolved", () => {
 		for (const requireReadTool of [false, true]) {
 			const fixture = createMcpFixture();
 			writeJson(path.join(fixture.agentDir, "mcp.json"), {
@@ -1162,7 +1162,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 				},
 			});
 
-			const { args, env } = buildPiArgs({
+			assert.throws(() => buildPiArgs({
 				baseArgs: ["-p"],
 				task: "hello",
 				sessionEnabled: false,
@@ -1170,11 +1170,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 				inheritSkills: false,
 				requireReadTool,
 				mcpDirectTools: ["chrome-devtools"],
-			});
-
-			assert.ok(args.includes("--no-tools"));
-			assert.equal(args.includes("--tools"), false);
-			assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
+			}), /Unresolved MCP direct-tool selectors: chrome-devtools\./);
 		}
 	});
 
@@ -1254,14 +1250,14 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		);
 	});
 
-	it("falls back to explicit builtins when direct MCP cache or config is missing or invalid", () => {
+	it("fails closed when direct MCP cache or config is missing or invalid", () => {
 		const missingFixture = createMcpFixture();
 		writeJson(path.join(missingFixture.agentDir, "mcp.json"), {
 			mcpServers: {
 				"chrome-devtools": { command: "npx", args: ["chrome-devtools-mcp"] },
 			},
 		});
-		const missingCache = buildPiArgs({
+		assert.throws(() => buildPiArgs({
 			baseArgs: ["-p"],
 			task: "hello",
 			sessionEnabled: false,
@@ -1269,17 +1265,13 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			inheritSkills: false,
 			tools: ["read", "bash"],
 			mcpDirectTools: ["chrome-devtools"],
-		});
-		assert.equal(
-			missingCache.args[missingCache.args.indexOf("--tools") + 1],
-			"read,bash",
-		);
+		}), /Unresolved MCP direct-tool selectors: chrome-devtools\./);
 
 		const invalidFixture = createMcpFixture();
 		writeMcpFixture(invalidFixture, {
 			cachedAt: Date.now() - 8 * 24 * 60 * 60 * 1000,
 		});
-		const staleCache = buildPiArgs({
+		assert.throws(() => buildPiArgs({
 			baseArgs: ["-p"],
 			task: "hello",
 			sessionEnabled: false,
@@ -1287,11 +1279,25 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			inheritSkills: false,
 			tools: ["read", "bash"],
 			mcpDirectTools: ["chrome-devtools"],
+		}), /Unresolved MCP direct-tool selectors: chrome-devtools\./);
+	});
+
+	it("preserves MCP configuration errors during direct-tool resolution", () => {
+		const fixture = createMcpFixture();
+		writeJson(path.join(fixture.agentDir, "mcp.json"), {
+			mcpServers: {
+				"remote-mcp": { url: "https://example.test/${MISSING_MCP_TOKEN}" },
+			},
 		});
-		assert.equal(
-			staleCache.args[staleCache.args.indexOf("--tools") + 1],
-			"read,bash",
-		);
+		assert.throws(() => buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["remote-mcp"],
+		}), /Missing environment variable in MCP server URL: MISSING_MCP_TOKEN/);
 	});
 
 	it("resolves project MCP config from the child cwd and expands PI_CODING_AGENT_DIR", () => {

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -803,4 +803,23 @@ Project prompt.
 		assert.equal(result.code, "denied_required_tool");
 		assert.match(result.message, /excludes required tool 'read'/);
 	});
+
+	it("reports unresolved runtime-style MCP selectors during preflight", async () => {
+		const cwd = path.join(tempDir, "repo-unresolved-runtime-mcp");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---
+name: worker
+description: Project worker
+tools:
+  - read
+  - mcp:rt__wiki/read_wiki_structure
+---
+Project prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({ agent: "worker", cwd, task: "Inspect" });
+		assert.equal(result.ok, false);
+		assert.equal(result.code, "denied_required_tool");
+		assert.match(result.message, /Unresolved MCP direct-tool selectors: rt__wiki\/read_wiki_structure\./);
+	});
 });


### PR DESCRIPTION
## Summary

This is the diagnostic-only slice for #1546. It fails child launch before spawn when a configured direct MCP selector cannot be resolved from configured package, git package, or Agent Plugin MCP metadata.

The runtime-registered MCP support remainder stays open and blocked on a host/pi-mcp-adapter handoff contract. This PR does not add the generic `mcp` gateway and does not weaken strict tool allowlists.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test --test-name-pattern 'MCP|mcp|direct MCP|runtime-style MCP|capability ceiling' test/unit/pi-args.test.ts test/unit/preflight.test.ts test/unit/capability-ceiling-pi-args.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/pi-args.test.ts test/unit/preflight.test.ts`
- `npm run typecheck`
- `git diff --check`

Refs #1546.


