### PR TITLE
fix: stop reload-recovered workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.
 - Fail native child launches before spawn when the requested local working directory is missing or not a directory, with the requested and resolved paths in the error.
 - Map report paths requested in workflow child tasks to the actual saved child output when workflow output routing overrides them.
+- Stop same-session workflows recovered after extension reload through the durable control channel.
 - Let agents declare extension mutation tools so real non-Git or untracked edits satisfy the implementation completion guard. Thanks to [@AlphaGodzilla](https://github.com/AlphaGodzilla) for #1532.
 - Deliver async results from an explicitly replaced predecessor session without accepting unrelated session results. Thanks to [@DresvyanskiyDenis](https://github.com/DresvyanskiyDenis) for #1531.
 

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -579,20 +579,21 @@ function stopAsyncRun(
 	if (initialStatus.mode === "workflow" && initialStatus.state === "running") {
 		if (child) {
 			const stopChild = options.state?.workflowChildStops?.get(initialRunId);
-			if (!stopChild) throw new SubagentRpcError("invalid_state", `Workflow ${initialRunId} is not controlled by this extension runtime; child stop is unavailable.`);
-			if (!stopChild(child.id, `Workflow child '${child.id}' stopped by RPC.`)) throw new SubagentRpcError("invalid_state", `Child '${childId}' in workflow ${initialRunId} is not available to stop.`);
-			emitChildStopping(initialRunId, location.asyncDir, child);
-			return {
-				runId: initialRunId,
-				asyncDir: location.asyncDir,
-				previousState: initialStatus.state,
-				state: "stopping",
-				childId: child.id,
-				message: `Stop requested for child ${child.id} in async run ${initialRunId}.`,
-			};
+			if (stopChild) {
+				if (!stopChild(child.id, `Workflow child '${child.id}' stopped by RPC.`)) throw new SubagentRpcError("invalid_state", `Child '${childId}' in workflow ${initialRunId} is not available to stop.`);
+				emitChildStopping(initialRunId, location.asyncDir, child);
+				return {
+					runId: initialRunId,
+					asyncDir: location.asyncDir,
+					previousState: initialStatus.state,
+					state: "stopping",
+					childId: child.id,
+					message: `Stop requested for child ${child.id} in async run ${initialRunId}.`,
+				};
+			}
 		}
 		const workflowController = options.state?.workflowControllers?.get(initialRunId);
-		if (workflowController) {
+		if (workflowController && !child) {
 			workflowController.abort(new Error("Workflow stopped by RPC."));
 			return {
 				runId: initialRunId,
@@ -602,7 +603,27 @@ function stopAsyncRun(
 				message: `Stop requested for async run ${initialRunId}.`,
 			};
 		}
-		throw new SubagentRpcError("invalid_state", `Workflow ${initialRunId} is not controlled by this extension runtime; reload recovery cannot stop it safely.`);
+		try {
+			deliverStopRequest({
+				asyncDir: location.asyncDir,
+				pid: initialStatus.pid,
+				kill: options.kill,
+				now: options.now,
+				source: "rpc-stop",
+				...(child ? { targetIndex: child.index, childId: child.id } : {}),
+			});
+		} catch (error) {
+			throw new SubagentRpcError("execution_failed", error instanceof Error ? error.message : String(error));
+		}
+		if (child) emitChildStopping(initialRunId, location.asyncDir, child);
+		return {
+			runId: initialRunId,
+			asyncDir: location.asyncDir,
+			previousState: initialStatus.state,
+			state: "stopping",
+			...(child ? { childId: child.id } : {}),
+			message: child ? `Stop requested for child ${child.id} in async run ${initialRunId}.` : `Stop requested for async run ${initialRunId}.`,
+		};
 	}
 
 	let status;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5676,10 +5676,6 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				if (paramsWithResolvedCwd.dir) {
 					try {
 						const location = resolveAsyncRunLocation(paramsWithResolvedCwd, DIRS.async, DIRS.results);
-						const existingStatus = readStatus(location.asyncDir ?? "");
-						if (existingStatus?.mode === "workflow" && existingStatus.state === "running") {
-							return { content: [{ type: "text", text: `Workflow ${existingStatus.runId} is not controlled by this extension runtime; reload recovery cannot stop it safely.` }], isError: true, details: { mode: "management", results: [] } };
-						}
 						const stopResult = stopAsyncRun(deps.state, location.resolvedId ?? targetRunId ?? path.basename(location.asyncDir ?? paramsWithResolvedCwd.dir), deps.kill, location, paramsWithResolvedCwd.childId);
 						return stopResult ?? { content: [{ type: "text", text: `No running or queued async run was found for '${targetRunId ?? paramsWithResolvedCwd.dir}'.` }], isError: true, details: { mode: "management", results: [] } };
 					} catch (error) {
@@ -5696,12 +5692,6 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 				if (resolved?.kind === "nested") return { content: [{ type: "text", text: "action='stop' supports current-session top-level async runs only." }], isError: true, details: { mode: "management", results: [] } };
 				if (resolved?.kind === "foreground") return { content: [{ type: "text", text: "action='stop' supports async runs only. Use action='interrupt' for foreground runs." }], isError: true, details: { mode: "management", results: [] } };
-				if (resolved?.kind === "async") {
-					const existingStatus = readStatus(resolved.location.asyncDir ?? "");
-					if (existingStatus?.mode === "workflow" && existingStatus.state === "running") {
-						return { content: [{ type: "text", text: `Workflow ${resolved.id} is not controlled by this extension runtime; reload recovery cannot stop it safely.` }], isError: true, details: { mode: "management", results: [] } };
-					}
-				}
 				const stopResult = stopAsyncRun(
 					deps.state,
 					resolved?.kind === "async" ? resolved.id : targetRunId,

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -694,6 +694,27 @@ describe("async interrupt action", () => {
 		}
 	});
 
+	it("stops a reload-recovered workflow through the durable control channel", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `stop-recovered-workflow-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "session", mode: "workflow" });
+		try {
+			const kills: Array<{ pid: number; signal?: NodeJS.Signals | 0 }> = [];
+			const result = await executorWithKill(state, (pid, signal) => {
+				kills.push({ pid, signal });
+				return true;
+			}).execute("stop-recovered-workflow", { action: "stop", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, undefined);
+			assert.match(text(result), new RegExp(`Stop requested for async run ${runId}`));
+			assert.equal(consumeStopRequestPayload(asyncDir)?.type, "stop");
+			assert.deepEqual(kills, [{ pid: 12345, signal: 0 }]);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
 	it("writes child-scoped stop requests for a running async run", async () => {
 		const state = createState();
 		state.currentSessionId = "session";

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -932,7 +932,7 @@ describe("subagent extension RPC bridge", () => {
 		}
 	});
 
-	it("rejects stop requests for reload-recovered workflows", async () => {
+	it("stops reload-recovered workflows through the durable control channel", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-rpc-stop-workflow-"));
 		try {
 			const events = new FakeEvents();
@@ -966,10 +966,11 @@ describe("subagent extension RPC bridge", () => {
 
 			const reply = await request(events, "stop-workflow", "stop", { id: "workflow-run" });
 
-			assert.equal(reply.success, false);
-			assert.equal((reply as { error: { code: string; message: string } }).error.code, "invalid_state");
-			assert.match((reply as { error: { message: string } }).error.message, /reload recovery cannot stop it safely/);
-			assert.equal(fs.existsSync(stopRequestPath(asyncDir)), false);
+			assert.equal(reply.success, true);
+			assert.equal((reply as { data: { runId?: string; state?: string; message?: string } }).data.runId, "workflow-run");
+			assert.equal((reply as { data: { state?: string } }).data.state, "stopping");
+			assert.match((reply as { data: { message?: string } }).data.message ?? "", /Stop requested for async run workflow-run/);
+			assert.equal(consumeStopRequestPayload(asyncDir)?.type, "stop");
 			assert.equal(killCalls, 0);
 
 			bridge.dispose();


### PR DESCRIPTION
## Summary

Allow `action: "stop"` to stop same-session workflows that were recovered after an extension reload by writing the existing durable stop request.

Live workflow controllers and live child stoppers keep their direct paths. Session ownership checks still fail closed before any durable stop request is written.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test --test-name-pattern 'stops a reload-recovered workflow through the durable control channel|stops reload-recovered workflows through the durable control channel|rejects stop requests for async runs from a different session|uses the live workflow controller for RPC run-level workflow stop|uses the live workflow child stopper for RPC child stop|writes child-scoped stop requests for a running async run' test/unit/async-interrupt-action.test.ts test/unit/rpc.test.ts`
- `npm run typecheck`
- `git diff --check`

Closes #1554.
