### PR TITLE
fix: reject excluded explicit models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Document unsupported native child options for external CLI agents in the subagent tool help, packaged guide, and packaged skill.
 
 ### Fixed
+- Fail explicitly requested models closed when a cached model exclusion is active, instead of silently selecting a fallback. Thanks to [@harpsychord](https://github.com/harpsychord) for #1556.
 - Classify workflow budget and timeout stops as partial terminal outcomes while preserving settled child evidence. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Show task intent and context-window use in compact in-progress async status rows.
 - Avoid attributing assistant-issued workflow stops to the user.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5893,6 +5893,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						parentModel,
 						forkAvailableModels,
 						agentConfig?.modelProvider ?? parentModel?.provider,
+						{ source: "inherited" },
 					);
 				const candidates = buildModelCandidates(
 					primaryModel,

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -206,6 +206,18 @@ export function isExcluded(modelId: string, provider: string): boolean {
 }
 
 /**
+ * Return the active exclusion matching a full model id, if any.
+ *
+ * The caller uses this for hard-fail diagnostics; fallback filtering should
+ * continue to use {@link filterFallbackCandidates}.
+ */
+export function findModelExclusion(fullId: string, now = Date.now()): Readonly<ModelExclusion> | undefined {
+	ensureLoaded();
+	const { provider, modelId } = parseModelKey(fullId);
+	return exclusions.find((entry) => entryMatches(entry, modelId, provider, now));
+}
+
+/**
  * Number of live (non-expired) exclusions.
  */
 export function getExcludedCount(): number {

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -1,6 +1,6 @@
 import { splitKnownThinkingSuffix, type ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
 import type { Usage } from "../../shared/types.ts";
-import { filterFallbackCandidates, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
+import { filterFallbackCandidates, findModelExclusion, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
 import { checkModelScope, type ModelScopeCheckRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
 import { redactSecretValues } from "./permissions.ts";
 
@@ -279,6 +279,14 @@ function enforceModelScopes(
 	for (const violation of violations) (onWarn ?? defaultScopeWarn)(violation);
 }
 
+function throwForExplicitModelExclusion(model: string): void {
+	const exclusion = findModelExclusion(model);
+	if (!exclusion) return;
+	const reason = redactSecretValues((exclusion.reason ?? "runtime-failure").replace(/[\u0000-\u001f\u007f]+/g, " ")).slice(0, 240);
+	const expiry = Number.isFinite(exclusion.expiresAt) ? `; expires: ${new Date(exclusion.expiresAt).toISOString()}` : "";
+	throw new Error(`Requested subagent model '${model}' is excluded and cannot be replaced by a fallback (reason: ${reason}${expiry}).`);
+}
+
 /**
  * Resolve the `--model` override passed to a spawned subagent.
  *
@@ -313,6 +321,9 @@ export function resolveSubagentModelOverride(
 	} else {
 		resolved = resolveRequiredSubagentModelCandidate(explicit, availableModels, preferredProvider);
 	}
+	if (resolved && explicit !== undefined && options?.source === "explicit") {
+		throwForExplicitModelExclusion(resolved);
+	}
 	if (resolved && options?.scope) {
 		const source: ModelSource = explicit === undefined ? "inherited" : (options.source ?? "inherited");
 		enforceModelScopes(resolved, options.scope, source, options.onWarn);
@@ -326,14 +337,15 @@ export function resolveEffectiveSubagentModel(
 	parentModel: ParentModel | undefined,
 	availableModels: AvailableModelInfo[] | undefined,
 	preferredProvider?: string,
-	options?: Omit<ResolveSubagentModelOverrideOptions, "source">,
+	options?: ResolveSubagentModelOverrideOptions,
 ): string | undefined {
+	const source = options?.source ?? (explicitModel !== undefined ? "explicit" : "inherited");
 	const resolved = resolveSubagentModelOverride(
 		explicitModel ?? agentModel,
 		parentModel,
 		availableModels,
 		preferredProvider,
-		{ ...options, source: explicitModel !== undefined ? "explicit" : "inherited" },
+		{ ...options, source },
 	);
 	if (resolved || explicitModel === undefined) return resolved;
 	return resolveSubagentModelOverride(
@@ -341,7 +353,7 @@ export function resolveEffectiveSubagentModel(
 		parentModel,
 		availableModels,
 		preferredProvider,
-		{ ...options, source: "inherited" },
+		{ ...options, source: options?.source ?? "inherited" },
 	);
 }
 

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -13,7 +13,7 @@ import {
 	resolveModelCandidate,
 	resolveSubagentModelOverride,
 } from "../../src/runs/shared/model-fallback.ts";
-import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
+import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 import { resolveModelScopesForAgent } from "../../src/runs/shared/model-scope.ts";
 
 beforeEach(() => clearExclusions());
@@ -281,6 +281,17 @@ describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () 
 		assert.equal(
 			resolveSubagentModelOverride("gpt-5-mini", parentModel, availableModels),
 			"openai/gpt-5-mini",
+		);
+	});
+
+	it("fails visibly when an explicit model is excluded instead of falling back", () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "rate limit" });
+		assert.throws(
+			() => resolveEffectiveSubagentModel("openai/gpt-5-mini", undefined, parentModel, availableModels),
+			(error: unknown) => {
+				const message = String(error);
+				return message.includes("openai/gpt-5-mini") && message.includes("rate limit") && message.includes("expires:");
+			},
 		);
 	});
 


### PR DESCRIPTION
## Summary

Fail explicit subagent model requests closed when the model is active in the model-exclusion TTL store.

The error names the requested model and includes the recorded reason and expiry. Fallback filtering stays unchanged for fallback candidates and inherited model behavior.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts test/unit/model-exclusions.test.ts test/unit/preflight.test.ts`
- `npm run typecheck`
- `git diff --check`

Thanks to [@harpsychord](https://github.com/harpsychord) for #1556.

Closes #1556.
