### PR TITLE
fix: finalize detached worktree handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Sync Herdr status after restoring active async jobs, so recovered work appears without waiting for another lifecycle event. Thanks to [@vicocamacho](https://github.com/vicocamacho) for #1553.
 - Report deterministic settlement diagnostics when background children fail before required output handoff.
 - Auto-resume workflow children once after setup-phase aborts that produce zero usage, preserving the retained transcript instead of rerunning the whole task.
+- Finalize detached foreground worktree handoffs after terminal child completion, preserving captured changes before cleanup. Thanks to [@jpriverar](https://github.com/jpriverar) for #1562.
 - Fail native child launches before spawn when the requested local working directory is missing or not a directory, with the requested and resolved paths in the error.
 - Map report paths requested in workflow child tasks to the actual saved child output when workflow output routing overrides them.
 - Stop same-session workflows recovered after extension reload through the durable control channel.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3756,6 +3756,9 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			},
 			onDetachedExit: (result) => {
 				try {
+					if (worktreeSetup) {
+						finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result });
+					}
 					try {
 						updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events, notify: true });
 					} catch {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2972,7 +2972,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.content[0]?.text ?? "", /handoffs/);
 	});
 
-	it("preserves a workflow worktree when its child detaches for supervisor coordination", { skip: !createSubagentExecutor ? "executor unavailable" : undefined }, async () => {
+	it("finalizes a workflow worktree when its child detaches for supervisor coordination", { skip: !createSubagentExecutor ? "executor unavailable" : undefined }, async () => {
 		execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
 		execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
 		execFileSync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
@@ -2980,6 +2980,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		execFileSync("git", ["add", "base.txt"], { cwd: tempDir });
 		execFileSync("git", ["commit", "-m", "base"], { cwd: tempDir, stdio: "ignore" });
 		mockPi.onCall({
+			writeFiles: [{ path: "feature.txt", content: "feature\n" }],
 			steps: [
 				{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Need a decision" })] },
 				{ delay: 500, jsonl: [events.assistantMessage("done after coordination")] },
@@ -3032,8 +3033,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(workflowValue[0]?.ok, false);
 		const handoffPath = workflowValue[0]?.artifactPaths.find((candidate) => candidate.endsWith(".json"));
 		assert.ok(handoffPath, result.content[0]?.text ?? "missing pending handoff");
-		const handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
+		let handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
 			groups: Array<{
+				children: Array<{ status: string; patch: { changed: boolean; filesChanged: number } }>;
 				cleanup: { state: string; tasks: Array<{ path: string; branch: string; preserved: boolean; worktreeRemoved: boolean; branchRemoved: boolean }> };
 			}>;
 		};
@@ -3048,9 +3050,19 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(branch);
 		assert.equal(fs.existsSync(worktreePath), true, "live detached worktree must remain present");
 
-		await new Promise((resolve) => setTimeout(resolve, 750));
-		execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: tempDir });
-		execFileSync("git", ["branch", "-D", branch], { cwd: tempDir, stdio: "ignore" });
+		for (let attempt = 0; attempt < 150 && handoff.groups[0]?.cleanup.state !== "complete"; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as typeof handoff;
+		}
+		assert.equal(handoff.groups[0]?.children[0]?.status, "completed");
+		assert.equal(handoff.groups[0]?.children[0]?.patch.changed, true);
+		assert.equal(handoff.groups[0]?.children[0]?.patch.filesChanged, 1);
+		assert.equal(handoff.groups[0]?.cleanup.state, "complete");
+		assert.equal(handoff.groups[0]?.cleanup.tasks[0]?.preserved, undefined);
+		assert.equal(handoff.groups[0]?.cleanup.tasks[0]?.worktreeRemoved, true);
+		assert.equal(handoff.groups[0]?.cleanup.tasks[0]?.branchRemoved, true);
+		assert.equal(fs.existsSync(worktreePath), false);
+		assert.equal(fs.existsSync(path.join(tempDir, "feature.txt")), false);
 	});
 
 	it("pauses an async workflow when its child detaches for supervisor coordination", { skip: !createSubagentExecutor ? "executor unavailable" : undefined }, async () => {
@@ -3146,8 +3158,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(persistedResult.results?.[0]?.detached, true);
 		const handoffPath = persistedResult.results?.[0]?.artifactPaths?.outputPath;
 		assert.ok(handoffPath, "missing preserved worktree handoff path");
-		const handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
+		let handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
 			groups: Array<{
+				children: Array<{ status: string; patch: { changed: boolean; filesChanged: number } }>;
 				cleanup: { state: string; tasks: Array<{ path: string; branch: string; preserved: boolean; worktreeRemoved: boolean; branchRemoved: boolean }> };
 			}>;
 		};
@@ -3179,8 +3192,17 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(persistedResult.state, "failed");
 		assert.equal(persistedResult.activityState, undefined);
 		assert.match(persistedResult.error ?? "", /unsupported-continuation/);
-		execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: tempDir });
-		execFileSync("git", ["branch", "-D", branch], { cwd: tempDir, stdio: "ignore" });
+		for (let attempt = 0; attempt < 150 && handoff.groups[0]?.cleanup.state !== "complete"; attempt++) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as typeof handoff;
+		}
+		assert.equal(handoff.groups[0]?.children[0]?.status, "completed");
+		assert.equal(handoff.groups[0]?.children[0]?.patch.changed, false);
+		assert.equal(handoff.groups[0]?.children[0]?.patch.filesChanged, 0);
+		assert.equal(handoff.groups[0]?.cleanup.state, "complete");
+		assert.equal(handoff.groups[0]?.cleanup.tasks[0]?.worktreeRemoved, true);
+		assert.equal(handoff.groups[0]?.cleanup.tasks[0]?.branchRemoved, true);
+		assert.equal(fs.existsSync(worktreePath), false);
 		fs.rmSync(started.details.asyncDir, { recursive: true, force: true });
 		fs.rmSync(resultPath, { force: true });
 	});


### PR DESCRIPTION
## Summary

This finalizes the pending managed-worktree handoff when a detached foreground child reaches its terminal callback. The callback now reuses the same single-run handoff finalizer as the attached path, so changes are captured before cleanup and the manifest records the terminal child result.

Closes #1562.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'finalizes a workflow worktree when its child detaches for supervisor coordination|pauses an async workflow when its child detaches for supervisor coordination|runs a direct single child in a managed worktree|gives parallel workflow children separate managed worktrees and durable handoffs' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
- `git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- ':!package-lock.json'`

Thanks to [@jpriverar](https://github.com/jpriverar) for reporting #1562.
