### PR TITLE
chore: deslop unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Support direct MCP tool launches from runtime-registered servers.
 - Document per-run thinking suffixes in model-facing subagent guidance. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1565.
-- Add `inheritGlobalContext` agent configuration so children can inherit repository context without repeating the operator's global context file. Thanks to [@hknatm](https://github.com/hknatm) for #1560.
+- Add `inheritGlobalContext` agent configuration so children can opt into the operator's global context file separately from repository context. Thanks to [@hknatm](https://github.com/hknatm) for #1560.
 - Add process-local event registration so independent Pi extensions can register runtime agents through the installed owner. Thanks to [@fmoda3](https://github.com/fmoda3) for #1533.
 - Add advisory launch preflight diagnostics for likely workspace scope and authority mismatches.
 - Document unsupported native child options for external CLI agents in the subagent tool help, packaged guide, and packaged skill.

--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -1,4 +1,5 @@
-import { registerRuntimeAgent, type RegisterRuntimeAgentInput, type RuntimeAgentDefinition, type RuntimeAgentRegistration } from "../agents/runtime-agent-registry.ts";
+import type { RegisterRuntimeAgentInput, RuntimeAgentDefinition, RuntimeAgentRegistration } from "../agents/runtime-agent-registry.ts";
+export { registerRuntimeAgent as registerAgent } from "../agents/runtime-agent-registry.ts";
 export {
 	RUNTIME_AGENT_REGISTER_EVENT,
 	RUNTIME_AGENT_REGISTER_VERSION,
@@ -9,7 +10,3 @@ export {
 } from "../agents/runtime-agent-events.ts";
 
 export type { RegisterRuntimeAgentInput, RuntimeAgentDefinition, RuntimeAgentRegistration };
-
-export function registerAgent(input: RegisterRuntimeAgentInput): RuntimeAgentRegistration {
-	return registerRuntimeAgent(input);
-}

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -156,7 +156,8 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 				detached: undefined,
 				...(outputReference ? { outputReference } : {}),
 				...(outputPathMapping ? { outputPathMapping } : {}),
-				...(result.interrupted ? { interrupted: true } : {}),
+				...(result.interrupted || result.stopped ? { interrupted: true } : {}),
+				...(result.stopped ? { stopped: true } : {}),
 				...(terminalOutcome ? { terminalOutcome } : {}),
 				...(result.error ? { error: result.error } : {}),
 			};
@@ -193,7 +194,7 @@ function workflowResultOutputPathMappingSummary(results: unknown): string {
 	return mappings.length > 0 ? ` Output path mappings: ${mappings.join("; ")}.` : "";
 }
 
-function publishedWorkflowResult(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, existing?: Record<string, unknown>, receipt?: WorkflowReceipt, settledStep?: WorkflowStatusStep): Record<string, unknown> {
+function publishedWorkflowResult(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, existing?: Record<string, unknown>, receipt?: WorkflowReceipt): Record<string, unknown> {
 	const sessionId = status.sessionId ?? (typeof existing?.sessionId === "string" ? existing.sessionId : undefined);
 	const resolution = workflowResolution(status, result);
 	const recovery = workflowRecovery(receipt);
@@ -351,7 +352,7 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 	} catch (error) {
 		receiptError = `Failed to reconcile async workflow receipt: ${error instanceof Error ? error.message : String(error)}`;
 	}
-	const published = publishedWorkflowResult(next, input.childRunId, input.result, asyncDir, existing, receipt, settledStep);
+	const published = publishedWorkflowResult(next, input.childRunId, input.result, asyncDir, existing, receipt);
 	writeAsyncResultFile(resultPath, published);
 	if (receiptError) {
 		appendDetachedWorkflowEvent(asyncDir, {

--- a/src/runs/shared/mcp-config-sources.ts
+++ b/src/runs/shared/mcp-config-sources.ts
@@ -371,9 +371,16 @@ function formatName(value: string, fallback: string): string {
 }
 
 function readJson(filePath: string): unknown | undefined {
+	let content: string;
 	try {
-		return JSON.parse(fs.readFileSync(filePath, "utf-8"));
-	} catch {
-		return undefined;
+		content = fs.readFileSync(filePath, "utf-8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw new Error(`Failed to read JSON file '${filePath}': ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+	}
+	try {
+		return JSON.parse(content);
+	} catch (error) {
+		throw new Error(`Invalid JSON in '${filePath}': ${error instanceof Error ? error.message : String(error)}`, { cause: error });
 	}
 }

--- a/src/runs/shared/mcp-direct-tool-allowlist.ts
+++ b/src/runs/shared/mcp-direct-tool-allowlist.ts
@@ -359,8 +359,7 @@ export function resolveMcpDirectToolNames(mcpDirectTools: string[] | undefined, 
 function parseSelections(selections: string[]): { servers: Set<string>; tools: Map<string, Set<string>> } {
 	const servers = new Set<string>();
 	const tools = new Map<string, Set<string>>();
-	for (let item of selections) {
-		item = item.replace(/\/+$/, "");
+	for (const item of selections) {
 		if (item.includes("/")) {
 			const [server, tool] = item.split("/", 2);
 			if (server && tool) {

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -200,9 +200,9 @@ function parseEntry(value: unknown, key: string, source: string): WorkflowReceip
 	const reason = (resumability as Record<string, unknown>).reason;
 	if (state === "resumable" && latestRunId === undefined) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' resumable entry has no retained run id.`);
 	if (state === "not-resumable" && (typeof reason !== "string" || !reason.trim())) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' non-resumable reason is missing.`);
-	parseTerminalOutcome(entry.terminalOutcome, `Invalid workflow receipt '${source}': entry '${key}' terminalOutcome`);
+	const terminalOutcome = parseTerminalOutcome(entry.terminalOutcome, `Invalid workflow receipt '${source}': entry '${key}' terminalOutcome`);
 	parseExternalCliReceiptMetadata(entry.externalAdapter, key, source);
-	return value as WorkflowReceiptEntry;
+	return { ...(value as WorkflowReceiptEntry), ...(terminalOutcome ? { terminalOutcome } : {}) };
 }
 
 function parseWorkflowResolution(value: unknown, source: string): WorkflowTerminalResolution | undefined {


### PR DESCRIPTION
## Summary

This is a narrow deslop cleanup over unreleased changes. It removes a pass-through runtime-agent API wrapper, tightens release-note wording, preserves stopped detached-child evidence in rebuilt workflow results, normalizes receipt terminal outcomes after parsing, removes duplicate MCP selector normalization, and keeps MCP JSON read failures actionable.

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/workflow-detach-reconcile.test.ts test/unit/workflow-receipt.test.ts test/unit/pi-args.test.ts test/unit/runtime-agent-registration.test.ts`
- `git diff --check`
- Fresh review: `/Users/nicobailon/.pi/agent/memory/extensions-subagent/lane-reports/deslop-unreleased-fresh-review.md` (`No issues found`)
