### PR TITLE
fix: return fast-mode provider payload directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Fail explicitly requested models closed when a cached model exclusion is active, instead of silently selecting a fallback. Thanks to [@harpsychord](https://github.com/harpsychord) for #1556.
+- Preserve fast-mode provider request root fields when adding OpenAI's priority service tier. Thanks to [@nothingrotf](https://github.com/nothingrotf) for #1570.
 - Classify workflow budget and timeout stops as partial terminal outcomes while preserving settled child evidence. Thanks to [@yceachan](https://github.com/yceachan) for #1530.
 - Show task intent and context-window use in compact in-progress async status rows.
 - Avoid attributing assistant-issued workflow stops to the user.

--- a/src/runs/shared/fast-mode-extension.ts
+++ b/src/runs/shared/fast-mode-extension.ts
@@ -1,10 +1,10 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { BeforeProviderRequestEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-function withPriorityServiceTier(payload: unknown): unknown {
-	if (!payload || typeof payload !== "object" || Array.isArray(payload)) return payload;
-	return { ...payload, service_tier: "priority" };
+export function rewriteFastModeProviderRequest(event: BeforeProviderRequestEvent): unknown {
+	if (!event.payload || typeof event.payload !== "object" || Array.isArray(event.payload)) return event.payload;
+	return { ...event.payload, service_tier: "priority" };
 }
 
 export default function registerSubagentFastModeExtension(pi: ExtensionAPI): void {
-	pi.on("before_provider_request", (event) => ({ payload: withPriorityServiceTier(event.payload) }));
+	pi.on("before_provider_request", rewriteFastModeProviderRequest);
 }

--- a/test/unit/fast-mode-extension.test.ts
+++ b/test/unit/fast-mode-extension.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { rewriteFastModeProviderRequest } from "../../src/runs/shared/fast-mode-extension.ts";
+
+describe("fast mode provider request", () => {
+	it("returns the rewritten provider payload without a wrapper", () => {
+		const payload = {
+			model: "gpt-5.6-luna",
+			input: [{ role: "user", content: "test" }],
+		};
+
+		assert.deepEqual(
+			rewriteFastModeProviderRequest({ type: "before_provider_request", payload }),
+			{
+				...payload,
+				service_tier: "priority",
+			},
+		);
+	});
+
+	it("preserves a non-object provider payload", () => {
+		assert.equal(
+			rewriteFastModeProviderRequest({ type: "before_provider_request", payload: "request" }),
+			"request",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Return the rewritten `before_provider_request` payload directly.
- Preserve the top-level provider fields when fast mode adds `service_tier: "priority"`.
- Add a regression test for object and non-object payloads.

## Problem

The hook returned `{ payload: rewrittenPayload }`. Pi treats every defined return value as the complete replacement payload.

This wrapper removed `model` from the request root. OpenAI Codex then rejected the request with:

```text
The 'None' model is not supported when using Codex with a ChatGPT account.
```

Normal requests worked because they did not load the fast-mode hook.

## Fix

The registered handler now returns the rewritten provider payload itself. The model and input fields remain at the request root.

## Verification

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/fast-mode-extension.test.ts`
- `npm run typecheck`
- `git diff --check`
- A live Pi request used `openai-codex/gpt-5.6-luna:xhigh` with the patched extension and returned `PI_SUBAGENTS_FAST_FIX_OK`.

The full local unit run reported 2,571 passes and five unrelated failures. Two failures read ambient MCP configuration. Two timing failures passed alone. One renderer test still failed alone and does not import this module.
