### PR TITLE
refactor: extract workflow settlement planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Extract detached workflow settlement planning into a focused workflow module while preserving fail-closed result handoff.
+
 ## [0.58.0] - 2026-08-27
 
 ### Highlights

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -9,8 +9,6 @@ import {
 	type IntercomEventBus,
 	type SingleResult,
 	type SubagentState,
-	type WorkflowRecoveryAction,
-	type WorkflowTerminalOutcome,
 	type WorkflowTerminalResolution,
 } from "../../shared/types.ts";
 import { updateActiveRunIndex } from "../background/active-run-index.ts";
@@ -19,130 +17,35 @@ import { resolveAsyncResumeTarget } from "../background/async-resume.ts";
 import { externalCliReceiptMetadata, normalizeExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
 import { outputPathMappingFromTask } from "../shared/single-output.ts";
 import { readWorkflowReceipt, workflowReceiptPath, writeWorkflowReceipt, type WorkflowReceipt } from "../../workflows/workflow-receipt.ts";
-import { workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
-
-function cloneWorkflowStatus(status: AsyncStatus): AsyncStatus {
-	return {
-		...status,
-		steps: status.steps?.map((step) => ({ ...step })),
-		workflow: status.workflow ? { ...status.workflow, trace: [...(status.workflow.trace ?? [])] } : status.workflow,
-	};
-}
-
-function childSucceeded(result: Pick<SingleResult, "exitCode" | "error" | "interrupted">): boolean {
-	return result.exitCode === 0 && !result.error && !result.interrupted;
-}
-
-const UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION = "unsupported-continuation: detached workflow child settled, but JavaScript workflow continuation was not persisted. Resume the workflow explicitly instead of treating the completed child as top-level workflow completion.";
-const INTERRUPTED_DETACHED_CHILD = "Interrupted. Waiting for explicit next action.";
-type WorkflowStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
-	outputPathMapping?: { requestedPath: string; savedPath: string };
-	interrupted?: boolean;
-};
-
-function findWorkflowStep(status: AsyncStatus, childRunId: string, workflowKey?: string): WorkflowStatusStep | undefined {
-	return status.steps?.find((candidate) => candidate.runId === childRunId)
-		?? (workflowKey ? status.steps?.find((candidate) => candidate.workflowKey === workflowKey) : undefined) as WorkflowStatusStep | undefined;
-}
+import {
+	applyDetachedChildSettlement,
+	classifyWorkflowSettlement,
+	findWorkflowSettlementStep,
+	planWorkflowSettlement,
+	promoteSettledPausedWorkflow,
+	workflowOutputPathMappingSummary,
+	workflowRecoveryActions,
+	workflowTerminalOutcomeForResult,
+	type WorkflowPublicChild,
+	type WorkflowStatusStep,
+} from "../../workflows/workflow-settlement.ts";
 
 export function applyDetachedChildToPausedWorkflow(
 	status: AsyncStatus,
 	input: { childRunId: string; result: Pick<SingleResult, "exitCode" | "error" | "interrupted" | "sessionFile" | "stopped">; workflowKey?: string },
 ): AsyncStatus | undefined {
-	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
-	const next = cloneWorkflowStatus(status);
-	const step = findWorkflowStep(next, input.childRunId, input.workflowKey);
-	if (!step) return undefined;
-	const succeeded = childSucceeded(input.result);
-	const failedSiblingError = next.steps?.find((candidate) => {
-		const candidateStep = candidate as WorkflowStatusStep;
-		return candidateStep !== step && candidateStep.status === "failed" && !candidateStep.interrupted && candidateStep.error;
-	})?.error;
-	const interruptedChildError = next.steps?.find((candidate) => {
-		const candidateStep = candidate as WorkflowStatusStep;
-		return candidateStep.status === "failed" && candidateStep.interrupted && candidateStep.error;
-	})?.error;
-	const updatedAt = Date.now();
-	step.status = succeeded ? "completed" : "failed";
-	step.endedAt = updatedAt;
-	delete step.activityState;
-	delete step.currentTool;
-	delete step.currentToolStartedAt;
-	if (input.result.sessionFile) step.sessionFile = input.result.sessionFile;
-	if (succeeded) {
-		delete step.error;
-		delete step.interrupted;
-	} else if (input.result.interrupted || input.result.stopped) {
-		step.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
-		step.interrupted = true;
-		if (input.result.stopped) step.stopped = true;
-	} else {
-		delete step.interrupted;
-		delete step.stopped;
-		if (input.result.error) step.error = input.result.error;
-	}
-	next.lastUpdate = updatedAt;
-	const promoted = promotePausedWorkflowIfSettled(next);
-	if (promoted?.state === "failed" && failedSiblingError) promoted.error = failedSiblingError;
-	else if (promoted?.state === "failed" && (input.result.interrupted || input.result.stopped)) promoted.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
-	else if (promoted?.state === "failed" && input.result.error) promoted.error = input.result.error;
-	else if (promoted?.state === "failed" && interruptedChildError) promoted.error = interruptedChildError;
-	const resolved = promoted ?? next;
-	const workflowState = resolved.state === "complete" ? "completed" : resolved.state === "paused" ? "paused" : resolved.state === "stopped" ? "stopped" : "failed";
-	resolved.workflowChildren = workflowChildSummary({ parentToolCallId: resolved.toolCallId ?? resolved.runId, workflowRunId: resolved.runId, workflowState, inventoryComplete: true, trace: resolved.workflow?.trace, steps: resolved.steps });
-	return resolved;
+	return applyDetachedChildSettlement(status, input);
 }
 
 export function promotePausedWorkflowIfSettled(status: AsyncStatus): AsyncStatus | undefined {
-	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
-	const next = cloneWorkflowStatus(status);
-	const stillOpen = next.steps?.some((candidate) =>
-		candidate.status === "running"
-		|| (candidate.status === "paused" && candidate.activityState === "needs_attention")
-	) === true;
-	if (stillOpen || !next.steps?.length) return undefined;
-	const failed = next.steps.some((candidate) => candidate.status === "failed");
-	const updatedAt = Date.now();
-	next.lastUpdate = updatedAt;
-	next.state = "failed";
-	next.endedAt = updatedAt;
-	delete next.activityState;
-	if (failed) return next;
-	next.error = UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION;
-	return next;
-}
-
-function workflowResolution(status: AsyncStatus, result: Pick<SingleResult, "interrupted">): WorkflowTerminalResolution | undefined {
-	if (status.state !== "complete" && status.state !== "failed") return undefined;
-	if (status.steps?.some((step) => {
-		const candidate = step as WorkflowStatusStep;
-		return candidate.status === "failed" && !candidate.interrupted;
-	})) return "failed-child";
-	if (result.interrupted || status.steps?.some((step) => {
-		const candidate = step as WorkflowStatusStep;
-		return candidate.status === "stopped" || candidate.stopped || candidate.interrupted || candidate.error === INTERRUPTED_DETACHED_CHILD;
-	})) return "interrupted-child";
-	return "settled-awaiting-resume";
-}
-
-function workflowRecovery(receipt: WorkflowReceipt | undefined): WorkflowRecoveryAction[] {
-	if (!receipt) return [];
-	return Object.values(receipt.entries).flatMap((entry) => entry.resumability.state === "resumable"
-		? [{ key: entry.key, call: "runs.run" as const, resume: { workflowRunId: receipt.workflowRunId, key: entry.key, latest: true as const }, taskRequired: true as const }]
-		: []);
-}
-
-function resultTerminalOutcome(result: Pick<SingleResult, "timedOut" | "turnBudgetExceeded" | "toolBudgetBlocked">): WorkflowTerminalOutcome | undefined {
-	if (result.timedOut) return { state: "partial", reason: "timeout" };
-	if (result.turnBudgetExceeded || result.toolBudgetBlocked) return { state: "partial", reason: "budget_exhausted" };
-	return undefined;
+	return promoteSettledPausedWorkflow(status);
 }
 
 function workflowResultChildren(status: AsyncStatus, childRunId: string, result: SingleResult, existingResults: unknown, receipt?: WorkflowReceipt): unknown {
 	const output = getSingleResultOutput(result);
 	const outputReference = result.savedOutputPath ?? result.outputReference?.path;
 	const outputPathMapping = outputPathMappingFromTask(result.task, outputReference);
-	const terminalOutcome = resultTerminalOutcome(result);
+	const terminalOutcome = workflowTerminalOutcomeForResult(result);
 	if (Array.isArray(existingResults)) {
 		return existingResults.map((entry) => {
 			if (!entry || typeof entry !== "object" || Array.isArray(entry)) return entry;
@@ -150,7 +53,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 			if (child.runId !== childRunId) return child;
 			return {
 				...child,
-				success: childSucceeded(result),
+				success: result.exitCode === 0 && !result.error && !result.interrupted,
 				output,
 				outputState: output.trim() ? "present" : "absent",
 				detached: undefined,
@@ -179,63 +82,11 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 	}));
 }
 
-function workflowResultOutputPathMappingSummary(results: unknown): string {
-	if (!Array.isArray(results)) return "";
-	const mappings = results.flatMap((entry) => {
-		if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
-		const child = entry as Record<string, unknown>;
-		const mapping = child.outputPathMapping;
-		if (!mapping || typeof mapping !== "object" || Array.isArray(mapping)) return [];
-		const { requestedPath, savedPath } = mapping as Record<string, unknown>;
-		if (typeof requestedPath !== "string" || typeof savedPath !== "string") return [];
-		const key = typeof child.workflowKey === "string" ? child.workflowKey : "child";
-		return [`'${key}': requested ${requestedPath} -> saved ${savedPath}`];
-	});
-	return mappings.length > 0 ? ` Output path mappings: ${mappings.join("; ")}.` : "";
-}
-
-function publishedWorkflowResult(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, existing?: Record<string, unknown>, receipt?: WorkflowReceipt): Record<string, unknown> {
-	const sessionId = status.sessionId ?? (typeof existing?.sessionId === "string" ? existing.sessionId : undefined);
-	const resolution = workflowResolution(status, result);
-	const recovery = workflowRecovery(receipt);
-	const results = workflowResultChildren(status, childRunId, result, existing?.results, receipt);
-	const summary = `${resolution === "settled-awaiting-resume"
-		? `Workflow lanes settled after detached child ${childRunId} finished. JavaScript workflow continuation was not persisted.${recovery.length ? " Use the listed keyed recovery action to continue a child." : " No retained child is resumable."}`
-		: status.state === "complete"
-		? `Workflow completed after detached child ${childRunId} finished.`
-		: status.error ?? (typeof existing?.summary === "string" ? existing.summary : "Workflow failed.")}${workflowResultOutputPathMappingSummary(results)}`;
-	return {
-		...(existing ?? {}),
-		id: status.runId,
-		runId: status.runId,
-		toolCallId: status.toolCallId,
-		agent: "workflow",
-		mode: "workflow",
-		success: status.state === "complete",
-		state: status.state,
-		summary,
-		error: status.error,
-		activityState: status.activityState,
-		endedAt: status.endedAt,
-		timestamp: Date.now(),
-		results,
-		workflow: status.workflow,
-		workflowChildren: status.workflowChildren,
-		...(receipt?.terminalOutcome ? { terminalOutcome: receipt.terminalOutcome } : {}),
-		...(resolution ? { workflowResolution: resolution, recovery } : {}),
-		reconciledFromDetachedChild: childRunId,
-		...(receipt ? { workflowReceipt: { path: path.join(asyncDir, "workflow-receipt.json"), receipt } } : {}),
-		asyncDir,
-		cwd: status.cwd,
-		sessionId,
-		completionOwnerId: status.completionOwnerId,
-	};
-}
-
 function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, resolution: WorkflowTerminalResolution | undefined): WorkflowReceipt | undefined {
-	const receiptPath = workflowReceiptPath(DIRS.async, status.runId);
+	const receiptRoot = path.dirname(asyncDir);
+	const receiptPath = workflowReceiptPath(receiptRoot, status.runId);
 	if (!fs.existsSync(receiptPath)) return undefined;
-	const receipt = readWorkflowReceipt(DIRS.async, status.runId);
+	const receipt = readWorkflowReceipt(receiptRoot, status.runId);
 	const step = status.steps?.find((candidate) => candidate.runId === childRunId);
 	const key = step?.workflowKey;
 	if (!key) throw new Error(`Workflow receipt '${status.runId}' cannot identify detached child '${childRunId}' by stable key.`);
@@ -254,7 +105,7 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 	const externalRunner = normalizeExternalCliRunnerStatus(result.runner?.type === "external-cli" ? result.runner : externalStep?.runner);
 	const externalProcess = result.externalProcess ?? externalStep?.externalProcess;
 	const externalAdapter = externalRunner ? externalCliReceiptMetadata({ runner: externalRunner, externalProcess, outputReference }) : entry.externalAdapter;
-	const childTerminalOutcome = resultTerminalOutcome(result) ?? entry.terminalOutcome;
+	const childTerminalOutcome = workflowTerminalOutcomeForResult(result) ?? entry.terminalOutcome;
 	if (externalAdapter) resumability = { state: "not-resumable", reason: externalAdapter.nonResumableReason };
 	const updatedEntry: WorkflowReceipt["entries"][string] = resumability.state === "resumable"
 		? {
@@ -287,7 +138,7 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 		...(receipt.terminalOutcome ? { terminalOutcome: receipt.terminalOutcome } : {}),
 		...(resolution ? { workflowResolution: resolution } : {}),
 	};
-	if (resolution) next.recovery = workflowRecovery(next);
+	if (resolution) next.recovery = workflowRecoveryActions(next);
 	else {
 		delete next.workflowResolution;
 		delete next.recovery;
@@ -325,17 +176,8 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 	if (!next) return false;
 	const outputReference = input.result.savedOutputPath ?? input.result.outputReference?.path;
 	const outputPathMapping = outputPathMappingFromTask(input.result.task, outputReference);
-	const settledStep = findWorkflowStep(next, input.childRunId, input.workflowKey);
+	const settledStep = findWorkflowSettlementStep(next, input.childRunId, input.workflowKey);
 	if (settledStep && outputPathMapping) settledStep.outputPathMapping = outputPathMapping;
-	writeAtomicJson(path.join(asyncDir, "status.json"), next);
-	updateActiveRunIndex(asyncDir, next.state, next.toolCallId);
-	if (job) {
-		job.status = next.state;
-		job.updatedAt = next.lastUpdate;
-		job.activityState = next.activityState;
-		job.steps = next.steps?.map((step, index) => ({ ...step, index }));
-		job.workflow = next.workflow;
-	}
 	const resultPath = resultFilePath(DIRS.results, input.workflowRunId);
 	let existing: Record<string, unknown> | undefined;
 	try {
@@ -346,14 +188,55 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 	}
 	let receipt: WorkflowReceipt | undefined;
 	let receiptError: string | undefined;
-	const resolution = workflowResolution(next, input.result);
+	const resolution = classifyWorkflowSettlement(next, input.result.interrupted);
 	try {
 		receipt = reconcileWorkflowReceipt(next, input.childRunId, input.result, asyncDir, resolution);
 	} catch (error) {
 		receiptError = `Failed to reconcile async workflow receipt: ${error instanceof Error ? error.message : String(error)}`;
 	}
-	const published = publishedWorkflowResult(next, input.childRunId, input.result, asyncDir, existing, receipt);
-	writeAsyncResultFile(resultPath, published);
+	const results = workflowResultChildren(next, input.childRunId, input.result, existing?.results, receipt) as WorkflowPublicChild[];
+	const recovery = workflowRecoveryActions(receipt);
+	const summary = `${resolution === "settled-awaiting-resume"
+		? `Workflow lanes settled after detached child ${input.childRunId} finished. JavaScript workflow continuation was not persisted.${recovery.length ? " Use the listed keyed recovery action to continue a child." : " No retained child is resumable."}`
+		: next.state === "complete"
+			? `Workflow completed after detached child ${input.childRunId} finished.`
+			: next.error ?? (typeof existing?.summary === "string" ? existing.summary : "Workflow failed.")}${workflowOutputPathMappingSummary(results)}`;
+	const plan = planWorkflowSettlement({
+		status: next,
+		summary,
+		children: results,
+		baseResult: {
+			...(existing ?? {}),
+			id: next.runId,
+			runId: next.runId,
+			toolCallId: next.toolCallId,
+			agent: "workflow",
+			mode: "workflow",
+			endedAt: next.endedAt,
+			workflow: next.workflow,
+			reconciledFromDetachedChild: input.childRunId,
+			asyncDir,
+			cwd: next.cwd,
+			sessionId: next.sessionId ?? (typeof existing?.sessionId === "string" ? existing.sessionId : undefined),
+			completionOwnerId: next.completionOwnerId,
+		},
+		receipt,
+		receiptPath: path.join(asyncDir, "workflow-receipt.json"),
+		receiptPersistenceError: receiptError,
+		resolution,
+		terminalOutcome: receipt?.terminalOutcome,
+		eventMetadata: { reconciledFromDetachedChild: input.childRunId },
+	});
+	writeAtomicJson(path.join(asyncDir, "status.json"), plan.status);
+	updateActiveRunIndex(asyncDir, plan.status.state, plan.status.toolCallId);
+	if (job) {
+		job.status = plan.status.state;
+		job.updatedAt = plan.status.lastUpdate;
+		job.activityState = plan.status.activityState;
+		job.steps = plan.status.steps?.map((step, index) => ({ ...step, index }));
+		job.workflow = plan.status.workflow;
+	}
+	writeAsyncResultFile(resultPath, plan.publicResult);
 	if (receiptError) {
 		appendDetachedWorkflowEvent(asyncDir, {
 			ts: Date.now(),
@@ -363,18 +246,12 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 			reconciledFromDetachedChild: input.childRunId,
 		});
 	}
-	if (next.state === "complete" || next.state === "failed") {
-		if (!resolution) throw new Error(`Terminal detached workflow '${input.workflowRunId}' has no resolution classification.`);
+	if (plan.completionEvent) {
 		appendDetachedWorkflowEvent(asyncDir, {
 			ts: Date.now(),
 			runId: input.workflowRunId,
-			type: "subagent.workflow.completed",
-			state: next.state,
-			workflowResolution: resolution,
-			...(receipt?.terminalOutcome ? { terminalOutcome: receipt.terminalOutcome } : {}),
-			recovery: workflowRecovery(receipt),
-			...(next.error ? { error: next.error } : {}),
-			reconciledFromDetachedChild: input.childRunId,
+			...plan.completionEvent,
+			recovery: plan.recovery,
 		});
 		input.events?.emit(SUBAGENT_ASYNC_COMPLETE_EVENT, {
 			id: input.workflowRunId,
@@ -382,16 +259,16 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 			source: "async",
 			mode: "workflow",
 			agent: "workflow",
-			success: next.state === "complete",
-			state: next.state,
-			workflowResolution: resolution,
-			...(receipt?.terminalOutcome ? { terminalOutcome: receipt.terminalOutcome } : {}),
-			recovery: workflowRecovery(receipt),
-			summary: typeof published.summary === "string" ? published.summary : (next.state === "complete" ? "Workflow completed." : next.error),
+			success: plan.status.state === "complete",
+			state: plan.status.state,
+			...(resolution ? { workflowResolution: resolution } : {}),
+			...(plan.receipt?.terminalOutcome ? { terminalOutcome: plan.receipt.terminalOutcome } : {}),
+			recovery: plan.recovery,
+			summary: typeof plan.publicResult.summary === "string" ? plan.publicResult.summary : plan.status.error,
 			reconciledFromDetachedChild: input.childRunId,
-			...(Array.isArray(published.results) ? { results: published.results } : {}),
-			sessionId: next.sessionId,
-			completionOwnerId: next.completionOwnerId,
+			results,
+			sessionId: plan.status.sessionId,
+			completionOwnerId: plan.status.completionOwnerId,
 			timestamp: Date.now(),
 			triggerTurn: true,
 		});

--- a/src/workflows/workflow-settlement.ts
+++ b/src/workflows/workflow-settlement.ts
@@ -1,0 +1,235 @@
+import type {
+	AsyncStatus,
+	WorkflowRecoveryAction,
+	WorkflowTerminalOutcome,
+	WorkflowTerminalResolution,
+} from "../shared/types.ts";
+import type { WorkflowReceipt } from "./workflow-receipt.ts";
+import { workflowChildSummary } from "./workflow-child-summary.ts";
+
+export const UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION = "unsupported-continuation: detached workflow child settled, but JavaScript workflow continuation was not persisted. Resume the workflow explicitly instead of treating the completed child as top-level workflow completion.";
+export const INTERRUPTED_DETACHED_CHILD = "Interrupted. Waiting for explicit next action.";
+export const EVIDENCE_PERSISTENCE_FAILED = "evidence-persistence-failed";
+
+export type WorkflowStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
+	outputPathMapping?: { requestedPath: string; savedPath: string };
+	interrupted?: boolean;
+};
+
+export interface WorkflowPublicChild {
+	workflowKey?: string;
+	agent?: string;
+	runId?: string;
+	output: string;
+	outputState: "present" | "absent";
+	structuredOutput?: unknown;
+	success: boolean;
+	terminalOutcome?: WorkflowTerminalOutcome;
+	outputReference?: string;
+	outputPathMapping?: { requestedPath: string; savedPath: string };
+	stopped?: boolean;
+	interrupted?: boolean;
+	detached?: boolean;
+	error?: string;
+	artifactPaths?: { outputPath: string };
+}
+
+export interface WorkflowSettlementPlan {
+	status: AsyncStatus;
+	publicResult: Record<string, unknown>;
+	receipt?: WorkflowReceipt;
+	recovery: WorkflowRecoveryAction[];
+	completionEvent?: Record<string, unknown>;
+}
+
+function cloneWorkflowStatus(status: AsyncStatus): AsyncStatus {
+	return {
+		...status,
+		steps: status.steps?.map((step) => ({ ...step })),
+		workflow: status.workflow ? { ...status.workflow, trace: [...(status.workflow.trace ?? [])] } : status.workflow,
+	};
+}
+
+function workflowState(status: AsyncStatus): "completed" | "failed" | "paused" | "stopped" {
+	return status.state === "complete" ? "completed" : status.state === "paused" ? "paused" : status.state === "stopped" ? "stopped" : "failed";
+}
+
+function withWorkflowChildren(status: AsyncStatus): AsyncStatus {
+	return {
+		...status,
+		workflowChildren: workflowChildSummary({
+			parentToolCallId: status.toolCallId ?? status.runId,
+			workflowRunId: status.runId,
+			workflowState: workflowState(status),
+			inventoryComplete: true,
+			trace: status.workflow?.trace,
+			steps: status.steps,
+		}),
+	};
+}
+
+export function findWorkflowSettlementStep(status: AsyncStatus, childRunId: string, workflowKey?: string): WorkflowStatusStep | undefined {
+	return status.steps?.find((candidate) => candidate.runId === childRunId)
+		?? (workflowKey ? status.steps?.find((candidate) => candidate.workflowKey === workflowKey) : undefined) as WorkflowStatusStep | undefined;
+}
+
+export function promoteSettledPausedWorkflow(status: AsyncStatus, now = Date.now()): AsyncStatus | undefined {
+	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
+	const next = cloneWorkflowStatus(status);
+	const stillOpen = next.steps?.some((candidate) =>
+		candidate.status === "running"
+		|| (candidate.status === "paused" && candidate.activityState === "needs_attention")
+	) === true;
+	if (stillOpen || !next.steps?.length) return undefined;
+	const failed = next.steps.some((candidate) => candidate.status === "failed");
+	next.lastUpdate = now;
+	next.state = "failed";
+	next.endedAt = now;
+	delete next.activityState;
+	if (!failed) next.error = UNSUPPORTED_DETACHED_WORKFLOW_CONTINUATION;
+	return withWorkflowChildren(next);
+}
+
+export function applyDetachedChildSettlement(
+	status: AsyncStatus,
+	input: { childRunId: string; result: { exitCode: number | null; error?: string; interrupted?: boolean; sessionFile?: string; stopped?: boolean }; workflowKey?: string; now?: number },
+): AsyncStatus | undefined {
+	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
+	const next = cloneWorkflowStatus(status);
+	const step = findWorkflowSettlementStep(next, input.childRunId, input.workflowKey);
+	if (!step) return undefined;
+	const succeeded = input.result.exitCode === 0 && !input.result.error && !input.result.interrupted;
+	const failedSiblingError = next.steps?.find((candidate) => {
+		const candidateStep = candidate as WorkflowStatusStep;
+		return candidateStep !== step && candidateStep.status === "failed" && !candidateStep.interrupted && candidateStep.error;
+	})?.error;
+	const interruptedChildError = next.steps?.find((candidate) => {
+		const candidateStep = candidate as WorkflowStatusStep;
+		return candidateStep.status === "failed" && candidateStep.interrupted && candidateStep.error;
+	})?.error;
+	const now = input.now ?? Date.now();
+	step.status = succeeded ? "completed" : "failed";
+	step.endedAt = now;
+	delete step.activityState;
+	delete step.currentTool;
+	delete step.currentToolStartedAt;
+	if (input.result.sessionFile) step.sessionFile = input.result.sessionFile;
+	if (succeeded) {
+		delete step.error;
+		delete step.interrupted;
+	} else if (input.result.interrupted || input.result.stopped) {
+		step.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
+		step.interrupted = true;
+		if (input.result.stopped) step.stopped = true;
+	} else {
+		delete step.interrupted;
+		delete step.stopped;
+		if (input.result.error) step.error = input.result.error;
+	}
+	next.lastUpdate = now;
+	const promoted = promoteSettledPausedWorkflow(next, now);
+	if (promoted?.state === "failed" && failedSiblingError) promoted.error = failedSiblingError;
+	else if (promoted?.state === "failed" && (input.result.interrupted || input.result.stopped)) promoted.error = input.result.error ?? INTERRUPTED_DETACHED_CHILD;
+	else if (promoted?.state === "failed" && input.result.error) promoted.error = input.result.error;
+	else if (promoted?.state === "failed" && interruptedChildError) promoted.error = interruptedChildError;
+	return withWorkflowChildren(promoted ?? next);
+}
+
+export function classifyWorkflowSettlement(status: AsyncStatus, interrupted = false): WorkflowTerminalResolution | undefined {
+	if (status.state !== "complete" && status.state !== "failed") return undefined;
+	if (status.steps?.some((step) => {
+		const candidate = step as WorkflowStatusStep;
+		return candidate.status === "failed" && !candidate.interrupted;
+	})) return "failed-child";
+	if (interrupted || status.steps?.some((step) => {
+		const candidate = step as WorkflowStatusStep;
+		return candidate.status === "stopped" || candidate.stopped || candidate.interrupted || candidate.error === INTERRUPTED_DETACHED_CHILD;
+	})) return "interrupted-child";
+	return "settled-awaiting-resume";
+}
+
+export function workflowRecoveryActions(receipt: WorkflowReceipt | undefined): WorkflowRecoveryAction[] {
+	if (!receipt) return [];
+	return Object.values(receipt.entries).flatMap((entry) => entry.resumability.state === "resumable"
+		? [{ key: entry.key, call: "runs.run" as const, resume: { workflowRunId: receipt.workflowRunId, key: entry.key, latest: true as const }, taskRequired: true as const }]
+		: []);
+}
+
+export function workflowTerminalOutcomeForResult(result: { timedOut?: boolean; turnBudgetExceeded?: boolean; toolBudgetBlocked?: boolean }): WorkflowTerminalOutcome | undefined {
+	if (result.timedOut) return { state: "partial", reason: "timeout" };
+	if (result.turnBudgetExceeded || result.toolBudgetBlocked) return { state: "partial", reason: "budget_exhausted" };
+	return undefined;
+}
+
+export function workflowOutputPathMappingSummary(children: readonly unknown[]): string {
+	const mappings = children.flatMap((entry) => {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+		const child = entry as Partial<WorkflowPublicChild>;
+		return child.outputPathMapping
+			? [`'${child.workflowKey ?? "child"}': requested ${child.outputPathMapping.requestedPath} -> saved ${child.outputPathMapping.savedPath}`]
+			: [];
+	});
+	return mappings.length > 0 ? ` Output path mappings: ${mappings.join("; ")}.` : "";
+}
+
+export function planWorkflowSettlement(input: {
+	status: AsyncStatus;
+	summary: string;
+	children: WorkflowPublicChild[];
+	baseResult: Record<string, unknown>;
+	receipt?: WorkflowReceipt;
+	receiptPath?: string;
+	receiptPersistenceError?: string;
+	resolution?: WorkflowTerminalResolution;
+	terminalOutcome?: WorkflowTerminalOutcome;
+	now?: number;
+	eventMetadata?: Record<string, unknown>;
+}): WorkflowSettlementPlan {
+	const now = input.now ?? Date.now();
+	let status = withWorkflowChildren(cloneWorkflowStatus(input.status));
+	let summary = input.summary;
+	let receipt = input.receipt;
+	let resolution = input.resolution;
+	if (input.receiptPersistenceError) {
+		const diagnostic = `${EVIDENCE_PERSISTENCE_FAILED}: ${input.receiptPersistenceError}`;
+		status = withWorkflowChildren({ ...status, state: "failed", error: diagnostic, activityState: undefined, endedAt: now, lastUpdate: now });
+		summary = `${diagnostic} Available child evidence was preserved, but workflow completion was not accepted.`;
+		receipt = undefined;
+		if (!resolution) resolution = classifyWorkflowSettlement(status);
+	}
+	const recovery = workflowRecoveryActions(receipt);
+	if (receipt) {
+		receipt = {
+			...receipt,
+			state: status.state === "complete" ? "complete" : status.state === "paused" ? "paused" : status.state === "stopped" ? "stopped" : "failed",
+			workflowChildren: status.workflowChildren,
+			...(resolution ? { workflowResolution: resolution, recovery } : {}),
+		};
+	}
+	const publicResult: Record<string, unknown> = {
+		...input.baseResult,
+		success: status.state === "complete",
+		state: status.state,
+		summary,
+		error: status.state === "complete" ? undefined : status.error ?? summary,
+		stopped: status.stopped ? true : undefined,
+		activityState: status.activityState,
+		workflowChildren: status.workflowChildren,
+		results: input.children,
+		...(input.terminalOutcome ? { terminalOutcome: input.terminalOutcome } : {}),
+		...(resolution ? { workflowResolution: resolution, recovery } : {}),
+		...(receipt && input.receiptPath ? { workflowReceipt: { path: input.receiptPath, receipt } } : {}),
+		timestamp: now,
+	};
+	const terminal = status.state === "complete" || status.state === "failed" || status.state === "stopped";
+	const completionEvent = terminal ? {
+		type: "subagent.workflow.completed",
+		state: status.state,
+		...(resolution ? { workflowResolution: resolution } : {}),
+		...(input.terminalOutcome ? { terminalOutcome: input.terminalOutcome } : {}),
+		...(status.error ? { error: status.error } : {}),
+		...(status.activityState ? { activityState: status.activityState } : {}),
+		...input.eventMetadata,
+	} : undefined;
+	return { status, publicResult, receipt, recovery, completionEvent };
+}

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -473,6 +473,30 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		assert.ok(published.summary?.includes(`'second': requested ${secondRequestedPath} -> saved ${secondSavedPath}`));
 	});
 
+	it("skips non-object existing result entries while summarizing output mappings", () => {
+		const workflowRunId = "workflow-existing-non-object-results";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const requestedPath = path.join(asyncDir, "requested.md");
+		const savedPath = path.join(asyncDir, "saved.md");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ ...pausedWorkflow("child-1"), runId: workflowRunId, sessionId: "session-1" }), "utf-8");
+		fs.writeFileSync(path.join(DIRS.results, `${workflowRunId}.json`), JSON.stringify({ activityState: "needs_attention", results: [null, { workflowKey: "detaches", runId: "child-1", success: false, output: "old", outputState: "present" }] }), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "child-1",
+			result: { index: 0, agent: "worker", task: `Write your findings to exactly this path: ${requestedPath}`, exitCode: 0, savedOutputPath: savedPath, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), true);
+
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { activityState?: string; summary?: string; results?: unknown[] };
+		assert.equal(published.activityState, undefined);
+		assert.equal(published.results?.[0], null);
+		assert.ok(published.summary?.includes(`'detaches': requested ${requestedPath} -> saved ${savedPath}`));
+	});
+
 	it("publishes detached completion when the workflow receipt is malformed", () => {
 		const workflowRunId = "workflow-malformed-receipt";
 		const asyncDir = path.join(DIRS.async, workflowRunId);
@@ -495,7 +519,7 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; error?: string; workflowReceipt?: unknown };
 		assert.equal(published.state, "failed");
 		assert.equal(published.success, false);
-		assert.match(published.error ?? "", /unsupported-continuation/);
+		assert.match(published.error ?? "", /evidence-persistence-failed/);
 		assert.equal(published.workflowReceipt, undefined);
 		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
 		assert.match(events, /"type":"subagent.workflow.receipt_write_failed"/);
@@ -530,10 +554,11 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			console.error = originalConsoleError;
 		}
 
-		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; error?: string; workflowReceipt?: unknown; reconciledFromDetachedChild?: string };
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; error?: string; summary?: string; workflowReceipt?: unknown; reconciledFromDetachedChild?: string };
 		assert.equal(published.state, "failed");
 		assert.equal(published.success, false);
-		assert.match(published.error ?? "", /unsupported-continuation/);
+		assert.match(published.error ?? "", /evidence-persistence-failed/);
+		assert.match(published.summary ?? "", /Available child evidence was preserved/);
 		assert.equal(published.workflowReceipt, undefined);
 		assert.equal(published.reconciledFromDetachedChild, "child-1");
 		assert.equal(emitted?.name, "subagent:async-complete");
@@ -547,7 +572,7 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			state: "failed",
 			workflowResolution: "settled-awaiting-resume",
 			recovery: [],
-			summary: "Workflow lanes settled after detached child child-1 finished. JavaScript workflow continuation was not persisted. No retained child is resumable.",
+			summary: published.summary,
 			reconciledFromDetachedChild: "child-1",
 			results: [{ workflowKey: "detaches", agent: "worker", runId: "child-1", success: true, output: "", outputState: "absent" }],
 			sessionId: "session-1",


### PR DESCRIPTION
## Summary

This extracts detached workflow settlement planning into `src/workflows/workflow-settlement.ts`.

The caller still owns the adapters for status writes, result files, active-run-index updates, receipt I/O, and event emission. Receipt persistence failures now keep the fail-closed terminal result with an explicit `evidence-persistence-failed` diagnostic.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/workflow-detach-reconcile.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'scripted-workflow-settlement' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh review: `workflow-settlement-review.md`
- Follow-up review: `workflow-settlement-followup-review.md`
