### PR TITLE
refactor: extract completion evidence planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Extract detached workflow settlement planning into a focused workflow module while preserving fail-closed result handoff.
+- Extract completion evidence planning into a focused module shared by foreground and background execution.
 
 ## [0.58.0] - 2026-08-27
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -50,7 +50,6 @@ import {
 	type SteeringTargetState,
 	type SteeringTargetStatus,
 	type SubagentChildStatusEvent,
-	type SettlementDiagnostic,
 	DEFAULT_MAX_OUTPUT,
 	type MaxOutputConfig,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -104,6 +103,7 @@ import { createSteeringStatus, recordSteeringRequest, steeringStatus, terminalSt
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { PROMPT_REDACTED, detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
 import { evaluateCompletionMutationGuard, expectsImplementationMutation, hasMutationToolCapability, validateImplementationToolContract } from "../shared/completion-guard.ts";
+import { planCompletionEvidence, projectSettlementDiagnostic } from "../shared/completion-evidence.ts";
 import {
 	createMutatingFailureState,
 	didMutatingToolFail,
@@ -1904,25 +1904,16 @@ async function runSingleStepInner(
 			}))
 			: undefined;
 		const mutationAttemptObserved = run.observedMutationAttempt === true || completionMutationEvidence?.attemptedMutation === true;
-		const completionGuardTriggered = completionGuard?.triggered === true && !mutationAttemptObserved;
-		const completionGuardBlocked = completionGuard?.blocked === true;
-		const mutationExpected = completionGuard?.expectedMutation ?? (completionGuardEnabled
-			&& hasMutationToolCapability(completionTools, completionToolPlan?.effectiveMcpTools ?? step.mcpDirectTools)
-			&& expectsImplementationMutation(step.agent, taskForCompletionGuard));
-		const fileMutationEffect = completionGuard
-			? {
-				status: completionGuardBlocked ? "blocked" as const : completionGuard.expectedMutation ? completionGuardTriggered ? "missing" as const : "observed" as const : "not-applicable" as const,
-				expected: completionGuard.expectedMutation,
-				attempted: completionGuardBlocked ? false : completionGuard.attemptedMutation || mutationAttemptObserved,
-				...(completionMutationEvidence ? { evidence: completionMutationEvidence } : {}),
-				...(completionGuardBlocked && completionGuard.message ? { message: completionGuard.message } : {}),
-				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
-			}
-			: undefined;
-		const completionGuardError = completionGuardTriggered && !isAgentContractV1(step.agentContract)
-			? "Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes."
-			: undefined;
-		const effectiveExitCode = toolAvailabilityError || (completionGuardTriggered && !isAgentContractV1(step.agentContract)) || midToolExitError || structuredError || emptyOutputError
+		const completionEvidence = planCompletionEvidence({
+			guard: completionGuard,
+			completionGuardEnabled,
+			mutationCapable: hasMutationToolCapability(completionTools, completionToolPlan?.effectiveMcpTools ?? step.mcpDirectTools),
+			implementationMutationExpected: expectsImplementationMutation(step.agent, taskForCompletionGuard),
+			mutationAttemptObserved,
+			mutationEvidence: completionMutationEvidence,
+			agentContractV1: isAgentContractV1(step.agentContract),
+		});
+		const effectiveExitCode = toolAvailabilityError || completionEvidence.legacyFailureError || midToolExitError || structuredError || emptyOutputError
 			? 1
 			: hiddenError?.hasError
 				? (hiddenError.exitCode ?? 1)
@@ -1938,7 +1929,7 @@ async function runSingleStepInner(
 		})) ? formatProcessSignalError(run.processSignal!) : undefined;
 		const error = formatSubagentExtensionConflictError(
 			toolAvailabilityError
-				?? completionGuardError
+				?? completionEvidence.legacyFailureError
 				?? midToolExitError
 				?? structuredError
 				?? emptyOutputError
@@ -1961,7 +1952,7 @@ async function runSingleStepInner(
 		});
 		modelAttempts.push(attempt);
 		if (candidate && startupAttemptIndex === 0) attemptedModels.push(candidate);
-		completionGuardTriggeredFinal = completionGuardTriggered;
+		completionGuardTriggeredFinal = completionEvidence.guardTriggered;
 		finalOutputSnapshot = outputSnapshot;
 		if (step.toolBudget) {
 			const toolMessages = run.messages.filter((message) => message.role === "toolResult");
@@ -1974,22 +1965,17 @@ async function runSingleStepInner(
 			: effectiveStructuredOutput
 				? { kind: "structured" as const, path: effectiveStructuredOutput.outputPath, missing: !fs.existsSync(effectiveStructuredOutput.outputPath) }
 			: undefined;
-		const settlementDiagnostic: SettlementDiagnostic | undefined = effectiveExitCode !== 0 || completionGuardTriggered || completionGuardBlocked
-			? {
-				finalTextPresent: Boolean(stripAcceptanceReport(run.finalOutput).trim()),
-				mutation: {
-					expected: mutationExpected,
-					attempted: completionGuard?.attemptedMutation === true || mutationAttemptObserved,
-					observed: mutationEvidence.attemptedMutation,
-				},
-				...(requiredOutput ? { requiredOutput } : {}),
-				afterCompactionSettlement: run.afterCompactionSettlement === true,
-			}
-			: undefined;
-		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect || settlementDiagnostic ? { effects: { ...(fileMutationEffect ? { fileMutation: fileMutationEffect } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunPiStreamingResult;
+		const settlementDiagnostic = projectSettlementDiagnostic(completionEvidence, {
+			terminalFailed: effectiveExitCode !== 0,
+			finalTextPresent: Boolean(stripAcceptanceReport(run.finalOutput).trim()),
+			mutationObserved: mutationEvidence.attemptedMutation,
+			requiredOutput,
+			afterCompactionSettlement: run.afterCompactionSettlement === true,
+		});
+		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(completionEvidence.fileMutation || settlementDiagnostic ? { effects: { ...(completionEvidence.fileMutation ? { fileMutation: completionEvidence.fileMutation } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunPiStreamingResult;
 		if (run.turnBudgetExceeded) break modelAttemptsLoop;
 		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
-		if (attempt.success || completionGuardTriggered) break modelAttemptsLoop;
+		if (attempt.success || completionEvidence.guardTriggered) break modelAttemptsLoop;
 
 		const startupFailure = isRetryableSubagentStartupFailure(omitUndefinedProperties({
 			exitCode: effectiveExitCode,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -55,7 +55,8 @@ import {
 import { buildSkillInjection, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
 import { effectiveToolTimeoutMs, formatToolTimeoutMessage, resolveToolTimeoutMs, toolTimeoutCallKey, toolTimeoutFromEnv } from "../shared/tool-timeout.ts";
-import { evaluateCompletionMutationGuard, validateImplementationToolContract } from "../shared/completion-guard.ts";
+import { evaluateCompletionMutationGuard, expectsImplementationMutation, hasMutationToolCapability, validateImplementationToolContract } from "../shared/completion-guard.ts";
+import { planCompletionEvidence } from "../shared/completion-evidence.ts";
 import { arbitrateCompletionGuardRescue } from "../shared/llm-intent-arbiter.ts";
 import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { preflightLaunchCwd } from "../shared/launch-cwd.ts";
@@ -1595,7 +1596,6 @@ async function runSingleAttempt(
 		: undefined;
 	const mutationAttemptObserved = observedMutationAttempt || mutationEvidence.attemptedMutation;
 	let completionGuardTriggered = completionGuard?.triggered === true && !mutationAttemptObserved;
-	const completionGuardBlocked = completionGuard?.blocked === true;
 	// The classifier is deliberately narrow, so a read-only review task can
 	// still be misread as implementation. Arbitrate BEFORE any failure side
 	// effect is published (effects, exit code, progress, notifications,
@@ -1612,31 +1612,26 @@ async function runSingleAttempt(
 		completionGuardTriggered = arbitration.triggered;
 		arbiterRescued = arbitration.rescued;
 	}
-	if (completionGuard) {
+	const completionEvidence = planCompletionEvidence({
+		guard: completionGuard,
+		guardTriggered: completionGuardTriggered,
+		completionGuardEnabled,
+		mutationCapable: hasMutationToolCapability(contractTools, toolPlan.effectiveMcpTools),
+		implementationMutationExpected: expectsImplementationMutation(agent.name, shared.originalTask ?? task),
+		mutationAttemptObserved,
+		mutationEvidence,
+		arbiterRescued,
+		agentContractV1: isAgentContractV1(options.agentContract),
+	});
+	if (completionEvidence.fileMutation) {
 		result.effects = {
 			...(result.effects ?? {}),
-			fileMutation: {
-				status: completionGuardBlocked
-					? "blocked"
-					: completionGuard.expectedMutation
-					? completionGuardTriggered
-						? "missing"
-						: arbiterRescued
-							? "not-applicable"
-							: "observed"
-					: "not-applicable",
-				expected: completionGuard.expectedMutation,
-				attempted: completionGuardBlocked ? false : completionGuard.attemptedMutation || mutationAttemptObserved,
-				evidence: mutationEvidence,
-				...(completionGuardBlocked && completionGuard.message ? { message: completionGuard.message } : {}),
-				...(completionGuardTriggered ? { message: "Subagent completed without making edits for an implementation task." } : {}),
-				...(arbiterRescued ? { resolvedBy: "llm-intent-arbiter" } : {}),
-			},
+			fileMutation: completionEvidence.fileMutation,
 		};
 	}
-	if (completionGuardTriggered && !isAgentContractV1(options.agentContract)) {
+	if (completionEvidence.legacyFailureError) {
 		result.exitCode = 1;
-		result.error = "Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes.";
+		result.error = completionEvidence.legacyFailureError;
 		progress.status = "failed";
 		progress.error = result.error;
 		emitControlEvent(buildControlEvent({

--- a/src/runs/shared/completion-evidence.ts
+++ b/src/runs/shared/completion-evidence.ts
@@ -1,0 +1,89 @@
+import type {
+	FileMutationEffect,
+	SettlementDiagnostic,
+	TrackedMutationEvidence,
+} from "../../shared/types.ts";
+import type { CompletionMutationGuardResult } from "./completion-guard.ts";
+
+export const MISSING_IMPLEMENTATION_MUTATION_MESSAGE = "Subagent completed without making edits for an implementation task.";
+export const MISSING_IMPLEMENTATION_MUTATION_ERROR = `${MISSING_IMPLEMENTATION_MUTATION_MESSAGE}\nIt appears to have returned planning or scratchpad output instead of applying changes.`;
+
+export interface CompletionEvidencePlan {
+	guardTriggered: boolean;
+	guardBlocked: boolean;
+	mutationExpected: boolean;
+	mutationAttempted: boolean;
+	fileMutation?: FileMutationEffect;
+	legacyFailureError?: string;
+}
+
+export function planCompletionEvidence(input: {
+	guard?: CompletionMutationGuardResult;
+	guardTriggered?: boolean;
+	completionGuardEnabled: boolean;
+	mutationCapable: boolean;
+	implementationMutationExpected: boolean;
+	mutationAttemptObserved: boolean;
+	mutationEvidence?: TrackedMutationEvidence;
+	arbiterRescued?: boolean;
+	agentContractV1: boolean;
+}): CompletionEvidencePlan {
+	const guardBlocked = input.guard?.blocked === true;
+	const guardTriggered = input.guardTriggered
+		?? (input.guard?.triggered === true && !input.mutationAttemptObserved);
+	const mutationExpected = input.guard?.expectedMutation
+		?? (input.completionGuardEnabled && input.mutationCapable && input.implementationMutationExpected);
+	const mutationAttempted = input.guard?.attemptedMutation === true || input.mutationAttemptObserved;
+	const fileMutation = input.guard
+		? {
+			status: guardBlocked
+				? "blocked" as const
+				: input.guard.expectedMutation
+					? guardTriggered
+						? "missing" as const
+						: input.arbiterRescued
+							? "not-applicable" as const
+							: "observed" as const
+					: "not-applicable" as const,
+			expected: input.guard.expectedMutation,
+			attempted: guardBlocked ? false : mutationAttempted,
+			...(input.mutationEvidence ? { evidence: input.mutationEvidence } : {}),
+			...(guardBlocked && input.guard.message ? { message: input.guard.message } : {}),
+			...(guardTriggered ? { message: MISSING_IMPLEMENTATION_MUTATION_MESSAGE } : {}),
+			...(input.arbiterRescued ? { resolvedBy: "llm-intent-arbiter" as const } : {}),
+		}
+		: undefined;
+	return {
+		guardTriggered,
+		guardBlocked,
+		mutationExpected,
+		mutationAttempted,
+		fileMutation,
+		legacyFailureError: guardTriggered && !input.agentContractV1
+			? MISSING_IMPLEMENTATION_MUTATION_ERROR
+			: undefined,
+	};
+}
+
+export function projectSettlementDiagnostic(
+	plan: Pick<CompletionEvidencePlan, "guardTriggered" | "guardBlocked" | "mutationExpected" | "mutationAttempted">,
+	input: {
+		terminalFailed: boolean;
+		finalTextPresent: boolean;
+		mutationObserved: boolean;
+		requiredOutput?: SettlementDiagnostic["requiredOutput"];
+		afterCompactionSettlement?: boolean;
+	},
+): SettlementDiagnostic | undefined {
+	if (!input.terminalFailed && !plan.guardTriggered && !plan.guardBlocked) return undefined;
+	return {
+		finalTextPresent: input.finalTextPresent,
+		mutation: {
+			expected: plan.mutationExpected,
+			attempted: plan.mutationAttempted,
+			observed: input.mutationObserved,
+		},
+		...(input.requiredOutput ? { requiredOutput: input.requiredOutput } : {}),
+		afterCompactionSettlement: input.afterCompactionSettlement === true,
+	};
+}

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -52,7 +52,7 @@ interface CompletionMutationGuardInput {
 	mutationEvidence?: TrackedMutationEvidence;
 }
 
-interface CompletionMutationGuardResult {
+export interface CompletionMutationGuardResult {
 	expectedMutation: boolean;
 	attemptedMutation: boolean;
 	triggered: boolean;

--- a/test/unit/completion-evidence.test.ts
+++ b/test/unit/completion-evidence.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	MISSING_IMPLEMENTATION_MUTATION_ERROR,
+	MISSING_IMPLEMENTATION_MUTATION_MESSAGE,
+	planCompletionEvidence,
+	projectSettlementDiagnostic,
+} from "../../src/runs/shared/completion-evidence.ts";
+
+const evidence = {
+	source: "tracked-files" as const,
+	trackedOnly: true as const,
+	changedFiles: [],
+	attemptedMutation: false,
+};
+
+describe("planCompletionEvidence", () => {
+	it("fails closed when expected mutation evidence is missing", () => {
+		const plan = planCompletionEvidence({
+			guard: { expectedMutation: true, attemptedMutation: false, triggered: true, blocked: false },
+			completionGuardEnabled: true,
+			mutationCapable: true,
+			implementationMutationExpected: true,
+			mutationAttemptObserved: false,
+			mutationEvidence: evidence,
+			agentContractV1: false,
+		});
+
+		assert.equal(plan.guardTriggered, true);
+		assert.equal(plan.legacyFailureError, MISSING_IMPLEMENTATION_MUTATION_ERROR);
+		assert.deepEqual(plan.fileMutation, {
+			status: "missing",
+			expected: true,
+			attempted: false,
+			evidence,
+			message: MISSING_IMPLEMENTATION_MUTATION_MESSAGE,
+		});
+	});
+
+	it("keeps agent contract v1 rejection in evidence without forcing execution failure", () => {
+		const plan = planCompletionEvidence({
+			guard: { expectedMutation: true, attemptedMutation: false, triggered: true, blocked: false },
+			completionGuardEnabled: true,
+			mutationCapable: true,
+			implementationMutationExpected: true,
+			mutationAttemptObserved: false,
+			agentContractV1: true,
+		});
+
+		assert.equal(plan.guardTriggered, true);
+		assert.equal(plan.fileMutation?.status, "missing");
+		assert.equal(plan.legacyFailureError, undefined);
+	});
+
+	it("projects blocked tool availability and arbiter rescue consistently", () => {
+		const blocked = planCompletionEvidence({
+			guard: { expectedMutation: true, attemptedMutation: false, triggered: false, blocked: true, message: "tools unavailable" },
+			completionGuardEnabled: true,
+			mutationCapable: false,
+			implementationMutationExpected: true,
+			mutationAttemptObserved: true,
+			agentContractV1: false,
+		});
+		assert.deepEqual(blocked.fileMutation, {
+			status: "blocked",
+			expected: true,
+			attempted: false,
+			message: "tools unavailable",
+		});
+		assert.equal(blocked.mutationAttempted, true);
+		assert.deepEqual(projectSettlementDiagnostic(blocked, {
+			terminalFailed: true,
+			finalTextPresent: false,
+			mutationObserved: true,
+		}), {
+			finalTextPresent: false,
+			mutation: { expected: true, attempted: true, observed: true },
+			afterCompactionSettlement: false,
+		});
+
+		const rescued = planCompletionEvidence({
+			guard: { expectedMutation: true, attemptedMutation: false, triggered: true, blocked: false },
+			guardTriggered: false,
+			completionGuardEnabled: true,
+			mutationCapable: true,
+			implementationMutationExpected: true,
+			mutationAttemptObserved: false,
+			arbiterRescued: true,
+			agentContractV1: false,
+		});
+		assert.deepEqual(rescued.fileMutation, {
+			status: "not-applicable",
+			expected: true,
+			attempted: false,
+			resolvedBy: "llm-intent-arbiter",
+		});
+		assert.equal(rescued.legacyFailureError, undefined);
+	});
+
+	it("derives fallback expectation when terminal failure prevents guard evaluation", () => {
+		const plan = planCompletionEvidence({
+			completionGuardEnabled: true,
+			mutationCapable: true,
+			implementationMutationExpected: true,
+			mutationAttemptObserved: false,
+			agentContractV1: false,
+		});
+		assert.equal(plan.mutationExpected, true);
+		assert.equal(plan.fileMutation, undefined);
+	});
+});
+
+describe("projectSettlementDiagnostic", () => {
+	it("emits explicit missing-output and mutation evidence on terminal failure", () => {
+		const plan = planCompletionEvidence({
+			completionGuardEnabled: true,
+			mutationCapable: true,
+			implementationMutationExpected: true,
+			mutationAttemptObserved: false,
+			agentContractV1: false,
+		});
+		assert.deepEqual(projectSettlementDiagnostic(plan, {
+			terminalFailed: true,
+			finalTextPresent: false,
+			mutationObserved: false,
+			requiredOutput: { kind: "file-only", path: "/tmp/report.md", missing: true },
+			afterCompactionSettlement: false,
+		}), {
+			finalTextPresent: false,
+			mutation: { expected: true, attempted: false, observed: false },
+			requiredOutput: { kind: "file-only", path: "/tmp/report.md", missing: true },
+			afterCompactionSettlement: false,
+		});
+	});
+
+	it("omits diagnostics for accepted completion with no guard finding", () => {
+		const plan = planCompletionEvidence({
+			completionGuardEnabled: false,
+			mutationCapable: false,
+			implementationMutationExpected: false,
+			mutationAttemptObserved: false,
+			agentContractV1: false,
+		});
+		assert.equal(projectSettlementDiagnostic(plan, {
+			terminalFailed: false,
+			finalTextPresent: true,
+			mutationObserved: false,
+		}), undefined);
+	});
+});


### PR DESCRIPTION
## Summary

Extracts completion evidence planning into a focused pure module shared by foreground and background execution.

The runners still own I/O, progress, result persistence, events, and process lifecycle. The new module only plans file-mutation effects, legacy fail-closed errors, and background settlement diagnostics from explicit inputs.

Closes #1572.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/completion-guard.test.ts test/unit/mutation-evidence.test.ts test/unit/completion-evidence.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'background implementation runs fail when no mutation attempt occurred|does not use shared-cwd sibling tracked edits as parallel completion-guard proof|background implementation challenges keep explicit no-change reports successful|agent contract v1 keeps async acceptance and file-mutation effects separate from execution|records blocked mutation effects when foreground implementation tools are missing|fails implementation runs that complete without mutation attempts|agent contract v1 records explicit completion guard as an effect|records blocked mutation effects when background implementation tools are missing|reports missing file-only output when a child exits without an error' test/integration/single-execution.test.ts test/integration/async-execution.test.ts`
- `npm run typecheck`
- `git diff --check`

## Review

Fresh-context review: `/Users/nicobailon/.pi/agent/memory/extensions-subagent/lane-reports/issue-1572-recovery-workflow.issue1572-review-recovery.json`
