### PR TITLE
fix: resume children after provider aborts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Remove assistant turn budgets, including hard termination, wrap-up prompt injection, and launch/configuration surface.
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
+### Fixed
+- Resume a retained child session once after a provider or transport abort follows useful progress, without restarting the task or involving the parent model.
+
 ## [0.58.0] - 2026-08-27
 
 ### Highlights

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -104,6 +104,7 @@ import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit
 import { PROMPT_REDACTED, detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
 import { evaluateCompletionMutationGuard, expectsImplementationMutation, hasMutationToolCapability, validateImplementationToolContract } from "../shared/completion-guard.ts";
 import { planCompletionEvidence, projectSettlementDiagnostic } from "../shared/completion-evidence.ts";
+import { planAbortRecovery } from "../shared/abort-recovery.ts";
 import {
 	createMutatingFailureState,
 	didMutatingToolFail,
@@ -1275,6 +1276,7 @@ interface SingleStepContext {
 	onExternalProcess?: (process: ExternalProcessStatus) => void;
 	onExternalJob?: (status: ExternalJobStatus) => void;
 	skipAcceptance?: () => boolean;
+	usageBudgetExhausted?: () => boolean;
 	/** False when sibling work in the same Git worktree could have caused the tracked diff. */
 	trackedMutationEvidenceForCompletionGuard?: boolean;
 	orcaProgressTab?: OrcaProgressTab;
@@ -1603,8 +1605,12 @@ async function runSingleStepInner(
 	let taskDeliveryOverride: SubagentTaskDelivery | undefined;
 	let contextOverflow = false;
 	let launchWarningsEmitted = false;
+	let abortRecoveryAttempted = false;
+	let nextAttemptTask = task;
 	modelAttemptsLoop: while (modelIndex < candidates.length) {
 		if (ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break;
+		const recoveringAbort = abortRecoveryAttempted;
+		const attemptTask = nextAttemptTask;
 		const candidate = candidates[modelIndex];
 		const expectedModelForVerification = candidate && !(step.skipPrimaryModelVerification && modelIndex === 0) ? candidate : undefined;
 		try {
@@ -1639,7 +1645,7 @@ async function runSingleStepInner(
 		const { args, env, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit: attemptCapabilityAudit, warnings } = buildPiArgs(omitUndefinedProperties({
 			parentSessionId: step.parentSessionId,
 			baseArgs: ["--mode", "json", "-p"],
-			task,
+			task: attemptTask,
 			taskDelivery: taskDeliveryOverride,
 			sessionEnabled,
 			sessionDir,
@@ -1893,7 +1899,7 @@ async function runSingleStepInner(
 			usage: run.usage,
 		});
 		modelAttempts.push(attempt);
-		if (candidate && startupAttemptIndex === 0) attemptedModels.push(candidate);
+		if (!recoveringAbort && candidate && startupAttemptIndex === 0) attemptedModels.push(candidate);
 		completionGuardTriggeredFinal = completionEvidence.guardTriggered;
 		finalOutputSnapshot = outputSnapshot;
 		if (step.toolBudget) {
@@ -1917,6 +1923,28 @@ async function runSingleStepInner(
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(completionEvidence.fileMutation || settlementDiagnostic ? { effects: { ...(completionEvidence.fileMutation ? { fileMutation: completionEvidence.fileMutation } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunPiStreamingResult;
 		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
 		if (attempt.success || completionEvidence.guardTriggered) break modelAttemptsLoop;
+		if (recoveringAbort) break modelAttemptsLoop;
+		const abortRecovery = planAbortRecovery({
+			messages: run.messages,
+			error,
+			processSignal: run.processSignal,
+			sessionAvailable: Boolean(step.sessionFile && fs.existsSync(step.sessionFile)),
+			alreadyResumed: abortRecoveryAttempted,
+			stopped: run.stopped,
+			interrupted: run.interrupted,
+			timedOut: run.timedOut,
+			toolBudgetExhausted: run.toolBudgetBlocked || toolBudgetBlocked,
+			usageBudgetExhausted: ctx.usageBudgetExhausted?.(),
+			structuredOutputFailed: Boolean(structuredError),
+			acceptanceFailed: false,
+			currentTool: run.currentTool,
+		});
+		if (abortRecovery.action === "resume") {
+			abortRecoveryAttempted = true;
+			nextAttemptTask = abortRecovery.prompt;
+			attemptNotes.push("[abort-recovery] provider/transport abort after useful progress; resuming the retained child session once.");
+			continue;
+		}
 
 		const startupFailure = isRetryableSubagentStartupFailure(omitUndefinedProperties({
 			exitCode: effectiveExitCode,
@@ -4076,6 +4104,7 @@ async function runSubagent(
 					onExternalProcess: (process) => updateExternalProcess(fi, process),
 					onExternalJob: (externalJob) => updateExternalJob(fi, externalJob),
 					skipAcceptance: () => timedOut || stopped || childStopRequests.has(fi),
+					usageBudgetExhausted: () => refreshUsageBudget()?.exhausted === true,
 					orcaProgressTab,
 				}), config.deadlineAt);
 				const taskEndTime = Date.now();
@@ -4471,6 +4500,7 @@ async function runSubagent(
 							onExternalProcess: (process) => updateExternalProcess(fi, process),
 							onExternalJob: (externalJob) => updateExternalJob(fi, externalJob),
 							skipAcceptance: () => timedOut || stopped || childStopRequests.has(fi),
+							usageBudgetExhausted: () => refreshUsageBudget()?.exhausted === true,
 							orcaProgressTab,
 						}), config.deadlineAt);
 						if (task.sessionFile) {
@@ -4825,6 +4855,7 @@ async function runSubagent(
 				onExternalProcess: (process) => updateExternalProcess(flatIndex, process),
 				onExternalJob: (externalJob) => updateExternalJob(flatIndex, externalJob),
 				skipAcceptance: () => timedOut || stopped || childStopRequests.has(flatIndex),
+				usageBudgetExhausted: () => refreshUsageBudget()?.exhausted === true,
 				orcaProgressTab,
 				}), config.deadlineAt);
 			} catch (error) {

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -57,6 +57,7 @@ import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
 import { effectiveToolTimeoutMs, formatToolTimeoutMessage, resolveToolTimeoutMs, toolTimeoutCallKey, toolTimeoutFromEnv } from "../shared/tool-timeout.ts";
 import { evaluateCompletionMutationGuard, expectsImplementationMutation, hasMutationToolCapability, validateImplementationToolContract } from "../shared/completion-guard.ts";
 import { planCompletionEvidence } from "../shared/completion-evidence.ts";
+import { planAbortRecovery } from "../shared/abort-recovery.ts";
 import { arbitrateCompletionGuardRescue } from "../shared/llm-intent-arbiter.ts";
 import { getPiSpawnCommand } from "../shared/pi-spawn.ts";
 import { preflightLaunchCwd } from "../shared/launch-cwd.ts";
@@ -1866,12 +1867,16 @@ async function runSyncCompletionInner(
 	// Escalated to "file" after an unexplained zero-activity startup failure so
 	// retries keep the task text out of argv (endpoint pre-exec scans may deny it).
 	let taskDeliveryOverride: SubagentTaskDelivery | undefined;
+	let abortRecoveryAttempted = false;
+	let nextAttemptTask = taskWithAcceptance;
 	modelAttemptsLoop: for (let modelIndex = 0; modelIndex < modelsToTry.length; modelIndex++) {
 		const candidate = modelsToTry[modelIndex];
 		for (let startupAttemptIndex = 0; ; startupAttemptIndex++) {
+			const recoveringAbort = abortRecoveryAttempted;
+			const attemptTask = nextAttemptTask;
 			const verifyModel = Boolean(candidate) && !(options.modelOverrideFromParent && modelIndex === 0);
 			const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
-			const result = await runSingleAttempt(runtimeCwd, agent, taskWithAcceptance, candidate, attemptOptions, {
+			const result = await runSingleAttempt(runtimeCwd, agent, attemptTask, candidate, attemptOptions, {
 				sessionEnabled,
 				systemPrompt,
 				resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
@@ -1891,7 +1896,7 @@ async function runSyncCompletionInner(
 				verifyModel,
 			});
 			lastResult = result;
-			if (startupAttemptIndex === 0) {
+			if (!recoveringAbort && startupAttemptIndex === 0) {
 				if (result.model) attemptedModels.push(result.model);
 				else if (candidate) attemptedModels.push(candidate);
 			}
@@ -1907,6 +1912,30 @@ async function runSyncCompletionInner(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
+			if (!attemptSucceeded && !recoveringAbort) {
+				const abortRecovery = planAbortRecovery({
+					messages: result.messages ?? [],
+					error: result.error,
+					processSignal: result.processSignal,
+					sessionAvailable: Boolean(options.sessionFile && existsSync(options.sessionFile)),
+					alreadyResumed: abortRecoveryAttempted,
+					stopped: result.stopped || result.detached || options.signal?.aborted,
+					interrupted: result.interrupted || intercomDetached || options.interruptSignal?.aborted,
+					timedOut: result.timedOut,
+					toolBudgetExhausted: result.toolBudgetBlocked,
+					usageBudgetExhausted: false,
+					structuredOutputFailed: result.structuredOutputFailed,
+					acceptanceFailed: false,
+					currentTool: result.progress?.currentTool,
+				});
+				if (abortRecovery.action === "resume") {
+					abortRecoveryAttempted = true;
+					nextAttemptTask = abortRecovery.prompt;
+					attemptNotes.push("[abort-recovery] provider/transport abort after useful progress; resuming the retained child session once.");
+					continue;
+				}
+			}
+			if (recoveringAbort && !attemptSucceeded) break modelAttemptsLoop;
 			if (options.workflowChildPermitLaunch && !attemptSucceeded) break modelAttemptsLoop;
 			// Preserve the legacy intercom handoff contract: once this logical run has
 			// been handed to a supervisor, terminating that attempt must not launch a
@@ -2001,6 +2030,7 @@ async function runSyncCompletionInner(
 		usage: emptyUsage(),
 		error: "Subagent did not produce a result.",
 	} satisfies SingleResult, options.context);
+	result.task = task;
 
 	result.usage = aggregateUsage;
 	result.attemptedModels = attemptedModels.length > 0 ? attemptedModels : undefined;

--- a/src/runs/shared/abort-recovery.ts
+++ b/src/runs/shared/abort-recovery.ts
@@ -1,0 +1,109 @@
+import type { Message } from "@earendil-works/pi-ai";
+
+export const ABORT_RECOVERY_PROMPT = "The prior run ended from a provider/transport abort after useful progress. Continue from the current files and transcript. Do not restart. Fix any validation failure or write the required report. Finish with final output.";
+
+export type AbortRecoveryPlan =
+	| { action: "resume"; prompt: typeof ABORT_RECOVERY_PROMPT }
+	| { action: "settle"; reason: string };
+
+const PROVIDER_ABORT_PATTERN = /(?:provider|transport|connection|stream|socket|request).*(?:abort|closed|reset|ended|terminated|error|fail)|(?:abort|closed|reset|ended|terminated|error|fail).*(?:provider|transport|connection|stream|socket|request)/i;
+const ABORT_ERROR_PATTERN = /\b(?:operation|request|response|stream|connection|transport|provider)?\s*(?:was\s+)?aborted\b/i;
+const TOOL_FAILURE_PREFIX = /^[\w.:@/-]+ failed (?:(?:\(exit \d+\):)|(?:with exit code \d+))(?:\s|$)/i;
+
+function isProviderAbortError(error: string): boolean {
+	return !TOOL_FAILURE_PREFIX.test(error.trim()) && (PROVIDER_ABORT_PATTERN.test(error) || ABORT_ERROR_PATTERN.test(error));
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? value as Record<string, unknown>
+		: undefined;
+}
+
+function contentParts(message: Record<string, unknown>): unknown[] {
+	return Array.isArray(message.content) ? message.content : [];
+}
+
+function terminalAssistant(messages: readonly Message[]): { message?: Record<string, unknown>; index: number } {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = record(messages[index]);
+		if (message?.role === "assistant") return { message, index };
+	}
+	return { index: messages.length };
+}
+
+function zeroOutputUsage(message: Record<string, unknown>): boolean {
+	const usage = record(message.usage);
+	return usage !== undefined && (usage.output ?? usage.outputTokens ?? 0) === 0;
+}
+
+function hasUsefulProgress(messages: readonly Message[], terminalIndex: number): boolean {
+	for (let index = 0; index < terminalIndex; index++) {
+		const message = record(messages[index]);
+		if (!message) continue;
+		if (message.role === "assistant" && contentParts(message).length > 0) return true;
+		if (message.role === "toolResult" && message.isError !== true) return true;
+	}
+	return false;
+}
+
+function hasUnresolvedToolCall(messages: readonly Message[]): boolean {
+	const pending = new Set<string>();
+	for (const rawMessage of messages) {
+		const message = record(rawMessage);
+		if (!message) continue;
+		if (message.role === "assistant") {
+			for (const rawPart of contentParts(message)) {
+				const part = record(rawPart);
+				if (part?.type === "toolCall" && typeof part.id === "string" && part.id) pending.add(part.id);
+			}
+		} else if (message.role === "toolResult" && typeof message.toolCallId === "string") {
+			pending.delete(message.toolCallId);
+		}
+	}
+	return pending.size > 0;
+}
+
+export function planAbortRecovery(input: {
+	messages: readonly Message[];
+	error?: string;
+	processSignal?: string | null;
+	sessionAvailable: boolean;
+	alreadyResumed: boolean;
+	stopped?: boolean;
+	interrupted?: boolean;
+	timedOut?: boolean;
+	toolBudgetExhausted?: boolean;
+	usageBudgetExhausted?: boolean;
+	structuredOutputFailed?: boolean;
+	acceptanceFailed?: boolean;
+	currentTool?: string;
+}): AbortRecoveryPlan {
+	if (input.alreadyResumed) return { action: "settle", reason: "resume already attempted" };
+	if (!input.sessionAvailable) return { action: "settle", reason: "retained session unavailable" };
+	if (input.stopped || input.interrupted) return { action: "settle", reason: "explicit stop or interrupt" };
+	if (input.processSignal) return { action: "settle", reason: "process terminated by signal" };
+	if (input.timedOut) return { action: "settle", reason: "elapsed timeout" };
+	if (input.toolBudgetExhausted || input.usageBudgetExhausted) return { action: "settle", reason: "budget exhausted" };
+	if (input.structuredOutputFailed) return { action: "settle", reason: "structured output failure" };
+	if (input.acceptanceFailed) return { action: "settle", reason: "acceptance failure" };
+	if (input.currentTool || hasUnresolvedToolCall(input.messages)) return { action: "settle", reason: "tool call still in flight" };
+
+	const terminal = terminalAssistant(input.messages);
+	const message = terminal.message;
+	const error = [input.error, typeof message?.errorMessage === "string" ? message.errorMessage : undefined]
+		.filter((value): value is string => Boolean(value))
+		.join("\n");
+	const emptyZeroUsageTerminal = message !== undefined
+		&& contentParts(message).length === 0
+		&& zeroOutputUsage(message);
+	const abortMarker = message?.stopReason === "aborted"
+		|| isProviderAbortError(error);
+	const equivalentProviderAbort = isProviderAbortError(error);
+	if ((!emptyZeroUsageTerminal || !abortMarker) && !equivalentProviderAbort) {
+		return { action: "settle", reason: "terminal response is not a provider abort" };
+	}
+	const progressLimit = emptyZeroUsageTerminal ? terminal.index : input.messages.length;
+	if (!hasUsefulProgress(input.messages, progressLimit)) return { action: "settle", reason: "no useful prior progress" };
+	return { action: "resume", prompt: ABORT_RECOVERY_PROMPT };
+}

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -3198,7 +3198,8 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 1);
 	});
 
-	it("background runs do not retry provider connection errors after completed tool work", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+	it("background runs resume the retained session once after a provider abort following completed tool work", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const sessionFile = path.join(tempDir, "async-abort-recovery-session.jsonl");
 		mockPi.onCall({
 			jsonl: [
 				events.toolStart("write", { path: "side-effect.txt", content: "done" }),
@@ -3215,14 +3216,15 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 					},
 				},
 			],
-			writeFiles: [{ path: "side-effect.txt", content: "done" }],
+			writeFiles: [{ path: "side-effect.txt", content: "done" }, { path: sessionFile, content: "{}\n" }],
 			exitCode: 1,
 		});
-		mockPi.onCall({ output: "fallback must not run" });
+		mockPi.onCall({ output: "Recovered asynchronously from retained session" });
 		const id = `async-fallback-provider-after-tool-${Date.now().toString(36)}`;
 		executeAsyncSingle(id, {
 			agent: "worker",
 			task: "Do work",
+			sessionFile,
 			agentConfig: makeAgent("worker", {
 				model: "openai/gpt-5-mini:high",
 				fallbackModels: ["anthropic/claude-sonnet-4:low"],
@@ -3245,10 +3247,15 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		});
 
 		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf-8"));
-		assert.equal(payload.success, false);
-		assert.equal(payload.results[0].modelAttempts.length, 1);
-		assert.match(payload.results[0].error ?? "", /Connection error/u);
-		assert.equal(mockPi.callCount(), 1);
+		assert.equal(payload.success, true);
+		assert.deepEqual(payload.results[0].attemptedModels, ["openai/gpt-5-mini:high"]);
+		assert.deepEqual(payload.results[0].modelAttempts.map((attempt: { success: boolean }) => attempt.success), [false, true]);
+		assert.equal(mockPi.callCount(), 2);
+		const firstArgs = readMockPiArgs(mockPi, 0);
+		const resumedArgs = readMockPiArgs(mockPi, 1);
+		assert.equal(firstArgs[firstArgs.indexOf("--session") + 1], sessionFile);
+		assert.equal(resumedArgs[resumedArgs.indexOf("--session") + 1], sessionFile);
+		assert.match(resumedArgs.at(-1) ?? "", /Continue from the current files and transcript/);
 		assert.equal(fs.readFileSync(path.join(tempDir, "side-effect.txt"), "utf-8"), "done");
 	});
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -4545,10 +4545,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		);
 
 		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
-		const child = result.details.workflow?.value as { ok?: boolean; output?: string; continuation?: { runIds?: string[] } };
+		const child = result.details.workflow?.value as { ok?: boolean; runId?: string; output?: string; continuation?: { runIds?: string[] } };
 		assert.equal(child.ok, true);
 		assert.match(child.output ?? "", /Recovered after workflow auto-resume/u);
-		assert.equal(child.continuation?.runIds?.length, 2);
+		assert.deepEqual(child.continuation?.runIds, [child.runId]);
 		assert.equal(mockPi.callCount(), 2);
 	});
 
@@ -5826,7 +5826,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 1);
 	});
 
-	it("does not retry provider connection errors after completed tool work", async () => {
+	it("resumes the retained session once after a provider abort following completed tool work", async () => {
+		const sessionFile = path.join(tempDir, "abort-recovery-session.jsonl");
 		mockPi.onCall({
 			jsonl: [
 				events.toolStart("write", { path: "side-effect.txt", content: "done" }),
@@ -5843,23 +5844,29 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 					},
 				},
 			],
-			writeFiles: [{ path: "side-effect.txt", content: "done" }],
+			writeFiles: [{ path: "side-effect.txt", content: "done" }, { path: sessionFile, content: "{}\n" }],
 			exitCode: 1,
 		});
-		mockPi.onCall({ output: "fallback must not run" });
+		mockPi.onCall({ output: "Recovered from retained session" });
 		const agents = [makeAgent("echo", {
 			model: "openai/gpt-5-mini",
 			fallbackModels: ["anthropic/claude-sonnet-4"],
 		})];
 
 		const result = await runSync(tempDir, agents, "echo", "Task", {
-			runId: "no-fallback-provider-after-tool",
+			runId: "resume-provider-after-tool",
+			sessionFile,
 		});
 
-		assert.equal(result.exitCode, 1);
-		assert.match(result.error ?? "", /Connection error/u);
-		assert.equal(result.modelAttempts?.length, 1);
-		assert.equal(mockPi.callCount(), 1);
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.finalOutput, "Recovered from retained session");
+		assert.deepEqual(result.attemptedModels, ["openai/gpt-5-mini"]);
+		assert.deepEqual(result.modelAttempts?.map((attempt) => attempt.success), [false, true]);
+		assert.equal(mockPi.callCount(), 2);
+		const [firstArgs, resumedArgs] = readAllCallArgs();
+		assert.equal(firstArgs?.[firstArgs.indexOf("--session") + 1], sessionFile);
+		assert.equal(resumedArgs?.[resumedArgs.indexOf("--session") + 1], sessionFile);
+		assert.match(resumedArgs?.at(-1) ?? "", /Continue from the current files and transcript/);
 		assert.equal(fs.readFileSync(path.join(tempDir, "side-effect.txt"), "utf-8"), "done");
 	});
 

--- a/test/unit/abort-recovery.test.ts
+++ b/test/unit/abort-recovery.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Message } from "@earendil-works/pi-ai";
+import { ABORT_RECOVERY_PROMPT, planAbortRecovery } from "../../src/runs/shared/abort-recovery.ts";
+
+function messages(...entries: unknown[]): Message[] {
+	return entries as Message[];
+}
+
+const progress = {
+	role: "assistant",
+	content: [{ type: "text", text: "Implemented the helper and running validation." }],
+	usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+};
+const aborted = {
+	role: "assistant",
+	content: [],
+	stopReason: "aborted",
+	usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+};
+
+function base(overrides: Partial<Parameters<typeof planAbortRecovery>[0]> = {}) {
+	return {
+		messages: messages(progress, aborted),
+		processSignal: undefined,
+		sessionAvailable: true,
+		alreadyResumed: false,
+		...overrides,
+	};
+}
+
+describe("planAbortRecovery", () => {
+	it("plans one same-session continuation after an abort with useful progress", () => {
+		assert.deepEqual(planAbortRecovery(base()), { action: "resume", prompt: ABORT_RECOVERY_PROMPT });
+	});
+
+	it("accepts a completed tool result as useful progress", () => {
+		const toolProgress = messages(
+			{ role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "bash", arguments: {} }], usage: { output: 1 } },
+			{ role: "toolResult", toolCallId: "call-1", isError: false, content: [{ type: "text", text: "tests passed" }] },
+			aborted,
+		);
+		assert.equal(planAbortRecovery(base({ messages: toolProgress })).action, "resume");
+	});
+
+	it("fails closed without progress, a retained session, or a first-attempt permit", () => {
+		assert.equal(planAbortRecovery(base({ messages: messages(aborted) })).action, "settle");
+		assert.equal(planAbortRecovery(base({ sessionAvailable: false })).action, "settle");
+		assert.equal(planAbortRecovery(base({ alreadyResumed: true })).action, "settle");
+	});
+
+	it("does not reinterpret an ordinary empty completion as an abort", () => {
+		const emptyStop = { ...aborted, stopReason: "stop" };
+		assert.equal(planAbortRecovery(base({ messages: messages(progress, emptyStop), processSignal: undefined })).action, "settle");
+	});
+
+	it("does not treat a process signal alone as provider abort evidence", () => {
+		const emptyStop = { ...aborted, stopReason: "stop" };
+		assert.equal(planAbortRecovery(base({ messages: messages(progress, emptyStop), processSignal: "SIGKILL" })).action, "settle");
+	});
+
+	it("does not resume when a process signal accompanies abort evidence", () => {
+		assert.deepEqual(planAbortRecovery(base({ processSignal: "SIGTERM" })), { action: "settle", reason: "process terminated by signal" });
+		assert.deepEqual(planAbortRecovery(base({
+			messages: messages(progress),
+			error: "Connection reset by provider transport",
+			processSignal: "SIGKILL",
+		})), { action: "settle", reason: "process terminated by signal" });
+	});
+
+	it("excludes operator control, timeouts, budgets, schema and acceptance failures", () => {
+		for (const excluded of [
+			{ stopped: true },
+			{ interrupted: true },
+			{ timedOut: true },
+			{ toolBudgetExhausted: true },
+			{ usageBudgetExhausted: true },
+			{ structuredOutputFailed: true },
+			{ acceptanceFailed: true },
+		]) {
+			assert.equal(planAbortRecovery(base(excluded)).action, "settle");
+		}
+	});
+
+	it("fails closed while a tool call is unresolved", () => {
+		const inFlight = messages(
+			{ role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "bash", arguments: {} }], usage: { output: 1 } },
+			aborted,
+		);
+		assert.deepEqual(planAbortRecovery(base({ messages: inFlight, currentTool: "bash" })), { action: "settle", reason: "tool call still in flight" });
+		assert.deepEqual(planAbortRecovery(base({ messages: inFlight, currentTool: undefined })), { action: "settle", reason: "tool call still in flight" });
+	});
+
+	it("recognizes an equivalent transport error without a terminal assistant record", () => {
+		assert.equal(planAbortRecovery(base({
+			messages: messages(progress),
+			processSignal: undefined,
+			error: "Connection reset by provider transport",
+		})).action, "resume");
+		assert.equal(planAbortRecovery(base({
+			messages: messages(progress, { ...aborted, stopReason: "error", errorMessage: "This operation was aborted" }),
+			processSignal: undefined,
+			error: "This operation was aborted",
+		})).action, "resume");
+	});
+
+	it("does not reinterpret a network-flavored task tool failure as a provider abort", () => {
+		assert.equal(planAbortRecovery(base({
+			messages: messages(progress),
+			processSignal: undefined,
+			error: "bash failed (exit 1): request connection error",
+		})).action, "settle");
+	});
+});


### PR DESCRIPTION
## Summary

This adds one runner-owned recovery path for provider or transport aborts after useful child progress. Foreground and background runners can resume the same retained child session once with an internal continuation prompt, then settle normally.

The change keeps the policy in a pure `abort-recovery` module. The runner adapters own the actual process launch, budgets, model-attempt evidence, and final settlement.

Closes #1580.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/abort-recovery.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test --test-name-pattern 'resumes the retained session once after a provider abort|does not retry raw connection stderr|does not retry on ordinary task/tool failures|does not retry non-SIGKILL' test/integration/single-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test --test-name-pattern 'background runs resume the retained session once after a provider abort|background runs do not retry raw connection stderr' test/integration/async-execution.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review found no issues.