### PR TITLE
fix: surface partial child handoff failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Fixed
 - Resume a retained child session once after a provider or transport abort follows useful progress, without restarting the task or involving the parent model.
 
+### Fixed
+- Mark missing required child handoffs with useful mutation evidence as partial needs-attention results.
+
 ## [0.58.0] - 2026-08-27
 
 ### Highlights

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -247,7 +247,7 @@ export function resolveAsyncRunLocation(params: AsyncResumeParams, asyncDirRoot:
 }
 
 function resultState(result: AsyncResultFile): AsyncStatus["state"] {
-	if (result.state === "complete" || result.state === "failed" || result.state === "paused" || result.state === "stopped" || result.state === "running" || result.state === "queued") {
+	if (result.state === "complete" || result.state === "failed" || result.state === "partial" || result.state === "paused" || result.state === "stopped" || result.state === "running" || result.state === "queued") {
 		return result.state;
 	}
 	return result.success ? "complete" : "failed";

--- a/src/runs/background/async-status-snapshot.ts
+++ b/src/runs/background/async-status-snapshot.ts
@@ -11,7 +11,7 @@ const DEFAULT_MAX_DEPTH = 3;
 const DEFAULT_MAX_STRING_LENGTH = 160;
 const DEFAULT_MAX_SERIALIZED_BYTES = 32 * 1024;
 
-export type AsyncStatusSnapshotState = "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+export type AsyncStatusSnapshotState = "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 export type AsyncStatusSnapshotKind = "subagent" | "workflow" | "step";
 
 export interface AsyncStatusSnapshotActivityV1 {
@@ -109,7 +109,7 @@ function normalizeState(value: string): AsyncStatusSnapshotState {
 }
 
 function terminalState(state: AsyncStatusSnapshotState): boolean {
-	return state === "complete" || state === "failed" || state === "paused" || state === "stopped" || state === "rejected";
+	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped" || state === "rejected";
 }
 
 function kindForMode(mode: SubagentRunMode | undefined): AsyncStatusSnapshotKind {

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -77,7 +77,7 @@ export interface AsyncRunSummary {
 	asyncDir: string;
 	toolCallId?: string;
 	sessionId?: string;
-	state: "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+	state: "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 	error?: string;
 	activityState?: ActivityState;
 	lastActivityAt?: number;
@@ -383,6 +383,7 @@ function sortRuns(runs: AsyncRunSummary[]): AsyncRunSummary[] {
 			case "running": return 0;
 			case "queued": return 1;
 			case "failed": return 2;
+			case "partial": return 2;
 			case "stopped": return 2;
 			case "paused": return 2;
 			case "complete": return 3;

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { resultFilePath } from "./result-files.ts";
-import type { AcceptanceLedger, ArtifactPaths, AsyncStatus, CostSummary, ModelAttempt } from "../../shared/types.ts";
+import type { AcceptanceLedger, ArtifactPaths, AsyncStatus, CostSummary, EffectsProjection, ExecutionProjection, ModelAttempt } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 
 export interface ImportedAsyncRoot {
@@ -33,6 +33,8 @@ export interface ImportedAsyncRootResult {
 	transcriptError?: string;
 	timedOut?: boolean;
 	stopped?: boolean;
+	execution?: ExecutionProjection;
+	effects?: EffectsProjection;
 }
 
 interface AsyncResultFile {
@@ -49,6 +51,8 @@ interface AsyncResultFile {
 		success?: boolean;
 		timedOut?: boolean;
 		stopped?: boolean;
+		execution?: ExecutionProjection;
+		effects?: EffectsProjection;
 		sessionFile?: string;
 		intercomTarget?: string;
 		model?: string;
@@ -67,8 +71,8 @@ interface AsyncResultFile {
 	}>;
 }
 
-const TERMINAL_STATES = new Set(["complete", "failed", "paused", "stopped"]);
-const TERMINAL_STEP_STATUSES = new Set(["complete", "completed", "failed", "paused", "stopped"]);
+const TERMINAL_STATES = new Set(["complete", "failed", "partial", "paused", "stopped"]);
+const TERMINAL_STEP_STATUSES = new Set(["complete", "completed", "failed", "partial", "paused", "stopped"]);
 
 function readResultFile(resultPath: string): AsyncResultFile | undefined {
 	try {
@@ -92,12 +96,12 @@ function isTerminalStatus(status: AsyncStatus | null, index: number): boolean {
 	return TERMINAL_STATES.has(status.state);
 }
 
-function resultState(result: AsyncResultFile | undefined, child: NonNullable<AsyncResultFile["results"]>[number] | undefined): "complete" | "failed" | "paused" | "stopped" | undefined {
+function resultState(result: AsyncResultFile | undefined, child: NonNullable<AsyncResultFile["results"]>[number] | undefined): "complete" | "failed" | "partial" | "paused" | "stopped" | undefined {
 	if (!result) return undefined;
 	if (child?.stopped === true) return "stopped";
 	if (child?.success === true) return "complete";
-	if (child?.success === false) return result.state === "stopped" ? "stopped" : result.state === "paused" ? "paused" : "failed";
-	if (result.state === "complete" || result.state === "failed" || result.state === "paused" || result.state === "stopped") return result.state;
+	if (child?.success === false) return result.state === "stopped" ? "stopped" : result.state === "paused" ? "paused" : result.state === "partial" ? "partial" : "failed";
+	if (result.state === "complete" || result.state === "failed" || result.state === "partial" || result.state === "paused" || result.state === "stopped") return result.state;
 	if (result.success === true) return "complete";
 	if (result.success === false) return "failed";
 	return undefined;
@@ -108,6 +112,10 @@ function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, 
 	const timedOut = step?.timedOut === true || status.timedOut === true;
 	const stopped = step?.stopped === true || status.stopped === true || status.state === "stopped";
 	const message = step?.error ?? status.error ?? (stopped ? "Subagent stopped by user." : `Attached async root ${root.runId} ended without a result file at ${root.resultPath}.`);
+	const partialStatus = status.state === "partial" || step?.status === "partial";
+	const execution = step?.execution ?? (partialStatus
+		? { status: "partial" as const, success: false, exitCode: 1, error: message }
+		: undefined);
 	return {
 		agent,
 		output: message,
@@ -126,6 +134,8 @@ function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, 
 		...(step?.structuredOutputPath ? { structuredOutputPath: step.structuredOutputPath } : {}),
 		...(step?.structuredOutputSchemaPath ? { structuredOutputSchemaPath: step.structuredOutputSchemaPath } : {}),
 		...(step?.acceptance ? { acceptance: step.acceptance } : {}),
+		...(execution ? { execution } : {}),
+		...(step?.effects ? { effects: step.effects } : {}),
 		...(step?.transcriptPath ? { transcriptPath: step.transcriptPath } : {}),
 	};
 }
@@ -159,6 +169,7 @@ function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null
 	const stopped = child?.stopped === true || step?.stopped === true || result.stopped === true || status?.stopped === true || state === "stopped";
 	const success = state === "complete" && !timedOut && !stopped;
 	const error = child?.error ?? (success ? undefined : stopped ? "Subagent stopped by user." : result.error ?? result.summary ?? status?.error ?? `Attached async root ${root.runId} did not complete successfully.`);
+	const execution = state ? { status: state === "complete" ? "completed" as const : state, success, exitCode: success ? 0 : 1, ...(error ? { error } : {}) } : undefined;
 	return {
 		agent,
 		output: success ? output : (output || error || ""),
@@ -182,6 +193,8 @@ function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null
 		...(child?.outputSaveError ? { outputSaveError: child.outputSaveError } : {}),
 		...(child?.transcriptPath ?? step?.transcriptPath ? { transcriptPath: child?.transcriptPath ?? step?.transcriptPath } : {}),
 		...(child?.transcriptError ? { transcriptError: child.transcriptError } : {}),
+		...(execution ? { execution } : {}),
+		...(child?.effects ?? step?.effects ? { effects: child?.effects ?? step?.effects } : {}),
 	};
 }
 

--- a/src/runs/background/resume-guidance.ts
+++ b/src/runs/background/resume-guidance.ts
@@ -39,7 +39,7 @@ export function formatResumeFirstFailedRunDetail(run: AsyncRunSummary): string |
 }
 
 export function formatResumeFirstFailedRunsNote(runs: AsyncRunSummary[]): string {
-	const failedRuns = runs.filter((run) => run.state === "failed");
+	const failedRuns = runs.filter((run) => run.state === "failed" || run.state === "partial");
 	const detachGuidance = failedRuns
 		.map(formatIntercomDetachGuidance)
 		.filter((guidance): guidance is string => Boolean(guidance));

--- a/src/runs/background/retained-children.ts
+++ b/src/runs/background/retained-children.ts
@@ -27,7 +27,7 @@ export interface RetainedChild {
 }
 
 function isRetainedChildState(state: AsyncRunSummary["state"]): state is RetainedChildState {
-	return state === "complete" || state === "failed" || state === "paused" || state === "stopped";
+	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped";
 }
 
 function isTerminalStepStatus(status: AsyncRunSummary["steps"][number]["status"]): boolean {

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -101,7 +101,7 @@ interface ResultChildOutcome {
 }
 
 interface ResultRepairData {
-	state: "complete" | "failed" | "paused" | "stopped" | "rejected";
+	state: "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 	results?: ResultChildOutcome[];
 }
 
@@ -117,7 +117,7 @@ function regularFileExists(filePath: string): boolean {
 function readResultRepairData(resultPath: string): ResultRepairData | undefined {
 	try {
 		const data = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { success?: boolean; state?: string; exitCode?: number; results?: unknown };
-		const state = data.success ? "complete" : data.state === "stopped" ? "stopped" : data.state === "rejected" ? "rejected" : data.state === "paused" || data.exitCode === 0 ? "paused" : "failed";
+		const state = data.success ? "complete" : data.state === "stopped" ? "stopped" : data.state === "rejected" ? "rejected" : data.state === "partial" ? "partial" : data.state === "paused" || data.exitCode === 0 ? "paused" : "failed";
 		const results = Array.isArray(data.results)
 			? data.results.map((entry, index) => {
 				if (!entry || typeof entry !== "object" || Array.isArray(entry)) return {};
@@ -157,7 +157,7 @@ function terminalStatusFromResult(status: AsyncStatus, resultPath: string, now: 
 			endedAt: step.endedAt ?? now,
 			durationMs: step.startedAt !== undefined && step.durationMs === undefined ? Math.max(0, now - step.startedAt) : step.durationMs,
 			exitCode: step.exitCode ?? (state === "complete" || state === "paused" ? 0 : 1),
-			error: state === "failed" || state === "stopped" ? step.error ?? child?.error : step.error,
+			error: state === "failed" || state === "partial" || state === "stopped" ? step.error ?? child?.error : step.error,
 			stopped: state === "stopped" ? true : step.stopped,
 			sessionFile: step.sessionFile ?? child?.sessionFile,
 			model,
@@ -290,7 +290,7 @@ function writeFailedRepair(asyncDir: string, status: AsyncStatus, resultPath: st
 }
 
 function terminal(state: AsyncStatus["state"]): boolean {
-	return state === "complete" || state === "failed" || state === "paused" || state === "stopped" || state === "rejected";
+	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped" || state === "rejected";
 }
 
 function* nestedRuns(children: NestedRunSummary[] | undefined): Generator<NestedRunSummary> {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -562,16 +562,28 @@ interface RunPiStreamingResult {
 
 const MAX_CHILD_FAILURE_DIAGNOSTIC_CHARS = 8_192;
 
+function formatRequiredOutputError(requiredOutput: {
+	kind: "file-only" | "structured";
+	path: string;
+	missing: boolean;
+} | undefined): string | undefined {
+	if (!requiredOutput?.missing) return undefined;
+	return `Required ${requiredOutput.kind} output was not produced: ${requiredOutput.path.slice(0, 2_048)}`;
+}
+
 function formatChildFailureDiagnostic(input: {
 	error: string | undefined;
 	afterCompactionSettlement?: boolean;
-	missingFileOnlyOutput?: string;
-	missingStructuredOutput?: string;
+	requiredOutput?: {
+		kind: "file-only" | "structured";
+		path: string;
+		missing: boolean;
+	};
 }): string | undefined {
+	const missingOutput = formatRequiredOutputError(input.requiredOutput);
 	const notes = [
 		input.afterCompactionSettlement ? "Child failure followed session compaction and agent settlement." : undefined,
-		input.missingFileOnlyOutput ? `Required file-only output was not produced: ${input.missingFileOnlyOutput.slice(0, 2_048)}` : undefined,
-		input.missingStructuredOutput ? `Required structured output was not produced: ${input.missingStructuredOutput.slice(0, 2_048)}` : undefined,
+		missingOutput && input.error !== missingOutput ? missingOutput : undefined,
 	].filter((note): note is string => Boolean(note));
 	if (notes.length === 0) return input.error;
 	const context = notes.join("\n");
@@ -1349,6 +1361,8 @@ async function runSingleStepInner(
 				structuredOutputPath: timedOut || stopped ? undefined : imported.structuredOutputPath,
 				structuredOutputSchemaPath: timedOut || stopped ? undefined : imported.structuredOutputSchemaPath,
 				acceptance: timedOut || stopped ? undefined : imported.acceptance,
+				execution: timedOut || stopped ? undefined : imported.execution,
+				effects: timedOut || stopped ? undefined : imported.effects,
 			});
 		} finally {
 			ctx.registerTimeout?.(undefined);
@@ -1825,12 +1839,15 @@ async function runSingleStepInner(
 		const hiddenError = run.exitCode === 0 && !run.error && !toolAvailabilityError && !structuredError && !midToolExitError
 			? detectSubagentError(errorMessages)
 			: null;
+		const terminalEmptyAfterUsefulWork = !validatedStructuredOutput
+			&& hasEmptyTerminalAssistantResponse(run.messages)
+			&& (run.toolCount > 0 || Boolean(run.finalOutput.trim()));
 		const emptyOutputError = run.exitCode === 0
 			&& !run.error
 			&& !toolAvailabilityError
 			&& !structuredError
-			&& !run.finalOutput.trim()
 			&& !validatedStructuredOutput
+			&& (!run.finalOutput.trim() || terminalEmptyAfterUsefulWork)
 			&& (!hiddenError?.hasError || hasEmptyTerminalAssistantResponse(run.messages))
 			? "Subagent produced no output (possible model cold-start or empty response)."
 			: undefined;
@@ -1862,7 +1879,15 @@ async function runSingleStepInner(
 			mutationEvidence: completionMutationEvidence,
 			agentContractV1: isAgentContractV1(step.agentContract),
 		});
-		const effectiveExitCode = toolAvailabilityError || completionEvidence.legacyFailureError || midToolExitError || structuredError || emptyOutputError
+		const finalOutputHasPersistableFileContent = run.exitCode === 0 && !run.error && !emptyOutputError && Boolean(stripAcceptanceReport(run.finalOutput).trim());
+		const requiredOutput = step.outputMode === "file-only" && step.outputPath
+			? { kind: "file-only" as const, path: step.outputPath, missing: !fs.existsSync(step.outputPath) && !finalOutputHasPersistableFileContent }
+			: effectiveStructuredOutput
+				? { kind: "structured" as const, path: effectiveStructuredOutput.outputPath, missing: !fs.existsSync(effectiveStructuredOutput.outputPath) }
+			: undefined;
+		const missingRequiredOutputError = formatRequiredOutputError(requiredOutput);
+		const missingRequiredOutputAfterMutation = Boolean(missingRequiredOutputError) && (mutationAttemptObserved || Boolean(mutationEvidence.changedFiles.length));
+		const effectiveExitCode = toolAvailabilityError || completionEvidence.legacyFailureError || midToolExitError || structuredError || emptyOutputError || missingRequiredOutputError
 			? 1
 			: hiddenError?.hasError
 				? (hiddenError.exitCode ?? 1)
@@ -1875,17 +1900,18 @@ async function runSingleStepInner(
 			timedOut: run.timedOut,
 			stopped: run.stopped,
 		})) ? formatProcessSignalError(run.processSignal!) : undefined;
+		const underlyingError = toolAvailabilityError
+			?? midToolExitError
+			?? structuredError
+			?? (missingRequiredOutputAfterMutation ? missingRequiredOutputError : undefined)
+			?? emptyOutputError
+			?? (hiddenError?.hasError
+				? hiddenError.details
+					? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
+					: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
+				: run.error || signalError || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined));
 		const error = formatSubagentExtensionConflictError(
-			toolAvailabilityError
-				?? completionEvidence.legacyFailureError
-				?? midToolExitError
-				?? structuredError
-				?? emptyOutputError
-				?? (hiddenError?.hasError
-					? hiddenError.details
-						? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
-						: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
-					: run.error || signalError || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined)),
+			underlyingError ?? missingRequiredOutputError ?? completionEvidence.legacyFailureError,
 			{
 				agent: step.agent,
 				ambientExtensionsEnabled: launchResolvedExtensions?.disableAmbientExtensions === false,
@@ -1900,7 +1926,7 @@ async function runSingleStepInner(
 		});
 		modelAttempts.push(attempt);
 		if (!recoveringAbort && candidate && startupAttemptIndex === 0) attemptedModels.push(candidate);
-		completionGuardTriggeredFinal = completionEvidence.guardTriggered;
+		completionGuardTriggeredFinal = completionEvidence.guardTriggered && !underlyingError && !missingRequiredOutputError;
 		finalOutputSnapshot = outputSnapshot;
 		if (step.toolBudget) {
 			const toolMessages = run.messages.filter((message) => message.role === "toolResult");
@@ -1908,11 +1934,6 @@ async function runSingleStepInner(
 			toolBudgetBlocked = Boolean(blockedMessage);
 			toolBudget = toolBudgetState(step.toolBudget, toolMessages.length, blockedMessage ? (blockedMessage as { toolName?: string }).toolName : undefined);
 		}
-		const requiredOutput = step.outputMode === "file-only" && step.outputPath
-			? { kind: "file-only" as const, path: step.outputPath, missing: !fs.existsSync(step.outputPath) }
-			: effectiveStructuredOutput
-				? { kind: "structured" as const, path: effectiveStructuredOutput.outputPath, missing: !fs.existsSync(effectiveStructuredOutput.outputPath) }
-			: undefined;
 		const settlementDiagnostic = projectSettlementDiagnostic(completionEvidence, {
 			terminalFailed: effectiveExitCode !== 0,
 			finalTextPresent: Boolean(stripAcceptanceReport(run.finalOutput).trim()),
@@ -1920,7 +1941,8 @@ async function runSingleStepInner(
 			requiredOutput,
 			afterCompactionSettlement: run.afterCompactionSettlement === true,
 		});
-		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(completionEvidence.fileMutation || settlementDiagnostic ? { effects: { ...(completionEvidence.fileMutation ? { fileMutation: completionEvidence.fileMutation } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunPiStreamingResult;
+		const fileMutationEffect = completionEvidence.fileMutation ?? (missingRequiredOutputAfterMutation ? { status: "observed" as const, expected: completionEvidence.mutationExpected, attempted: true, evidence: mutationEvidence } : undefined);
+		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect || settlementDiagnostic ? { effects: { ...(fileMutationEffect ? { fileMutation: fileMutationEffect } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunPiStreamingResult;
 		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
 		if (attempt.success || completionEvidence.guardTriggered) break modelAttemptsLoop;
 		if (recoveringAbort) break modelAttemptsLoop;
@@ -2093,12 +2115,7 @@ async function runSingleStepInner(
 	const effectiveFinalError = formatChildFailureDiagnostic({
 		error: baseFinalError,
 		afterCompactionSettlement: effectiveFinalExitCode !== 0 ? finalResult?.afterCompactionSettlement : undefined,
-		missingFileOnlyOutput: effectiveFinalExitCode !== 0 && finalResult?.effects?.settlementDiagnostic?.requiredOutput?.kind === "file-only" && finalResult.effects.settlementDiagnostic.requiredOutput.missing
-			? finalResult.effects.settlementDiagnostic.requiredOutput.path
-			: undefined,
-		missingStructuredOutput: effectiveFinalExitCode !== 0 && finalResult?.effects?.settlementDiagnostic?.requiredOutput?.kind === "structured" && finalResult.effects.settlementDiagnostic.requiredOutput.missing
-			? finalResult.effects.settlementDiagnostic.requiredOutput.path
-			: undefined,
+		requiredOutput: effectiveFinalExitCode !== 0 ? finalResult?.effects?.settlementDiagnostic?.requiredOutput : undefined,
 	});
 
 	const artifactErrors = artifactPaths && ctx.artifactConfig?.enabled !== false
@@ -2367,6 +2384,25 @@ function resolveAsyncStepTranscriptPath(input: {
 }
 
 type SingleStepResult = Awaited<ReturnType<typeof runSingleStep>>;
+
+function missingRequiredOutputAfterUsefulMutation(result: SingleStepResult): boolean {
+	const effects = result.effects;
+	return effects?.settlementDiagnostic?.requiredOutput?.missing === true
+		&& (effects.settlementDiagnostic.mutation.attempted || effects.fileMutation?.attempted === true || Boolean(effects.fileMutation?.evidence?.changedFiles.length));
+}
+
+function partialExecutionWithUsefulMutation(result: SingleStepResult): boolean {
+	const fileMutation = result.effects?.fileMutation;
+	return result.execution?.status === "partial" && (fileMutation?.attempted === true || Boolean(fileMutation?.evidence?.changedFiles.length));
+}
+
+function partialEvidenceResult(result: SingleStepResult): boolean {
+	return missingRequiredOutputAfterUsefulMutation(result) || partialExecutionWithUsefulMutation(result);
+}
+
+function concreteFailureResult(result: SingleStepResult): boolean {
+	return result.success === false && !partialEvidenceResult(result);
+}
 
 function combinedAbortSignal(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
 	const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
@@ -2721,6 +2757,7 @@ async function runSubagent(
 	const statusResultSummary = (state: AsyncStatus["state"]): string => {
 		if (statusPayload.error) return statusPayload.error;
 		if (state === "paused") return "Paused after interrupt. Waiting for explicit next action.";
+		if (state === "partial") return "Subagent needs attention after partial work.";
 		if (state === "stopped") return stopMessage;
 		if (state === "rejected") return "Subagent rejected.";
 		return state === "complete" ? "Subagent completed." : "Subagent failed.";
@@ -2729,7 +2766,7 @@ async function runSubagent(
 		if (step.status === "complete" || step.status === "completed") return true;
 		if (step.status === "failed" || step.status === "stopped" || step.status === "rejected") return false;
 		if (state === "complete") return true;
-		if (state === "failed" || state === "stopped" || state === "rejected") return false;
+		if (state === "failed" || state === "partial" || state === "stopped" || state === "rejected") return false;
 		return undefined;
 	};
 	const writeRecoverableStatusResult = (): void => {
@@ -2746,7 +2783,7 @@ async function runSubagent(
 			success: state === "complete",
 			state,
 			summary,
-			error: state === "failed" || state === "stopped" || state === "rejected" ? summary : undefined,
+			error: state === "failed" || state === "partial" || state === "stopped" || state === "rejected" ? summary : undefined,
 			stopped: state === "stopped" ? true : undefined,
 			results: statusPayload.steps.map((step) => omitUndefinedProperties({
 				agent: step.agent,
@@ -5158,7 +5195,8 @@ async function runSubagent(
 		timedOut: result.timedOut,
 		stopped: result.stopped,
 	})));
-	statusPayload.state = stopped || signalTerminated ? "stopped" : timedOut || usageBudgetExceeded || statusPayload.error ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed";
+	const partialWithEvidence = !stopped && !signalTerminated && !timedOut && !usageBudgetExceeded && !interrupted && results.some(partialEvidenceResult) && !results.some(concreteFailureResult);
+	statusPayload.state = stopped || signalTerminated ? "stopped" : timedOut || usageBudgetExceeded ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : partialWithEvidence ? "partial" : "failed";
 	closeSteerInbox(asyncDir, statusPayload.state, (filePath, payload) => runPersistence.write(filePath, payload));
 	disposeControlInbox();
 	for (const request of consumeSteerRequests(asyncDir)) deliverSteerRequest(request);
@@ -5191,6 +5229,14 @@ async function runSubagent(
 	if (usageBudgetExceeded && statusPayload.usageBudget && !statusPayload.error) {
 		statusPayload.error = usageBudgetExceededMessage(statusPayload.usageBudget);
 	}
+	if (partialWithEvidence) {
+		const partialResult = results.find(partialEvidenceResult);
+		statusPayload.activityState = "needs_attention";
+		statusPayload.error = partialResult?.error ?? statusPayload.error;
+		for (const step of statusPayload.steps) {
+			if (step.status === "failed") step.activityState = "needs_attention";
+		}
+	}
 	statusPayload.endedAt = runEndedAt;
 	statusPayload.lastUpdate = runEndedAt;
 	setOptionalProperty(statusPayload, "sessionFile", effectiveSessionFile);
@@ -5200,8 +5246,10 @@ async function runSubagent(
 	setOptionalProperty(statusPayload, "shareUrl", shareUrl);
 	setOptionalProperty(statusPayload, "gistUrl", gistUrl);
 	setOptionalProperty(statusPayload, "shareError", shareError);
-	if (statusPayload.state === "failed" && !statusPayload.error) {
-		const failedStep = statusPayload.steps.find((s) => s.status === "failed");
+	if ((statusPayload.state === "failed" || statusPayload.state === "partial") && !statusPayload.error) {
+		const concreteFailure = results.find(concreteFailureResult);
+		const failedStep = concreteFailure ? undefined : statusPayload.steps.find((s) => s.status === "failed");
+		if (concreteFailure?.error) statusPayload.error = concreteFailure.error;
 		if (failedStep?.agent) {
 			statusPayload.error = `Step failed: ${failedStep.agent}`;
 		}
@@ -5213,9 +5261,9 @@ async function runSubagent(
 			id,
 			agent: agentName,
 			mode: resultMode,
-			success: !stopped && !timedOut && !usageBudgetExceeded && !interrupted && !signalTerminated && results.every((r) => r.success),
-			state: stopped || signalTerminated ? "stopped" : timedOut || usageBudgetExceeded ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : "failed",
-			summary: stopped ? stopMessage : signalTerminated ? (statusPayload.error ?? "Subagent process terminated by signal.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : usageBudgetExceeded ? (statusPayload.error ?? "Usage budget exhausted.") : interrupted ? "Paused after interrupt. Waiting for explicit next action." : summary,
+			success: statusPayload.state === "complete",
+			state: statusPayload.state,
+			summary: stopped ? stopMessage : signalTerminated ? (statusPayload.error ?? "Subagent process terminated by signal.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : usageBudgetExceeded ? (statusPayload.error ?? "Usage budget exhausted.") : interrupted ? "Paused after interrupt. Waiting for explicit next action." : statusPayload.state === "partial" ? (statusPayload.error ?? summary) : summary,
 			...(config.timeoutMs !== undefined ? { timeoutMs: config.timeoutMs } : {}),
 			...(config.deadlineAt !== undefined ? { deadlineAt: config.deadlineAt } : {}),
 			...(statusPayload.toolBudget ? { toolBudget: statusPayload.toolBudget } : {}),
@@ -5276,7 +5324,7 @@ async function runSubagent(
 			capabilityAudit: statusPayload.capabilityAudit,
 			...(config.parentWorkflowRunId ? { parentWorkflowRunId: config.parentWorkflowRunId } : {}),
 			...(config.workflowKey ? { workflowKey: config.workflowKey } : {}),
-			exitCode: stopped || timedOut || usageBudgetExceeded ? 1 : interrupted || results.every((r) => r.success) ? 0 : 1,
+			exitCode: statusPayload.state === "complete" || statusPayload.state === "paused" ? 0 : 1,
 			timestamp: runEndedAt,
 			durationMs: runEndedAt - overallStartTime,
 			totalTokens: statusPayload.totalTokens,

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -618,7 +618,7 @@ export async function waitForSubagents(
 		const allNow = runsForIds(initialAsyncIds, deps);
 		const terminal = allNow.filter((run) => !ACTIVE_STATES.includes(run.state) && initialAsyncIds.has(run.id));
 		finishedAsyncCount = terminal.length;
-		failedAsyncCount = terminal.filter((run) => run.state === "failed").length;
+		failedAsyncCount = terminal.filter((run) => run.state === "failed" || run.state === "partial").length;
 		terminalSummary = summarizeTerminalRuns(terminal, providerFinishedCount);
 		resumeGuidance = formatResumeFirstFailedRunsNote(terminal);
 		completions = collectWaitCompletions(terminal, deps.state, deps.resultsDir ?? DIRS.results);

--- a/src/runs/background/terminal-run-index.ts
+++ b/src/runs/background/terminal-run-index.ts
@@ -18,7 +18,7 @@ interface TerminalRunIndexEntry {
 }
 
 function isTerminalState(state: AsyncStatus["state"]): boolean {
-	return state === "complete" || state === "failed" || state === "paused" || state === "stopped" || state === "rejected";
+	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped" || state === "rejected";
 }
 
 function indexRoot(asyncDirRoot: string): string {

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -1453,7 +1453,10 @@ async function runSingleAttempt(
 			: messages;
 		const errInfo = detectSubagentError(errorMessages);
 		const missingOutput = !finalText?.trim() && !validatedStructuredOutput;
-		if (missingOutput && (!errInfo.hasError || hasEmptyTerminalAssistantResponse(messages))) {
+		const terminalEmptyAfterUsefulWork = !validatedStructuredOutput
+			&& hasEmptyTerminalAssistantResponse(messages)
+			&& (progress.toolCount > 0 || Boolean(finalText?.trim()));
+		if ((missingOutput || terminalEmptyAfterUsefulWork) && (!errInfo.hasError || hasEmptyTerminalAssistantResponse(messages))) {
 			result.exitCode = 1;
 			result.error = "Subagent produced no output (possible model cold-start or empty response).";
 		} else if (errInfo.hasError) {

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -286,7 +286,7 @@ function sanitizeTurnBudget(value: unknown): TurnBudgetState | undefined {
 }
 
 function sanitizeState(value: unknown, fallback: NestedRunState): NestedRunState {
-	return value === "queued" || value === "running" || value === "complete" || value === "failed" || value === "paused" || value === "stopped"
+	return value === "queued" || value === "running" || value === "complete" || value === "failed" || value === "partial" || value === "paused" || value === "stopped"
 		? value
 		: fallback;
 }
@@ -436,7 +436,7 @@ export function parseNestedEventRecords(content: string, route: NestedRoute): Ne
 }
 
 function terminal(state: NestedRunState): boolean {
-	return state === "complete" || state === "failed" || state === "paused" || state === "stopped";
+	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped";
 }
 
 function mergeBoundedChildren(existing: NestedRunSummary[] | undefined, incoming: NestedRunSummary[] | undefined): NestedRunSummary[] | undefined {

--- a/src/runs/shared/nested-render.ts
+++ b/src/runs/shared/nested-render.ts
@@ -8,13 +8,14 @@ export interface NestedRunCounts {
 	paused: number;
 	complete: number;
 	failed: number;
+	partial: number;
 	rejected: number;
 	stopped: number;
 	queued: number;
 }
 
 export function countNestedRuns(children: NestedRunSummary[] | undefined): NestedRunCounts {
-	const counts: NestedRunCounts = { total: 0, running: 0, paused: 0, complete: 0, failed: 0, rejected: 0, stopped: 0, queued: 0 };
+	const counts: NestedRunCounts = { total: 0, running: 0, paused: 0, complete: 0, failed: 0, partial: 0, rejected: 0, stopped: 0, queued: 0 };
 	for (const child of children ?? []) {
 		counts.total++;
 		counts[child.state]++;
@@ -24,6 +25,7 @@ export function countNestedRuns(children: NestedRunSummary[] | undefined): Neste
 		counts.paused += nested.paused;
 		counts.complete += nested.complete;
 		counts.failed += nested.failed;
+		counts.partial += nested.partial;
 		counts.rejected += nested.rejected;
 		counts.stopped += nested.stopped;
 		counts.queued += nested.queued;
@@ -38,6 +40,7 @@ export function formatNestedAggregate(children: NestedRunSummary[] | undefined):
 		counts.running > 0 ? `${counts.running} running` : "",
 		counts.paused > 0 ? `${counts.paused} paused` : "",
 		counts.failed > 0 ? `${counts.failed} failed` : "",
+		counts.partial > 0 ? `${counts.partial} partial` : "",
 		counts.rejected > 0 ? `${counts.rejected} rejected` : "",
 		counts.stopped > 0 ? `${counts.stopped} stopped` : "",
 		counts.complete > 0 ? `${counts.complete} complete` : "",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -366,7 +366,7 @@ export interface AgentContract {
 
 export type ChainGateLayer = "execution" | "acceptance";
 
-export type ExecutionProjectionStatus = "completed" | "failed" | "paused" | "stopped" | "detached";
+export type ExecutionProjectionStatus = "completed" | "failed" | "partial" | "paused" | "stopped" | "detached";
 
 export interface ExecutionProjection {
 	status: ExecutionProjectionStatus;
@@ -1296,7 +1296,7 @@ export interface AsyncParallelGroupStatus {
 	stepIndex: number;
 }
 
-export type NestedRunState = "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+export type NestedRunState = "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 export type NestedOwnerState = "live" | "gone" | "unknown";
 
 export interface NestedRunAddress {
@@ -1310,7 +1310,7 @@ export interface NestedRunAddress {
 
 export interface NestedStepSummary {
 	agent: string;
-	status: "pending" | "running" | "complete" | "completed" | "failed" | "paused" | "stopped" | "rejected";
+	status: "pending" | "running" | "complete" | "completed" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 	model?: string;
 	thinking?: string;
 	sessionFile?: string;
@@ -1555,7 +1555,7 @@ export interface AsyncStatus {
 	mode: SubagentRunMode;
 	context?: "fresh" | "fork" | "mixed";
 	isNested?: boolean;
-	state: "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+	state: "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 	/** Display-only dismissal marker for a reload-orphaned workflow. */
 	displayDismissedAt?: number;
 	error?: string;
@@ -1624,7 +1624,7 @@ export interface AsyncStatus {
 		parentWorkflowRunId?: string;
 		outputName?: string;
 		structured?: boolean;
-		status: "pending" | "running" | "complete" | "completed" | "failed" | "paused" | "stopped" | "rejected";
+		status: "pending" | "running" | "complete" | "completed" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 		stopRequested?: boolean;
 		stopRequestedAt?: number;
 		children?: NestedRunSummary[];
@@ -1705,7 +1705,7 @@ export interface AsyncJobState {
 	cwd?: string;
 	/** Parent-resolved child session root retained for trusted live transcript lookup. */
 	sessionRoot?: string;
-	status: "queued" | "running" | "complete" | "failed" | "paused" | "stopped" | "rejected";
+	status: "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 	/** Short caller-facing task/goal shown in fleet surfaces when available. */
 	description?: string;
 	pid?: number;

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -681,6 +681,7 @@ function widgetActivity(job: AsyncJobState): string {
 	if (job.status === "queued") return "queued…";
 	if (job.status === "paused") return "Paused";
 	if (job.status === "stopped") return "Stopped";
+	if (job.status === "partial") return "Partial";
 	if (job.status === "failed") return "Failed";
 	return "Done";
 }
@@ -1125,6 +1126,7 @@ function nestedStatusGlyph(state: NestedRunSummary["state"] | NestedStepSummary[
 	if (state === "running") return theme.fg("accent", runningGlyph(seed));
 	if (state === "complete" || state === "completed") return theme.fg("success", "✓");
 	if (state === "failed") return theme.fg("error", "✗");
+	if (state === "partial") return theme.fg("warning", "■");
 	if (state === "paused") return theme.fg("warning", "■");
 	if (state === "stopped") return theme.fg("warning", "■");
 	return theme.fg("muted", "◦");
@@ -1172,6 +1174,7 @@ function nestedActivity(input: Pick<NestedRunSummary | NestedStepSummary, "activ
 	if (state === "queued" || state === "pending") return "queued…";
 	if (state === "paused") return "Paused";
 	if (state === "stopped") return "Stopped";
+	if (state === "partial") return "Partial";
 	if (state === "failed") return "Failed";
 	return "Done";
 }

--- a/src/workflows/workflow-settlement.ts
+++ b/src/workflows/workflow-settlement.ts
@@ -221,7 +221,7 @@ export function planWorkflowSettlement(input: {
 		...(receipt && input.receiptPath ? { workflowReceipt: { path: input.receiptPath, receipt } } : {}),
 		timestamp: now,
 	};
-	const terminal = status.state === "complete" || status.state === "failed" || status.state === "stopped";
+	const terminal = status.state === "complete" || status.state === "failed" || status.state === "partial" || status.state === "stopped";
 	const completionEvent = terminal ? {
 		type: "subagent.workflow.completed",
 		state: status.state,

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -591,7 +591,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		await waitForAsyncResultFile(id);
 		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
 		assert.equal(status.state, "failed");
-		assert.equal(status.error, "Step failed: worker");
+		assert.equal(status.error, "Detached for intercom coordination before task completion.");
 		assert.equal(status.steps?.[0]?.error, "Detached for intercom coordination before task completion.");
 	});
 
@@ -5364,6 +5364,136 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0].error, "provider exploded");
 	});
 
+	it("prioritizes a missing file-only handoff over the completion guard", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const partialOutput = "I’ll inspect the retained candidate before changing it.";
+		const repo = createRepo("pi-subagents-missing-handoff-partial-");
+		const outputPath = path.join(repo, "missing-challenge-report.md");
+		mockPi.onCall({
+			jsonl: [
+				events.assistantMessage(partialOutput),
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "mock/test-model",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+			],
+			writeFiles: [{ path: "input.md", content: "changed by retained child\n" }],
+		});
+
+		const task = [
+			"You are reviving a previous subagent conversation.",
+			"",
+			"Original run: source-run",
+			"Original agent: worker",
+			"Original session file: /tmp/source-session.jsonl",
+			"",
+			"Use the stored session context as background. Answer the orchestrator's follow-up below. Do not assume the original child process is still alive.",
+			"",
+			"Follow-up:",
+			"Implementation challenge pass 1 for the accepted candidate. Reconsider it and implement any better current-scope change.",
+		].join("\n");
+		const id = `async-missing-handoff-guard-${Date.now().toString(36)}`;
+		try {
+			executeAsyncSingle(id, {
+				agent: "worker",
+				task,
+				agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: repo, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false,
+				sessionRoot: path.join(tempDir, "sessions"),
+				output: outputPath,
+				outputMode: "file-only",
+				maxSubagentDepth: 2,
+			});
+
+			const resultPath = await waitForAsyncResultFile(id);
+			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+			const child = payload.results[0];
+			const diagnostic = child?.error ?? "";
+			assert.equal(payload.success, false);
+			assert.equal(payload.state, "partial");
+			assert.equal(child?.success, false);
+			assert.match(diagnostic, new RegExp(`^Required file-only output was not produced: ${escapeRegExp(outputPath)}$`));
+			assert.doesNotMatch(diagnostic, /completed without making edits/);
+			assert.doesNotMatch(child?.modelAttempts?.[0]?.error ?? "", /completed without making edits/);
+			assert.equal(child?.effects?.fileMutation?.status, "observed");
+			assert.equal(child?.effects?.fileMutation?.attempted, true);
+			assert.deepEqual(child?.effects?.fileMutation?.evidence?.changedFiles, ["input.md"]);
+			assert.equal(child?.effects?.settlementDiagnostic?.requiredOutput?.missing, true);
+			assert.equal(fs.existsSync(outputPath), false);
+
+			const status = await waitForAsyncState(id, (candidate) => candidate.state === "partial");
+			assert.equal(status.activityState, "needs_attention");
+			assert.equal(status.steps?.[0]?.activityState, "needs_attention");
+			assert.equal(status.steps?.[0]?.error, diagnostic);
+			const eventsText = fs.readFileSync(path.join(ASYNC_DIR, id, "events.jsonl"), "utf-8");
+			assert.doesNotMatch(eventsText, /completed without making edits/);
+		} finally {
+			removeTempDir(repo);
+		}
+	});
+
+	it("preserves terminal empty-output diagnostics after useful child work", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const partialOutput = "I’ll inspect the retained candidate before changing it.";
+		const outputPath = path.join(tempDir, "missing-aborted-report.md");
+		mockPi.onCall({
+			jsonl: [
+				events.toolStart("read", { path: "src/index.ts" }),
+				events.toolEnd("read"),
+				events.toolResult("read", "file contents"),
+				events.assistantMessage(partialOutput),
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "mock/test-model",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+			],
+			exitCode: 0,
+		});
+
+		const id = `async-aborted-empty-handoff-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Implement the approved file changes",
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			output: outputPath,
+			outputMode: "file-only",
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		const child = payload.results[0];
+		const diagnostic = child?.error ?? "";
+		assert.equal(payload.success, false);
+		assert.equal(child?.success, false);
+		assert.match(diagnostic, /^Subagent produced no output \(possible model cold-start or empty response\)\./);
+		assert.match(diagnostic, /Required file-only output was not produced/);
+		assert.doesNotMatch(diagnostic, /completed without making edits/);
+		assert.doesNotMatch(child?.modelAttempts?.[0]?.error ?? "", /completed without making edits/);
+		assert.equal(child?.effects?.settlementDiagnostic?.requiredOutput?.missing, true);
+		assert.equal(child?.effects?.settlementDiagnostic?.finalTextPresent, true);
+		assert.equal(fs.existsSync(outputPath), false);
+
+		const eventsText = fs.readFileSync(path.join(ASYNC_DIR, id, "events.jsonl"), "utf-8");
+		assert.doesNotMatch(eventsText, /completed without making edits/);
+	});
+
 	it("reports bounded compaction failure context when file-only output is missing", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const terminalError = `This operation was aborted${"x".repeat(12_000)}`;
 		mockPi.onCall({
@@ -5428,6 +5558,103 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.ok(fs.readFileSync(logPath, "utf-8").includes(`## Summary\noracle:\n${diagnostic}`));
 	});
 
+	it("preserves partial imported async roots with mutation evidence", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const sourceId = `partial-source-${Date.now().toString(36)}`;
+		const sourceDir = path.join(ASYNC_DIR, sourceId);
+		const message = "Required file-only output was not produced: report.md";
+		const effects = { fileMutation: { status: "observed", expected: true, attempted: true, evidence: { source: "tracked-files", trackedOnly: true, cwd: tempDir, changedFiles: ["input.md"], attemptedMutation: true } } };
+		fs.mkdirSync(sourceDir, { recursive: true });
+		fs.writeFileSync(path.join(sourceDir, "status.json"), JSON.stringify({
+			runId: sourceId,
+			mode: "single",
+			state: "partial",
+			activityState: "needs_attention",
+			startedAt: Date.now(),
+			error: message,
+			steps: [{ agent: "worker", status: "failed", activityState: "needs_attention", error: message, effects }],
+		}), "utf-8");
+
+		const id = `async-imported-partial-${Date.now().toString(36)}`;
+		executeAsyncChain(id, {
+			chain: [],
+			attachRoot: { runId: sourceId, asyncDir: sourceDir, resultPath: path.join(RESULTS_DIR, `${sourceId}.json`), index: 0, agent: "worker" },
+			agents: [makeAgent("worker")],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		assert.equal(payload.success, false);
+		assert.equal(payload.state, "partial");
+		assert.equal(payload.summary, message);
+		assert.equal(payload.results[0]?.execution?.status, "partial");
+		assert.deepEqual(payload.results[0]?.effects?.fileMutation?.evidence?.changedFiles, ["input.md"]);
+
+		const status = await waitForAsyncState(id, (candidate) => candidate.state === "partial");
+		assert.equal(status.activityState, "needs_attention");
+		assert.equal(status.steps?.[0]?.activityState, "needs_attention");
+	});
+
+	it("keeps concrete sibling failures above partial mutation evidence", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const repo = createRepo("pi-subagents-partial-sibling-failure-");
+		const outputPath = path.join(repo, "missing-report.md");
+		mockPi.onCall({
+			matchArgIncludes: "Write required report",
+			jsonl: [
+				events.assistantMessage("I changed the file but did not hand off the report."),
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "mock/test-model",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+			],
+			writeFiles: [{ path: "input.md", content: "changed before missing report\n" }],
+		});
+		mockPi.onCall({ matchArgIncludes: "Fail normally", stderr: "ordinary sibling failure", exitCode: 1 });
+
+		const id = `async-partial-sibling-failure-${Date.now().toString(36)}`;
+		try {
+			executeAsyncChain(id, {
+				chain: [{
+					parallel: [
+						{ agent: "partial", task: "Write required report" },
+						{ agent: "failure", task: "Fail normally" },
+					],
+					concurrency: 2,
+				}],
+				resultMode: "parallel",
+				agents: [makeAgent("partial", { output: outputPath, outputMode: "file-only" }), makeAgent("failure", { completionGuard: false })],
+				ctx: { pi: { events: { emit() {} } }, cwd: repo, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false,
+				maxSubagentDepth: 2,
+			});
+
+			const payload = await readAsyncPayload(id);
+			assert.equal(payload.success, false);
+			assert.equal(payload.state, "failed");
+			assert.match(payload.summary, /ordinary sibling failure/);
+			assert.equal(payload.results[0]?.effects?.fileMutation?.status, "observed");
+			assert.equal(payload.results[0]?.effects?.settlementDiagnostic?.requiredOutput?.missing, true);
+			assert.match(payload.results[1]?.error ?? "", /ordinary sibling failure/);
+
+			const status = await waitForAsyncState(id, (candidate) => candidate.state === "failed");
+			assert.equal(status.activityState, undefined);
+			assert.match(status.error ?? "", /ordinary sibling failure/);
+		} finally {
+			removeTempDir(repo);
+		}
+	});
+
 	it("reports missing file-only output when a child exits without an error", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ delay: 2_100, exitCode: 1 });
 
@@ -5452,7 +5679,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.success, false);
 		assert.equal(payload.exitCode, 1);
 		assert.equal(child?.success, false);
-		assert.match(diagnostic, /^Subagent failed\.\nRequired file-only output was not produced:/);
+		assert.match(diagnostic, /^Required file-only output was not produced:/);
 		assert.equal(fs.existsSync(outputPath), false);
 		assert.equal(child?.output, "");
 		assert.equal(child?.effects?.settlementDiagnostic?.requiredOutput?.kind, "file-only");

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -4367,6 +4367,38 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		]);
 	});
 
+	it("preserves terminal empty-output diagnostics after useful foreground work", async () => {
+		const partialOutput = "I’ll inspect the retained candidate before changing it.";
+		mockPi.onCall({
+			jsonl: [
+				events.toolStart("read", { path: "src/index.ts" }),
+				events.toolEnd("read"),
+				events.toolResult("read", "file contents"),
+				events.assistantMessage(partialOutput),
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "mock/test-model",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+			],
+			exitCode: 0,
+		});
+
+		const result = await runSync(tempDir, [makeAgent("worker")], "worker", "Implement the approved file changes", {
+			runId: "foreground-aborted-empty-output",
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /^Subagent produced no output \(possible model cold-start or empty response\)\./);
+		assert.doesNotMatch(result.error ?? "", /completed without making edits/);
+		assert.equal(result.finalOutput, partialOutput);
+	});
+
 	it("agent contract v1 reports omitted acceptance separately without injecting a prompt", async () => {
 		mockPi.onCall({ output: "Plan only" });
 		const agents = [makeAgent("worker", { tools: ["read", "write"] })];

--- a/test/unit/chain-root-attachment.test.ts
+++ b/test/unit/chain-root-attachment.test.ts
@@ -111,6 +111,55 @@ describe("async chain root attachment", () => {
 		assert.equal(result.output, "root failed");
 	});
 
+	it("imports a partial root without collapsing it to failed", async () => {
+		const importedRoot = root();
+		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+			runId: importedRoot.runId,
+			mode: "single",
+			state: "partial",
+			activityState: "needs_attention",
+			startedAt: 1,
+			error: "Required file-only output was not produced: report.md",
+			steps: [{ agent: "worker", status: "failed", activityState: "needs_attention", error: "Required file-only output was not produced: report.md" }],
+		});
+		writeJson(importedRoot.resultPath, {
+			state: "partial",
+			success: false,
+			summary: "Required file-only output was not produced: report.md",
+			results: [{ agent: "worker", output: "Required file-only output was not produced: report.md", error: "Required file-only output was not produced: report.md", success: false, effects: { fileMutation: { status: "observed", expected: true, attempted: true, evidence: { source: "tracked-files", trackedOnly: true, cwd: tempDir, changedFiles: ["input.md"], attemptedMutation: true } } } }],
+		});
+
+		const result = await waitForImportedAsyncRoot(importedRoot, { pollIntervalMs: 1 });
+
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.error, "Required file-only output was not produced: report.md");
+		assert.equal(result.execution?.status, "partial");
+		assert.deepEqual(result.effects?.fileMutation?.evidence?.changedFiles, ["input.md"]);
+	});
+
+	it("fails a partial root that never produced a result file", async () => {
+		const importedRoot = root();
+		const effects = { fileMutation: { status: "observed", expected: true, attempted: true, evidence: { source: "tracked-files", trackedOnly: true, cwd: tempDir, changedFiles: ["input.md"], attemptedMutation: true } } };
+		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+			runId: importedRoot.runId,
+			mode: "single",
+			state: "partial",
+			startedAt: 1,
+			error: "Required file-only output was not produced: report.md",
+			steps: [{ agent: "worker", status: "failed", activityState: "needs_attention", error: "Required file-only output was not produced: report.md", effects }],
+		});
+
+		const result = await waitForImportedAsyncRoot(importedRoot, {
+			pollIntervalMs: 1,
+			terminalResultGraceMs: 0,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.error, "Required file-only output was not produced: report.md");
+		assert.equal(result.execution?.status, "partial");
+		assert.deepEqual(result.effects?.fileMutation?.evidence?.changedFiles, ["input.md"]);
+	});
+
 	it("fails a terminal root that never produced a result file", async () => {
 		const importedRoot = root();
 		writeJson(path.join(importedRoot.asyncDir, "status.json"), {


### PR DESCRIPTION
## Summary

This fixes #1576 by making failed child runs with useful mutation evidence but a missing required handoff surface as partial needs-attention results.

The missing report is now the primary diagnostic for that path. The result stays non-successful, preserves mutation evidence in `effects.fileMutation`, and keeps generic empty-output diagnostics for cases without tracked mutation evidence.

Closes #1576.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'prioritizes a missing file-only handoff over the completion guard|preserves terminal empty-output diagnostics after useful child work|reports bounded compaction failure context when file-only output is missing|preserves terminal empty-output diagnostics after useful foreground work' test/integration/async-execution.test.ts test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh review: `issue-1576-partial-evidence-review.md`
- follow-up review: `issue-1576-partial-evidence-followup-review.md`
