### PR TITLE
fix(fleet): guard prompt audit summary when task is not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Prevent Fleet prompt audit rendering from crashing on malformed non-string task payloads. Thanks to [@bengidev](https://github.com/bengidev) for #1586.
 - Resume a retained child session once after a provider or transport abort follows useful progress, without restarting the task or involving the parent model.
 
 ### Fixed

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3576,7 +3576,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const currentProvider = parentModel?.provider;
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const modelScopes = resolveModelScopesForAgent(data.modelScope, agentConfig.name, parentModel);
-	let task = params.task ?? "";
+	let task = typeof params.task === "string" ? params.task : "";
 	let modelOverride: string | undefined = resolveEffectiveSubagentModel(
 		params.model as string | undefined,
 		agentConfig.model,

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -355,7 +355,12 @@ function foregroundPromptAuditCount(item: Extract<FleetItem, { kind: "foreground
 	return [...item.control.activeChildren.keys()].filter((index) => getLivePromptAudit(item.control, index)).length;
 }
 
-function authoredPromptSummary(text: string): string | undefined {
+function promptAuditString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function authoredPromptSummary(text: unknown): string | undefined {
+	if (typeof text !== "string") return undefined;
 	const summary = text.replace(/\s+/g, " ").trim();
 	return summary ? truncateToWidth(summary, PROMPT_AUDIT_SUMMARY_WIDTH, "…") : undefined;
 }
@@ -366,11 +371,11 @@ function foregroundAuthoredPromptSummary(item: Extract<FleetItem, { kind: "foreg
 	return prompt ? authoredPromptSummary(prompt.authoredTask) : undefined;
 }
 
-function promptAuditText(prompt: LivePromptAudit, view: PromptAuditView): string {
+function promptAuditText(prompt: LivePromptAudit, view: PromptAuditView): string | undefined {
 	switch (view) {
-		case "authored": return prompt.authoredTask;
-		case "runtime": return prompt.runtimeAdditions;
-		case "effective": return prompt.finalEffectivePrompt;
+		case "authored": return promptAuditString(prompt.authoredTask);
+		case "runtime": return promptAuditString(prompt.runtimeAdditions);
+		case "effective": return promptAuditString(prompt.finalEffectivePrompt);
 	}
 }
 

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -309,6 +309,37 @@ describe("native subagent fleet", () => {
 		}
 	});
 
+	it("does not crash Fleet render when live prompt audit stores a non-string authored task", () => {
+		const state = stateForTest();
+		const control = {
+			runId: "bad-prompt-run",
+			sessionId: "session-current",
+			mode: "single" as const,
+			startedAt: 10,
+			updatedAt: 20,
+			activeChildren: new Map([[0, { index: 0, agent: "worker", startedAt: 10, updatedAt: 20 }]]),
+		};
+		state.foregroundControls.set(control.runId, control);
+		registerLivePromptAudit(control, 0, { nested: "task payload" } as unknown as string, "effective prompt");
+		const component = new SubagentFleetComponent(
+			{ terminal: { rows: 28, columns: 100 }, requestRender() {} } as never,
+			theme as never,
+			state,
+			() => {},
+			{ refreshMs: 60_000, markdownTheme },
+		);
+		try {
+			assert.doesNotThrow(() => component.render(100));
+			const rendered = component.render(100).join("\n");
+			assert.doesNotMatch(rendered, /nested|task payload/);
+			component.handleInput("p");
+			assert.doesNotThrow(() => component.render(100));
+			assert.match(component.render(100).join("\n"), /Selected prompt unavailable/);
+		} finally {
+			component.dispose();
+		}
+	});
+
 	it("shows live prompt summaries and opens Prompt Audit with the authored prompt visible", async () => {
 		const sentinel = "PROMPT_AUDIT_SENTINEL_1021";
 		const secondSentinel = "PROMPT_AUDIT_SECOND_CHILD";


### PR DESCRIPTION
## Why

Fleet crashes pi when live prompt audit data contains a non-string `authoredTask`. `authoredPromptSummary` calls `text.replace` without a type guard. `runSinglePath` can register the raw `params.task` value before later string coercion, so structured or malformed task payloads reach the audit store as non-strings.

## Scope

- `src/runs/foreground/subagent-executor.ts` — coerce `params.task` to string at single-run entry (`typeof params.task === "string" ? params.task : ""`).
- `src/tui/fleet.ts` — return `undefined` from `authoredPromptSummary` when input is not a string.
- `test/unit/fleet.test.ts` — regression test that Fleet render survives a non-string authored task in live prompt audit.

## Tradeoffs

Display-layer guard alone would hide bad data but leave non-string tasks flowing into execution paths. Registration-time coercion fixes the source. The Fleet guard covers any already-live malformed audit entries until the child finishes.

## Blast Radius

Touches foreground single-run task normalization and Fleet prompt summary rendering only. No API or schema changes. Safe for callers that already pass string tasks.

## Verification

```bash
node --test test/unit/fleet.test.ts
```

39 passed, 0 failed. Includes new test `does not crash Fleet render when live prompt audit stores a non-string authored task`.

Manual repro before fix:

```javascript
// TypeError: text.replace is not a function
authoredPromptSummary({ nested: "task payload" })
```

After fix: `authoredPromptSummary` returns `undefined`; Fleet `render()` does not throw.