### PR TITLE
refactor: extract child launch planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Extract child launch planning into a focused internal module shared by async workflow launch setup.
 - Extract detached workflow settlement planning into a focused workflow module while preserving fail-closed result handoff.
 - Extract completion evidence planning into a focused module shared by foreground and background execution.
 - Extract direct MCP grant planning into a pure module while keeping source loading and child launch wiring in adapters.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -14,9 +14,10 @@ import { discoverAgents, formatUnknownAgentError, unknownAgentDiagnosticContext,
 import { appendAgentRefinementOverlay } from "../../agents/agent-refinements.ts";
 import { writePrivateAtomicJson } from "../../shared/atomic-json.ts";
 import { currentCompletionOwnerId } from "../../shared/completion-owner.ts";
+import { planChildLaunch, resolveStepBehavior, suppressProgressForReadOnlyTask, type ResolvedStepBehavior } from "../shared/child-launch-plan.ts";
 import { applyThinkingSuffix, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/pi-args.ts";
 import { injectOutputPathSystemPrompt, injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
-import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveChainPath, resolveExistingReadPaths, resolveStepBehavior, suppressProgressForReadOnlyTask, writeInitialProgressFile, type ChainStep, type ResolvedStepBehavior, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
+import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveChainPath, resolveExistingReadPaths, writeInitialProgressFile, type ChainStep, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import type { ContextMode } from "../shared/context-mode.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
@@ -800,19 +801,21 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			envValue: params.toolTimeoutMsEnv ?? toolTimeoutFromEnv(),
 		});
 		if (resolvedToolTimeout.error) throw new AsyncStartValidationError(resolvedToolTimeout.error);
-		const stepCwd = resolveChildCwd(runnerCwd, s.cwd);
-		const instructionCwd = behaviorCwd ?? stepCwd;
-		const readExistenceCwd = behaviorCwd ? stepCwd : instructionCwd;
-		let behavior = suppressProgressForReadOnlyTask(resolvedBehavior ?? resolveStepBehavior(a, buildStepOverrides(s), chainSkills), s.task, originalTask);
-		const inheritedRelativeParallelOutput = parallelOutputNamespace && s.output === undefined && typeof behavior.output === "string" && !path.isAbsolute(behavior.output);
-		if (inheritedRelativeParallelOutput && parallelOutputNamespace.taskIndex !== undefined) {
-			behavior = {
-				...behavior,
-				output: path.join(`parallel-${parallelOutputNamespace.stepIndex}`, `${parallelOutputNamespace.taskIndex}-${s.agent}`, behavior.output as string),
-			};
-		}
-		const namespaceOutputPath = Boolean(inheritedRelativeParallelOutput && parallelOutputNamespace.taskIndex === undefined);
-		const skillNames = behavior.skills === false ? [] : behavior.skills;
+		const launchPlan = planChildLaunch({
+			agentConfig: a,
+			stepOverrides: buildStepOverrides(s),
+			task: s.task,
+			originalTask,
+			runnerCwd,
+			runtimeCwd: ctx.cwd,
+			stepCwdInput: s.cwd,
+			behaviorCwd,
+			chainSkills,
+			outputBaseDir,
+			parallelOutputNamespace,
+			resolvedBehavior,
+		});
+		const { stepCwd, instructionCwd, readExistenceCwd, behavior, namespaceOutputPath, outputPath, skillNames } = launchPlan;
 		const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
 			skillNames,
 			stepCwd,
@@ -837,7 +840,6 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const isFirstProgressAgent = behavior.progress && !progressPrecreated && !progressInstructionCreated;
 		if (behavior.progress) progressInstructionCreated = true;
 		const progressInstructions = buildChainInstructions({ ...behavior, output: false, reads: false }, progressDir, isFirstProgressAgent);
-		const outputPath = resolveSingleOutputPath(behavior.output, ctx.cwd, instructionCwd, outputBaseDir);
 		if (!namespaceOutputPath) systemPrompt = injectOutputPathSystemPrompt(systemPrompt, outputPath, a);
 		const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Async step (${s.agent})`);
 		if (validationError) throw new AsyncStartValidationError(validationError);

--- a/src/runs/shared/child-launch-plan.ts
+++ b/src/runs/shared/child-launch-plan.ts
@@ -1,0 +1,151 @@
+import * as path from "node:path";
+import type { AgentConfig } from "../../agents/agents.ts";
+import { resolveChildCwd } from "../../shared/utils.ts";
+import type { OutputMode } from "../../shared/types.ts";
+import { resolveSingleOutputPath } from "./single-output.ts";
+
+export interface ResolvedStepBehavior {
+	output: string | false;
+	outputMode: OutputMode;
+	reads: string[] | false;
+	progress: boolean;
+	skills: string[] | false;
+	model?: string;
+	fast?: boolean;
+}
+
+export type OutputOverrideInput = string | boolean;
+
+export interface StepOverrides {
+	output?: OutputOverrideInput;
+	outputMode?: OutputMode;
+	reads?: string[] | false;
+	progress?: boolean;
+	skills?: string[] | false;
+	model?: string;
+	fast?: boolean;
+}
+
+export interface ChildLaunchPlanInput {
+	agentConfig: AgentConfig;
+	stepOverrides: StepOverrides;
+	task?: string;
+	originalTask?: string;
+	runnerCwd: string;
+	runtimeCwd: string;
+	stepCwdInput?: string;
+	behaviorCwd?: string;
+	chainSkills?: string[];
+	outputBaseDir?: string;
+	parallelOutputNamespace?: { stepIndex: number; taskIndex?: number };
+	resolvedBehavior?: ResolvedStepBehavior;
+}
+
+export interface ChildLaunchPlan {
+	stepCwd: string;
+	instructionCwd: string;
+	readExistenceCwd: string;
+	behavior: ResolvedStepBehavior;
+	inheritedRelativeParallelOutput: boolean;
+	namespaceOutputPath: boolean;
+	outputPath?: string;
+	skillNames: string[];
+}
+
+export function normalizeOutputOverride(output: unknown): string | false | undefined {
+	if (output === false || output === "false") return false;
+	if (output === true || output === "true") return undefined;
+	return typeof output === "string" && output.length > 0 ? output : undefined;
+}
+
+export function resolveStepBehavior(
+	agentConfig: AgentConfig,
+	stepOverrides: StepOverrides,
+	chainSkills?: string[],
+): ResolvedStepBehavior {
+	const stepOutput = normalizeOutputOverride(stepOverrides.output);
+	const output = stepOutput !== undefined
+		? stepOutput
+		: normalizeOutputOverride(agentConfig.output) ?? false;
+
+	const reads = stepOverrides.reads !== undefined
+		? stepOverrides.reads
+		: agentConfig.defaultReads ?? false;
+
+	const progress = stepOverrides.progress !== undefined
+		? stepOverrides.progress
+		: agentConfig.defaultProgress ?? false;
+
+	let skills: string[] | false;
+	if (stepOverrides.skills === false) {
+		skills = false;
+	} else if (stepOverrides.skills !== undefined) {
+		skills = [...stepOverrides.skills];
+		if (chainSkills && chainSkills.length > 0) {
+			skills = [...new Set([...skills, ...chainSkills])];
+		}
+	} else {
+		skills = agentConfig.skills ? [...agentConfig.skills] : [];
+		if (chainSkills && chainSkills.length > 0) {
+			skills = [...new Set([...skills, ...chainSkills])];
+		}
+	}
+
+	const outputMode = stepOverrides.outputMode ?? agentConfig.outputMode ?? "inline";
+	const model = stepOverrides.model ?? agentConfig.model;
+	const fast = stepOverrides.fast ?? agentConfig.fast;
+	return { output, outputMode, reads, progress, skills, model, fast };
+}
+
+export function resolveTaskTextForFileUpdatePolicy(task: string | undefined, originalTask?: string): string | undefined {
+	if (!task) return originalTask;
+	return originalTask ? task.replaceAll("{task}", originalTask) : task;
+}
+
+export function taskDisallowsFileUpdates(task: string | undefined): boolean {
+	if (!task) return false;
+	return /\breview[- ]only\b/i.test(task)
+		|| /\bread[- ]only\s+(?:review|audit|inspection|pass)\b/i.test(task)
+		|| /\b(?:no|without)\s+(?:file\s+)?edits?\b/i.test(task)
+		|| /\b(?:do not|don't|must not)\s+(?:edit|modify|write|touch)\b/i.test(task)
+		|| /\bleave\s+files?\s+unchanged\b/i.test(task);
+}
+
+export function suppressProgressForReadOnlyTask(behavior: ResolvedStepBehavior, task: string | undefined, originalTask?: string): ResolvedStepBehavior {
+	const policyTask = resolveTaskTextForFileUpdatePolicy(task, originalTask);
+	return behavior.progress && taskDisallowsFileUpdates(policyTask) ? { ...behavior, progress: false } : behavior;
+}
+
+export function planChildLaunch(input: ChildLaunchPlanInput): ChildLaunchPlan {
+	const stepCwd = resolveChildCwd(input.runnerCwd, input.stepCwdInput);
+	const instructionCwd = input.behaviorCwd ?? stepCwd;
+	const readExistenceCwd = input.behaviorCwd ? stepCwd : instructionCwd;
+	let behavior = suppressProgressForReadOnlyTask(
+		input.resolvedBehavior ?? resolveStepBehavior(input.agentConfig, input.stepOverrides, input.chainSkills),
+		input.task,
+		input.originalTask,
+	);
+
+	const inheritedRelativeParallelOutput = Boolean(
+		input.parallelOutputNamespace
+		&& input.stepOverrides.output === undefined
+		&& typeof behavior.output === "string"
+		&& !path.isAbsolute(behavior.output),
+	);
+	if (inheritedRelativeParallelOutput && input.parallelOutputNamespace?.taskIndex !== undefined) {
+		behavior = {
+			...behavior,
+			output: path.join(
+				`parallel-${input.parallelOutputNamespace.stepIndex}`,
+				`${input.parallelOutputNamespace.taskIndex}-${input.agentConfig.name}`,
+				behavior.output as string,
+			),
+		};
+	}
+
+	const namespaceOutputPath = inheritedRelativeParallelOutput && input.parallelOutputNamespace?.taskIndex === undefined;
+	const skillNames = behavior.skills === false ? [] : behavior.skills;
+	const outputPath = resolveSingleOutputPath(behavior.output, input.runtimeCwd, instructionCwd, input.outputBaseDir);
+
+	return { stepCwd, instructionCwd, readExistenceCwd, behavior, inheritedRelativeParallelOutput, namespaceOutputPath, outputPath, skillNames };
+}

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -7,41 +7,19 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { discoverAgents, formatUnknownAgentError, unknownAgentDiagnosticContext, type AgentConfig, type AgentScope, type UnknownAgentDiagnosticContext } from "../agents/agents.ts";
 import { normalizeSkillInput } from "../agents/skills.ts";
+import { normalizeOutputOverride, type OutputOverrideInput, type ResolvedStepBehavior, type StepOverrides } from "../runs/shared/child-launch-plan.ts";
 import { CHAIN_RUNS_DIR, type AcceptanceInput, type AgentContract, type ChainGateLayer, type JsonSchemaObject, type OutputMode, type ToolBudgetConfig } from "./types.ts";
 const CHAIN_DIR_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const INITIAL_PROGRESS_CONTENT = "# Progress\n\n## Status\nIn Progress\n\n## Tasks\n\n## Files Changed\n\n## Notes\n";
 
-// =============================================================================
-// Behavior Resolution Types
-// =============================================================================
-
-export interface ResolvedStepBehavior {
-	output: string | false;
-	outputMode: OutputMode;
-	reads: string[] | false;
-	progress: boolean;
-	skills: string[] | false;
-	model?: string;
-	fast?: boolean;
-}
-
-export type OutputOverrideInput = string | boolean;
-
-export interface StepOverrides {
-	output?: OutputOverrideInput;
-	outputMode?: OutputMode;
-	reads?: string[] | false;
-	progress?: boolean;
-	skills?: string[] | false;
-	model?: string;
-	fast?: boolean;
-}
-
-function normalizeOutputOverride(output: unknown): string | false | undefined {
-	if (output === false || output === "false") return false;
-	if (output === true || output === "true") return undefined;
-	return typeof output === "string" && output.length > 0 ? output : undefined;
-}
+export {
+	planChildLaunch,
+	resolveStepBehavior,
+	resolveTaskTextForFileUpdatePolicy,
+	suppressProgressForReadOnlyTask,
+	taskDisallowsFileUpdates,
+} from "../runs/shared/child-launch-plan.ts";
+export type { ChildLaunchPlan, ChildLaunchPlanInput, OutputOverrideInput, ResolvedStepBehavior, StepOverrides } from "../runs/shared/child-launch-plan.ts";
 
 // =============================================================================
 // Chain Step Types
@@ -237,78 +215,6 @@ export function resolveChainTemplates(
 		// Default: first step uses {task}, others use {previous}
 		return i === 0 ? "{task}" : "{previous}";
 	});
-}
-
-// =============================================================================
-// Behavior Resolution
-// =============================================================================
-
-/**
- * Resolve effective chain behavior per step.
- * Priority: step override > agent frontmatter > false (disabled)
- */
-export function resolveStepBehavior(
-	agentConfig: AgentConfig,
-	stepOverrides: StepOverrides,
-	chainSkills?: string[],
-): ResolvedStepBehavior {
-	// Output: step override > frontmatter > false (no output)
-	const stepOutput = normalizeOutputOverride(stepOverrides.output);
-	const output =
-		stepOutput !== undefined
-			? stepOutput
-			: normalizeOutputOverride(agentConfig.output) ?? false;
-
-	// Reads: step override > frontmatter defaultReads > false (no reads)
-	const reads =
-		stepOverrides.reads !== undefined
-			? stepOverrides.reads
-			: agentConfig.defaultReads ?? false;
-
-	// Progress: step override > frontmatter defaultProgress > false
-	const progress =
-		stepOverrides.progress !== undefined
-			? stepOverrides.progress
-			: agentConfig.defaultProgress ?? false;
-
-	let skills: string[] | false;
-	if (stepOverrides.skills === false) {
-		skills = false;
-	} else if (stepOverrides.skills !== undefined) {
-		skills = [...stepOverrides.skills];
-		if (chainSkills && chainSkills.length > 0) {
-			skills = [...new Set([...skills, ...chainSkills])];
-		}
-	} else {
-		skills = agentConfig.skills ? [...agentConfig.skills] : [];
-		if (chainSkills && chainSkills.length > 0) {
-			skills = [...new Set([...skills, ...chainSkills])];
-		}
-	}
-
-	const outputMode = stepOverrides.outputMode ?? agentConfig.outputMode ?? "inline";
-	const model = stepOverrides.model ?? agentConfig.model;
-	const fast = stepOverrides.fast ?? agentConfig.fast;
-	return { output, outputMode, reads, progress, skills, model, fast };
-}
-
-export function resolveTaskTextForFileUpdatePolicy(task: string | undefined, originalTask?: string): string | undefined {
-	if (!task) return originalTask;
-	return originalTask ? task.replaceAll("{task}", originalTask) : task;
-}
-
-export function taskDisallowsFileUpdates(task: string | undefined): boolean {
-	if (!task) return false;
-	return /\breview[- ]only\b/i.test(task)
-		|| /\bread[- ]only\s+(?:review|audit|inspection|pass)\b/i.test(task)
-		|| /\b(?:no|without)\s+(?:file\s+)?edits?\b/i.test(task)
-		|| /\b(?:do not|don't|must not)\s+(?:edit|modify|write|touch)\b/i.test(task)
-		|| /\bleave\s+files?\s+unchanged\b/i.test(task);
-}
-
-export function suppressProgressForReadOnlyTask(behavior: ResolvedStepBehavior, task: string | undefined, originalTask?: string): ResolvedStepBehavior {
-	const policyTask = resolveTaskTextForFileUpdatePolicy(task, originalTask);
-	return behavior.progress && taskDisallowsFileUpdates(policyTask) ? { ...behavior, progress: false } : behavior;
 }
 
 // =============================================================================

--- a/test/unit/child-launch-plan.test.ts
+++ b/test/unit/child-launch-plan.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import type { AgentConfig } from "../../src/agents/agents.ts";
+import { planChildLaunch, resolveStepBehavior } from "../../src/runs/shared/child-launch-plan.ts";
+
+const agent = {
+	name: "worker",
+	output: "report.md",
+	outputMode: "file-only",
+	defaultReads: ["brief.md"],
+	defaultProgress: true,
+	skills: ["typescript"],
+	model: "openai-codex/gpt-5.6-luna",
+	fast: true,
+} as AgentConfig;
+
+describe("child launch planning", () => {
+	it("resolves cwd, behavior, skills, model, and output path without side effects", () => {
+		const runnerCwd = path.join("/tmp", "repo");
+		const resolvedRunnerCwd = path.resolve(runnerCwd);
+		const plan = planChildLaunch({
+			agentConfig: agent,
+			stepOverrides: { skills: ["review"], outputMode: "inline" },
+			task: "Implement the change",
+			runnerCwd,
+			runtimeCwd: runnerCwd,
+			stepCwdInput: "packages/cli",
+			chainSkills: ["shared"],
+		});
+
+		assert.equal(plan.stepCwd, path.join(resolvedRunnerCwd, "packages/cli"));
+		assert.equal(plan.instructionCwd, plan.stepCwd);
+		assert.equal(plan.readExistenceCwd, plan.stepCwd);
+		assert.equal(plan.outputPath, path.join(resolvedRunnerCwd, "packages/cli", "report.md"));
+		assert.deepEqual(plan.skillNames, ["review", "shared"]);
+		assert.deepEqual(plan.behavior, {
+			output: "report.md",
+			outputMode: "inline",
+			reads: ["brief.md"],
+			progress: true,
+			skills: ["review", "shared"],
+			model: "openai-codex/gpt-5.6-luna",
+			fast: true,
+		});
+	});
+
+	it("keeps dynamic namespace output unresolved until fanout items materialize", () => {
+		const runnerCwd = path.join("/tmp", "repo");
+		const resolvedRunnerCwd = path.resolve(runnerCwd);
+		const plan = planChildLaunch({
+			agentConfig: agent,
+			stepOverrides: {},
+			runnerCwd,
+			runtimeCwd: runnerCwd,
+			parallelOutputNamespace: { stepIndex: 2 },
+		});
+
+		assert.equal(plan.namespaceOutputPath, true);
+		assert.equal(plan.behavior.output, "report.md");
+		assert.equal(plan.outputPath, path.join(resolvedRunnerCwd, "report.md"));
+	});
+
+	it("namespaces inherited relative parallel output for concrete items", () => {
+		const runnerCwd = path.join("/tmp", "repo");
+		const resolvedRunnerCwd = path.resolve(runnerCwd);
+		const plan = planChildLaunch({
+			agentConfig: agent,
+			stepOverrides: {},
+			runnerCwd,
+			runtimeCwd: runnerCwd,
+			parallelOutputNamespace: { stepIndex: 2, taskIndex: 4 },
+		});
+
+		assert.equal(plan.namespaceOutputPath, false);
+		assert.equal(plan.behavior.output, path.join("parallel-2", "4-worker", "report.md"));
+		assert.equal(plan.outputPath, path.join(resolvedRunnerCwd, "parallel-2", "4-worker", "report.md"));
+	});
+
+	it("suppresses progress for read-only templated tasks", () => {
+		const behavior = resolveStepBehavior(agent, {});
+		const plan = planChildLaunch({
+			agentConfig: agent,
+			stepOverrides: {},
+			resolvedBehavior: behavior,
+			task: "{task}",
+			originalTask: "Review-only. Do not edit files.",
+			runnerCwd: "/tmp/repo",
+			runtimeCwd: "/tmp/repo",
+		});
+
+		assert.equal(plan.behavior.progress, false);
+	});
+});


### PR DESCRIPTION
## Summary

Extracts child launch planning into a focused internal module for resolved behavior, cwd, output, progress, skills, and model inputs. The async workflow launch adapter now consumes that plan while keeping skill discovery, prompt injection, validation, runner construction, status updates, and result evidence handling in the caller.

Closes #1573.

## Validation

- `node --test test/unit/child-launch-plan.test.ts`
- `node --test test/integration/template-resolution.test.ts`
- `node --test test/unit/async-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'isolates colliding inherited agent-default outputs|isolates inherited outputs that collide with a resumed child output|reroutes a later inherited agent-default output collision' test/integration/single-execution.test.ts`\n- `npm run typecheck`\n- `git diff --check`\n\nFresh review: `/Users/nicobailon/.pi/agent/memory/extensions-subagent/lane-reports/issue-1573-review.md`