### PR TITLE
refactor: extract async status projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Extract async status snapshot projection into a pure internal module while preserving RPC and widget wire compatibility.
 - Extract child launch planning into a focused internal module shared by async workflow launch setup.
 - Extract detached workflow settlement planning into a focused workflow module while preserving fail-closed result handoff.
 - Extract completion evidence planning into a focused module shared by foreground and background execution.

--- a/src/runs/background/async-status-snapshot.ts
+++ b/src/runs/background/async-status-snapshot.ts
@@ -1,268 +1,31 @@
-import { sanitizeDisplayText, truncateDisplayText } from "../../shared/display-text.ts";
-import type { AsyncJobState, AsyncJobStep, NestedRunSummary, NestedStepSummary, SubagentRunMode, SubagentState } from "../../shared/types.ts";
+import type { AsyncJobState, SubagentState } from "../../shared/types.ts";
+import {
+	ASYNC_STATUS_SNAPSHOT_KIND,
+	ASYNC_STATUS_SNAPSHOT_VERSION,
+	projectAsyncStatusSnapshot,
+	type AsyncStatusSnapshotOptions,
+	type AsyncStatusSnapshotV1,
+} from "../shared/async-status-projection.ts";
 
-export const ASYNC_STATUS_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
-export const ASYNC_STATUS_SNAPSHOT_VERSION = 1;
+export {
+	ASYNC_STATUS_SNAPSHOT_KIND,
+	ASYNC_STATUS_SNAPSHOT_VERSION,
+} from "../shared/async-status-projection.ts";
+export type {
+	AsyncStatusSnapshotActivityV1,
+	AsyncStatusSnapshotCapsV1,
+	AsyncStatusSnapshotKind,
+	AsyncStatusSnapshotNodeV1,
+	AsyncStatusSnapshotOmittedV1,
+	AsyncStatusSnapshotOptions,
+	AsyncStatusSnapshotState,
+	AsyncStatusSnapshotV1,
+} from "../shared/async-status-projection.ts";
+
 export const ASYNC_STATUS_SNAPSHOT_WIDGET_PREFIX = "PI_SUBAGENT_ASYNC_JSON:";
 
-const DEFAULT_MAX_RUNS = 20;
-const DEFAULT_MAX_CHILDREN_PER_NODE = 8;
-const DEFAULT_MAX_DEPTH = 3;
-const DEFAULT_MAX_STRING_LENGTH = 160;
-const DEFAULT_MAX_SERIALIZED_BYTES = 32 * 1024;
-
-export type AsyncStatusSnapshotState = "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
-export type AsyncStatusSnapshotKind = "subagent" | "workflow" | "step";
-
-export interface AsyncStatusSnapshotActivityV1 {
-	state?: string;
-	currentTool?: string;
-	lastActivityAt?: number;
-	currentToolStartedAt?: number;
-	turnCount?: number;
-	toolCount?: number;
-}
-
-export interface AsyncStatusSnapshotNodeV1 {
-	id: string;
-	kind: AsyncStatusSnapshotKind;
-	label: string;
-	state: AsyncStatusSnapshotState;
-	startedAt?: number;
-	updatedAt?: number;
-	endedAt?: number;
-	activity?: AsyncStatusSnapshotActivityV1;
-	children?: AsyncStatusSnapshotNodeV1[];
-}
-
-export interface AsyncStatusSnapshotCapsV1 {
-	maxRuns: number;
-	maxChildrenPerNode: number;
-	maxDepth: number;
-	maxStringLength: number;
-	maxSerializedBytes: number;
-}
-
-export interface AsyncStatusSnapshotOmittedV1 {
-	runs: number;
-	children: number;
-	byteLimitExceeded: boolean;
-}
-
-export interface AsyncStatusSnapshotV1 {
-	kind: typeof ASYNC_STATUS_SNAPSHOT_KIND;
-	version: typeof ASYNC_STATUS_SNAPSHOT_VERSION;
-	generatedAt: number;
-	caps: AsyncStatusSnapshotCapsV1;
-	omitted: AsyncStatusSnapshotOmittedV1;
-	runs: AsyncStatusSnapshotNodeV1[];
-}
-
-export interface AsyncStatusSnapshotOptions {
-	generatedAt?: number;
-	maxRuns?: number;
-	maxChildrenPerNode?: number;
-	maxDepth?: number;
-	maxStringLength?: number;
-	maxSerializedBytes?: number;
-}
-
-interface BuildContext {
-	caps: AsyncStatusSnapshotCapsV1;
-	omitted: AsyncStatusSnapshotOmittedV1;
-}
-
-function resolveCaps(options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshotCapsV1 {
-	return {
-		maxRuns: Math.max(0, Math.floor(options.maxRuns ?? DEFAULT_MAX_RUNS)),
-		maxChildrenPerNode: Math.max(0, Math.floor(options.maxChildrenPerNode ?? DEFAULT_MAX_CHILDREN_PER_NODE)),
-		maxDepth: Math.max(0, Math.floor(options.maxDepth ?? DEFAULT_MAX_DEPTH)),
-		maxStringLength: Math.max(0, Math.floor(options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH)),
-		maxSerializedBytes: Math.max(256, Math.floor(options.maxSerializedBytes ?? DEFAULT_MAX_SERIALIZED_BYTES)),
-	};
-}
-
-function publicText(value: unknown, fallback: string, maxLength: number): string {
-	if (typeof value !== "string") return fallback;
-	const normalized = sanitizeDisplayText(value.slice(0, Math.max(0, maxLength * 4)));
-	return truncateDisplayText(normalized || fallback, maxLength);
-}
-
-function publicOptionalText(value: unknown, maxLength: number): string | undefined {
-	if (typeof value !== "string") return undefined;
-	const normalized = sanitizeDisplayText(value.slice(0, Math.max(0, maxLength * 4)));
-	return normalized ? truncateDisplayText(normalized, maxLength) : undefined;
-}
-
-function publicTime(value: unknown): number | undefined {
-	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
-}
-
-function publicCount(value: unknown): number | undefined {
-	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
-}
-
-function normalizeState(value: string): AsyncStatusSnapshotState {
-	if (value === "completed") return "complete";
-	if (value === "pending") return "queued";
-	return value as AsyncStatusSnapshotState;
-}
-
-function terminalState(state: AsyncStatusSnapshotState): boolean {
-	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped" || state === "rejected";
-}
-
-function kindForMode(mode: SubagentRunMode | undefined): AsyncStatusSnapshotKind {
-	return mode === "workflow" ? "workflow" : "subagent";
-}
-
-function labelForAgents(agents: readonly string[] | undefined, fallback: string, maxLength: number): string {
-	if (!agents?.length) return publicText(fallback, fallback, maxLength);
-	const visible = agents.slice(0, 3).map((agent) => publicText(agent, "agent", maxLength)).join(", ");
-	const suffix = agents.length > 3 ? `, +${agents.length - 3} more` : "";
-	return truncateDisplayText(`${visible}${suffix}`, maxLength);
-}
-
-function activityFor(source: {
-	activityState?: unknown;
-	currentTool?: unknown;
-	lastActivityAt?: unknown;
-	currentToolStartedAt?: unknown;
-	turnCount?: unknown;
-	toolCount?: unknown;
-}, ctx: BuildContext): AsyncStatusSnapshotActivityV1 | undefined {
-	const activity: AsyncStatusSnapshotActivityV1 = {
-		...(typeof source.activityState === "string" ? { state: publicText(source.activityState, "unknown", ctx.caps.maxStringLength) } : {}),
-		...(publicOptionalText(source.currentTool, ctx.caps.maxStringLength) ? { currentTool: publicOptionalText(source.currentTool, ctx.caps.maxStringLength) } : {}),
-		...(publicTime(source.lastActivityAt) !== undefined ? { lastActivityAt: publicTime(source.lastActivityAt) } : {}),
-		...(publicTime(source.currentToolStartedAt) !== undefined ? { currentToolStartedAt: publicTime(source.currentToolStartedAt) } : {}),
-		...(publicCount(source.turnCount) !== undefined ? { turnCount: publicCount(source.turnCount) } : {}),
-		...(publicCount(source.toolCount) !== undefined ? { toolCount: publicCount(source.toolCount) } : {}),
-	};
-	return Object.keys(activity).length ? activity : undefined;
-}
-
-function appendBoundedChildren(children: AsyncStatusSnapshotNodeV1[], source: readonly AsyncStatusSnapshotNodeV1[], ctx: BuildContext): void {
-	const remaining = Math.max(0, ctx.caps.maxChildrenPerNode - children.length);
-	children.push(...source.slice(0, remaining));
-	ctx.omitted.children += Math.max(0, source.length - remaining);
-}
-
-function buildStepNode(step: AsyncJobStep | NestedStepSummary, index: number, depth: number, ctx: BuildContext): AsyncStatusSnapshotNodeV1 {
-	const state = normalizeState(step.status);
-	const updatedAt = publicTime(step.endedAt) ?? publicTime(step.lastActivityAt) ?? publicTime(step.startedAt);
-	const node: AsyncStatusSnapshotNodeV1 = {
-		id: publicText("workflowKey" in step && step.workflowKey ? step.workflowKey : "runId" in step && step.runId ? step.runId : `step:${index}`, `step:${index}`, ctx.caps.maxStringLength),
-		kind: "step",
-		label: publicText("label" in step && step.label ? step.label : step.agent, "step", ctx.caps.maxStringLength),
-		state,
-		...(publicTime(step.startedAt) !== undefined ? { startedAt: publicTime(step.startedAt) } : {}),
-		...(updatedAt !== undefined ? { updatedAt } : {}),
-		...(terminalState(state) && publicTime(step.endedAt) !== undefined ? { endedAt: publicTime(step.endedAt) } : {}),
-		...(activityFor(step, ctx) ? { activity: activityFor(step, ctx) } : {}),
-	};
-	if (depth < ctx.caps.maxDepth && step.children?.length) {
-		const nested = step.children.map((child, childIndex) => buildNestedNode(child, childIndex, depth + 1, ctx));
-		const bounded: AsyncStatusSnapshotNodeV1[] = [];
-		appendBoundedChildren(bounded, nested, ctx);
-		if (bounded.length) node.children = bounded;
-	} else if (step.children?.length) {
-		ctx.omitted.children += step.children.length;
-	}
-	return node;
-}
-
-function buildNestedNode(child: NestedRunSummary, index: number, depth: number, ctx: BuildContext): AsyncStatusSnapshotNodeV1 {
-	const state = normalizeState(child.state);
-	const updatedAt = publicTime(child.lastUpdate) ?? publicTime(child.endedAt) ?? publicTime(child.lastActivityAt) ?? publicTime(child.startedAt);
-	const node: AsyncStatusSnapshotNodeV1 = {
-		id: publicText(child.id, `nested:${index}`, ctx.caps.maxStringLength),
-		kind: kindForMode(child.mode),
-		label: child.agent ? publicText(child.agent, "subagent", ctx.caps.maxStringLength) : labelForAgents(child.agents, child.mode ?? "subagent", ctx.caps.maxStringLength),
-		state,
-		...(publicTime(child.startedAt) !== undefined ? { startedAt: publicTime(child.startedAt) } : {}),
-		...(updatedAt !== undefined ? { updatedAt } : {}),
-		...(terminalState(state) && publicTime(child.endedAt) !== undefined ? { endedAt: publicTime(child.endedAt) } : {}),
-		...(activityFor(child, ctx) ? { activity: activityFor(child, ctx) } : {}),
-	};
-	if (depth < ctx.caps.maxDepth) {
-		const nestedSteps = child.steps?.map((step, stepIndex) => buildStepNode(step, stepIndex, depth + 1, ctx)) ?? [];
-		const nestedChildren = child.children?.map((nested, childIndex) => buildNestedNode(nested, childIndex, depth + 1, ctx)) ?? [];
-		const bounded: AsyncStatusSnapshotNodeV1[] = [];
-		appendBoundedChildren(bounded, [...nestedSteps, ...nestedChildren], ctx);
-		if (bounded.length) node.children = bounded;
-	} else {
-		ctx.omitted.children += (child.steps?.length ?? 0) + (child.children?.length ?? 0);
-	}
-	return node;
-}
-
-function buildRunNode(job: AsyncJobState, ctx: BuildContext): AsyncStatusSnapshotNodeV1 {
-	const state = normalizeState(job.status);
-	const updatedAt = publicTime(job.updatedAt) ?? publicTime(job.startedAt);
-	const node: AsyncStatusSnapshotNodeV1 = {
-		id: publicText(job.asyncId, "async", ctx.caps.maxStringLength),
-		kind: kindForMode(job.mode),
-		label: labelForAgents(job.agents, job.mode ?? "subagent", ctx.caps.maxStringLength),
-		state,
-		...(publicTime(job.startedAt) !== undefined ? { startedAt: publicTime(job.startedAt) } : {}),
-		...(updatedAt !== undefined ? { updatedAt } : {}),
-		...(terminalState(state) && updatedAt !== undefined ? { endedAt: updatedAt } : {}),
-		...(activityFor(job, ctx) ? { activity: activityFor(job, ctx) } : {}),
-	};
-	if (ctx.caps.maxDepth > 0) {
-		const stepChildren = job.steps?.map((step, index) => buildStepNode(step, step.index ?? index, 1, ctx)) ?? [];
-		const nestedChildren = job.nestedChildren?.map((child, index) => buildNestedNode(child, index, 1, ctx)) ?? [];
-		const bounded: AsyncStatusSnapshotNodeV1[] = [];
-		appendBoundedChildren(bounded, [...stepChildren, ...nestedChildren], ctx);
-		if (bounded.length) node.children = bounded;
-	} else {
-		ctx.omitted.children += (job.steps?.length ?? 0) + (job.nestedChildren?.length ?? 0);
-	}
-	return node;
-}
-
-function snapshotBytes(snapshot: AsyncStatusSnapshotV1): number {
-	return Buffer.byteLength(JSON.stringify(snapshot), "utf8");
-}
-
-function enforceByteLimit(snapshot: AsyncStatusSnapshotV1): void {
-	if (snapshotBytes(snapshot) <= snapshot.caps.maxSerializedBytes) return;
-	snapshot.omitted.byteLimitExceeded = true;
-	const runs = snapshot.runs;
-	const initialOmittedRuns = snapshot.omitted.runs;
-	let lower = 0;
-	let upper = Math.max(0, runs.length - 1);
-	while (lower < upper) {
-		const retained = Math.ceil((lower + upper) / 2);
-		snapshot.runs = runs.slice(0, retained);
-		snapshot.omitted.runs = initialOmittedRuns + runs.length - retained;
-		if (snapshotBytes(snapshot) <= snapshot.caps.maxSerializedBytes) lower = retained;
-		else upper = retained - 1;
-	}
-	snapshot.runs = runs.slice(0, lower);
-	snapshot.omitted.runs = initialOmittedRuns + runs.length - lower;
-}
-
 export function buildAsyncStatusSnapshot(jobs: Iterable<AsyncJobState>, options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshotV1 {
-	const caps = resolveCaps(options);
-	const ctx: BuildContext = { caps, omitted: { runs: 0, children: 0, byteLimitExceeded: false } };
-	const sorted = [...jobs].sort((left, right) => {
-		const leftUpdated = left.updatedAt ?? left.startedAt ?? 0;
-		const rightUpdated = right.updatedAt ?? right.startedAt ?? 0;
-		return rightUpdated - leftUpdated || left.asyncId.localeCompare(right.asyncId);
-	});
-	ctx.omitted.runs += Math.max(0, sorted.length - caps.maxRuns);
-	const snapshot: AsyncStatusSnapshotV1 = {
-		kind: ASYNC_STATUS_SNAPSHOT_KIND,
-		version: ASYNC_STATUS_SNAPSHOT_VERSION,
-		generatedAt: options.generatedAt ?? Date.now(),
-		caps,
-		omitted: ctx.omitted,
-		runs: sorted.slice(0, caps.maxRuns).map((job) => buildRunNode(job, ctx)),
-	};
-	enforceByteLimit(snapshot);
-	return snapshot;
+	return projectAsyncStatusSnapshot(jobs, options);
 }
 
 export function asyncStatusSnapshotJobsForState(state: SubagentState | undefined, sessionId: string | null | undefined): AsyncJobState[] {

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -1,0 +1,325 @@
+import { sanitizeDisplayText, truncateDisplayText } from "../../shared/display-text.ts";
+import { formatModelThinking } from "../../shared/formatters.ts";
+import type { AsyncJobState, AsyncJobStep, NestedRunSummary, NestedStepSummary, SubagentRunMode } from "../../shared/types.ts";
+
+export const ASYNC_STATUS_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
+export const ASYNC_STATUS_SNAPSHOT_VERSION = 1;
+
+const DEFAULT_MAX_RUNS = 20;
+const DEFAULT_MAX_CHILDREN_PER_NODE = 8;
+const DEFAULT_MAX_DEPTH = 3;
+const DEFAULT_MAX_STRING_LENGTH = 160;
+const DEFAULT_MAX_SERIALIZED_BYTES = 32 * 1024;
+
+export type AsyncStatusSnapshotState = "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
+export type AsyncStatusSnapshotKind = "subagent" | "workflow" | "step";
+
+export interface AsyncStatusSnapshotActivityV1 {
+	state?: string;
+	currentTool?: string;
+	lastActivityAt?: number;
+	currentToolStartedAt?: number;
+	turnCount?: number;
+	toolCount?: number;
+}
+
+export interface AsyncStatusSnapshotNodeV1 {
+	id: string;
+	kind: AsyncStatusSnapshotKind;
+	label: string;
+	state: AsyncStatusSnapshotState;
+	startedAt?: number;
+	updatedAt?: number;
+	endedAt?: number;
+	activity?: AsyncStatusSnapshotActivityV1;
+	children?: AsyncStatusSnapshotNodeV1[];
+}
+
+export interface AsyncStatusSnapshotCapsV1 {
+	maxRuns: number;
+	maxChildrenPerNode: number;
+	maxDepth: number;
+	maxStringLength: number;
+	maxSerializedBytes: number;
+}
+
+export interface AsyncStatusSnapshotOmittedV1 {
+	runs: number;
+	children: number;
+	byteLimitExceeded: boolean;
+}
+
+export interface AsyncStatusSnapshotV1 {
+	kind: typeof ASYNC_STATUS_SNAPSHOT_KIND;
+	version: typeof ASYNC_STATUS_SNAPSHOT_VERSION;
+	generatedAt: number;
+	caps: AsyncStatusSnapshotCapsV1;
+	omitted: AsyncStatusSnapshotOmittedV1;
+	runs: AsyncStatusSnapshotNodeV1[];
+}
+
+export interface AsyncStatusSnapshotOptions {
+	generatedAt?: number;
+	maxRuns?: number;
+	maxChildrenPerNode?: number;
+	maxDepth?: number;
+	maxStringLength?: number;
+	maxSerializedBytes?: number;
+}
+
+export interface AsyncStatusWorkflowRow {
+	name: string;
+	state: AsyncJobStep["status"];
+	modelThinking?: string;
+	activity?: string;
+	startedAt?: number;
+	tokens?: number;
+	window?: number;
+	overflow?: number;
+}
+
+interface ProjectionContext {
+	caps: AsyncStatusSnapshotCapsV1;
+	omitted: AsyncStatusSnapshotOmittedV1;
+}
+
+function resolveCaps(options: AsyncStatusSnapshotOptions): AsyncStatusSnapshotCapsV1 {
+	return {
+		maxRuns: Math.max(0, Math.floor(options.maxRuns ?? DEFAULT_MAX_RUNS)),
+		maxChildrenPerNode: Math.max(0, Math.floor(options.maxChildrenPerNode ?? DEFAULT_MAX_CHILDREN_PER_NODE)),
+		maxDepth: Math.max(0, Math.floor(options.maxDepth ?? DEFAULT_MAX_DEPTH)),
+		maxStringLength: Math.max(0, Math.floor(options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH)),
+		maxSerializedBytes: Math.max(256, Math.floor(options.maxSerializedBytes ?? DEFAULT_MAX_SERIALIZED_BYTES)),
+	};
+}
+
+function publicText(value: unknown, fallback: string, maxLength: number): string {
+	if (typeof value !== "string") return fallback;
+	const normalized = sanitizeDisplayText(value.slice(0, Math.max(0, maxLength * 4)));
+	return truncateDisplayText(normalized || fallback, maxLength);
+}
+
+function publicOptionalText(value: unknown, maxLength: number): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = sanitizeDisplayText(value.slice(0, Math.max(0, maxLength * 4)));
+	return normalized ? truncateDisplayText(normalized, maxLength) : undefined;
+}
+
+function publicTime(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function publicCount(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function normalizeState(value: string): AsyncStatusSnapshotState {
+	if (value === "completed") return "complete";
+	if (value === "pending") return "queued";
+	return value as AsyncStatusSnapshotState;
+}
+
+function terminalState(state: AsyncStatusSnapshotState): boolean {
+	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped" || state === "rejected";
+}
+
+function kindForMode(mode: SubagentRunMode | undefined): AsyncStatusSnapshotKind {
+	return mode === "workflow" ? "workflow" : "subagent";
+}
+
+function labelForAgents(agents: readonly string[] | undefined, fallback: string, maxLength: number): string {
+	if (!agents?.length) return publicText(fallback, fallback, maxLength);
+	const visible = agents.slice(0, 3).map((agent) => publicText(agent, "agent", maxLength)).join(", ");
+	const suffix = agents.length > 3 ? `, +${agents.length - 3} more` : "";
+	return truncateDisplayText(`${visible}${suffix}`, maxLength);
+}
+
+function activityFor(source: {
+	activityState?: unknown;
+	currentTool?: unknown;
+	lastActivityAt?: unknown;
+	currentToolStartedAt?: unknown;
+	turnCount?: unknown;
+	toolCount?: unknown;
+}, ctx: ProjectionContext): AsyncStatusSnapshotActivityV1 | undefined {
+	const currentTool = publicOptionalText(source.currentTool, ctx.caps.maxStringLength);
+	const lastActivityAt = publicTime(source.lastActivityAt);
+	const currentToolStartedAt = publicTime(source.currentToolStartedAt);
+	const turnCount = publicCount(source.turnCount);
+	const toolCount = publicCount(source.toolCount);
+	const activity: AsyncStatusSnapshotActivityV1 = {
+		...(typeof source.activityState === "string" ? { state: publicText(source.activityState, "unknown", ctx.caps.maxStringLength) } : {}),
+		...(currentTool ? { currentTool } : {}),
+		...(lastActivityAt !== undefined ? { lastActivityAt } : {}),
+		...(currentToolStartedAt !== undefined ? { currentToolStartedAt } : {}),
+		...(turnCount !== undefined ? { turnCount } : {}),
+		...(toolCount !== undefined ? { toolCount } : {}),
+	};
+	return Object.keys(activity).length ? activity : undefined;
+}
+
+function appendBoundedChildren(children: AsyncStatusSnapshotNodeV1[], source: readonly AsyncStatusSnapshotNodeV1[], ctx: ProjectionContext): void {
+	const remaining = Math.max(0, ctx.caps.maxChildrenPerNode - children.length);
+	children.push(...source.slice(0, remaining));
+	ctx.omitted.children += Math.max(0, source.length - remaining);
+}
+
+function projectStep(step: AsyncJobStep | NestedStepSummary, index: number, depth: number, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
+	const state = normalizeState(step.status);
+	const startedAt = publicTime(step.startedAt);
+	const endedAt = publicTime(step.endedAt);
+	const updatedAt = endedAt ?? publicTime(step.lastActivityAt) ?? startedAt;
+	const activity = activityFor(step, ctx);
+	const node: AsyncStatusSnapshotNodeV1 = {
+		id: publicText("workflowKey" in step && step.workflowKey ? step.workflowKey : "runId" in step && step.runId ? step.runId : `step:${index}`, `step:${index}`, ctx.caps.maxStringLength),
+		kind: "step",
+		label: publicText("label" in step && step.label ? step.label : step.agent, "step", ctx.caps.maxStringLength),
+		state,
+		...(startedAt !== undefined ? { startedAt } : {}),
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(terminalState(state) && endedAt !== undefined ? { endedAt } : {}),
+		...(activity ? { activity } : {}),
+	};
+	if (depth < ctx.caps.maxDepth && step.children?.length) {
+		const nested = step.children.map((child, childIndex) => projectNestedRun(child, childIndex, depth + 1, ctx));
+		const bounded: AsyncStatusSnapshotNodeV1[] = [];
+		appendBoundedChildren(bounded, nested, ctx);
+		if (bounded.length) node.children = bounded;
+	} else if (step.children?.length) {
+		ctx.omitted.children += step.children.length;
+	}
+	return node;
+}
+
+function projectNestedRun(child: NestedRunSummary, index: number, depth: number, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
+	const state = normalizeState(child.state);
+	const startedAt = publicTime(child.startedAt);
+	const endedAt = publicTime(child.endedAt);
+	const updatedAt = publicTime(child.lastUpdate) ?? endedAt ?? publicTime(child.lastActivityAt) ?? startedAt;
+	const activity = activityFor(child, ctx);
+	const node: AsyncStatusSnapshotNodeV1 = {
+		id: publicText(child.id, `nested:${index}`, ctx.caps.maxStringLength),
+		kind: kindForMode(child.mode),
+		label: child.agent ? publicText(child.agent, "subagent", ctx.caps.maxStringLength) : labelForAgents(child.agents, child.mode ?? "subagent", ctx.caps.maxStringLength),
+		state,
+		...(startedAt !== undefined ? { startedAt } : {}),
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(terminalState(state) && endedAt !== undefined ? { endedAt } : {}),
+		...(activity ? { activity } : {}),
+	};
+	if (depth < ctx.caps.maxDepth) {
+		const nestedSteps = child.steps?.map((step, stepIndex) => projectStep(step, stepIndex, depth + 1, ctx)) ?? [];
+		const nestedChildren = child.children?.map((nested, childIndex) => projectNestedRun(nested, childIndex, depth + 1, ctx)) ?? [];
+		const bounded: AsyncStatusSnapshotNodeV1[] = [];
+		appendBoundedChildren(bounded, [...nestedSteps, ...nestedChildren], ctx);
+		if (bounded.length) node.children = bounded;
+	} else {
+		ctx.omitted.children += (child.steps?.length ?? 0) + (child.children?.length ?? 0);
+	}
+	return node;
+}
+
+function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
+	const state = normalizeState(job.status);
+	const startedAt = publicTime(job.startedAt);
+	const updatedAt = publicTime(job.updatedAt) ?? startedAt;
+	const activity = activityFor(job, ctx);
+	const node: AsyncStatusSnapshotNodeV1 = {
+		id: publicText(job.asyncId, "async", ctx.caps.maxStringLength),
+		kind: kindForMode(job.mode),
+		label: labelForAgents(job.agents, job.mode ?? "subagent", ctx.caps.maxStringLength),
+		state,
+		...(startedAt !== undefined ? { startedAt } : {}),
+		...(updatedAt !== undefined ? { updatedAt } : {}),
+		...(terminalState(state) && updatedAt !== undefined ? { endedAt: updatedAt } : {}),
+		...(activity ? { activity } : {}),
+	};
+	if (ctx.caps.maxDepth > 0) {
+		const stepChildren = job.steps?.map((step, index) => projectStep(step, step.index ?? index, 1, ctx)) ?? [];
+		const nestedChildren = job.nestedChildren?.map((child, index) => projectNestedRun(child, index, 1, ctx)) ?? [];
+		const bounded: AsyncStatusSnapshotNodeV1[] = [];
+		appendBoundedChildren(bounded, [...stepChildren, ...nestedChildren], ctx);
+		if (bounded.length) node.children = bounded;
+	} else {
+		ctx.omitted.children += (job.steps?.length ?? 0) + (job.nestedChildren?.length ?? 0);
+	}
+	return node;
+}
+
+function snapshotBytes(snapshot: AsyncStatusSnapshotV1): number {
+	return Buffer.byteLength(JSON.stringify(snapshot), "utf8");
+}
+
+function enforceByteLimit(snapshot: AsyncStatusSnapshotV1): void {
+	if (snapshotBytes(snapshot) <= snapshot.caps.maxSerializedBytes) return;
+	snapshot.omitted.byteLimitExceeded = true;
+	const runs = snapshot.runs;
+	const initialOmittedRuns = snapshot.omitted.runs;
+	let lower = 0;
+	let upper = Math.max(0, runs.length - 1);
+	while (lower < upper) {
+		const retained = Math.ceil((lower + upper) / 2);
+		snapshot.runs = runs.slice(0, retained);
+		snapshot.omitted.runs = initialOmittedRuns + runs.length - retained;
+		if (snapshotBytes(snapshot) <= snapshot.caps.maxSerializedBytes) lower = retained;
+		else upper = retained - 1;
+	}
+	snapshot.runs = runs.slice(0, lower);
+	snapshot.omitted.runs = initialOmittedRuns + runs.length - lower;
+}
+
+function workflowStepActivity(step: AsyncJobStep): string | undefined {
+	if (step.currentTool) return `tool ${step.currentTool}`;
+	if (step.currentPath) return step.currentPath.split(/[\\/]/).at(-1);
+	if (step.activityState === "needs_attention") return "needs attention";
+	if (step.activityState === "active_long_running") return "long-running";
+	if (step.turnCount !== undefined) return `${step.turnCount} turns`;
+	if (step.toolCount !== undefined) return `${step.toolCount} tools`;
+	return undefined;
+}
+
+function workflowStepName(step: AsyncJobStep, index: number): string {
+	const key = step.workflowKey ?? `step ${index + 1}`;
+	const label = step.label && step.label !== key ? ` · ${step.label}` : "";
+	const phase = step.phase ? `${step.phase}: ` : "";
+	return `${phase}${key}${label} (${step.agent})`;
+}
+
+/** Project loaded workflow child facts into compact rows; visibility bounds and rendering remain caller-owned. */
+export function projectAsyncWorkflowRows(steps: readonly AsyncJobStep[] | undefined): AsyncStatusWorkflowRow[] {
+	return (steps ?? []).map((step, index) => {
+		const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
+		const activity = workflowStepActivity(step);
+		return {
+			name: workflowStepName(step, index),
+			state: step.status,
+			...(modelThinking ? { modelThinking } : {}),
+			...(activity ? { activity } : {}),
+			...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
+			...(step.tokens?.total !== undefined ? { tokens: step.tokens.total } : {}),
+			...(step.tokens?.window !== undefined ? { window: step.tokens.window } : {}),
+		};
+	});
+}
+
+/** Project already-loaded async status facts into the bounded public snapshot shape. */
+export function projectAsyncStatusSnapshot(jobs: Iterable<AsyncJobState>, options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshotV1 {
+	const caps = resolveCaps(options);
+	const ctx: ProjectionContext = { caps, omitted: { runs: 0, children: 0, byteLimitExceeded: false } };
+	const sorted = [...jobs].sort((left, right) => {
+		const leftUpdated = left.updatedAt ?? left.startedAt ?? 0;
+		const rightUpdated = right.updatedAt ?? right.startedAt ?? 0;
+		return rightUpdated - leftUpdated || left.asyncId.localeCompare(right.asyncId);
+	});
+	ctx.omitted.runs += Math.max(0, sorted.length - caps.maxRuns);
+	const snapshot: AsyncStatusSnapshotV1 = {
+		kind: ASYNC_STATUS_SNAPSHOT_KIND,
+		version: ASYNC_STATUS_SNAPSHOT_VERSION,
+		generatedAt: options.generatedAt ?? Date.now(),
+		caps,
+		omitted: ctx.omitted,
+		runs: sorted.slice(0, caps.maxRuns).map((job) => projectRun(job, ctx)),
+	};
+	enforceByteLimit(snapshot);
+	return snapshot;
+}

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -3,6 +3,7 @@ import { type EditorComponent, isKeyRelease, Key, matchesKey, truncateToWidth, v
 import { snapshotExternalRuns } from "../api/external-runs.ts";
 import { formatModelThinking } from "../shared/formatters.ts";
 import type { AsyncJobState, AsyncJobStep, FleetViewPlacement, HerdrProjectPaneSnapshot, NestedRunSummary, NestedStepSummary, SubagentState } from "../shared/types.ts";
+import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
@@ -30,18 +31,7 @@ type FleetStatusEntry = {
 	external?: true;
 	projectPane?: HerdrProjectPaneSnapshot;
 	nestedChildren?: NestedRunSummary[];
-	workflowRows?: FleetWorkflowRow[];
-};
-
-type FleetWorkflowRow = {
-	name: string;
-	state: AsyncJobStep["status"];
-	modelThinking?: string;
-	activity?: string;
-	startedAt?: number;
-	tokens?: number;
-	window?: number;
-	overflow?: number;
+	workflowRows?: AsyncStatusWorkflowRow[];
 };
 
 type FleetNestedRow = {
@@ -57,7 +47,7 @@ type FleetNestedRow = {
 type FleetTreeRow =
 	| { kind: "owner"; entry: FleetStatusEntry }
 	| { kind: "child"; entry: FleetStatusEntry; last: boolean }
-	| { kind: "workflow"; ownerKey: string; row: FleetWorkflowRow; last: boolean }
+	| { kind: "workflow"; ownerKey: string; row: AsyncStatusWorkflowRow; last: boolean }
 	| { kind: "nested"; ownerKey: string; row: FleetNestedRow; last: boolean };
 
 export interface FleetStatusOptions {
@@ -111,40 +101,7 @@ function nestedActivity(node: NestedRunSummary | NestedStepSummary): string | un
 	return undefined;
 }
 
-function workflowStepActivity(step: AsyncJobStep): string | undefined {
-	if (step.currentTool) return `tool ${step.currentTool}`;
-	if (step.currentPath) return step.currentPath.split(/[\\/]/).at(-1);
-	if (step.activityState === "needs_attention") return "needs attention";
-	if (step.activityState === "active_long_running") return "long-running";
-	if (step.turnCount !== undefined) return `${step.turnCount} turns`;
-	if (step.toolCount !== undefined) return `${step.toolCount} tools`;
-	return undefined;
-}
-
-function workflowStepName(step: AsyncJobStep, index: number): string {
-	const key = step.workflowKey ?? `step ${index + 1}`;
-	const label = step.label && step.label !== key ? ` · ${step.label}` : "";
-	const phase = step.phase ? `${step.phase}: ` : "";
-	return `${phase}${key}${label} (${step.agent})`;
-}
-
-function workflowFleetRows(steps: AsyncJobStep[] | undefined): FleetWorkflowRow[] {
-	return (steps ?? []).map((step, index) => {
-		const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
-		const activity = workflowStepActivity(step);
-		return {
-			name: workflowStepName(step, index),
-			state: step.status,
-			...(modelThinking ? { modelThinking } : {}),
-			...(activity ? { activity } : {}),
-			...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
-			...(step.tokens?.total !== undefined ? { tokens: step.tokens.total } : {}),
-			...(step.tokens?.window !== undefined ? { window: step.tokens.window } : {}),
-		};
-	});
-}
-
-function visibleWorkflowRows(rows: FleetWorkflowRow[] | undefined, visibleLimit: number): FleetWorkflowRow[] {
+function visibleWorkflowRows(rows: AsyncStatusWorkflowRow[] | undefined, visibleLimit: number): AsyncStatusWorkflowRow[] {
 	if (!rows?.length) return [];
 	if (rows.length <= visibleLimit) return rows;
 	const selected = new Set<number>();
@@ -377,7 +334,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				tokens: job.totalTokens?.total ?? 0,
 				...(job.totalTokens?.window !== undefined ? { window: job.totalTokens.window } : {}),
 				state: job.status,
-				...(job.steps?.length ? { workflowRows: workflowFleetRows(job.steps) } : {}),
+				...(job.steps?.length ? { workflowRows: projectAsyncWorkflowRows(job.steps) } : {}),
 				...(job.nestedChildren?.length ? { nestedChildren: job.nestedChildren } : {}),
 			});
 			continue;
@@ -703,7 +660,7 @@ export class SubagentFleetStatus {
 		return truncateToWidth(`${left}${theme.fg("dim", elapsed)}`, width);
 	}
 
-	private renderWorkflowRow(row: FleetWorkflowRow, last: boolean, width: number, theme: Theme): string {
+	private renderWorkflowRow(row: AsyncStatusWorkflowRow, last: boolean, width: number, theme: Theme): string {
 		const marker = last ? "└─" : "├─";
 		const indent = "    ";
 		if (row.overflow !== undefined) return truncateToWidth(`${indent}${marker} ${theme.fg("dim", `+${row.overflow} hidden workflow steps`)}`, width);

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AsyncJobState } from "../../src/shared/types.ts";
+import {
+	ASYNC_STATUS_SNAPSHOT_KIND,
+	ASYNC_STATUS_SNAPSHOT_VERSION,
+	projectAsyncWorkflowRows,
+	projectAsyncStatusSnapshot,
+} from "../../src/runs/shared/async-status-projection.ts";
+
+function job(input: Partial<AsyncJobState> & Pick<AsyncJobState, "asyncId" | "status">): AsyncJobState {
+	return {
+		asyncDir: `/tmp/${input.asyncId}`,
+		...input,
+	} as AsyncJobState;
+}
+
+describe("async status projection", () => {
+	it("projects already-loaded jobs in deterministic newest-first order", () => {
+		const snapshot = projectAsyncStatusSnapshot([
+			job({ asyncId: "older", status: "complete", agents: ["reviewer"], updatedAt: 10 }),
+			job({
+				asyncId: "newer",
+				status: "running",
+				mode: "workflow",
+				agents: ["worker"],
+				updatedAt: 20,
+				steps: [{ agent: "worker", status: "pending" }],
+			}),
+		], { generatedAt: 30 });
+
+		assert.equal(snapshot.kind, ASYNC_STATUS_SNAPSHOT_KIND);
+		assert.equal(snapshot.version, ASYNC_STATUS_SNAPSHOT_VERSION);
+		assert.equal(snapshot.generatedAt, 30);
+		assert.deepEqual(snapshot.runs.map(({ id, kind, state }) => ({ id, kind, state })), [
+			{ id: "newer", kind: "workflow", state: "running" },
+			{ id: "older", kind: "subagent", state: "complete" },
+		]);
+		assert.equal(snapshot.runs[0]?.children?.[0]?.state, "queued");
+	});
+
+	it("preserves partial needs-attention status while excluding private evidence", () => {
+		const snapshot = projectAsyncStatusSnapshot([job({
+			asyncId: "partial-run",
+			status: "partial",
+			agents: ["writer"],
+			activityState: "needs_attention",
+			steps: [{
+				agent: "writer",
+				status: "partial",
+				activityState: "needs_attention",
+				error: "Required file-only output was not produced: /private/report.md",
+				effects: { fileMutation: true },
+			}],
+		})], { generatedAt: 1 });
+
+		assert.equal(snapshot.runs[0]?.state, "partial");
+		assert.equal(snapshot.runs[0]?.activity?.state, "needs_attention");
+		assert.equal(snapshot.runs[0]?.children?.[0]?.state, "partial");
+		assert.equal(snapshot.runs[0]?.children?.[0]?.activity?.state, "needs_attention");
+		const serialized = JSON.stringify(snapshot);
+		assert.doesNotMatch(serialized, /private\/report|fileMutation|Required file-only output/);
+	});
+
+	it("projects compact Fleet workflow rows without applying UI bounds", () => {
+		const rows = projectAsyncWorkflowRows([{
+			agent: "reviewer",
+			workflowKey: "review",
+			label: "Fresh review",
+			phase: "quality",
+			status: "partial",
+			activityState: "needs_attention",
+			startedAt: 10,
+			tokens: { input: 20, output: 5, total: 25, window: 18 },
+		}]);
+
+		assert.deepEqual(rows, [{
+			name: "quality: review · Fresh review (reviewer)",
+			state: "partial",
+			activity: "needs attention",
+			startedAt: 10,
+			tokens: 25,
+			window: 18,
+		}]);
+	});
+});


### PR DESCRIPTION
## Summary

Extracts async status snapshot and Fleet workflow-row projection into a focused internal module. The adapters still own state filtering, widget encoding, row visibility, and rendering.

Closes #1575.

## Validation

- `node --test test/unit/async-status-projection.test.ts test/unit/async-status-snapshot.test.ts test/unit/fleet-status.test.ts test/unit/rpc.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'emits a bounded versioned async snapshot in RPC mode' test/integration/render-widget.test.ts`
- `npm run typecheck`
- `git diff --check`
