### PR TITLE
fix: degrade run status when persisted fan-out budget state is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Let operators configure the default `subagent_wait` window and report window expiry as non-error active work while preserving strict headless draining. Thanks to [@Shujakuinkuraudo](https://github.com/Shujakuinkuraudo) for #1591.
+- Degrade run status to the stored fan-out budget snapshot when persisted state is unavailable, instead of failing the entire run list. Thanks to [@qsgy-edge](https://github.com/qsgy-edge) for #1595.
 - Enforce MCP server `includeTools`/`excludeTools` policies for child direct-tool grants, including adapter-compatible glob matching. Thanks to [@Shujakuinkuraudo](https://github.com/Shujakuinkuraudo) for #1590.
 - Prevent Fleet prompt audit rendering from crashing on malformed non-string task payloads. Thanks to [@bengidev](https://github.com/bengidev) for #1586.
 - Resume a retained child session once after a provider or transport abort follows useful progress, without restarting the task or involving the parent model.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -240,8 +240,17 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 	const { activityState, lastActivityAt } = deriveAsyncActivityState(asyncDir, status);
 	const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId })
 		?? sanitizeProcessTerminal(status.processTerminal, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId }, path.join(asyncDir, "status.json"));
-	const runFanoutBudgetDescriptor = readRunFanoutBudgetDescriptor(asyncDir);
-	const runFanoutBudget = runFanoutBudgetDescriptor ? getRunFanoutBudgetSnapshot(runFanoutBudgetDescriptor) : status.runFanoutBudget;
+	// Degrade to the status-stored snapshot when the persisted budget is unavailable (e.g. removed
+	// by OS temp cleanup) instead of failing the whole run list; admission paths stay strict.
+	// Degrade to the status-stored snapshot when the persisted budget vanishes (e.g. removed by OS
+	// temp cleanup) instead of failing the entire run list; admission paths stay strict.
+	let runFanoutBudget: AsyncStatus["runFanoutBudget"] = status.runFanoutBudget;
+	try {
+		const runFanoutBudgetDescriptor = readRunFanoutBudgetDescriptor(asyncDir);
+		if (runFanoutBudgetDescriptor) runFanoutBudget = getRunFanoutBudgetSnapshot(runFanoutBudgetDescriptor);
+	} catch (error) {
+		nestedWarnings.push(`Run fan-out status unavailable: ${getErrorMessage(error)}`);
+	}
 	const steps = status.steps ?? [];
 	const chainStepCount = status.chainStepCount ?? steps.length;
 	const parallelGroups = normalizeParallelGroups(status.parallelGroups, steps.length, chainStepCount);

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -240,10 +240,9 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 	const { activityState, lastActivityAt } = deriveAsyncActivityState(asyncDir, status);
 	const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId })
 		?? sanitizeProcessTerminal(status.processTerminal, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId }, path.join(asyncDir, "status.json"));
+	const nestedProjectionAllowed = nestedWarnings.length === 0;
 	// Degrade to the status-stored snapshot when the persisted budget is unavailable (e.g. removed
 	// by OS temp cleanup) instead of failing the whole run list; admission paths stay strict.
-	// Degrade to the status-stored snapshot when the persisted budget vanishes (e.g. removed by OS
-	// temp cleanup) instead of failing the entire run list; admission paths stay strict.
 	let runFanoutBudget: AsyncStatus["runFanoutBudget"] = status.runFanoutBudget;
 	try {
 		const runFanoutBudgetDescriptor = readRunFanoutBudgetDescriptor(asyncDir);
@@ -255,7 +254,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 	const chainStepCount = status.chainStepCount ?? steps.length;
 	const parallelGroups = normalizeParallelGroups(status.parallelGroups, steps.length, chainStepCount);
 	let nestedChildren: NestedRunSummary[] = [];
-	if (nestedWarnings.length === 0 && nestedRoute) {
+	if (nestedProjectionAllowed && nestedRoute) {
 		try {
 			// The route is resolved by the caller via buildNestedRouteIndex, so this
 			// avoids a fresh scan of the nested-events directory per run.

--- a/test/unit/run-fanout-budget.test.ts
+++ b/test/unit/run-fanout-budget.test.ts
@@ -14,7 +14,8 @@ import {
 	RunFanoutLimitError,
 	validateRunFanoutBudgetDescriptor,
 } from "../../src/runs/shared/run-fanout-budget.ts";
-import { resolveMaxSubagentSpawnsPerRun } from "../../src/shared/types.ts";
+import { resolveMaxSubagentSpawnsPerRun, type AsyncStatus } from "../../src/shared/types.ts";
+import { summarizeAsyncStatus } from "../../src/runs/background/async-status.ts";
 
 const directories: string[] = [];
 const externalDirectories: string[] = [];
@@ -45,6 +46,27 @@ describe("run fan-out budget", () => {
 			process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN = invalid;
 			assert.equal(resolveMaxSubagentSpawnsPerRun(undefined), 64);
 		}
+	});
+
+	it("degrades status projection when persisted budget state is removed", () => {
+		const descriptor = budget(2);
+		fs.rmSync(path.join(descriptor.directory, "claims"), { recursive: true, force: true });
+		const asyncDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-fanout-status-"));
+		directories.push(asyncDir);
+		fs.writeFileSync(path.join(asyncDir, "run-fanout-budget.json"), JSON.stringify(descriptor), "utf-8");
+		const fallback = { used: 1, limit: 2, remaining: 1 };
+		const status = {
+			runId: "run-1",
+			mode: "single",
+			state: "running",
+			startedAt: 100,
+			lastUpdate: 200,
+			steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+			runFanoutBudget: fallback,
+		} as AsyncStatus;
+		const summary = summarizeAsyncStatus(asyncDir, status);
+		assert.deepEqual(summary.runFanoutBudget, fallback);
+		assert.ok(summary.nestedWarnings?.some((warning) => warning.includes("Run fan-out status unavailable")));
 	});
 
 	it("persists claims and rejects the responsible next path at the exact cap", () => {

--- a/test/unit/run-fanout-budget.test.ts
+++ b/test/unit/run-fanout-budget.test.ts
@@ -15,7 +15,8 @@ import {
 	validateRunFanoutBudgetDescriptor,
 } from "../../src/runs/shared/run-fanout-budget.ts";
 import { resolveMaxSubagentSpawnsPerRun, type AsyncStatus } from "../../src/shared/types.ts";
-import { summarizeAsyncStatus } from "../../src/runs/background/async-status.ts";
+import { listAsyncRuns, summarizeAsyncStatus } from "../../src/runs/background/async-status.ts";
+import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 
 const directories: string[] = [];
 const externalDirectories: string[] = [];
@@ -67,6 +68,53 @@ describe("run fan-out budget", () => {
 		const summary = summarizeAsyncStatus(asyncDir, status);
 		assert.deepEqual(summary.runFanoutBudget, fallback);
 		assert.ok(summary.nestedWarnings?.some((warning) => warning.includes("Run fan-out status unavailable")));
+	});
+
+	it("keeps nested status projection when persisted budget state is removed", () => {
+		const runId = "run-fanout-nested-status";
+		const asyncRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-fanout-nested-root-"));
+		directories.push(asyncRoot);
+		const asyncDir = path.join(asyncRoot, runId);
+		fs.mkdirSync(asyncDir, { recursive: true });
+		const route = createNestedRoute(runId);
+		directories.push(path.dirname(route.eventSink));
+		const descriptor = budget(2);
+		fs.rmSync(path.join(descriptor.directory, "claims"), { recursive: true, force: true });
+		fs.writeFileSync(path.join(asyncDir, "run-fanout-budget.json"), JSON.stringify(descriptor), "utf-8");
+		const fallback = { used: 1, limit: 2, remaining: 1 };
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+			runId,
+			mode: "single",
+			state: "running",
+			startedAt: 100,
+			lastUpdate: 200,
+			steps: [{ agent: "worker", status: "running" }],
+			runFanoutBudget: fallback,
+		}), "utf-8");
+		writeNestedEvent(route, {
+			type: "subagent.nested.started",
+			ts: 300,
+			parentRunId: runId,
+			parentStepIndex: 0,
+			child: {
+				id: "nested-child",
+				parentRunId: runId,
+				parentStepIndex: 0,
+				depth: 1,
+				path: [{ runId, stepIndex: 0 }],
+				mode: "single",
+				state: "running",
+				agent: "nested-worker",
+				startedAt: 100,
+				lastUpdate: 300,
+			},
+		});
+
+		const summary = listAsyncRuns(asyncRoot, { states: ["running"], repairScan: true })[0];
+		assert.deepEqual(summary?.runFanoutBudget, fallback);
+		assert.equal(summary?.nestedChildren?.[0]?.id, "nested-child");
+		assert.equal(summary?.steps[0]?.children?.[0]?.id, "nested-child");
+		assert.ok(summary?.nestedWarnings?.some((warning) => warning.includes("Run fan-out status unavailable")));
 	});
 
 	it("persists claims and rejects the responsible next path at the exact cap", () => {


### PR DESCRIPTION
## Problem

A run's persisted fan-out budget directory can be removed by OS temp cleanup (observed on Windows: `%TEMP%\pi-subagents-user-<user>\run-fanout-budgets\<run>` loses `claims/` or the whole directory; pi-subagents itself never deletes it). After that:

```
Error: Run fan-out claims directory is unreadable at '...\claims': ENOENT: no such file or directory, scandir '...\claims'
    at claimCount (src/runs/shared/run-fanout-budget.ts:212:11)
```

`statusToSummary` threw, which failed the **entire** retained-children list and goal mission evaluation ("Failed to evaluate goal missions") for every run — one stale directory took down status display for all runs.

## Change

In `statusToSummary`, when the persisted budget descriptor/snapshot is unavailable, degrade to the `status.json`-stored snapshot and record a nested warning (`Run fan-out status unavailable: ...`) instead of throwing. This mirrors the existing `Nested status unavailable` degradation pattern.

Admission paths (`claimRunFanoutBatch` / `commitRunFanoutBatch` / `validateRunFanoutBudgetDescriptor`) are untouched and stay strict — a missing budget can still not silently widen fan-out admission.

## Evidence

- `npm run typecheck` clean.
- `test/unit/run-fanout-budget.test.ts`: 8/8 pass, incl. new case "degrades status projection when persisted budget state is removed" (removes `claims/`, asserts summary falls back to the stored snapshot and carries the warning).
- Pre-existing, unrelated failures in the local full unit run (`agent-eject-disable`, watchdog timing) reproduce identically with the change stashed, so they are not introduced here.