### PR TITLE
fix: enforce globalConcurrencyLimit for workflowScript children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Apply `globalConcurrencyLimit` to `workflowScript` children launched through `runs.run` and `runs.all`, not only legacy multi-child runners. Thanks to [@mateominato](https://github.com/mateominato) for #1600.
 - Ignore nested `.pi` and `sync-backups` directories during agent discovery so stale backup definitions cannot become executable agents. Thanks to [@arlishansenn](https://github.com/arlishansenn) for #1596.
 - Let projects layer agent overrides by the active parent model provider without duplicating agent definitions. Thanks to [@arichiardi](https://github.com/arichiardi) for #1597.
 - Let operators configure the default `subagent_wait` window and report window expiry as non-error active work while preserving strict headless draining. Thanks to [@Shujakuinkuraudo](https://github.com/Shujakuinkuraudo) for #1591.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,7 +241,7 @@ The tool timer tracks each active `toolCallId` separately and never extends the 
 { "globalConcurrencyLimit": 20 }
 ```
 
-Caps simultaneously running children inside existing durable legacy multi-child runs. New orchestration uses `workflowScript` and `runs.all`.
+Caps simultaneously running children inside one run, including durable legacy multi-child runs and `workflowScript` launches through `runs.run`/`runs.all`. Queued workflow children retain their stable keys and begin when a running sibling releases capacity. The default is `20`.
 
 ## `maxSubagentSpawnsPerSession`
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4844,6 +4844,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					try {
 						const workflow = await runWorkflowScript({
 							script: workflowScript,
+							globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 							timeoutMs: timeout,
 							signal: controller.signal,
 							registerStopChild: (stop) => {
@@ -5050,6 +5051,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				const workflow = await runWorkflowScript({
 					script: requestParams.workflowScript,
 					...(delegatedWorkflowPermit ? { oneUsePermit: { claim: (key: string) => claimWorkflowChildPermit(delegatedWorkflowPermit, _id, key) } } : {}),
+					globalConcurrencyLimit: deps.config.globalConcurrencyLimit,
 					timeoutMs: timeout,
 					signal,
 					...(workflowState ? { state: workflowState } : {}),

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
 import { Worker } from "node:worker_threads";
+import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../runs/shared/parallel-utils.ts";
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const requireFromPackage = createRequire(import.meta.url);
@@ -740,6 +741,8 @@ export interface RunWorkflowScriptOptions {
 	oneUsePermit?: { claim: (key: string) => string | undefined };
 	timeoutMs?: number;
 	signal?: AbortSignal;
+	/** Maximum children executing concurrently within this workflow. Defaults to 20. */
+	globalConcurrencyLimit?: number;
 	admit?: (calls: Array<{ key: string; params: Record<string, unknown> }>) => void | Promise<void>;
 	launch: (key: string, params: Record<string, unknown>, signal: AbortSignal, admission: { admitted: boolean; batch: boolean }) => Promise<WorkflowScriptChildResult>;
 	resolveResume?: (reference: WorkflowReceiptResumeReference, signal: AbortSignal) => string | WorkflowResolvedResumeReference | Promise<string | WorkflowResolvedResumeReference>;
@@ -1149,6 +1152,10 @@ function setupAbortResumeParams(params: Record<string, unknown>, result: Workflo
 export async function runWorkflowScript(options: RunWorkflowScriptOptions): Promise<WorkflowScriptResult> {
 	if (!options.script.trim()) throw new Error("workflowScript must not be empty.");
 	if (options.timeoutMs !== undefined && (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1)) throw new Error("workflow script timeout must be a positive integer.");
+	if (options.globalConcurrencyLimit !== undefined && (!Number.isInteger(options.globalConcurrencyLimit) || options.globalConcurrencyLimit < 1)) {
+		throw new Error("workflow script global concurrency limit must be a positive integer.");
+	}
+	const launchSemaphore = new Semaphore(options.globalConcurrencyLimit ?? DEFAULT_GLOBAL_CONCURRENCY_LIMIT);
 
 	let acornPath: string;
 	try {
@@ -1528,13 +1535,23 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 					if (resolvedResumeLineage.at(-1) !== resolvedResumeId) resolvedResumeLineage.push(resolvedResumeId!);
 				}
 				const launchParams = resolvedResumeId ? { ...params, resume: resolvedResumeId } : params;
-				const result = await options.launch(key, launchParams, childSignal, { admitted: true, batch: batch !== undefined });
-				const autoResumeParams = setupAbortResumeParams(params, result, childSignal);
-				if (!autoResumeParams) return result;
-				resolvedResumeLineage = [...new Set([...(resolvedResumeLineage ?? []), result.runId!])];
-				trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(autoResumeParams), phase: "auto-resume", runId: result.runId });
-				traceChanged();
-				return options.launch(key, autoResumeParams, childSignal, { admitted: true, batch: batch !== undefined });
+				await launchSemaphore.acquire();
+				try {
+					if (settled || finishing || stoppedLaunches.has(key) || childSignal.aborted) {
+						const reason = childSignal.reason;
+						const text = children.get(key)?.error ?? (reason instanceof Error ? reason.message : typeof reason === "string" ? reason : "Workflow script aborted.");
+						return stoppedChildResult(key, text);
+					}
+					const result = await options.launch(key, launchParams, childSignal, { admitted: true, batch: batch !== undefined });
+					const autoResumeParams = setupAbortResumeParams(params, result, childSignal);
+					if (!autoResumeParams) return result;
+					resolvedResumeLineage = [...new Set([...(resolvedResumeLineage ?? []), result.runId!])];
+					trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(autoResumeParams), phase: "auto-resume", runId: result.runId });
+					traceChanged();
+					return options.launch(key, autoResumeParams, childSignal, { admitted: true, batch: batch !== undefined });
+				} finally {
+					launchSemaphore.release();
+				}
 			}).then((result) => {
 				let normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
 				if (resolvedResumeLineage?.length && normalized.runId) {

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -337,6 +337,48 @@ describe("scripted workflow runtime", () => {
 		]);
 	});
 
+	it("caps concurrent workflow child launches across runs.all", async () => {
+		let active = 0;
+		let maxActive = 0;
+		const result = await runWorkflowScript({
+			script: `return await runs.all([
+				{ key: "one", agent: "worker", task: "one" },
+				{ key: "two", agent: "worker", task: "two" },
+				{ key: "three", agent: "worker", task: "three" },
+				{ key: "four", agent: "worker", task: "four" }
+			]);`,
+			globalConcurrencyLimit: 2,
+			async launch(key) {
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				await new Promise((resolve) => setTimeout(resolve, 20));
+				active -= 1;
+				return { key, ok: true, output: key, artifactPaths: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.equal(maxActive, 2);
+		assert.deepEqual((result.value as Array<{ key: string }>).map(({ key }) => key), ["one", "two", "three", "four"]);
+	});
+
+	it("rejects an invalid workflow concurrency limit before launching", async () => {
+		let launches = 0;
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return runs.run("one", { agent: "worker", task: "one" });`,
+				globalConcurrencyLimit: 0,
+				async launch(key) {
+					launches += 1;
+					return { key, ok: true, output: key, artifactPaths: [] };
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			/workflow script global concurrency limit must be a positive integer/,
+		);
+		assert.equal(launches, 0);
+	});
+
 	it("returns runs.all launch errors without aborting successful siblings", async () => {
 		const result = await runWorkflowScript({
 			script: `


### PR DESCRIPTION
## Summary

- apply the existing per-run `globalConcurrencyLimit` semaphore to `workflowScript` children launched through `runs.run` / `runs.all`
- pass the configured limit through both foreground and detached workflow hosts
- re-check abort/stop state after a queued child acquires capacity
- document the expanded setting and add focused concurrency/validation tests

## Why

`globalConcurrencyLimit` currently reaches the durable legacy background runner, but `runWorkflowScript()` calls its host `launch` function directly. That leaves the primary modern orchestration path effectively unlimited even when operators configure a lower bound.

I reproduced this with 0.56.0 and 0.58.0: a `runs.all` workflow with four children and `globalConcurrencyLimit: 2` started all four child bash windows simultaneously. This is especially surprising because the config description presents the key as the global cap within one run.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/scripted-workflow.test.ts` — **83 passed**
- `npm run typecheck` — pass
- full `npm run test:unit` — **2581 passed, 0 failed, 10 cancelled**; all cancellations are the pre-existing `herdr-inspector.test.ts` pending-promise group and are unrelated to this change
