### PR TITLE
feat: accept child id on /subagents-stop for child-scoped stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add explicit `allowNestedSubagents` agent authorization for nested fanout without replacing inherited tools or extensions. Thanks to [@tutu359](https://github.com/tutu359) for #1587.
+- Accept a child id on `/subagents-stop <run-id> <child-id>` so RPC hosts and non-TUI sessions can stop one child of a multi-child async run or workflow without stopping the whole run. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1603.
 
 ### Changed
 - Extract async status snapshot projection into a pure internal module while preserving RPC and widget wire compatibility.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -249,6 +249,7 @@ subagent({ action: "doctor" })
 - Direct id calls execute immediately.
 - `/subagents-stop` without an id opens a selector with confirmation when a TUI is available. Use `↑`/`↓` or `j`/`k` to move through the selector.
 - In non-TUI contexts the slash command prints exact `subagent({ action: "stop", id })` and `/subagents-stop <id>` commands.
+- Pass a child id to stop one child of a multi-child async run or workflow while the rest continue: `/subagents-stop <run-id> <child-id>` (equivalent to `subagent({ action: "stop", id, childId })`). Child ids come from status output, the async status snapshot, or `/subagents-inspect-rpc` replies. Only pending or running children are stoppable; the request is rejected for anything else instead of widening to a run-level stop.
 - Inactive schedules can appear in the selector, but they are labeled as schedules and route through `schedule.pause`, not `stop`.
 
 ### steer

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -820,11 +820,15 @@ export function registerSlashCommands(
 	}
 
 	pi.registerCommand("subagents-stop", {
-		description: "Stop a current-session async subagent run",
+		description: "Stop a current-session async subagent run, or one child of it with /subagents-stop <run-id> <child-id>",
 		handler: async (args, ctx) => {
-			const id = args.trim();
+			const [id, childId, ...extra] = args.trim().split(/\s+/).filter(Boolean);
+			if (extra.length > 0) {
+				sendSlashText(pi, "Usage: /subagents-stop [run-id] [child-id]");
+				return;
+			}
 			if (id) {
-				await runSlashSubagent(pi, ctx, { action: "stop", id });
+				await runSlashSubagent(pi, ctx, childId ? { action: "stop", id, childId } : { action: "stop", id });
 				return;
 			}
 

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -597,6 +597,58 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		});
 	});
 
+	it("/subagents-stop forwards a child id for child-scoped stops", async () => {
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		let requestedParams: unknown;
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
+			const payload = data as { requestId: string; params?: unknown };
+			requestedParams = payload.params;
+			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId: payload.requestId });
+			events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
+				requestId: payload.requestId,
+				result: {
+					content: [{ type: "text", text: "Stop requested for child step-0-agent-0 in async workflow run-123." }],
+					details: { mode: "management", results: [] },
+				},
+				isError: false,
+			});
+		});
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage() {},
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		await commands.get("subagents-stop")!.handler("run-123 step-0-agent-0", createCommandContext());
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(requestedParams, { action: "stop", id: "run-123", childId: "step-0-agent-0" });
+	});
+
+	it("/subagents-stop rejects extra arguments with usage text", async () => {
+		const sent: unknown[] = [];
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const pi = {
+			events: createEventBus(),
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage(message: unknown) { sent.push(message); },
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		await commands.get("subagents-stop")!.handler("run-123 child-0 unexpected", createCommandContext());
+
+		assert.equal(sent.length, 1);
+		assert.match(String((sent[0] as { content?: unknown }).content ?? ""), /Usage: \/subagents-stop \[run-id\] \[child-id\]/);
+	});
+
 	it("/run accepts an agent without a task", async () => {
 		const sent: unknown[] = [];
 		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();


### PR DESCRIPTION
## What

`/subagents-stop <run-id> <child-id>` now forwards `{ action: "stop", id, childId }` instead of only accepting a bare run id.

## Why

Child-scoped stop shipped in 0.55.0 (#1367): `subagent({ action: "stop", id, childId })` and the extension RPC `stop` method can stop one pending/running child of a multi-child async run or workflow while the rest continue, and malformed child stop requests are rejected instead of widening to a run-level stop.

But the `/subagents-stop` slash command — the bridge surface non-TUI sessions and RPC hosts actually drive — only forwarded a top-level run id. A downstream host application embedding Pi over RPC can inspect children (`/subagents-inspect-rpc`) and stop whole runs, but had no way to stop one stuck child without killing the run.

## How

- The command splits args into `<run-id> [child-id]`; with a child id it forwards `{ action: "stop", id, childId }` through the existing slash bridge, so all existing validation (child resolution, pending/running-only, workflow child-stop availability) applies unchanged.
- Extra arguments fail closed with usage text instead of being silently dropped.
- Selector behavior (no args) is unchanged.

## Tests

- New: `/subagents-stop` forwards `{ action: "stop", id, childId }` for `run-123 step-0-agent-0`.
- New: extra arguments are rejected with `Usage: /subagents-stop [run-id] [child-id]`.
- `test/integration/slash-commands.test.ts`: 26/30 pass; the 4 `/run` failures reproduce identically on `main` in this environment (pre-existing).
- `npm run typecheck` clean; unit suite matches `main` (same pre-existing environment failures).