### PR TITLE
fix: report aborted no-output child diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Report aborted or signalled no-output child runs with their terminal stop, stderr, or process signal before missing-output handoff diagnostics.
 - Apply `globalConcurrencyLimit` to `workflowScript` children launched through `runs.run` and `runs.all`, not only legacy multi-child runners. Thanks to [@mateominato](https://github.com/mateominato) for #1600.
 - Ignore nested `.pi` and `sync-backups` directories during agent discovery so stale backup definitions cannot become executable agents. Thanks to [@arlishansenn](https://github.com/arlishansenn) for #1596.
 - Let projects layer agent overrides by the active parent model provider without duplicating agent definitions. Thanks to [@arichiardi](https://github.com/arichiardi) for #1597.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -101,7 +101,7 @@ import { markProcessTerminalCandidateLeaseRelease, writeProcessTerminalCandidate
 import { createOwnedProcessTreeController, type OwnedProcessTreeController } from "./owned-process-tree.ts";
 import { createSteeringStatus, recordSteeringRequest, steeringStatus, terminalSteeringNoticeState, updateSteeringTarget } from "./steering.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
-import { PROMPT_REDACTED, detectSubagentError, extractTextFromContent, extractToolArgsPreview, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
+import { PROMPT_REDACTED, detectSubagentError, extractTextFromContent, extractToolArgsPreview, formatEmptyTerminalAssistantResponseError, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
 import { evaluateCompletionMutationGuard, expectsImplementationMutation, hasMutationToolCapability, validateImplementationToolContract } from "../shared/completion-guard.ts";
 import { planCompletionEvidence, projectSettlementDiagnostic } from "../shared/completion-evidence.ts";
 import { planAbortRecovery } from "../shared/abort-recovery.ts";
@@ -1075,22 +1075,26 @@ function runPiStreaming(
 			const finalOutput = getFinalOutput(messages) || rawStdoutTail.text().trim();
 			const finalError = error ?? assistantError;
 			const forcedDrainAfterFinalSuccess = Boolean(forcedTerminationSignal || signal) && (cleanTerminalAssistantStopReceived || agentSettledReceived) && !finalError;
+			const forcedDrainAfterEmptyTerminal = forcedDrainAfterFinalSuccess && hasEmptyTerminalAssistantResponse(messages);
+			const forcedDrainError = forcedDrainAfterEmptyTerminal && stderr.trim()
+				? stderr.trim()
+				: undefined;
 			const signalError = isUnexplainedProcessSignal({
 				processSignal: signal,
 				interrupted,
 				timedOut,
 				stopped,
-				forcedDrainAfterFinalSuccess,
+				forcedDrainAfterFinalSuccess: forcedDrainAfterFinalSuccess && !forcedDrainAfterEmptyTerminal,
 			}) ? formatProcessSignalError(signal!) : undefined;
 			resolve(omitUndefinedProperties({
 				stderr,
-				exitCode: timedOut || stopped ? 1 : interrupted || forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
+				exitCode: timedOut || stopped ? 1 : interrupted || (forcedDrainAfterFinalSuccess && !forcedDrainAfterEmptyTerminal) ? 0 : forcedTerminationSignal || signal ? (exitCode ?? 1) : exitCode,
 				messages,
 				usage,
 				toolCount,
 				durationMs: Date.now() - startedAt,
 				model,
-				error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : interrupted || forcedDrainAfterFinalSuccess ? undefined : finalError ?? signalError,
+				error: stopped ? (stopMessage ?? "Subagent stopped by user.") : timedOut ? (timeoutMessage ?? "Subagent timed out.") : interrupted || (forcedDrainAfterFinalSuccess && !forcedDrainAfterEmptyTerminal) ? undefined : finalError ?? forcedDrainError ?? signalError,
 				protocolError,
 				finalOutput: (timedOut || stopped) && !finalOutput.trim() ? (stopped ? stopMessage ?? "Subagent stopped by user." : timeoutMessage ?? "Subagent timed out.") : finalOutput,
 				outputState: finalOutput.trim() ? "present" : "absent",
@@ -1853,7 +1857,7 @@ async function runSingleStepInner(
 			&& !validatedStructuredOutput
 			&& (!run.finalOutput.trim() || terminalEmptyAfterUsefulWork)
 			&& (!hiddenError?.hasError || hasEmptyTerminalAssistantResponse(run.messages))
-			? "Subagent produced no output (possible model cold-start or empty response)."
+			? formatEmptyTerminalAssistantResponseError(run.messages)
 			: undefined;
 		const completionGuardEnabled = isAgentContractV1(step.agentContract) ? step.completionGuard === true : step.completionGuard !== false;
 		const completionToolPlan = resolvedTaskToolPlan;
@@ -1907,13 +1911,17 @@ async function runSingleStepInner(
 		const underlyingError = toolAvailabilityError
 			?? midToolExitError
 			?? structuredError
-			?? (missingRequiredOutputAfterMutation ? missingRequiredOutputError : undefined)
+			?? run.error
+			?? signalError
+			?? (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined)
+			?? ((emptyOutputError || missingRequiredOutputError) && run.stderr.trim() ? run.stderr.trim() : undefined)
 			?? emptyOutputError
+			?? (missingRequiredOutputAfterMutation ? missingRequiredOutputError : undefined)
 			?? (hiddenError?.hasError
 				? hiddenError.details
 					? `${hiddenError.errorType} failed (exit ${effectiveExitCode}): ${hiddenError.details}`
 					: `${hiddenError.errorType} failed with exit code ${effectiveExitCode}`
-				: run.error || signalError || (run.exitCode !== 0 && run.stderr.trim() ? run.stderr.trim() : undefined));
+				: undefined);
 		const error = formatSubagentExtensionConflictError(
 			underlyingError ?? missingRequiredOutputError ?? completionEvidence.legacyFailureError,
 			{

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -46,6 +46,7 @@ import {
 	findLatestSessionFile,
 	detectSubagentError,
 	hasEmptyTerminalAssistantResponse,
+	formatEmptyTerminalAssistantResponseError,
 	extractToolArgsPreview,
 	extractTextFromContent,
 	boundStreamedRecentTools,
@@ -1296,13 +1297,17 @@ async function runSingleAttempt(
 			const rawStdout = rawStdoutTail.text();
 			let closeError = result.error ?? toolDiagnosticError ?? assistantError;
 			const forcedDrainAfterFinalSuccess = Boolean(forcedTerminationSignal || signal) && (cleanTerminalAssistantStopReceived || agentSettledReceived) && !closeError;
+			const forcedDrainAfterEmptyTerminal = forcedDrainAfterFinalSuccess && hasEmptyTerminalAssistantResponse(result.messages ?? []);
 			if (signal) result.processSignal = signal;
+			if (!closeError && forcedDrainAfterEmptyTerminal && stderr.trim()) {
+				closeError = stderr.trim();
+			}
 			if (!closeError && isUnexplainedProcessSignal({
 				processSignal: signal,
 				interrupted: result.interrupted,
 				timedOut: result.timedOut,
 				stopped: result.stopped,
-				forcedDrainAfterFinalSuccess,
+				forcedDrainAfterFinalSuccess: forcedDrainAfterFinalSuccess && !forcedDrainAfterEmptyTerminal,
 			})) {
 				closeError = formatProcessSignalError(signal!);
 			}
@@ -1312,7 +1317,7 @@ async function runSingleAttempt(
 			if (code !== 0 && stderr.trim() && !closeError && !forcedDrainAfterFinalSuccess) {
 				closeError = stderr.trim();
 			}
-			const finalCode = forcedDrainAfterFinalSuccess ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
+			const finalCode = forcedDrainAfterFinalSuccess && !forcedDrainAfterEmptyTerminal ? 0 : forcedTerminationSignal || signal ? (code ?? 1) : (code ?? 0);
 			if (!result.error && closeError) result.error = closeError;
 			finish(finalCode);
 		});
@@ -1461,7 +1466,7 @@ async function runSingleAttempt(
 			&& (progress.toolCount > 0 || Boolean(finalText?.trim()));
 		if ((missingOutput || terminalEmptyAfterUsefulWork) && (!errInfo.hasError || hasEmptyTerminalAssistantResponse(messages))) {
 			result.exitCode = 1;
-			result.error = "Subagent produced no output (possible model cold-start or empty response).";
+			result.error = formatEmptyTerminalAssistantResponseError(messages);
 		} else if (errInfo.hasError) {
 			result.exitCode = errInfo.exitCode ?? 1;
 			result.error = errInfo.details

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -479,7 +479,7 @@ function messageError(message: unknown): string | undefined {
 export function isRetryableModelFailureAttempt(input: { error: string | undefined; messages?: readonly unknown[]; toolCount?: number }): boolean {
 	if (!isRetryableModelFailure(input.error)) return false;
 	if ((input.toolCount ?? 0) > 0) return false;
-	if (input.error === "Subagent produced no output (possible model cold-start or empty response).") return true;
+	if (input.error === "Subagent produced no output (possible model cold-start or empty response)." || /^Subagent produced no output after terminal assistant stopReason "[^"]+"\.$/.test(input.error ?? "")) return true;
 	if ((input.toolCount ?? 0) === 0 && (input.messages?.length ?? 0) === 0) return true;
 	const error = input.error?.trim();
 	return Boolean(error && input.messages?.some((message) => messageError(message)?.trim() === error));

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -482,6 +482,20 @@ export function hasEmptyTerminalAssistantResponse(messages: Message[]): boolean 
 		&& lastAssistant.usage.output === 0;
 }
 
+export function formatEmptyTerminalAssistantResponseError(messages: Message[]): string {
+	const lastAssistant = messages.findLast((message) => message.role === "assistant");
+	const errorMessage = lastAssistant && "errorMessage" in lastAssistant && typeof lastAssistant.errorMessage === "string" && lastAssistant.errorMessage.trim()
+		? lastAssistant.errorMessage.trim()
+		: undefined;
+	if (errorMessage) return errorMessage;
+	const stopReason = lastAssistant && "stopReason" in lastAssistant && typeof lastAssistant.stopReason === "string" && lastAssistant.stopReason.trim()
+		? lastAssistant.stopReason.trim()
+		: undefined;
+	return stopReason && stopReason !== "stop"
+		? `Subagent produced no output after terminal assistant stopReason "${stopReason}".`
+		: "Subagent produced no output (possible model cold-start or empty response).";
+}
+
 /**
  * Detect errors in subagent execution from messages (only errors with no subsequent success)
  */

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -5364,7 +5364,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.results[0].error, "provider exploded");
 	});
 
-	it("prioritizes a missing file-only handoff over the completion guard", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+	it("reports terminal abort before a missing file-only handoff after mutation", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const partialOutput = "I’ll inspect the retained candidate before changing it.";
 		const repo = createRepo("pi-subagents-missing-handoff-partial-");
 		const outputPath = path.join(repo, "missing-challenge-report.md");
@@ -5419,7 +5419,8 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			assert.equal(payload.success, false);
 			assert.equal(payload.state, "partial");
 			assert.equal(child?.success, false);
-			assert.match(diagnostic, new RegExp(`^Required file-only output was not produced: ${escapeRegExp(outputPath)}$`));
+			assert.match(diagnostic, /^Subagent produced no output after terminal assistant stopReason "aborted"\./);
+			assert.match(diagnostic, new RegExp(`Required file-only output was not produced: ${escapeRegExp(outputPath)}`));
 			assert.doesNotMatch(diagnostic, /completed without making edits/);
 			assert.doesNotMatch(child?.modelAttempts?.[0]?.error ?? "", /completed without making edits/);
 			assert.equal(child?.effects?.fileMutation?.status, "observed");
@@ -5482,7 +5483,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const diagnostic = child?.error ?? "";
 		assert.equal(payload.success, false);
 		assert.equal(child?.success, false);
-		assert.match(diagnostic, /^Subagent produced no output \(possible model cold-start or empty response\)\./);
+		assert.match(diagnostic, /^Subagent produced no output after terminal assistant stopReason "aborted"\./);
 		assert.match(diagnostic, /Required file-only output was not produced/);
 		assert.doesNotMatch(diagnostic, /completed without making edits/);
 		assert.doesNotMatch(child?.modelAttempts?.[0]?.error ?? "", /completed without making edits/);
@@ -5492,6 +5493,56 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 
 		const eventsText = fs.readFileSync(path.join(ASYNC_DIR, id, "events.jsonl"), "utf-8");
 		assert.doesNotMatch(eventsText, /completed without making edits/);
+	});
+
+	it("reports zero-exit terminal stderr before missing file-only output after settlement", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const outputPath = path.join(tempDir, "missing-stderr-report.md");
+		const terminalStderr = "Extension error: stale ctx after session replacement";
+		mockPi.onCall({
+			jsonl: [
+				events.toolStart("read", { path: "src/index.ts" }),
+				events.toolEnd("read"),
+				events.toolResult("read", "file contents"),
+				events.assistantMessage("I found the candidate seam."),
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "mock/test-model",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+				{ type: "agent_settled" },
+			],
+			stderr: terminalStderr,
+		});
+
+		const id = `async-stderr-empty-handoff-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Implement the approved file changes",
+			agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			output: outputPath,
+			outputMode: "file-only",
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		const child = payload.results[0];
+		const diagnostic = child?.error ?? "";
+		assert.equal(payload.success, false);
+		assert.equal(child?.success, false);
+		assert.match(diagnostic, new RegExp(`^${escapeRegExp(terminalStderr)}`));
+		assert.match(diagnostic, /Required file-only output was not produced/);
+		assert.doesNotMatch(diagnostic, /^Subagent produced no output \(possible model cold-start or empty response\)\./);
+		assert.equal(fs.existsSync(outputPath), false);
 	});
 
 	it("reports bounded compaction failure context when file-only output is missing", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -4394,7 +4394,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		});
 
 		assert.equal(result.exitCode, 1);
-		assert.match(result.error ?? "", /^Subagent produced no output \(possible model cold-start or empty response\)\./);
+		assert.match(result.error ?? "", /^Subagent produced no output after terminal assistant stopReason "aborted"\./);
 		assert.doesNotMatch(result.error ?? "", /completed without making edits/);
 		assert.equal(result.finalOutput, partialOutput);
 	});


### PR DESCRIPTION
Fixes #1602.

This keeps no-output workflow children fail-closed, but reports the concrete terminal cause first when an empty terminal assistant message, stderr, or process signal explains the failure. Missing required file-only output remains visible as follow-on context instead of hiding the upstream abort.

Validation:

- foreground fallback and diagnostics slice
- async fallback and diagnostics slice
- `npm run typecheck`
- `git diff --check`

Fresh reviews: initial review found concrete ordering gaps, follow-up found a model fallback regression, and the final exact-head follow-up returned no issues.
