### PR TITLE
feat: add /subagents-steer host bridge for live async runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add `/subagents-steer <run-id> [--child <child-id>] <message>`, a host bridge for steering live async runs from non-TUI sessions and RPC hosts, with fail-closed child-id resolution and pause-and-revive recovery disabled so callers keep exact-child authority. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1608.
 - Add explicit `allowNestedSubagents` agent authorization for nested fanout without replacing inherited tools or extensions. Thanks to [@tutu359](https://github.com/tutu359) for #1587.
 - Accept a child id on `/subagents-stop <run-id> <child-id>` so RPC hosts and non-TUI sessions can stop one child of a multi-child async run or workflow without stopping the whole run. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1603.
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -262,6 +262,8 @@ Only a top-level single run may interrupt after the acknowledgment deadline and 
 
 The persisted `steering` ledger retains 20 requests and replaces the old `steerCount`/`lastSteerAt` fields.
 
+The `/subagents-steer <run-id> [--child <child-id>] <message>` slash command is the host bridge for non-TUI sessions and RPC hosts. `--child` accepts the stable child identity shown in status output and inspect replies (workflow key, child run id, or `step:<index>`) and resolves it to the child index before steering; unknown or ambiguous child ids fail closed. Flags are parsed only between the run id and the message tail — once the message starts, `--` tokens are message text. The bridge always disables pause-and-revive recovery (`steeringRecovery: false`), matching the extension RPC `nonRecoveringSteer` guarantee so the caller keeps authority over the exact child it addressed.
+
 ## Acceptance gates
 
 Every run resolves an effective acceptance policy. Callers may omit `acceptance` for the inferred default, or set it on single runs, top-level parallel task items, chain steps, static parallel tasks, and dynamic fanout templates.

--- a/skills/pi-subagents/references/prompting-and-roles.md
+++ b/skills/pi-subagents/references/prompting-and-roles.md
@@ -27,6 +27,7 @@ Agents use the `subagent(...)` tool with `workflowScript` for execution, and `ac
 - `/subagents` — interactive admin for inspecting agents and editing model, thinking, or system prompt
 - `/subagents-stop [run-id]` — stop a current-session top-level async run; opens a selector when no id is given
 - `/subagents-detach [run-id]` — detach an active foreground single-subagent run without terminating its child
+- `/subagents-steer <run-id> [--child <child-id>] <message>` — steer a live async run (or one child of it) from non-TUI sessions and RPC hosts
 - `/subagent-cost` — show parent plus child token usage and cost for the session
 - `/subagents-fleet` — open the live fleet inspector with per-child controls; `Ctrl+Alt+F` opens it during an active foreground turn, `↑↓`/`jk` selects children, `PgUp`/`PgDn` scrolls transcript detail, `s` steers the selected live async child, and `D` stops its top-level async run after confirmation
 - `/subagents-watchdog` — inspect or configure the opt-in adversarial change watchdog (model, on/off, recommend-model, check)

--- a/src/runs/shared/child-identity.ts
+++ b/src/runs/shared/child-identity.ts
@@ -1,4 +1,4 @@
-import type { AsyncStatus } from "../../shared/types.ts";
+import type { AsyncStatus, NestedRunSummary } from "../../shared/types.ts";
 
 export type AsyncStatusStep = NonNullable<AsyncStatus["steps"]>[number];
 
@@ -6,6 +6,7 @@ export interface ResolvedAsyncStatusChild {
 	index: number;
 	step: AsyncStatusStep;
 	id: string;
+	nested?: NestedRunSummary;
 }
 
 export type AsyncStatusChildResolution =
@@ -20,11 +21,25 @@ export function asyncStatusChildIdentityCandidates(step: AsyncStatusStep, index:
 	return [...new Set([step.workflowKey, step.runId, `step:${index}`].filter((value): value is string => typeof value === "string" && value.length > 0))];
 }
 
-export function resolveAsyncStatusChild(status: Pick<AsyncStatus, "runId" | "steps">, childId: string): AsyncStatusChildResolution {
+export function resolveAsyncStatusChild(
+	status: Pick<AsyncStatus, "runId" | "steps">,
+	childId: string,
+	options: { includeNested?: boolean } = {},
+): AsyncStatusChildResolution {
 	const matches: ResolvedAsyncStatusChild[] = [];
 	for (const [index, step] of (status.steps ?? []).entries()) {
-		if (!asyncStatusChildIdentityCandidates(step, index).includes(childId)) continue;
-		matches.push({ index, step, id: asyncStatusChildIdentity(step, index) });
+		if (asyncStatusChildIdentityCandidates(step, index).includes(childId)) {
+			matches.push({ index, step, id: asyncStatusChildIdentity(step, index) });
+		}
+		if (options.includeNested) {
+			const findNested = (children: readonly NestedRunSummary[] | undefined): void => {
+				for (const nested of children ?? []) {
+					if (nested.id === childId) matches.push({ index, step, id: nested.id, nested });
+					findNested(nested.children);
+				}
+			};
+			findNested(step.children);
+		}
 	}
 	if (matches.length === 1) return { ok: true, child: matches[0]! };
 	if (matches.length > 1) return { ok: false, code: "ambiguous", message: `Child '${childId}' is ambiguous under async run '${status.runId}'.` };

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -22,6 +22,8 @@ import { listAsyncRuns, formatAsyncRunProgressLabel, type AsyncRunSummary } from
 import { encodeInspectReply, handleInspectRpcArgs, INSPECT_WIDGET_KEY } from "../runs/background/inspect-rpc.ts";
 import { listScheduledRunSummaries } from "../runs/background/scheduled-runs.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
+import { resolveAsyncStatusChild } from "../runs/shared/child-identity.ts";
+import { readStatus } from "../shared/utils.ts";
 import { FLEET_OPEN_SHORTCUT } from "../shared/shortcuts.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
 import { registerPromptWorkflowCommands } from "./prompt-workflows.ts";
@@ -864,6 +866,70 @@ export function registerSlashCommands(
 				return;
 			}
 			await runSlashSubagent(pi, ctx, { action: "stop", id: result.target.id });
+		},
+	});
+
+	pi.registerCommand("subagents-steer", {
+		description: "Steer a live async subagent run with a message, or one child of it with --child <child-id>",
+		handler: async (args, ctx) => {
+			const tokens = args.trim().split(/\s+/).filter(Boolean);
+			const usage = "Usage: /subagents-steer <run-id> [--child <child-id>] <message>";
+			const [id, ...rest] = tokens;
+			if (!id || id.startsWith("--")) {
+				sendSlashText(pi, usage);
+				return;
+			}
+			// Only the optional child selector is parsed as a flag. Everything
+			// after the run id (or selector) is free-form message text, including
+			// a leading token such as `--verbose`.
+			let childId: string | undefined;
+			let messageStart = 0;
+			if (rest[0] === "--child" && rest[1] && !rest[1].startsWith("--")) {
+				childId = rest[1];
+				messageStart = 2;
+			}
+			const message = rest.slice(messageStart).join(" ").trim();
+			if (!message) {
+				sendSlashText(pi, usage);
+				return;
+			}
+			let targetId = id;
+			let childIndex: number | undefined;
+			if (childId !== undefined) {
+				const sessionId = state.currentSessionId ?? ctx.sessionManager.getSessionId() ?? undefined;
+				const run = listAsyncRuns(DIRS.async, {
+					runId: id,
+					states: ["queued", "running", "paused"],
+					...(sessionId ? { sessionId } : {}),
+				})[0];
+				const status = run ? readStatus(run.asyncDir) : null;
+				if (!run || !status) {
+					sendSlashText(pi, `No current-session async run found for '${id}'.`);
+					return;
+				}
+				const resolutionStatus = {
+					...status,
+					steps: status.steps?.map((step, index) => ({ ...step, children: run.steps[index]?.children ?? step.children })),
+				};
+				const resolution = resolveAsyncStatusChild(resolutionStatus, childId, { includeNested: true });
+				if (!resolution.ok) {
+					sendSlashText(pi, resolution.message);
+					return;
+				}
+				if (resolution.child.nested) targetId = resolution.child.nested.id;
+				else if (resolution.child.step.runId) targetId = resolution.child.step.runId;
+				else childIndex = resolution.child.index;
+			}
+			await runSlashSubagent(pi, ctx, {
+				action: "steer",
+				id: targetId,
+				message,
+				...(childIndex !== undefined ? { index: childIndex } : {}),
+				// Host-style exact-child authority, matching the extension RPC
+				// nonRecoveringSteer guarantee: never swap the addressed child for
+				// a pause-and-revive replacement after a missed acknowledgment.
+				steeringRecovery: false,
+			});
 		},
 	});
 

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -8,6 +8,7 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { registerAgent } from "../../src/api/agents.ts";
 import { clearRuntimeAgentsForPi } from "../../src/agents/runtime-agent-registry.ts";
 import { scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
+import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
 import { ASYNC_DIR, DIRS } from "../../src/shared/types.ts";
 import type { WatchdogReviewFunction } from "../../src/watchdog/runtime.ts";
@@ -647,6 +648,198 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 
 		assert.equal(sent.length, 1);
 		assert.match(String((sent[0] as { content?: unknown }).content ?? ""), /Usage: \/subagents-stop \[run-id\] \[child-id\]/);
+	});
+
+	it("/subagents-steer forwards a run-level steer with host-style recovery disabled", async () => {
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		let requestedParams: unknown;
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
+			const payload = data as { requestId: string; params?: unknown };
+			requestedParams = payload.params;
+			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId: payload.requestId });
+			events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
+				requestId: payload.requestId,
+				result: {
+					content: [{ type: "text", text: "Steer delivered to run-123." }],
+					details: { mode: "management", results: [] },
+				},
+				isError: false,
+			});
+		});
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage() {},
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		await commands.get("subagents-steer")!.handler("run-123 wrap up and report", createCommandContext());
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(requestedParams, { action: "steer", id: "run-123", message: "wrap up and report", steeringRecovery: false });
+	});
+
+	it("/subagents-steer --child resolves workflow and nested children to direct runs", async () => {
+		const runId = "steer-itest-child-resolution";
+		const childRunId = `${runId}-child`;
+		const nestedChildRunId = `${runId}-nested`;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+			runId,
+			sessionId: "session-test",
+			mode: "workflow",
+			state: "paused",
+			activityState: "needs_attention",
+			startedAt: 100,
+			lastUpdate: 200,
+			steps: [
+				{
+					agent: "worker",
+					status: "complete",
+					startedAt: 100,
+					children: [{
+						id: nestedChildRunId,
+						parentRunId: runId,
+						parentStepIndex: 0,
+						depth: 1,
+						path: [{ runId, stepIndex: 0 }],
+						state: "running",
+						asyncDir: path.join(ASYNC_DIR, nestedChildRunId),
+					}],
+				},
+				{ agent: "scout", workflowKey: "detaches", status: "paused", runId: childRunId, startedAt: 110, activityState: "needs_attention" },
+			],
+		}, null, 2), "utf-8");
+		updateActiveRunIndex(asyncDir, "paused");
+
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		let requestedParams: unknown;
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
+			const payload = data as { requestId: string; params?: unknown };
+			requestedParams = payload.params;
+			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId: payload.requestId });
+			events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
+				requestId: payload.requestId,
+				result: {
+					content: [{ type: "text", text: "Steer delivered." }],
+					details: { mode: "management", results: [] },
+				},
+				isError: false,
+			});
+		});
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage() {},
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		await commands.get("subagents-steer")!.handler(`${runId} --child detaches --verbose`, createCommandContext());
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(requestedParams, { action: "steer", id: childRunId, message: "--verbose", steeringRecovery: false });
+		await commands.get("subagents-steer")!.handler(`${runId} --child ${nestedChildRunId} continue`, createCommandContext());
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(requestedParams, { action: "steer", id: nestedChildRunId, message: "continue", steeringRecovery: false });
+	});
+
+	it("/subagents-steer --child fails closed for an unknown child id", async () => {
+		const runId = "steer-itest-child-resolution";
+		const sent: unknown[] = [];
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		let requested = false;
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, () => {
+			requested = true;
+		});
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage(message: unknown) { sent.push(message); },
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		await commands.get("subagents-steer")!.handler(`${runId} --child nope hurry up`, createCommandContext());
+
+		assert.equal(requested, false);
+		assert.equal(sent.length, 1);
+		assert.match(String((sent[0] as { content?: unknown }).content ?? ""), /was not found under async run/);
+	});
+
+	it("/subagents-steer requires a message", async () => {
+		const sent: unknown[] = [];
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		let requested = false;
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, () => {
+			requested = true;
+		});
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage(message: unknown) { sent.push(message); },
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		await commands.get("subagents-steer")!.handler("run-123", createCommandContext());
+
+		assert.equal(requested, false);
+		assert.equal(sent.length, 1);
+		assert.match(String((sent[0] as { content?: unknown }).content ?? ""), /Usage: \/subagents-steer <run-id>/);
+	});
+
+	it("/subagents-steer treats leading -- tokens as message text", async () => {
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		let requestedParams: unknown;
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
+			const payload = data as { requestId: string; params?: unknown };
+			requestedParams = payload.params;
+			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId: payload.requestId });
+			events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
+				requestId: payload.requestId,
+				result: {
+					content: [{ type: "text", text: "Steer delivered." }],
+					details: { mode: "management", results: [] },
+				},
+				isError: false,
+			});
+		});
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage() {},
+		};
+
+		registerSlashCommands!(pi, createState(process.cwd()));
+		await commands.get("subagents-steer")!.handler("run-123 --verbose", createCommandContext());
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(requestedParams, { action: "steer", id: "run-123", message: "--verbose", steeringRecovery: false });
+
+		await commands.get("subagents-steer")!.handler("run-123 --child --verbose", createCommandContext());
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(requestedParams, { action: "steer", id: "run-123", message: "--child --verbose", steeringRecovery: false });
 	});
 
 	it("/run accepts an agent without a task", async () => {

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -746,6 +746,43 @@ describe("async interrupt action", () => {
 		}
 	});
 
+	it("/subagents-stop rejects a nested-only child without writing a parent target request", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `stop-nested-${Date.now().toString(36)}`;
+		const nestedChildId = `${runId}-nested`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "session" });
+		try {
+			const statusPath = path.join(asyncDir, "status.json");
+			writeJson(statusPath, {
+				...JSON.parse(fs.readFileSync(statusPath, "utf-8")),
+				steps: [{
+					agent: "wrapper",
+					status: "running",
+					startedAt: 100,
+					children: [{
+						id: nestedChildId,
+						parentRunId: runId,
+						parentStepIndex: 0,
+						depth: 1,
+						path: [{ runId, stepIndex: 0 }],
+						state: "running",
+					}],
+				}],
+			});
+
+			const result = await executorWithKill(state, () => {
+				throw new Error("nested-only child stop must not signal the parent runner");
+			}).execute("stop-nested", { action: "stop", id: runId, childId: nestedChildId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, true);
+			assert.match(text(result), new RegExp(`Child '${nestedChildId}' was not found under async run '${runId}'`));
+			assert.equal(consumeStopRequestPayload(asyncDir), undefined);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
 	it("dismisses only a reload-recovered running workflow without terminating work", async () => {
 		const state = createState();
 		state.currentSessionId = "session";


### PR DESCRIPTION
## What

`/subagents-steer <run-id> [--child <child-id>] <message>` — a slash-command bridge that forwards `{ action: "steer", id, message, steeringRecovery: false }`, with `--child` resolving a stable child id to its step index.

## Why

Steering is the missing leg of the host control loop. Today a host embedding Pi over RPC (or any non-TUI session) can:

- inspect children — `/subagents-inspect-rpc` (#1254)
- stop runs (and soon single children) — `/subagents-stop` (#1603)

…but cannot steer a live child without burning a model turn on the `subagent` tool. The in-process extension RPC has `steer` with acknowledged receipts and the `nonRecoveringSteer` guarantee; hosts driving Pi's RPC mode cannot reach it. This closes that gap with the same slash-bridge pattern as the existing host surfaces.

## How

- Args: `<run-id> [--child <child-id>] <message...>`; unknown flags and a missing message fail with usage text instead of steering the wrong target.
- `--child` accepts the stable child identity already shown in status output and inspect replies (workflow key, child run id, or `step:<index>`) and resolves it to the step index via `resolveAsyncStatusChild` against the run's `status.json`; unknown/ambiguous ids fail closed.
- Forwards `steeringRecovery: false`, matching the extension RPC `nonRecoveringSteer` guarantee — a host that addressed a specific child never gets a silent pause-and-revive replacement.
- All existing steer validation applies unchanged (async-only targeting, authority policy, delivery receipts).

## Tests

- New: run-level steer forwards `{ action: "steer", id, message, steeringRecovery: false }`.
- New: `--child step:1` resolves to `index: 1` against a two-child running fixture.
- New: unknown child id fails closed (no steer dispatched).
- New: missing message / unknown flag print usage and dispatch nothing.
- `test/integration/slash-commands.test.ts`: 28 pass; the 4 `/run` failures reproduce identically on `main` in this environment (pre-existing).
- `npm run typecheck` clean.
