### PR TITLE
fix: accept leaf model verification ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Accept bare leaf model ids reported by provider drivers when verifying provider-qualified launch candidates. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.
 - Report aborted or signalled no-output child runs with their terminal stop, stderr, or process signal before missing-output handoff diagnostics.
 - Apply `globalConcurrencyLimit` to `workflowScript` children launched through `runs.run` and `runs.all`, not only legacy multi-child runners. Thanks to [@mateominato](https://github.com/mateominato) for #1600.
 - Ignore nested `.pi` and `sync-backups` directories during agent discovery so stale backup definitions cannot become executable agents. Thanks to [@arlishansenn](https://github.com/arlishansenn) for #1596.

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -24,7 +24,12 @@ export function formatSubagentModelVerificationError(expectedModel: string, obse
 	const observedBase = splitThinkingSuffix(observedModel).baseModel;
 	if (expectedBase === observedBase) return undefined;
 	const expectedEntry = availableModels.find((entry) => entry.fullId === expectedBase);
-	if (expectedEntry && expectedEntry.id === observedBase) return undefined;
+	if (expectedEntry) {
+		if (expectedEntry.id === observedBase) return undefined;
+		const expectedIdLeaf = expectedEntry.id.slice(expectedEntry.id.lastIndexOf("/") + 1);
+		const expectedFullIdLeaf = expectedEntry.fullId.slice(expectedEntry.fullId.lastIndexOf("/") + 1);
+		if (expectedIdLeaf === observedBase || expectedFullIdLeaf === observedBase) return undefined;
+	}
 	return `model_verification_failed: child reported a different model than the launch candidate. Expected '${expectedModel}' but observed '${observedModel}'.`;
 }
 

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -54,6 +54,38 @@ describe("model fallback helpers", () => {
 		);
 	});
 
+	it("accepts a bare leaf reported by an Anthropic gateway driver", () => {
+		const gatewayModels = [{
+			provider: "bifrost-anthropic",
+			id: "vertex/claude-fable-5",
+			fullId: "bifrost-anthropic/vertex/claude-fable-5",
+		}];
+		assert.equal(
+			formatSubagentModelVerificationError(
+				"bifrost-anthropic/vertex/claude-fable-5:high",
+				"claude-fable-5",
+				gatewayModels,
+			),
+			undefined,
+		);
+		assert.match(
+			formatSubagentModelVerificationError(
+				"bifrost-anthropic/vertex/claude-fable-5:high",
+				"wrong-provider/claude-fable-5",
+				gatewayModels,
+			) ?? "",
+			/model_verification_failed/,
+		);
+		assert.match(
+			formatSubagentModelVerificationError(
+				"bifrost-anthropic/vertex/claude-fable-5:high",
+				"claude-sonnet-4",
+				gatewayModels,
+			) ?? "",
+			/model_verification_failed/,
+		);
+	});
+
 	it("resolves unique owner/name ids when the owner is not a registered provider", () => {
 		const registry = [
 			...availableModels,


### PR DESCRIPTION
## Summary

Fixes #1609 by accepting the bare leaf model id that some provider drivers report when the launch candidate is provider-qualified.

The verifier still fails closed for unrelated observed models, wrong-provider observed strings, and wrong leaves. This only changes the verification comparison. It does not change model resolution, fallback candidate selection, retry policy, public API, or provider registry shape.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts`
- `git diff --check origin/main...HEAD`
- `npm run typecheck`
- Fresh exact-head review: No issues found

## Credit

Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.
