### PR TITLE
fix: recover compaction-induced child aborts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed
 - Accept bare leaf model ids reported by provider drivers when verifying provider-qualified launch candidates. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.
+- Resume compaction-induced child aborts once when retained state is safe, and report the exact recovery blocker otherwise.
 - Report aborted or signalled no-output child runs with their terminal stop, stderr, or process signal before missing-output handoff diagnostics.
 - Apply `globalConcurrencyLimit` to `workflowScript` children launched through `runs.run` and `runs.all`, not only legacy multi-child runners. Thanks to [@mateominato](https://github.com/mateominato) for #1600.
 - Ignore nested `.pi` and `sync-backups` directories during agent discovery so stale backup definitions cannot become executable agents. Thanks to [@arlishansenn](https://github.com/arlishansenn) for #1596.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -557,6 +557,7 @@ interface RunPiStreamingResult {
 	currentToolArgs?: string;
 	currentPath?: string;
 	afterCompactionSettlement?: boolean;
+	abortRecoveryDiagnostic?: string;
 	effects?: import("../../shared/types.ts").EffectsProjection;
 }
 
@@ -574,6 +575,7 @@ function formatRequiredOutputError(requiredOutput: {
 function formatChildFailureDiagnostic(input: {
 	error: string | undefined;
 	afterCompactionSettlement?: boolean;
+	abortRecoveryDiagnostic?: string;
 	requiredOutput?: {
 		kind: "file-only" | "structured";
 		path: string;
@@ -582,6 +584,7 @@ function formatChildFailureDiagnostic(input: {
 }): string | undefined {
 	const missingOutput = formatRequiredOutputError(input.requiredOutput);
 	const notes = [
+		input.abortRecoveryDiagnostic,
 		input.afterCompactionSettlement ? "Child failure followed session compaction and agent settlement." : undefined,
 		missingOutput && input.error !== missingOutput ? missingOutput : undefined,
 	].filter((note): note is string => Boolean(note));
@@ -756,8 +759,19 @@ function runPiStreaming(
 			appendChildEvent(event as unknown as Record<string, unknown>);
 			transcriptWriter?.writeChildEvent(event);
 			if (event.type === "compaction_start") compactionStartedReceived = true;
+			if (event.type === "compaction_end" && event.willRetry === true) {
+				compactionStartedReceived = false;
+				afterCompactionSettlement = false;
+			}
+			if (event.type === "agent_start" || event.type === "auto_retry_start") {
+				compactionStartedReceived = false;
+				afterCompactionSettlement = false;
+			}
 			const lifecycleAction = projectChildLifecycle(event, false, childLifecycleState);
-			if (event.type === "agent_settled" && lifecycleAction === "start-drain") agentSettledReceived = true;
+			if (event.type === "agent_settled" && lifecycleAction === "start-drain") {
+				agentSettledReceived = true;
+				afterCompactionSettlement = compactionStartedReceived;
+			}
 			applyChildLifecycle(lifecycleAction);
 
 			if (isChildWatchdogStatusEvent(event)) {
@@ -865,6 +879,7 @@ function runPiStreaming(
 		let cleanTerminalAssistantStopReceived = false;
 		let agentSettledReceived = false;
 		let compactionStartedReceived = false;
+		let afterCompactionSettlement = false;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		let watchdogTailTimer: NodeJS.Timeout | undefined;
@@ -1112,7 +1127,7 @@ function runPiStreaming(
 				currentTool,
 				currentToolArgs,
 				currentPath,
-				afterCompactionSettlement: (compactionStartedReceived && agentSettledReceived) || undefined,
+				afterCompactionSettlement: afterCompactionSettlement || undefined,
 			}));
 		});
 
@@ -1955,30 +1970,39 @@ async function runSingleStepInner(
 		});
 		const fileMutationEffect = completionEvidence.fileMutation ?? (missingRequiredOutputAfterMutation ? { status: "observed" as const, expected: completionEvidence.mutationExpected, attempted: true, evidence: mutationEvidence } : undefined);
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect || settlementDiagnostic ? { effects: { ...(fileMutationEffect ? { fileMutation: fileMutationEffect } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunPiStreamingResult;
-		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
-		if (attempt.success || completionEvidence.guardTriggered) break modelAttemptsLoop;
-		if (recoveringAbort) break modelAttemptsLoop;
-		const abortRecovery = planAbortRecovery({
+		const abortRecovery = !attempt.success ? planAbortRecovery({
 			messages: run.messages,
 			error,
 			processSignal: run.processSignal,
 			sessionAvailable: Boolean(step.sessionFile && fs.existsSync(step.sessionFile)),
 			alreadyResumed: abortRecoveryAttempted,
-			stopped: run.stopped,
+			stopped: run.stopped || ctx.stopSignal?.aborted || ctx.skipAcceptance?.(),
 			interrupted: run.interrupted,
-			timedOut: run.timedOut,
+			timedOut: run.timedOut || ctx.timeoutSignal?.aborted,
 			toolBudgetExhausted: run.toolBudgetBlocked || toolBudgetBlocked,
 			usageBudgetExhausted: ctx.usageBudgetExhausted?.(),
 			structuredOutputFailed: Boolean(structuredError),
 			acceptanceFailed: false,
 			currentTool: run.currentTool,
-		});
-		if (abortRecovery.action === "resume") {
+			afterCompactionSettlement: run.afterCompactionSettlement,
+		}) : undefined;
+		if (abortRecovery?.action === "settle" && abortRecovery.diagnostic) {
+			attempt.error = attempt.error
+				? `${abortRecovery.diagnostic}\n${attempt.error.slice(0, 8_000)}`
+				: abortRecovery.diagnostic;
+			if (finalResult) finalResult.abortRecoveryDiagnostic = abortRecovery.diagnostic;
+		}
+		if (run.stopped || run.timedOut || ctx.timeoutSignal?.aborted || ctx.stopSignal?.aborted || ctx.skipAcceptance?.()) break modelAttemptsLoop;
+		if (abortRecovery?.action === "settle" && abortRecovery.diagnostic) break modelAttemptsLoop;
+		if (attempt.success) break modelAttemptsLoop;
+		if (recoveringAbort) break modelAttemptsLoop;
+		if (abortRecovery?.action === "resume") {
 			abortRecoveryAttempted = true;
 			nextAttemptTask = abortRecovery.prompt;
 			attemptNotes.push("[abort-recovery] provider/transport abort after useful progress; resuming the retained child session once.");
 			continue;
 		}
+		if (completionEvidence.guardTriggered) break modelAttemptsLoop;
 
 		const startupFailure = isRetryableSubagentStartupFailure(omitUndefinedProperties({
 			exitCode: effectiveExitCode,
@@ -2127,6 +2151,7 @@ async function runSingleStepInner(
 	const effectiveFinalError = formatChildFailureDiagnostic({
 		error: baseFinalError,
 		afterCompactionSettlement: effectiveFinalExitCode !== 0 ? finalResult?.afterCompactionSettlement : undefined,
+		abortRecoveryDiagnostic: effectiveFinalExitCode !== 0 ? finalResult?.abortRecoveryDiagnostic : undefined,
 		requiredOutput: effectiveFinalExitCode !== 0 ? finalResult?.effects?.settlementDiagnostic?.requiredOutput : undefined,
 	});
 

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -296,6 +296,9 @@ function snapshotStreamResult(result: SingleResult, progress: AgentProgress): Si
 	return snapshot;
 }
 
+const AFTER_COMPACTION_SETTLEMENT = Symbol("afterCompactionSettlement");
+type AbortRecoverySingleResult = SingleResult & { [AFTER_COMPACTION_SETTLEMENT]?: true };
+
 async function runSingleAttempt(
 	runtimeCwd: string,
 	agent: AgentConfig,
@@ -570,6 +573,7 @@ async function runSingleAttempt(
 			return result;
 		}
 	}
+	let afterCompactionSettlement = false;
 	const exitCode = await new Promise<number>((resolve) => {
 		const proc = spawn(spawnSpec.command, spawnSpec.args, {
 			cwd: options.cwd ?? runtimeCwd,
@@ -652,6 +656,7 @@ async function runSingleAttempt(
 		let forcedTerminationSignal = false;
 		let cleanTerminalAssistantStopReceived = false;
 		let agentSettledReceived = false;
+		let compactionStartedReceived = false;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardKillTimer: NodeJS.Timeout | undefined;
 		let watchdogTailTimer: NodeJS.Timeout | undefined;
@@ -960,8 +965,20 @@ async function runSingleAttempt(
 			}
 			shared.transcriptWriter?.writeChildEvent(evt);
 			shared.orcaProgressTab?.event(evt);
+			if (evt.type === "compaction_start") compactionStartedReceived = true;
+			if (evt.type === "compaction_end" && evt.willRetry === true) {
+				compactionStartedReceived = false;
+				afterCompactionSettlement = false;
+			}
+			if (evt.type === "agent_start" || evt.type === "auto_retry_start") {
+				compactionStartedReceived = false;
+				afterCompactionSettlement = false;
+			}
 			const lifecycleAction = projectChildLifecycle(evt, false, childLifecycleState);
-			if (evt.type === "agent_settled" && lifecycleAction === "start-drain") agentSettledReceived = true;
+			if (evt.type === "agent_settled" && lifecycleAction === "start-drain") {
+				agentSettledReceived = true;
+				afterCompactionSettlement = compactionStartedReceived;
+			}
 			applyChildLifecycle(lifecycleAction);
 
 			if (isChildWatchdogStatusEvent(evt)) {
@@ -1389,6 +1406,9 @@ async function runSingleAttempt(
 		}
 	});
 	result.exitCode = exitCode;
+	if (afterCompactionSettlement) {
+		(result as AbortRecoverySingleResult)[AFTER_COMPACTION_SETTLEMENT] = true;
+	}
 	if (interruptedByControl) {
 		result.exitCode = 0;
 		result.interrupted = true;
@@ -1923,7 +1943,8 @@ async function runSyncCompletionInner(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
-			if (!attemptSucceeded && !recoveringAbort) {
+			if (!attemptSucceeded) {
+				const afterCompactionSettlement = (result as AbortRecoverySingleResult)[AFTER_COMPACTION_SETTLEMENT];
 				const abortRecovery = planAbortRecovery({
 					messages: result.messages ?? [],
 					error: result.error,
@@ -1938,12 +1959,18 @@ async function runSyncCompletionInner(
 					structuredOutputFailed: result.structuredOutputFailed,
 					acceptanceFailed: false,
 					currentTool: result.progress?.currentTool,
+					afterCompactionSettlement,
 				});
 				if (abortRecovery.action === "resume") {
 					abortRecoveryAttempted = true;
 					nextAttemptTask = abortRecovery.prompt;
 					attemptNotes.push("[abort-recovery] provider/transport abort after useful progress; resuming the retained child session once.");
 					continue;
+				}
+				if (abortRecovery.diagnostic) {
+					result.error = result.error ? `${result.error}\n${abortRecovery.diagnostic}` : abortRecovery.diagnostic;
+					attempt.error = result.error;
+					break modelAttemptsLoop;
 				}
 			}
 			if (recoveringAbort && !attemptSucceeded) break modelAttemptsLoop;

--- a/src/runs/shared/abort-recovery.ts
+++ b/src/runs/shared/abort-recovery.ts
@@ -4,7 +4,7 @@ export const ABORT_RECOVERY_PROMPT = "The prior run ended from a provider/transp
 
 export type AbortRecoveryPlan =
 	| { action: "resume"; prompt: typeof ABORT_RECOVERY_PROMPT }
-	| { action: "settle"; reason: string };
+	| { action: "settle"; reason: string; diagnostic?: string };
 
 const PROVIDER_ABORT_PATTERN = /(?:provider|transport|connection|stream|socket|request).*(?:abort|closed|reset|ended|terminated|error|fail)|(?:abort|closed|reset|ended|terminated|error|fail).*(?:provider|transport|connection|stream|socket|request)/i;
 const ABORT_ERROR_PATTERN = /\b(?:operation|request|response|stream|connection|transport|provider)?\s*(?:was\s+)?aborted\b/i;
@@ -78,32 +78,42 @@ export function planAbortRecovery(input: {
 	structuredOutputFailed?: boolean;
 	acceptanceFailed?: boolean;
 	currentTool?: string;
+	afterCompactionSettlement?: boolean;
 }): AbortRecoveryPlan {
-	if (input.alreadyResumed) return { action: "settle", reason: "resume already attempted" };
-	if (!input.sessionAvailable) return { action: "settle", reason: "retained session unavailable" };
-	if (input.stopped || input.interrupted) return { action: "settle", reason: "explicit stop or interrupt" };
-	if (input.processSignal) return { action: "settle", reason: "process terminated by signal" };
-	if (input.timedOut) return { action: "settle", reason: "elapsed timeout" };
-	if (input.toolBudgetExhausted || input.usageBudgetExhausted) return { action: "settle", reason: "budget exhausted" };
-	if (input.structuredOutputFailed) return { action: "settle", reason: "structured output failure" };
-	if (input.acceptanceFailed) return { action: "settle", reason: "acceptance failure" };
-	if (input.currentTool || hasUnresolvedToolCall(input.messages)) return { action: "settle", reason: "tool call still in flight" };
-
 	const terminal = terminalAssistant(input.messages);
 	const message = terminal.message;
-	const error = [input.error, typeof message?.errorMessage === "string" ? message.errorMessage : undefined]
-		.filter((value): value is string => Boolean(value))
-		.join("\n");
+	const terminalError = typeof message?.errorMessage === "string" ? message.errorMessage : undefined;
 	const emptyZeroUsageTerminal = message !== undefined
 		&& contentParts(message).length === 0
 		&& zeroOutputUsage(message);
-	const abortMarker = message?.stopReason === "aborted"
-		|| isProviderAbortError(error);
-	const equivalentProviderAbort = isProviderAbortError(error);
-	if ((!emptyZeroUsageTerminal || !abortMarker) && !equivalentProviderAbort) {
-		return { action: "settle", reason: "terminal response is not a provider abort" };
-	}
+	const terminalAssistantAbort = message?.stopReason === "aborted"
+		|| (message?.stopReason === "error" && terminalError !== undefined && isProviderAbortError(terminalError));
+	const abortCandidate = emptyZeroUsageTerminal && terminalAssistantAbort;
+	const compactionAbortCandidate = input.afterCompactionSettlement === true && abortCandidate;
+	const settle = (reason: string): AbortRecoveryPlan => ({
+		action: "settle",
+		reason,
+		...(compactionAbortCandidate
+			? { diagnostic: `Compaction-induced child abort could not be resumed safely: ${reason}.` }
+			: {}),
+	});
+
+	if (input.alreadyResumed) return settle("resume already attempted");
+	if (!input.sessionAvailable) return settle("retained session unavailable");
+	if (input.stopped || input.interrupted) return settle("explicit stop or interrupt");
+	// A compaction abort can leave the child process open until the runner's
+	// terminal drain sends SIGTERM. The compaction + settlement markers make
+	// that cleanup signal non-authoritative; explicit stop/interrupt still wins.
+	if (input.processSignal && !compactionAbortCandidate) return settle("process terminated by signal");
+	if (input.timedOut) return settle("elapsed timeout");
+	if (input.toolBudgetExhausted || input.usageBudgetExhausted) return settle("budget exhausted");
+	if (input.structuredOutputFailed) return settle("structured output failure");
+	if (input.acceptanceFailed) return settle("acceptance failure");
+	if (input.currentTool) return settle(`active tool '${input.currentTool.slice(0, 128)}' remains in flight`);
+	if (hasUnresolvedToolCall(input.messages)) return settle("unresolved tool call remains in transcript");
+	if (!input.afterCompactionSettlement) return settle("compaction settlement not verified");
+	if (!abortCandidate) return settle("terminal assistant abort evidence not verified");
 	const progressLimit = emptyZeroUsageTerminal ? terminal.index : input.messages.length;
-	if (!hasUsefulProgress(input.messages, progressLimit)) return { action: "settle", reason: "no useful prior progress" };
+	if (!hasUsefulProgress(input.messages, progressLimit)) return settle("no useful prior progress");
 	return { action: "resume", prompt: ABORT_RECOVERY_PROMPT };
 }

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -3198,26 +3198,29 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 1);
 	});
 
-	it("background runs resume the retained session once after a provider abort following completed tool work", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+	it("background runs resume the retained session once after a compaction-induced abort following completed tool work", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const sessionFile = path.join(tempDir, "async-abort-recovery-session.jsonl");
 		mockPi.onCall({
 			jsonl: [
 				events.toolStart("write", { path: "side-effect.txt", content: "done" }),
 				events.toolEnd("write"),
 				events.toolResult("write", "Wrote side-effect.txt"),
+				{ type: "compaction_start" },
 				{
 					type: "message_end",
 					message: {
 						role: "assistant",
 						content: [],
 						model: "openai/gpt-5-mini",
-						errorMessage: "Connection error.",
-						usage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
 					},
 				},
+				{ type: "agent_settled" },
 			],
 			writeFiles: [{ path: "side-effect.txt", content: "done" }, { path: sessionFile, content: "{}\n" }],
-			exitCode: 1,
+			keepAliveAfterFinalMessageMs: 5_000,
+			exitCode: 0,
 		});
 		mockPi.onCall({ output: "Recovered asynchronously from retained session" });
 		const id = `async-fallback-provider-after-tool-${Date.now().toString(36)}`;
@@ -3257,6 +3260,162 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(resumedArgs[resumedArgs.indexOf("--session") + 1], sessionFile);
 		assert.match(resumedArgs.at(-1) ?? "", /Continue from the current files and transcript/);
 		assert.equal(fs.readFileSync(path.join(tempDir, "side-effect.txt"), "utf-8"), "done");
+	});
+
+	it("background compaction abort without a retained session does not fall back", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [
+				events.assistantMessage("I inspected the source."),
+				{ type: "compaction_start" },
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "openai/gpt-5-mini",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+				{ type: "agent_settled" },
+			],
+			keepAliveAfterFinalMessageMs: 5_000,
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Fallback must not run" });
+		const id = `async-compaction-abort-no-session-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", {
+				model: "openai/gpt-5-mini:high",
+				fallbackModels: ["anthropic/claude-sonnet-4:low"],
+			}),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			availableModels: [
+				{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+				{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+			],
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf-8"));
+		assert.equal(payload.success, false);
+		assert.match(payload.results[0]?.error ?? "", /Compaction-induced child abort could not be resumed safely: retained session unavailable\./);
+		assert.doesNotMatch(payload.results[0]?.output ?? "", /Fallback must not run/);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("background does not use compaction recovery for a generic empty assistant abort after a compaction retry", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const sessionFile = path.join(tempDir, "async-generic-empty-after-compaction-retry-session.jsonl");
+		mockPi.onCall({
+			jsonl: [
+				{ type: "compaction_start" },
+				{ type: "compaction_end", willRetry: true },
+				{ type: "agent_settled" },
+				{ type: "agent_start" },
+				events.assistantMessage("The compaction retry produced useful output.", "openai/gpt-5-mini"),
+				{ type: "agent_settled" },
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "openai/gpt-5-mini",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+				{ type: "agent_settled" },
+			],
+			writeFiles: [{ path: sessionFile, content: "{}\n" }],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Compaction recovery must not run" });
+		const id = `async-no-compaction-recovery-after-retry-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			sessionFile,
+			agentConfig: makeAgent("worker", { model: "openai/gpt-5-mini" }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			availableModels: [{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" }],
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf-8"));
+		assert.equal(payload.success, false);
+		assert.match(payload.results[0]?.error ?? "", /Subagent produced no output after terminal assistant stopReason "aborted"\./u);
+		assert.equal(payload.results[0]?.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("background does not use compaction recovery after compaction_end willRetry false and a continued agent turn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const sessionFile = path.join(tempDir, "async-generic-empty-after-successful-compaction-session.jsonl");
+		mockPi.onCall({
+			jsonl: [
+				{ type: "compaction_start" },
+				{ type: "compaction_end", willRetry: false },
+				{ type: "agent_start" },
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "openai/gpt-5-mini",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+				{ type: "agent_settled" },
+			],
+			writeFiles: [{ path: sessionFile, content: "{}\n" }],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Compaction recovery must not run" });
+		const id = `async-no-compaction-recovery-after-successful-compaction-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			sessionFile,
+			agentConfig: makeAgent("worker", { model: "openai/gpt-5-mini" }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			availableModels: [{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" }],
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+		});
+
+		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf-8"));
+		assert.equal(payload.success, false);
+		assert.match(payload.results[0]?.error ?? "", /Subagent produced no output after terminal assistant stopReason "aborted"\./u);
+		assert.equal(payload.results[0]?.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
 	});
 
 	it("background single thinking override replaces primary and fallback suffixes", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
@@ -5546,9 +5705,12 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	});
 
 	it("reports bounded compaction failure context when file-only output is missing", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
-		const terminalError = `This operation was aborted${"x".repeat(12_000)}`;
+		const terminalError = `This operation was aborted\n${"x".repeat(12_000)}`;
 		mockPi.onCall({
 			jsonl: [
+				events.toolStart("read", { path: "src/index.ts" }),
+				events.toolEnd("read"),
+				events.toolResult("read", "file contents"),
 				{ type: "compaction_start" },
 				{
 					type: "message_end",
@@ -5589,6 +5751,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.success, false);
 		assert.equal(child?.success, false);
 		assert.match(diagnostic, /^This operation was aborted/);
+		assert.match(diagnostic, /Compaction-induced child abort could not be resumed safely: retained session unavailable\./);
 		assert.match(diagnostic, /failure followed session compaction and agent settlement/);
 		assert.match(diagnostic, /Required file-only output was not produced/);
 		assert.ok(diagnostic.length <= 8_192);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -4399,6 +4399,39 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.finalOutput, partialOutput);
 	});
 
+	it("reports why an unsafe foreground compaction abort cannot resume without falling back", async () => {
+		mockPi.onCall({
+			jsonl: [
+				events.toolStart("read", { path: "src/index.ts" }),
+				events.toolEnd("read"),
+				events.toolResult("read", "file contents"),
+				{ type: "compaction_start" },
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "mock/test-model",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+				{ type: "agent_settled" },
+			],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Fallback must not run" });
+
+		const result = await runSync(tempDir, [makeAgent("worker", { model: "mock/test-model", fallbackModels: ["mock/fallback-model"] })], "worker", "Inspect the current source", {
+			runId: "foreground-compaction-abort-no-session",
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /^Subagent produced no output after terminal assistant stopReason "aborted"\./);
+		assert.match(result.error ?? "", /Compaction-induced child abort could not be resumed safely: retained session unavailable\./);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
 	it("agent contract v1 reports omitted acceptance separately without injecting a prompt", async () => {
 		mockPi.onCall({ output: "Plan only" });
 		const agents = [makeAgent("worker", { tools: ["read", "write"] })];
@@ -4580,7 +4613,12 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const child = result.details.workflow?.value as { ok?: boolean; runId?: string; output?: string; continuation?: { runIds?: string[] } };
 		assert.equal(child.ok, true);
 		assert.match(child.output ?? "", /Recovered after workflow auto-resume/u);
-		assert.deepEqual(child.continuation?.runIds, [child.runId]);
+		// The workflow-level setup recovery is a distinct launch, so its receipt
+		// retains both the failed source run and the resumed child run. The
+		// compaction planner no longer hides this source by resuming it first.
+		assert.equal(child.continuation?.runIds?.length, 2);
+		assert.notEqual(child.continuation?.runIds?.[0], child.runId);
+		assert.equal(child.continuation?.runIds?.at(-1), child.runId);
 		assert.equal(mockPi.callCount(), 2);
 	});
 
@@ -5858,26 +5896,133 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 1);
 	});
 
-	it("resumes the retained session once after a provider abort following completed tool work", async () => {
-		const sessionFile = path.join(tempDir, "abort-recovery-session.jsonl");
+	it("does not use compaction recovery for a generic empty assistant abort after a compaction retry", async () => {
+		const sessionFile = path.join(tempDir, "generic-empty-after-compaction-retry-session.jsonl");
 		mockPi.onCall({
 			jsonl: [
-				events.toolStart("write", { path: "side-effect.txt", content: "done" }),
-				events.toolEnd("write"),
-				events.toolResult("write", "Wrote side-effect.txt"),
+				{ type: "compaction_start" },
+				{ type: "compaction_end", willRetry: true },
+				{ type: "agent_settled" },
+				{ type: "agent_start" },
+				events.assistantMessage("The compaction retry produced useful output.", "openai/gpt-5-mini"),
+				{ type: "agent_settled" },
 				{
 					type: "message_end",
 					message: {
 						role: "assistant",
 						content: [],
 						model: "openai/gpt-5-mini",
-						errorMessage: "Connection error.",
-						usage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
 					},
 				},
+				{ type: "agent_settled" },
+			],
+			writeFiles: [{ path: sessionFile, content: "{}\n" }],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Compaction recovery must not run" });
+		const agents = [makeAgent("echo", { model: "openai/gpt-5-mini" })];
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "no-compaction-recovery-after-compaction-retry",
+			sessionFile,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /Subagent produced no output after terminal assistant stopReason "aborted"\./u);
+		assert.equal(result.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("does not use compaction recovery after compaction_end willRetry false and a continued agent turn", async () => {
+		const sessionFile = path.join(tempDir, "generic-empty-after-successful-compaction-session.jsonl");
+		mockPi.onCall({
+			jsonl: [
+				{ type: "compaction_start" },
+				{ type: "compaction_end", willRetry: false },
+				{ type: "agent_start" },
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "openai/gpt-5-mini",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+				{ type: "agent_settled" },
+			],
+			writeFiles: [{ path: sessionFile, content: "{}\n" }],
+			exitCode: 0,
+		});
+		mockPi.onCall({ output: "Compaction recovery must not run" });
+		const agents = [makeAgent("echo", { model: "openai/gpt-5-mini" })];
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "no-compaction-recovery-after-successful-compaction",
+			sessionFile,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /Subagent produced no output after terminal assistant stopReason "aborted"\./u);
+		assert.equal(result.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("does not use compaction recovery for a generic provider abort after normal settlement", async () => {
+		const sessionFile = path.join(tempDir, "generic-provider-after-compaction-session.jsonl");
+		mockPi.onCall({
+			jsonl: [
+				{ type: "compaction_start" },
+				events.assistantMessage("Compaction completed and the child settled normally.", "openai/gpt-5-mini"),
+				{ type: "agent_settled" },
+			],
+			writeFiles: [{ path: sessionFile, content: "{}\n" }],
+			stderr: "APIConnectionError: Connection reset by provider transport.",
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "Compaction recovery must not run" });
+		const agents = [makeAgent("echo", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+
+		const result = await runSync(tempDir, agents, "echo", "Task", {
+			runId: "no-compaction-recovery-after-normal-settlement",
+			sessionFile,
+		});
+
+		assert.equal(result.exitCode, 1);
+		assert.match(result.error ?? "", /Connection reset by provider transport/u);
+		assert.equal(result.modelAttempts?.length, 1);
+		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("resumes the retained session once after a compaction-induced abort following completed tool work", async () => {
+		const sessionFile = path.join(tempDir, "abort-recovery-session.jsonl");
+		mockPi.onCall({
+			jsonl: [
+				events.toolStart("write", { path: "side-effect.txt", content: "done" }),
+				events.toolEnd("write"),
+				events.toolResult("write", "Wrote side-effect.txt"),
+				{ type: "compaction_start" },
+				{
+					type: "message_end",
+					message: {
+						role: "assistant",
+						content: [],
+						model: "openai/gpt-5-mini",
+						stopReason: "aborted",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+					},
+				},
+				{ type: "agent_settled" },
 			],
 			writeFiles: [{ path: "side-effect.txt", content: "done" }, { path: sessionFile, content: "{}\n" }],
-			exitCode: 1,
+			keepAliveAfterFinalMessageMs: 5_000,
+			exitCode: 0,
 		});
 		mockPi.onCall({ output: "Recovered from retained session" });
 		const agents = [makeAgent("echo", {

--- a/test/unit/abort-recovery.test.ts
+++ b/test/unit/abort-recovery.test.ts
@@ -30,8 +30,12 @@ function base(overrides: Partial<Parameters<typeof planAbortRecovery>[0]> = {}) 
 }
 
 describe("planAbortRecovery", () => {
-	it("plans one same-session continuation after an abort with useful progress", () => {
-		assert.deepEqual(planAbortRecovery(base()), { action: "resume", prompt: ABORT_RECOVERY_PROMPT });
+	it("does not recover an abort without verified compaction settlement", () => {
+		assert.deepEqual(planAbortRecovery(base()), { action: "settle", reason: "compaction settlement not verified" });
+	});
+
+	it("plans the same retained-session continuation for a compaction-induced abort", () => {
+		assert.deepEqual(planAbortRecovery(base({ afterCompactionSettlement: true, processSignal: "SIGTERM" })), { action: "resume", prompt: ABORT_RECOVERY_PROMPT });
 	});
 
 	it("accepts a completed tool result as useful progress", () => {
@@ -40,7 +44,7 @@ describe("planAbortRecovery", () => {
 			{ role: "toolResult", toolCallId: "call-1", isError: false, content: [{ type: "text", text: "tests passed" }] },
 			aborted,
 		);
-		assert.equal(planAbortRecovery(base({ messages: toolProgress })).action, "resume");
+		assert.equal(planAbortRecovery(base({ messages: toolProgress, afterCompactionSettlement: true })).action, "resume");
 	});
 
 	it("fails closed without progress, a retained session, or a first-attempt permit", () => {
@@ -87,21 +91,55 @@ describe("planAbortRecovery", () => {
 			{ role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "bash", arguments: {} }], usage: { output: 1 } },
 			aborted,
 		);
-		assert.deepEqual(planAbortRecovery(base({ messages: inFlight, currentTool: "bash" })), { action: "settle", reason: "tool call still in flight" });
-		assert.deepEqual(planAbortRecovery(base({ messages: inFlight, currentTool: undefined })), { action: "settle", reason: "tool call still in flight" });
+		assert.deepEqual(planAbortRecovery(base({ messages: inFlight, currentTool: "bash" })), { action: "settle", reason: "active tool 'bash' remains in flight" });
+		assert.deepEqual(planAbortRecovery(base({ messages: inFlight, currentTool: undefined })), { action: "settle", reason: "unresolved tool call remains in transcript" });
 	});
 
-	it("recognizes an equivalent transport error without a terminal assistant record", () => {
-		assert.equal(planAbortRecovery(base({
+	it("names the exact blocker when compaction abort recovery is unsafe", () => {
+		assert.deepEqual(planAbortRecovery(base({ sessionAvailable: false, afterCompactionSettlement: true })), {
+			action: "settle",
+			reason: "retained session unavailable",
+			diagnostic: "Compaction-induced child abort could not be resumed safely: retained session unavailable.",
+		});
+		assert.deepEqual(planAbortRecovery(base({ currentTool: "bash", afterCompactionSettlement: true })), {
+			action: "settle",
+			reason: "active tool 'bash' remains in flight",
+			diagnostic: "Compaction-induced child abort could not be resumed safely: active tool 'bash' remains in flight.",
+		});
+	});
+
+	it("requires terminal assistant abort evidence for compaction recovery", () => {
+		assert.deepEqual(planAbortRecovery(base({
 			messages: messages(progress),
 			processSignal: undefined,
 			error: "Connection reset by provider transport",
-		})).action, "resume");
+		})), { action: "settle", reason: "compaction settlement not verified" });
+		assert.deepEqual(planAbortRecovery(base({
+			messages: messages(progress),
+			processSignal: undefined,
+			error: "Connection reset by provider transport",
+			afterCompactionSettlement: true,
+		})), { action: "settle", reason: "terminal assistant abort evidence not verified" });
 		assert.equal(planAbortRecovery(base({
 			messages: messages(progress, { ...aborted, stopReason: "error", errorMessage: "This operation was aborted" }),
 			processSignal: undefined,
 			error: "This operation was aborted",
+			afterCompactionSettlement: true,
 		})).action, "resume");
+	});
+
+	it("does not recover a generic transport abort after a normally settled compaction", () => {
+		const settled = {
+			role: "assistant",
+			content: [{ type: "text", text: "Compaction completed and the child settled normally." }],
+			stopReason: "stop",
+			usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+		};
+		assert.deepEqual(planAbortRecovery(base({
+			messages: messages(progress, settled),
+			error: "Connection reset by provider transport",
+			afterCompactionSettlement: true,
+		})), { action: "settle", reason: "terminal assistant abort evidence not verified" });
 	});
 
 	it("does not reinterpret a network-flavored task tool failure as a provider abort", () => {


### PR DESCRIPTION
## Summary

This adds the narrow compaction-abort recovery path prepared from the #1602 follow-up work.

A child can now resume its retained session once when the same attempt shows useful progress, verified compaction settlement, and empty terminal assistant abort evidence. Unsafe cases fail closed with a concrete recovery blocker, and generic provider or transport aborts after historical compaction markers do not use this path.

Follow-up to #1602.

## Validation

- Setup-abort lineage test: 1 passed.
- `test/unit/abort-recovery.test.ts`: 13 passed.
- Foreground compaction/no-output focused tests: passed.
- Background compaction/no-output focused tests: passed.
- Foreground and background compaction retry latch regressions: passed.
- `git diff --check origin/main...HEAD`: passed.
- `npm run typecheck`: passed.
- Fresh exact-head review: No issues found.
