### PR TITLE
feat: show async work lanes in status widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Accept a child id on `/subagents-stop <run-id> <child-id>` so RPC hosts and non-TUI sessions can stop one child of a multi-child async run or workflow without stopping the whole run. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1603.
 
 ### Changed
+- Show optional lane/work-item context in async status rows, including known phase, gate, next action, output, run reference, and stale/blocked signals without adding render-time I/O.
 - Extract async status snapshot projection into a pure internal module while preserving RPC and widget wire compatibility.
 - Extract child launch planning into a focused internal module shared by async workflow launch setup.
 - Extract detached workflow settlement planning into a focused workflow module while preserving fail-closed result handoff.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -58,6 +58,7 @@ interface AsyncRunStepSummary {
 	stopped?: boolean;
 	turnBudget?: TurnBudgetState;
 	turnBudgetExceeded?: boolean;
+	toolBudgetBlocked?: boolean;
 	wrapUpRequested?: boolean;
 	acceptance?: AsyncJobStep["acceptance"];
 	agentContract?: AsyncJobStep["agentContract"];
@@ -309,6 +310,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 			...(step.stopRequestedAt !== undefined ? { stopRequestedAt: step.stopRequestedAt } : {}),
 			...(step.turnBudget ? { turnBudget: step.turnBudget } : {}),
 			...(step.turnBudgetExceeded !== undefined ? { turnBudgetExceeded: step.turnBudgetExceeded } : {}),
+			...(step.toolBudgetBlocked !== undefined ? { toolBudgetBlocked: step.toolBudgetBlocked } : {}),
 			...(step.wrapUpRequested !== undefined ? { wrapUpRequested: step.wrapUpRequested } : {}),
 			...(step.acceptance ? { acceptance: step.acceptance } : {}),
 			...(step.agentContract ? { agentContract: step.agentContract } : {}),
@@ -318,6 +320,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 			...(step.execution ? { execution: step.execution } : {}),
 			...(step.review ? { review: step.review } : {}),
 			...(step.effects ? { effects: step.effects } : {}),
+			...(step.watchdog ? { watchdog: step.watchdog } : {}),
 			...(step.processTerminal ? { processTerminal: sanitizeProcessTerminal(step.processTerminal, { runId: status.runId, runnerProcessInstanceId: step.processTerminal.runnerProcessInstanceId }, `${path.join(asyncDir, "status.json")} step ${index}`) } : {}),
 			...(step.capabilityCeiling ? { capabilityCeiling: step.capabilityCeiling } : {}),
 			...(step.capabilityAudit ? { capabilityAudit: step.capabilityAudit } : {}),

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -278,6 +278,153 @@ export function compactTaskText(task: string | undefined, label?: string): strin
 	return previewDisplayText(normalized, COMPACT_TASK_MAX_CHARS);
 }
 
+export interface AsyncLaneProjection {
+	label?: string;
+	role: string;
+	phase?: string;
+	state: AsyncJobState["status"] | AsyncJobStep["status"];
+	gate?: string;
+	next?: string;
+	output?: string;
+	ref: string;
+	chips: string[];
+}
+
+const LANE_VALUE_MAX_CHARS = 48;
+
+function boundedLaneValue(value: string | undefined, maxChars = LANE_VALUE_MAX_CHARS): string | undefined {
+	if (!value?.trim() || value.trim() === PROMPT_REDACTED) return undefined;
+	return previewDisplayText(oneLine(value), maxChars);
+}
+
+function laneStepForJob(job: AsyncJobState): AsyncJobStep | undefined {
+	const steps = job.steps ?? [];
+	if (steps.length === 0) return undefined;
+	if (job.currentStep !== undefined) {
+		const current = steps[job.currentStep];
+		if (current && (current.index === undefined || current.index === job.currentStep)) return current;
+		// Active parallel groups retain flat indices while exposing only the group slice.
+		const indexedCurrent = steps.find((step) => step.index === job.currentStep);
+		if (indexedCurrent) return indexedCurrent;
+		return steps[0];
+	}
+	return steps.find((step) => step.status === "running")
+		?? steps.find((step) => step.status === "pending")
+		?? steps.at(-1);
+}
+
+function laneTraceForJob(job: AsyncJobState): NonNullable<AsyncJobState["workflow"]>["trace"][number] | undefined {
+	return Array.isArray(job.workflow?.trace) ? job.workflow.trace.at(-1) : undefined;
+}
+
+function laneGate(step: AsyncJobStep | undefined): string | undefined {
+	const review = step?.review?.status ?? step?.acceptance?.reviewResult?.status;
+	if (review === "blockers") return "review blockers";
+	if (review === "review-required") return "review required";
+	if (review === "reviewed") return "reviewed";
+	const acceptance = step?.acceptance?.status;
+	if (acceptance === "review-required") return "acceptance review";
+	if (acceptance === "checked" || acceptance === "verified" || acceptance === "accepted") return "acceptance";
+	return undefined;
+}
+
+function laneNextAction(state: AsyncLaneProjection["state"], step: AsyncJobStep | undefined, output: string | undefined, gate: string | undefined): string | undefined {
+	if (step?.watchdog?.phase === "stale") return "inspect stale state";
+	if (step?.toolBudgetBlocked === true || step?.turnBudgetExceeded === true) return "inspect blocked state";
+	if (gate === "review blockers") return "resolve review blockers";
+	if (gate === "review required" || gate === "acceptance review") return "review output";
+	if (step?.activityState === "needs_attention") return "inspect attention";
+	if (state === "queued" || state === "pending") return "await launch";
+	if (state === "failed" || state === "rejected") return "inspect failure";
+	if (state === "partial") return "inspect partial state";
+	if (state === "paused") return "inspect paused state";
+	if (state === "stopped") return "inspect stopped state";
+	if ((state === "complete" || state === "completed") && gate === "reviewed") return "ready";
+	if ((state === "complete" || state === "completed") && output) return "inspect output";
+	return undefined;
+}
+
+function isTerminalLaneState(state: AsyncJobState["status"]): boolean {
+	return state !== "queued" && state !== "running";
+}
+
+/** Project already-loaded async status facts into one bounded, render-only lane row. */
+export function projectAsyncLane(job: AsyncJobState, selectedStep = laneStepForJob(job)): AsyncLaneProjection | undefined {
+	const trace = laneTraceForJob(job);
+	const label = compactTaskText(selectedStep?.description, selectedStep?.label)
+		?? boundedLaneValue(trace?.label)
+		?? boundedLaneValue(selectedStep?.workflowKey ?? job.workflowKey);
+	const role = boundedLaneValue(selectedStep?.agent ?? trace?.agent ?? job.agents?.[0] ?? widgetJobName(job), 32) ?? "subagent";
+	const phase = boundedLaneValue(selectedStep?.phase ?? trace?.phase);
+	const gate = laneGate(selectedStep);
+	const output = boundedLaneValue(selectedStep?.outputName);
+	const ref = boundedLaneValue(selectedStep?.workflowKey ?? job.workflowKey ?? job.asyncId.slice(0, 8), 24) ?? job.asyncId.slice(0, 8);
+	const chips = [
+		selectedStep?.context,
+		selectedStep?.structured ? "structured" : undefined,
+		selectedStep?.activityState === "active_long_running" ? "long-running" : undefined,
+		selectedStep?.activityState === "needs_attention" ? "attention" : undefined,
+		selectedStep?.watchdog?.phase === "stale" ? "stale" : undefined,
+		selectedStep?.toolBudgetBlocked === true || selectedStep?.turnBudgetExceeded === true ? "blocked" : undefined,
+	].filter((chip): chip is string => Boolean(chip));
+	const state = isTerminalLaneState(job.status) ? job.status : selectedStep?.status ?? job.status;
+	const next = laneNextAction(state, selectedStep, output, gate);
+	if (!label && !phase && !gate && !output && !selectedStep?.workflowKey && !job.workflowKey && !trace?.label && !trace?.phase) return undefined;
+	return { ...(label ? { label } : {}), role, ...(phase ? { phase } : {}), state, ...(gate ? { gate } : {}), ...(next ? { next } : {}), ...(output ? { output } : {}), ref, chips };
+}
+
+function laneStateLabel(state: AsyncLaneProjection["state"], theme: Theme): string {
+	if (state === "running") return theme.fg("accent", "running");
+	if (state === "queued" || state === "pending") return theme.fg("muted", state);
+	if (state === "complete" || state === "completed") return theme.fg("success", "complete");
+	if (state === "failed" || state === "rejected") return theme.fg("error", state === "rejected" ? "rejected" : "failed");
+	return theme.fg("warning", state);
+}
+
+function formatLaneProjection(lane: AsyncLaneProjection, theme: Theme): string {
+	const label = boundedLaneValue(lane.label, 56);
+	const identity = [label, lane.role ? `role:${lane.role}` : undefined].filter(Boolean).join(" · ");
+	return `${theme.fg("dim", "lane:")} ${identity ? theme.bold(identity) : theme.bold(lane.role)} · ${laneStateLabel(lane.state, theme)}`;
+}
+
+function formatLaneChip(chip: string, theme: Theme): string {
+	const text = `[${chip}]`;
+	if (chip === "blocked") return theme.fg("error", text);
+	if (chip === "stale") return theme.fg("warning", text);
+	return text;
+}
+
+function formatLaneProjectionDetails(lane: AsyncLaneProjection, theme: Theme): string | undefined {
+	const details = [
+		lane.phase ? `phase:${lane.phase}` : undefined,
+		lane.gate ? `gate:${lane.gate}` : undefined,
+		lane.next ? `next:${lane.next}` : undefined,
+		lane.output ? `out:${lane.output}` : undefined,
+		lane.ref ? `ref:${lane.ref}` : undefined,
+	].filter(Boolean);
+	const chips = lane.chips.map((chip) => formatLaneChip(chip, theme));
+	return [...(details.length ? [theme.fg("dim", details.join(" · "))] : []), ...chips].join(" · ") || undefined;
+}
+
+function formatLaneProjectionLines(lane: AsyncLaneProjection, theme: Theme, indent: string): string[] {
+	const details = formatLaneProjectionDetails(lane, theme);
+	return [
+		`${indent}${formatLaneProjection(lane, theme)}`,
+		...(details ? [`${indent}  ${details}`] : []),
+	];
+}
+
+function laneRenderKey(job: AsyncJobState): unknown {
+	const lane = projectAsyncLane(job);
+	return lane ? [lane.label, lane.role, lane.phase, lane.state, lane.gate, lane.next, lane.output, lane.ref, lane.chips] : undefined;
+}
+
+function widgetLaneDetailLines(job: AsyncJobState, theme: Theme): string[] {
+	if (job.steps?.length && (job.mode === "parallel" || job.mode === "chain")) return [];
+	const lane = projectAsyncLane(job);
+	return lane ? formatLaneProjectionLines(lane, theme, "  ") : [];
+}
+
 function workflowLabelForResult(details: Details, resultIndex: number): string | undefined {
 	const flatIndex = details.results[resultIndex]?.progress?.index ?? resultIndex;
 	const visit = (nodes: NonNullable<Details["workflowGraph"]>["nodes"]): string | undefined => {
@@ -593,6 +740,15 @@ function widgetStepRenderKey(step: AsyncJobStep, index: number, expanded = false
 		step.model,
 		step.thinking,
 		step.context,
+		step.description,
+		step.outputName,
+		step.structured,
+		step.acceptance?.status,
+		step.acceptance?.reviewResult?.status,
+		step.review?.status,
+		step.toolBudgetBlocked,
+		step.turnBudgetExceeded,
+		step.watchdog?.phase,
 		step.error,
 		expanded ? expandedStepActivityRenderKey(step) : undefined,
 		nestedRenderKey(step.children, expanded),
@@ -641,6 +797,7 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 		parallelGroups: job.parallelGroups,
 		steps: job.steps?.map((step, index) => widgetStepRenderKey(step, index, expanded)),
 		nestedChildren: nestedRenderKey(job.nestedChildren, expanded),
+		lane: laneRenderKey(job),
 		stepsTotal: job.stepsTotal,
 		runningSteps: job.runningSteps,
 		completedSteps: job.completedSteps,
@@ -802,6 +959,8 @@ function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded =
 		const label = compactTaskText(step.description, step.label);
 		const display = label ? `${label} (${step.agent})` : step.agent;
 		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${display} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
+		const lane = projectAsyncLane(job, step);
+		if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "    "));
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 8 : 6)) lines.push(`    ${nestedLine}`);
 	}
 	return lines;
@@ -1286,6 +1445,8 @@ function foregroundStyleWidgetStepLines(
 	const stats = widgetStepStats(theme, step);
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
 	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
+	const lane = projectAsyncLane(job, step);
+	if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "    "));
 	const task = compactTaskText(step.description, step.label);
 	if (task) lines.push(`    ${theme.fg("dim", `task: ${task}`)}`);
 	const activity = widgetStepActivityLine(step, width, expanded, job.updatedAt);
@@ -1314,10 +1475,14 @@ function foregroundStyleWidgetStepLines(
 }
 
 function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, frame?: number): string[] {
-	if (!job.steps?.length) return [
-		`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-		...formatNestedWidgetLines(job.nestedChildren, theme, width, expanded, job.updatedAt, expanded ? 12 : 6).map((line) => `  ${line}`),
-	];
+	if (!job.steps?.length) {
+		const lane = projectAsyncLane(job);
+		return [
+			...(lane ? formatLaneProjectionLines(lane, theme, "  ") : []),
+			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
+			...formatNestedWidgetLines(job.nestedChildren, theme, width, expanded, job.updatedAt, expanded ? 12 : 6).map((line) => `  ${line}`),
+		];
+	}
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
 	const total = job.stepsTotal ?? job.steps.length;
 	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
@@ -1361,6 +1526,8 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 		const task = compactTaskText(step.description, step.label);
 		const taskSuffix = task ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", `task: ${task}`)}` : "";
 		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${taskSuffix}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
+		const lane = projectAsyncLane(job, step);
+		if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "  "));
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, 6)) lines.push(`    ${nestedLine}`);
 	}
 	if (job.steps.some((step) => step.status === "running")) lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
@@ -1499,9 +1666,18 @@ function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number, fra
 	const stats = widgetStats(job, theme);
 	const activity = widgetActivity(job);
 	const status = job.status === "complete" ? "done" : job.status;
+	const lane = projectAsyncLane(job);
+	const laneSummary = lane
+		? [lane.label ?? lane.role, lane.phase ? `phase:${lane.phase}` : undefined, lane.output ? `out:${lane.output}` : undefined, `ref:${lane.ref}`].filter(Boolean).join(" · ")
+		: "";
+	const laneSignals = lane
+		? [lane.next ? `next:${lane.next}` : undefined, ...lane.chips.map((chip) => formatLaneChip(chip, theme))].filter(Boolean).join(" · ")
+		: "";
 	const parts = [
 		`${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}`,
 		theme.fg("dim", status),
+		laneSignals ? laneSignals : "",
+		laneSummary ? theme.fg("dim", laneSummary) : "",
 		stats,
 		activity && activity.toLowerCase() !== status ? theme.fg("dim", activity) : "",
 	].filter(Boolean);
@@ -1647,6 +1823,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		items.push([
 			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
+			...widgetLaneDetailLines(job, theme),
 			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 		]);
 		slots--;
@@ -1664,6 +1841,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 		items.push([
 			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
+			...widgetLaneDetailLines(job, theme),
 			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 		]);
 		slots--;

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -37,7 +37,7 @@ describe("async status helpers", () => {
 				outputFile,
 				steps: [
 					{ agent: "scout", status: "complete", durationMs: 10, description: "Inspect auth only" },
-					{ agent: "worker", status: "running", durationMs: 20, description: "Patch billing only", contextLimit: 128_000 },
+					{ agent: "worker", status: "running", durationMs: 20, description: "Patch billing only", contextLimit: 128_000, toolBudgetBlocked: true, watchdog: { phase: "stale", seq: 2, lastUpdate: 200, followUpPending: false } },
 				],
 			});
 			const descriptor = createRunFanoutBudget("run-a", 64);
@@ -63,6 +63,8 @@ describe("async status helpers", () => {
 			assert.equal(runs[0]?.steps[0]?.description, "Inspect auth only");
 			assert.equal(runs[0]?.steps[1]?.description, "Patch billing only");
 			assert.equal(runs[0]?.steps[1]?.contextLimit, 128_000);
+			assert.equal(runs[0]?.steps[1]?.toolBudgetBlocked, true);
+			assert.equal(runs[0]?.steps[1]?.watchdog?.phase, "stale");
 			const text = formatAsyncRunList(runs);
 			assert.match(text, /Run fan-out: 3\/64 used, 61 remaining/);
 			assert.match(text, /output: .*output-1\.log/);

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -3,10 +3,11 @@ import { describe, it } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { extractToolArgsPreview } from "../../src/shared/utils.ts";
 
-const { buildWidgetLines, clearLegacyResultAnimationTimer, compactTaskText, renderWidget } = await import("../../src/tui/render.ts") as {
+const { buildWidgetLines, clearLegacyResultAnimationTimer, compactTaskText, projectAsyncLane, renderWidget } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean, frame?: number) => string[];
 	clearLegacyResultAnimationTimer: (context: { state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> } }) => void;
 	compactTaskText: (task: string | undefined, label?: string) => string | undefined;
+	projectAsyncLane: (job: Record<string, unknown>) => { label?: string; role: string; phase?: string; state: string; gate?: string; next?: string; output?: string; ref: string; chips: string[] } | undefined;
 	renderWidget: (ctx: Record<string, unknown>, jobs: Array<Record<string, unknown>>) => void;
 };
 
@@ -89,6 +90,171 @@ function resetWidgetLayout(): void {
 }
 
 describe("subagent async widget rendering", () => {
+	it("projects known workflow metadata into a compact lane row", () => {
+		const job = {
+			asyncId: "lane-run-123456",
+			asyncDir: "/tmp/lane-run",
+			status: "running",
+			mode: "parallel",
+			agents: ["reviewer", "writer"],
+			steps: [
+				{
+					index: 0,
+					agent: "reviewer",
+					status: "running",
+					phase: "fresh-review",
+					label: "Review #1610",
+					workflowKey: "review",
+					description: "Inspect the current status surface",
+					outputName: "review.md",
+					context: "fresh",
+					review: { status: "review-required" },
+				},
+				{ index: 1, agent: "writer", status: "pending", phase: "implementation", label: "Fix candidate", workflowKey: "writer", outputName: "fix.md" },
+			],
+		};
+
+		assert.deepEqual(projectAsyncLane(job), {
+			label: "Review #1610 — Inspect the current status surface",
+			role: "reviewer",
+			phase: "fresh-review",
+			state: "running",
+			gate: "review required",
+			next: "review output",
+			output: "review.md",
+			ref: "review",
+			chips: ["fresh"],
+		});
+		const text = buildWidgetLines([job], theme, 180).join("\n");
+		assert.match(text, /lane: Review #1610 — Inspect the current status surface · role:reviewer · running/);
+		assert.match(text, /phase:fresh-review · gate:review required · next:review output · out:review\.md · ref:review · \[fresh\]/);
+		assert.match(text, /lane: Fix candidate/);
+		assert.match(text, /lane: Fix candidate · role:writer · pending/);
+		assert.match(text, /phase:implementation · next:await launch · out:fix\.md/);
+	});
+
+	it("keeps simple one-off async rows on the existing fallback projection", () => {
+		const job = {
+			asyncId: "simple-run",
+			asyncDir: "/tmp/simple-run",
+			status: "running",
+			mode: "single",
+			agents: ["scout"],
+			description: "Explore the repository",
+			outputFile: "/tmp/simple-run/output-0.log",
+			currentTool: "read",
+		};
+
+		assert.equal(projectAsyncLane(job), undefined);
+		const text = buildWidgetLines([job], theme, 180).join("\n");
+		assert.match(text, /async subagent scout · background/);
+		assert.match(text, /⎿  read/);
+		assert.doesNotMatch(text, /lane:/);
+	});
+
+	it("keeps lane state and next-action signals distinct for terminal and attention states", () => {
+		const states = [
+			{ status: "complete", expectedState: "complete", expectedNext: "inspect output" },
+			{ status: "failed", expectedState: "failed", expectedNext: "inspect failure" },
+			{ status: "paused", expectedState: "paused", expectedNext: "inspect paused state" },
+			{ status: "stopped", expectedState: "stopped", expectedNext: "inspect stopped state" },
+		] as const;
+		for (const [index, candidate] of states.entries()) {
+			const lane = projectAsyncLane({
+				asyncId: `state-${index}`,
+				asyncDir: `/tmp/state-${index}`,
+				status: candidate.status,
+				mode: "single",
+				agents: ["worker"],
+				workflowKey: "stateful",
+				description: "stateful work item",
+				steps: [{ agent: "worker", status: candidate.status, outputName: "result.md" }],
+			});
+			assert.equal(lane?.state, candidate.expectedState);
+			assert.equal(lane?.next, candidate.expectedNext);
+		}
+		const attention = projectAsyncLane({
+			asyncId: "attention",
+			asyncDir: "/tmp/attention",
+			status: "running",
+			mode: "single",
+			agents: ["reviewer"],
+			steps: [{ agent: "reviewer", status: "running", label: "Review", activityState: "needs_attention" }],
+		});
+		assert.equal(attention?.next, "inspect attention");
+		assert.deepEqual(attention?.chips, ["attention"]);
+	});
+
+	it("surfaces stale and tool/turn budget blocked states", () => {
+		const staleJob = {
+			asyncId: "stale-run",
+			asyncDir: "/tmp/stale-run",
+			status: "running",
+			mode: "single",
+			agents: ["worker"],
+			steps: [{ agent: "worker", status: "running", label: "Stale work", watchdog: { phase: "stale" } }],
+		};
+		const stale = projectAsyncLane(staleJob);
+		assert.equal(stale?.next, "inspect stale state");
+		assert.deepEqual(stale?.chips, ["stale"]);
+
+		const blockedJobs: Array<Record<string, unknown>> = [];
+		for (const [index, field] of (["toolBudgetBlocked", "turnBudgetExceeded"] as const).entries()) {
+			const blockedJob = {
+				asyncId: `blocked-run-${index}`,
+				asyncDir: `/tmp/blocked-run-${index}`,
+				status: "running",
+				mode: "single",
+				agents: ["worker"],
+				steps: [{ agent: "worker", status: "running", label: "Blocked work", [field]: true }],
+			};
+			blockedJobs.push(blockedJob);
+			const blocked = projectAsyncLane(blockedJob);
+			assert.equal(blocked?.next, "inspect blocked state");
+			assert.deepEqual(blocked?.chips, ["blocked"]);
+		}
+
+		const text = buildWidgetLines([staleJob, ...blockedJobs], theme, 180).join("\n");
+		assert.match(text, /next:inspect stale state/);
+		assert.match(text, /\[stale\]/);
+		assert.match(text, /next:inspect blocked state/);
+		assert.match(text, /\[blocked\]/);
+	});
+
+	it("keeps stale and blocked lane signals in crowded progressive rows", () => {
+		resetWidgetLayout();
+		withStdoutSize(22, 120, () => {
+			const jobs = [
+				{
+					asyncId: "progressive-stale",
+					asyncDir: "/tmp/progressive-stale",
+					status: "running",
+					mode: "single",
+					agents: ["watcher"],
+					steps: [{ agent: "watcher", status: "running", label: "Stale lane", watchdog: { phase: "stale" } }],
+				},
+				{
+					asyncId: "progressive-blocked",
+					asyncDir: "/tmp/progressive-blocked",
+					status: "running",
+					mode: "single",
+					agents: ["budgeter"],
+					steps: [{ agent: "budgeter", status: "running", label: "Blocked lane", toolBudgetBlocked: true }],
+				},
+			];
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, jobs);
+			const lines = renderWidgetLines(ui.widgets.at(-1));
+			assert.equal(lines.length, 3, "22 terminal rows should select the collapsed progressive tier");
+			const text = lines.join("\n");
+			assert.match(text, /next:inspect stale state/);
+			assert.match(text, /\[stale\]/);
+			assert.match(text, /next:inspect blocked state/);
+			assert.match(text, /\[blocked\]/);
+		});
+		resetWidgetLayout();
+	});
+
 	it("orders running jobs before queued summaries and completions", () => {
 		const lines = buildWidgetLines([
 			{ asyncId: "done-1", asyncDir: "/tmp/done", status: "complete", agents: ["reviewer"], startedAt: 0, updatedAt: 1000 },
@@ -398,6 +564,48 @@ describe("subagent async widget rendering", () => {
 			const lines = renderWidgetLines(ui.widgets.at(-1));
 			assert.equal(lines.length, 14);
 			assert.match(lines.join("\n"), /parallel · running/);
+		});
+		resetWidgetLayout();
+	});
+
+	it("selects the current flat-indexed member from a collapsed parallel group", () => {
+		resetWidgetLayout();
+		withStdoutSize(22, 120, () => {
+			const parallelGroupJob = {
+				asyncId: "run-parallel-slice",
+				asyncDir: "/tmp/run-parallel-slice",
+				status: "running",
+				mode: "chain",
+				agents: ["producer", "reviewer", "worker"],
+				activeParallelGroup: true,
+				currentStep: 3,
+				chainStepCount: 2,
+				parallelGroups: [{ start: 2, count: 2, stepIndex: 1 }],
+				steps: [
+					{ index: 2, agent: "reviewer", status: "complete", label: "First parallel member", description: "First member task", phase: "first-phase", workflowKey: "first-ref", outputName: "first.md" },
+					{ index: 3, agent: "worker", status: "running", label: "Current parallel member", description: "Current member task", phase: "current-phase", workflowKey: "current-ref", outputName: "current.md" },
+				],
+			};
+			const direct = projectAsyncLane(parallelGroupJob);
+			assert.equal(direct?.label, "Current parallel member — Current member task");
+			assert.equal(direct?.role, "worker");
+			assert.equal(direct?.phase, "current-phase");
+			assert.equal(direct?.output, "current.md");
+			assert.equal(direct?.ref, "current-ref");
+
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, [parallelGroupJob, {
+				asyncId: "run-parallel-sibling",
+				asyncDir: "/tmp/run-parallel-sibling",
+				status: "running",
+				mode: "single",
+				agents: ["sibling"],
+				currentTool: "read",
+			}]);
+			const lines = renderWidgetLines(ui.widgets.at(-1));
+			const text = lines.join("\n");
+			assert.match(text, /Current parallel member — Current member task/);
+			assert.doesNotMatch(text, /First parallel member — First member task/);
 		});
 		resetWidgetLayout();
 	});


### PR DESCRIPTION
## Summary

This adds a bounded lane/work-item projection to the async status widget.

The renderer now uses already-loaded status, workflow, and output metadata to show a compact work label, role, phase, gate, next action, output basename, and chips when that data exists. Simple one-off async runs keep the existing fallback shape.

Fixes #1610.

## Performance guard

The render path stays pure and bounded. It does not add worktree scans, Git or GitHub calls, network calls, recursive filesystem scans, live diff stats, or extra polling.

## Validation

- `test/integration/render-widget.test.ts` and `test/unit/render-helpers.test.ts`: passed.
- Stale and blocked lane projection regressions: passed.
- `npm run typecheck`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Render-path source proof: no filesystem, process, network, Git, GitHub, worktree scan, recursive scan, or live-diff calls in `src/tui/render.ts`.
- Fresh exact-head review: No issues found.
