### PR TITLE
feat: human-readable child session names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Give every subagent child session a human-readable display name (`agent: task excerpt`, workflow node label preferred): applied to the child's own Pi session via `pi.setSessionName` (intercom routing targets keep precedence) and echoed as an optional `sessionName` field across result, live-progress, async status, workflow, nested, and intercom payloads so hosts can label child runs without reading child session files.
 - Add `/subagents-steer <run-id> [--child <child-id>] <message>`, a host bridge for steering live async runs from non-TUI sessions and RPC hosts, with fail-closed child-id resolution and pause-and-revive recovery disabled so callers keep exact-child authority. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1608.
 - Add explicit `allowNestedSubagents` agent authorization for nested fanout without replacing inherited tools or extensions. Thanks to [@tutu359](https://github.com/tutu359) for #1587.
 - Accept a child id on `/subagents-stop <run-id> <child-id>` so RPC hosts and non-TUI sessions can stop one child of a multi-child async run or workflow without stopping the whole run. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1603.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Give every subagent child session a human-readable display name (`agent: task excerpt`, workflow node label preferred): applied to the child's own Pi session via `pi.setSessionName` (intercom routing targets keep precedence) and echoed as an optional `sessionName` field across result, live-progress, async status, workflow, nested, and intercom payloads so hosts can label child runs without reading child session files.
+- Give every subagent child session a human-readable display name (`agent: task excerpt`, workflow node label preferred): applied to the child's own Pi session via `pi.setSessionName` (intercom routing targets keep precedence) and echoed as an optional `sessionName` field across result, live-progress, async status, workflow, nested, and intercom payloads so hosts can label child runs without reading child session files. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1615.
 - Add `/subagents-steer <run-id> [--child <child-id>] <message>`, a host bridge for steering live async runs from non-TUI sessions and RPC hosts, with fail-closed child-id resolution and pause-and-revive recovery disabled so callers keep exact-child authority. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1608.
 - Add explicit `allowNestedSubagents` agent authorization for nested fanout without replacing inherited tools or extensions. Thanks to [@tutu359](https://github.com/tutu359) for #1587.
 - Accept a child id on `/subagents-stop <run-id> <child-id>` so RPC hosts and non-TUI sessions can stop one child of a multi-child async run or workflow without stopping the whole run. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1603.

--- a/src/intercom/result-intercom.ts
+++ b/src/intercom/result-intercom.ts
@@ -104,6 +104,7 @@ function compactNestedRun(run: NestedRunSummary | PublicNestedRunSummary, depth 
 		})),
 		...(run.asyncDir ? { asyncDir: run.asyncDir } : {}),
 		...(run.sessionId ? { sessionId: run.sessionId } : {}),
+		...(run.sessionName ? { sessionName: run.sessionName } : {}),
 		...(run.sessionFile ? { sessionFile: run.sessionFile } : {}),
 		...(run.intercomTarget ? { intercomTarget: run.intercomTarget } : {}),
 		...(run.ownerIntercomTarget ? { ownerIntercomTarget: run.ownerIntercomTarget } : {}),
@@ -132,6 +133,7 @@ function compactNestedRun(run: NestedRunSummary | PublicNestedRunSummary, depth 
 		...(run.error ? { error: run.error } : {}),
 		...(run.steps?.length ? { steps: run.steps.slice(0, 12).map((step) => ({
 			agent: step.agent,
+			...(step.sessionName ? { sessionName: step.sessionName } : {}),
 			status: step.status,
 			...(step.model ? { model: step.model } : {}),
 			...(step.thinking ? { thinking: step.thinking } : {}),

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -39,6 +39,8 @@ export type AsyncResumeTarget = {
 	state: AsyncStatus["state"];
 	mode?: SubagentRunMode;
 	agent: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	index: number;
 	cwd?: string;
 	sessionFile?: string;
@@ -62,11 +64,12 @@ interface AsyncResultFile {
 	cwd?: string;
 	sessionId?: string;
 	sessionFile?: string;
+	sessionName?: string;
 	model?: string;
 	thinking?: string;
 	launchContractDigest?: string;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
-	results?: Array<{ agent?: string; success?: boolean; sessionFile?: string; intercomTarget?: string; model?: string; thinking?: string; launchContractDigest?: string; capabilityCeiling?: ResolvedSubagentCapabilityCeiling }>;
+	results?: Array<{ agent?: string; sessionName?: string; success?: boolean; sessionFile?: string; intercomTarget?: string; model?: string; thinking?: string; launchContractDigest?: string; capabilityCeiling?: ResolvedSubagentCapabilityCeiling }>;
 }
 
 export interface AsyncRunLocation {
@@ -103,6 +106,7 @@ function validateResultFile(value: unknown, resultPath: string): AsyncResultFile
 			const child = ensureObject(entry, `${resultPath} results[${index}]`);
 			const agent = validateOptionalString(child, "agent", resultPath, `results[${index}].agent`);
 			const sessionFile = validateOptionalString(child, "sessionFile", resultPath, `results[${index}].sessionFile`);
+			const sessionName = validateOptionalString(child, "sessionName", resultPath, `results[${index}].sessionName`);
 			const intercomTarget = validateOptionalString(child, "intercomTarget", resultPath, `results[${index}].intercomTarget`);
 			const model = validateOptionalString(child, "model", resultPath, `results[${index}].model`);
 			const thinking = validateOptionalString(child, "thinking", resultPath, `results[${index}].thinking`);
@@ -110,7 +114,7 @@ function validateResultFile(value: unknown, resultPath: string): AsyncResultFile
 			const capabilityCeiling = child.capabilityCeiling === undefined ? undefined : parseSubagentCapabilityCeiling(child.capabilityCeiling, `async result file '${resultPath}' results[${index}].capabilityCeiling`);
 			const success = child.success;
 			if (success !== undefined && typeof success !== "boolean") throw new Error(`Invalid async result file '${resultPath}': results[${index}].success must be a boolean.`);
-			return { agent, sessionFile, intercomTarget, model, thinking, launchContractDigest, ...(capabilityCeiling ? { capabilityCeiling } : {}), ...(typeof success === "boolean" ? { success } : {}) };
+			return { agent, sessionName, sessionFile, intercomTarget, model, thinking, launchContractDigest, ...(capabilityCeiling ? { capabilityCeiling } : {}), ...(typeof success === "boolean" ? { success } : {}) };
 		});
 	}
 	const success = data.success;
@@ -267,6 +271,7 @@ function validateStatusForResume(status: AsyncStatus | null, source: string): vo
 			const stepRecord = step as Record<string, unknown>;
 			if (typeof stepRecord.agent !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].agent must be a string.`);
 			if (stepRecord.sessionFile !== undefined && typeof stepRecord.sessionFile !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].sessionFile must be a string.`);
+			if (stepRecord.sessionName !== undefined && typeof stepRecord.sessionName !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].sessionName must be a string.`);
 			if (stepRecord.model !== undefined && typeof stepRecord.model !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].model must be a string.`);
 			if (stepRecord.thinking !== undefined && typeof stepRecord.thinking !== "string") throw new Error(`Invalid async status '${source}': steps[${index}].thinking must be a string.`);
 			if (stepRecord.thinkingCeiling !== undefined) stepRecord.thinkingCeiling = parseThinkingLevel(stepRecord.thinkingCeiling, `async status '${source}' steps[${index}].thinkingCeiling`);
@@ -477,6 +482,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 					state,
 					...(mode ? { mode } : {}),
 					agent: selectedStep.agent,
+					...(selectedStep.sessionName ?? result?.results?.[requestedIndex]?.sessionName ? { sessionName: selectedStep.sessionName ?? result?.results?.[requestedIndex]?.sessionName } : {}),
 					index: requestedIndex,
 					cwd: status?.cwd ?? result?.cwd,
 					sessionFile: selectedStep.sessionFile ?? status?.sessionFile ?? result?.sessionFile,
@@ -508,6 +514,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 				state,
 				...(mode ? { mode } : {}),
 				agent: selected.step.agent,
+				...(selected.step.sessionName ?? result?.results?.[selected.index]?.sessionName ? { sessionName: selected.step.sessionName ?? result?.results?.[selected.index]?.sessionName } : {}),
 				index: selected.index,
 				cwd: status?.cwd ?? result?.cwd,
 				sessionFile: selected.step.sessionFile ?? status?.sessionFile ?? result?.sessionFile,
@@ -553,6 +560,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 		state,
 		...(mode ? { mode } : {}),
 		agent,
+		...(statusSteps[index]?.sessionName ?? resultSteps[index]?.sessionName ? { sessionName: statusSteps[index]?.sessionName ?? resultSteps[index]?.sessionName } : {}),
 		index,
 		...(resumeCwd ? { cwd: resumeCwd } : {}),
 		...(resolvedSessionFile ? { sessionFile: resolvedSessionFile } : {}),

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -526,7 +526,7 @@ function formatActivityFacts(input: { activityState?: ActivityState; lastActivit
 }
 
 function formatStepLine(step: AsyncRunStepSummary): string {
-	const display = step.label ? `${step.label} (${step.agent})` : step.agent;
+	const display = step.sessionName?.trim() || (step.label ? `${step.label} (${step.agent})` : step.agent);
 	const context = contextModeLabel(step.context);
 	const phase = step.phase ? `[${step.phase}] ` : "";
 	const parts = [`${step.index + 1}. ${phase}${display}${context ? ` ${context}` : ""}`, step.status];

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -22,6 +22,8 @@ interface AsyncRunStepSummary {
 	index: number;
 	childId?: string;
 	agent: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	context?: ContextMode;
 	label?: string;
 	description?: string;
@@ -271,6 +273,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 			index,
 			childId: asyncStatusChildIdentity(step, index),
 			agent: step.agent,
+			...(step.sessionName ? { sessionName: step.sessionName } : {}),
 			...(step.context ? { context: step.context } : {}),
 			...(step.label ? { label: step.label } : {}),
 			...(step.description ? { description: step.description } : {}),

--- a/src/runs/background/chain-append.ts
+++ b/src/runs/background/chain-append.ts
@@ -5,6 +5,7 @@ import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { appendJsonl } from "../../shared/artifacts.ts";
 import type { AsyncParallelGroupStatus, AsyncStatus, WorkflowGraphNode, WorkflowGraphSnapshot } from "../../shared/types.ts";
 import { PROMPT_REDACTED, readStatus } from "../../shared/utils.ts";
+import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 import type { DynamicRunnerGroup, ParallelStepGroup, RunnerStep, RunnerSubagentStep } from "../shared/parallel-utils.ts";
 import { isDynamicRunnerGroup, isParallelGroup } from "../shared/parallel-utils.ts";
 
@@ -160,8 +161,10 @@ export function statusStepDescription(task: string | undefined): string | undefi
 
 function statusStepForTask(task: RunnerSubagentStep): StatusStep {
 	const description = statusStepDescription(task.task);
+	const sessionName = task.sessionName ?? deriveChildSessionName({ agent: task.agent, task: task.task, label: task.label });
 	return {
 		agent: task.agent,
+		...(sessionName ? { sessionName } : {}),
 		...(description ? { description } : {}),
 		...(task.context ? { context: task.context } : {}),
 		phase: task.phase,

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -12,6 +12,8 @@ export interface ImportedAsyncRoot {
 
 export interface ImportedAsyncRootResult {
 	agent: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	output: string;
 	success: boolean;
 	exitCode: number;
@@ -46,6 +48,7 @@ interface AsyncResultFile {
 	stopped?: boolean;
 	results?: Array<{
 		agent?: string;
+		sessionName?: string;
 		output?: string;
 		error?: string;
 		success?: boolean;
@@ -124,6 +127,7 @@ function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, 
 		error: message,
 		...(timedOut ? { timedOut: true } : {}),
 		...(stopped ? { stopped: true } : {}),
+		...(step?.sessionName ? { sessionName: step.sessionName } : {}),
 		...(step?.sessionFile ?? status.sessionFile ? { sessionFile: step?.sessionFile ?? status.sessionFile } : {}),
 		...(step?.model ? { model: step.model } : {}),
 		...(step?.attemptedModels ? { attemptedModels: step.attemptedModels } : {}),
@@ -149,6 +153,7 @@ function outputFromTimeout(root: ImportedAsyncRoot, status: AsyncStatus | null, 
 		exitCode: 1,
 		error: message,
 		timedOut: true,
+		...(step?.sessionName ? { sessionName: step.sessionName } : {}),
 		...(step?.sessionFile ?? status?.sessionFile ? { sessionFile: step?.sessionFile ?? status?.sessionFile } : {}),
 		...(step?.model ? { model: step.model } : {}),
 		...(step?.attemptedModels ? { attemptedModels: step.attemptedModels } : {}),
@@ -178,6 +183,7 @@ function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null
 		...(error ? { error } : {}),
 		...(timedOut ? { timedOut: true } : {}),
 		...(stopped ? { stopped: true } : {}),
+		...(child?.sessionName ?? step?.sessionName ? { sessionName: child?.sessionName ?? step?.sessionName } : {}),
 		...(child?.sessionFile ?? step?.sessionFile ?? status?.sessionFile ? { sessionFile: child?.sessionFile ?? step?.sessionFile ?? status?.sessionFile } : {}),
 		...(child?.intercomTarget ? { intercomTarget: child.intercomTarget } : {}),
 		...(child?.model ?? step?.model ? { model: child?.model ?? step?.model } : {}),

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -72,6 +72,14 @@ function uniqueStrings(values: Array<string | undefined>): string[] {
 	return result;
 }
 
+function fleetChildDisplayName(child: { agent?: string; sessionName?: string }, fallback = "subagent"): string {
+	return child.sessionName?.trim() || child.agent || fallback;
+}
+
+function fleetStepDisplayName(step: Pick<AsyncJobStep, "agent" | "sessionName" | "label">): string {
+	return step.sessionName?.trim() || (step.label ? `${step.label} (${step.agent})` : step.agent);
+}
+
 function resolveMaybeRelative(asyncDir: string, filePath: string | undefined): string | undefined {
 	if (!filePath) return undefined;
 	return path.resolve(asyncDir, filePath);
@@ -283,7 +291,8 @@ function formatActivityFacts(input: {
 }
 
 function foregroundModeName(control: ForegroundControl): string {
-	if (control.mode === "single" && control.currentAgent) return control.currentAgent;
+	const currentDisplayName = control.sessionName?.trim() || control.currentAgent;
+	if (control.mode === "single" && currentDisplayName) return currentDisplayName;
 	return control.mode;
 }
 
@@ -302,7 +311,8 @@ function formatForegroundFleetLines(controls: ForegroundControl[]): string[] {
 			toolCount: control.toolCount,
 			...(control.tokens !== undefined ? { tokens: { total: control.tokens } } : {}),
 		});
-		const current = control.currentAgent ? ` | ${control.currentAgent}${control.currentIndex !== undefined ? ` #${control.currentIndex}` : ""}` : "";
+		const currentDisplayName = control.sessionName?.trim() || control.currentAgent;
+		const current = currentDisplayName ? ` | ${currentDisplayName}${control.currentIndex !== undefined ? ` #${control.currentIndex}` : ""}` : "";
 		lines.push(`- ${control.runId} | running | ${foregroundModeName(control)}${current}${activity ? ` | ${activity}` : ""}`);
 		lines.push(`  status: subagent({ action: "status", id: "${control.runId}" })`);
 		lines.push("  transcript: live in the expanded foreground result; persisted session transcript appears after completion when sessions are enabled.");
@@ -317,7 +327,7 @@ function formatDetachedForegroundFleetLines(runs: ForegroundRun[]): string[] {
 	const ordered = [...runs].sort((left, right) => right.updatedAt - left.updatedAt);
 	for (const run of ordered) {
 		const detachedChildren = run.children.filter((child) => child.status === "detached");
-		const childSummary = detachedChildren.map((child) => `${child.agent} #${child.index}`).join(", ");
+		const childSummary = detachedChildren.map((child) => `${fleetChildDisplayName(child)} #${child.index}`).join(", ");
 		lines.push(`- ${run.runId} | detached | ${run.mode}${childSummary ? ` | ${childSummary}` : ""}`);
 		lines.push(`  status: subagent({ action: "status", id: "${run.runId}" })`);
 		lines.push(`  recovery: reply to the supervisor request first, then wait with subagent_wait({ id: "${run.runId}" }); do not resume or launch a replacement while any child remains detached.`);
@@ -338,7 +348,7 @@ function formatAsyncFleetLines(runs: AsyncRunSummary[]): string[] {
 		lines.push(`  status: subagent({ action: "status", id: "${run.id}" })`);
 		lines.push(`  transcript: subagent({ action: "status", id: "${run.id}", view: "transcript" })`);
 		for (const step of run.steps) {
-			const display = step.label ? `${step.label} (${step.agent})` : step.agent;
+			const display = fleetStepDisplayName(step);
 			const stepContext = contextModeLabel(step.context);
 			const phase = step.phase ? `[${step.phase}] ` : "";
 			const stepActivity = formatActivityFacts(step);
@@ -435,7 +445,7 @@ function selectTranscriptStep(status: AsyncStatus, options: TranscriptOptions): 
 	}
 	const step = selectedIndex !== undefined ? steps[selectedIndex] : undefined;
 	const hint = options.index === undefined && steps.length > 1
-		? `Tip: pass index to inspect a specific child transcript (${steps.map((candidate, index) => `${index}=${candidate.agent}`).join(", ")}).`
+		? `Tip: pass index to inspect a specific child transcript (${steps.map((candidate, index) => `${index}=${fleetChildDisplayName(candidate)}`).join(", ")}).`
 		: undefined;
 	return { index: selectedIndex, step, hint };
 }
@@ -445,7 +455,7 @@ function stepStateLine(mode: SubagentRunMode, index: number | undefined, step: A
 	const modelThinking = formatModelThinking(step.model, step.thinking);
 	const context = contextModeLabel(step.context);
 	const parts = [
-		`${mode === "parallel" ? "Agent" : "Step"}: ${index} (${step.agent})${context ? ` ${context}` : ""}`,
+		`${mode === "parallel" ? "Agent" : "Step"}: ${index} (${fleetChildDisplayName(step)})${context ? ` ${context}` : ""}`,
 		step.status,
 		formatActivityFacts(step),
 		modelThinking,
@@ -553,7 +563,7 @@ export function formatNestedRunTranscript(run: NestedRunSummary, options: Transc
 		`Nested run: ${run.id}`,
 		`State: ${run.state}`,
 		run.mode ? `Mode: ${run.mode}` : undefined,
-		run.agent ? `Agent: ${run.agent}` : run.agents?.length ? `Agents: ${run.agents.join(", ")}` : undefined,
+		run.sessionName?.trim() ? `Agent: ${run.sessionName.trim()}` : run.agent ? `Agent: ${run.agent}` : run.agents?.length ? `Agents: ${run.agents.join(", ")}` : undefined,
 	].filter((line): line is string => Boolean(line));
 	appendKnownArtifacts(lines, { outputPaths: [], sessionFile: run.sessionFile });
 	if (!run.sessionFile) {
@@ -601,8 +611,8 @@ export function formatAsyncResultTranscript(data: {
 	const lines = [
 		`Run: ${runId}`,
 		`State: ${data.state ?? (data.success ? "complete" : "failed")}`,
-		index !== undefined && child ? `Child: ${index} (${child.agent ?? "subagent"})` : undefined,
-		index === undefined && children.length > 1 ? `Tip: pass index to inspect a specific child transcript (${children.map((candidate, childIndex) => `${childIndex}=${candidate.agent ?? "subagent"}`).join(", ")}).` : undefined,
+		index !== undefined && child ? `Child: ${index} (${fleetChildDisplayName(child)})` : undefined,
+		index === undefined && children.length > 1 ? `Tip: pass index to inspect a specific child transcript (${children.map((candidate, childIndex) => `${childIndex}=${fleetChildDisplayName(candidate)}`).join(", ")}).` : undefined,
 	].filter((line): line is string => Boolean(line));
 	appendKnownArtifacts(lines, { outputPaths: [], sessionFile, resultPath });
 	appendTranscriptBody(lines, "Result transcript tail", transcriptLines.filter((line) => line.trim()), output.split(/\r?\n/).length > lineLimit);

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -579,14 +579,14 @@ export function formatAsyncResultTranscript(data: {
 	sessionFile?: string;
 	agent?: string;
 	exitCode?: number | null;
-	results?: Array<{ agent?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null }>;
+	results?: Array<{ agent?: string; sessionName?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null }>;
 }, resultPath: string, options: TranscriptOptions = {}): string {
 	const lineLimit = transcriptLineLimit(options.lines);
 	const runId = data.runId ?? data.id ?? path.basename(resultPath, ".json");
 	const children = Array.isArray(data.results)
 		? data.results
 		: data.agent
-			? [{ agent: data.agent, output: data.output, summary: data.summary, sessionFile: data.sessionFile, state: data.state, success: data.success, exitCode: data.exitCode }]
+			? [{ agent: data.agent, sessionName: undefined, output: data.output, summary: data.summary, sessionFile: data.sessionFile, state: data.state, success: data.success, exitCode: data.exitCode }]
 			: [];
 	let index = options.index;
 	if (index !== undefined && !Number.isInteger(index)) throw new Error("Transcript index must be an integer.");

--- a/src/runs/background/result-watcher.ts
+++ b/src/runs/background/result-watcher.ts
@@ -67,6 +67,7 @@ type ResultWatcherDeps = {
 
 type ResultFileChild = {
 	agent?: string;
+	sessionName?: string;
 	output?: string;
 	structuredOutput?: unknown;
 	outputState?: SubagentOutputState;
@@ -482,6 +483,7 @@ export function createResultWatcher(
 							: undefined;
 				return {
 					agent: result.agent ?? data.agent ?? `step-${index + 1}`,
+					...(result.sessionName ? { sessionName: result.sessionName } : {}),
 					status: resolveSubagentResultStatus({
 						success: result.success,
 						state: childState,

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -622,7 +622,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 		}
 		try {
 			const raw = fs.readFileSync(resultPath, "utf-8");
-			const data = JSON.parse(raw) as { id?: string; runId?: string; toolCallId?: string; agent?: string; success?: boolean; summary?: string; output?: string; exitCode?: number; state?: string; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; processSignal?: string | null; sessionFile?: string; parallelHandoff?: { path?: string }; results?: Array<{ agent?: string; runId?: string; workflowKey?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; interrupted?: boolean; processSignal?: string | null }> };
+			const data = JSON.parse(raw) as { id?: string; runId?: string; toolCallId?: string; agent?: string; success?: boolean; summary?: string; output?: string; exitCode?: number; state?: string; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; processSignal?: string | null; sessionFile?: string; parallelHandoff?: { path?: string }; results?: Array<{ agent?: string; sessionName?: string; runId?: string; workflowKey?: string; output?: string; summary?: string; sessionFile?: string; state?: string; success?: boolean; exitCode?: number | null; stopped?: boolean; timedOut?: boolean; turnBudgetExceeded?: boolean; interrupted?: boolean; processSignal?: string | null }> };
 			if (params.view === "transcript") {
 				try {
 					return { content: [{ type: "text", text: formatAsyncResultTranscript(data, resultPath, { index: params.index, lines: params.lines }) }], details: { mode: "single", results: [] } };

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -70,7 +70,7 @@ function formatWorkflowDebug(status: AsyncStatus): string[] {
 		status.mode === "workflow" ? `Workflow children: ${(status.steps ?? []).length}` : undefined,
 	].filter((line): line is string => line !== undefined);
 	for (const [index, step] of (status.steps ?? []).entries()) {
-		lines.push(`  ${index + 1}. key ${step.workflowKey ?? "n/a"} · ${step.agent} · ${step.status} · async ${step.async === undefined ? "unknown" : step.async ? "yes" : "no"}${step.runId ? ` · run ${step.runId}` : ""}`);
+		lines.push(`  ${index + 1}. key ${step.workflowKey ?? "n/a"} · ${runStatusStepDisplayName(step)} · ${step.status} · async ${step.async === undefined ? "unknown" : step.async ? "yes" : "no"}${step.runId ? ` · run ${step.runId}` : ""}`);
 	}
 	return lines;
 }
@@ -152,7 +152,12 @@ function stepLineLabel(status: AsyncStatus, index: number): string {
 	return `Step ${index + 1}`;
 }
 
+function runStatusStepDisplayName(step: { agent: string; sessionName?: string; label?: string }): string {
+	return step.sessionName?.trim() || (step.label ? `${step.label} (${step.agent})` : step.agent);
+}
+
 function nestedRunDisplayName(run: NestedRunSummary): string {
+	if (run.sessionName?.trim()) return run.sessionName.trim();
 	if (run.agent) return run.agent;
 	if (run.agents?.length) return run.agents.join(", ");
 	return run.id;
@@ -197,7 +202,7 @@ function formatRememberedForegroundStatus(run: ForegroundResumeRun): string {
 	for (const child of run.children) {
 		const output = rememberedForegroundChildOutput(child).trim().split(/\r?\n/).find((line) => line.trim());
 		const parts = [
-			`${child.index + 1}. ${child.agent} ${child.status}`,
+			`${child.index + 1}. ${child.sessionName?.trim() || child.agent} ${child.status}`,
 			child.exitCode !== undefined ? `exit ${child.exitCode}` : undefined,
 			child.detachedReason ? `detached: ${child.detachedReason}` : undefined,
 			child.acceptance ? `acceptance: ${child.acceptance.status}` : undefined,
@@ -241,7 +246,7 @@ function formatRememberedForegroundTranscript(run: ForegroundResumeRun, options:
 	const lines = [
 		`Run: ${run.runId}`,
 		`State: ${child.status}`,
-		`Child: ${index} (${child.agent})`,
+		`Child: ${index} (${child.sessionName?.trim() || child.agent})`,
 		child.sessionFile ? `Session: ${child.sessionFile}` : undefined,
 		child.transcriptPath ? `Transcript: ${child.transcriptPath}` : undefined,
 		child.artifactPaths?.outputPath ? `Output: ${child.artifactPaths.outputPath}` : undefined,
@@ -277,7 +282,7 @@ function formatNestedExactStatus(rootRunId: string, run: NestedRunSummary): stri
 		for (const [index, step] of run.steps.entries()) {
 			const activity = step.status === "running" ? formatActivityLabel(step.lastActivityAt, step.activityState) : undefined;
 			const budget = step.turnBudget ? `, turn budget: ${step.turnBudget.turnCount}/${step.turnBudget.maxTurns}+${step.turnBudget.graceTurns} (${step.turnBudget.outcome})` : "";
-			lines.push(`  ${index + 1}. ${step.agent} ${step.status}${activity ? `, ${activity}` : ""}${budget}${step.error ? `, error: ${step.error}` : ""}`);
+			lines.push(`  ${index + 1}. ${step.sessionName?.trim() || step.agent} ${step.status}${activity ? `, ${activity}` : ""}${budget}${step.error ? `, error: ${step.error}` : ""}`);
 			lines.push(...formatNestedRunStatusLines(step.children, { indent: "    ", commandHints: true }));
 		}
 	}
@@ -535,7 +540,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				const errorText = step.error ? `, error: ${step.error}` : "";
 				const acceptanceText = step.acceptance?.status ? `, acceptance: ${step.acceptance.status}` : "";
 				const budgetText = step.turnBudget ? `, turn budget: ${step.turnBudget.turnCount}/${step.turnBudget.maxTurns}+${step.turnBudget.graceTurns} (${step.turnBudget.outcome})` : "";
-				const display = step.label ? `${step.label} (${step.agent})` : step.agent;
+				const display = runStatusStepDisplayName(step);
 				const phase = step.phase ? `[${step.phase}] ` : "";
 				lines.push(`${stepLineLabel(status, index)}: ${phase}${display} ${step.status}${modelText}${stepActivityText ? `, ${stepActivityText}` : ""}${steeringSuffix}${acceptanceText}${budgetText}${errorText}`);
 				if (step.runner?.type === "external-cli") {

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -24,6 +24,7 @@ interface StartedRunMetadata {
 	parallelGroups?: AsyncParallelGroupStatus[];
 	startedAt?: number;
 	sessionFile?: string;
+	sessionName?: string;
 }
 
 interface ReconcileAsyncRunOptions {
@@ -90,6 +91,7 @@ function appendJsonlBestEffort(filePath: string, payload: object): void {
 
 interface ResultChildOutcome {
 	agent?: string;
+	sessionName?: string;
 	success?: boolean;
 	error?: string;
 	sessionFile?: string;
@@ -159,6 +161,7 @@ function terminalStatusFromResult(status: AsyncStatus, resultPath: string, now: 
 			exitCode: step.exitCode ?? (state === "complete" || state === "paused" ? 0 : 1),
 			error: state === "failed" || state === "partial" || state === "stopped" ? step.error ?? child?.error : step.error,
 			stopped: state === "stopped" ? true : step.stopped,
+			sessionName: step.sessionName ?? child?.sessionName,
 			sessionFile: step.sessionFile ?? child?.sessionFile,
 			model,
 			thinking,
@@ -254,6 +257,7 @@ function buildFailedRepair(status: AsyncStatus, asyncDir: string, now: number, r
 			summary: message,
 			results: repairedSteps.map((step) => ({
 				agent: step.agent,
+				...(step.sessionName ? { sessionName: step.sessionName } : {}),
 				output: step.status === "complete" || step.status === "completed" ? "" : message,
 				error: step.status === "complete" || step.status === "completed" ? undefined : step.error ?? message,
 				success: step.status === "complete" || step.status === "completed",

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -4014,7 +4014,7 @@ async function runSubagent(
 					: step.parallel.outputPath;
 				const taskText = task.task ?? step.parallel.task;
 				const materializedTask = step.parallel.namespaceOutputPath ? injectSingleOutputInstruction(taskText, outputPath, step.parallel) : taskText;
-				const sessionName = deriveChildSessionName({ agent: step.parallel.agent, task: materializedTask, label: task.label ?? step.parallel.label });
+				const sessionName = deriveChildSessionName({ agent: step.parallel.agent, task: taskText, label: task.label ?? step.parallel.label });
 				return omitUndefinedProperties({
 					...step.parallel,
 					runFanoutPath: `chain[${stepIndex}].expand[${itemIndex}]`,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1442,11 +1442,13 @@ async function runSingleStepInner(
 			});
 		}
 	}
+	// Derive from the pre-acceptance task so internal acceptance/recovery
+	// instructions never leak into the display name.
+	const childSessionName = step.sessionName ?? deriveChildSessionName({ agent: step.agent, task, label: step.label });
 	if (step.effectiveAcceptance) {
 		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContractV1(step.agentContract), structuredOutput: Boolean(step.structuredOutput?.acceptanceReportPath) });
 		if (acceptancePrompt) task = `${task}\n${acceptancePrompt}`;
 	}
-	const childSessionName = step.sessionName ?? deriveChildSessionName({ agent: step.agent, task, label: step.label });
 	const sessionEnabled = Boolean(step.sessionFile) || ctx.sessionEnabled;
 	const sessionDir = step.sessionFile ? undefined : ctx.sessionDir;
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -79,6 +79,7 @@ import {
 	Semaphore,
 } from "../shared/parallel-utils.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
+import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/chain-outputs.ts";
 import { createStructuredOutputRuntime, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
@@ -220,6 +221,8 @@ interface SubagentRunConfig {
 
 interface StepResult {
 	agent: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	context?: "fresh" | "fork";
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	capabilityAudit?: import("../shared/capability-ceiling.ts").SubagentCapabilityAudit;
@@ -1443,6 +1446,7 @@ async function runSingleStepInner(
 		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContractV1(step.agentContract), structuredOutput: Boolean(step.structuredOutput?.acceptanceReportPath) });
 		if (acceptancePrompt) task = `${task}\n${acceptancePrompt}`;
 	}
+	const childSessionName = step.sessionName ?? deriveChildSessionName({ agent: step.agent, task, label: step.label });
 	const sessionEnabled = Boolean(step.sessionFile) || ctx.sessionEnabled;
 	const sessionDir = step.sessionFile ? undefined : ctx.sessionDir;
 
@@ -1524,6 +1528,7 @@ async function runSingleStepInner(
 			: {};
 		return omitUndefinedProperties({
 			agent: step.agent,
+			...(childSessionName ? { sessionName: childSessionName } : {}),
 			context: step.context,
 			output: finalizedOutput.displayOutput,
 			outputState: external.output.trim() ? "present" : "absent",
@@ -1589,6 +1594,7 @@ async function runSingleStepInner(
 			: {};
 		return omitUndefinedProperties({
 			agent: step.agent,
+			...(childSessionName ? { sessionName: childSessionName } : {}),
 			context: step.context,
 			output: finalizedOutput.displayOutput,
 			outputState: external.output.trim() ? "present" : "absent",
@@ -1704,6 +1710,7 @@ async function runSingleStepInner(
 			cwd: step.cwd ?? ctx.cwd,
 			promptFileStem: step.agent,
 			intercomSessionName: ctx.childIntercomTarget,
+			sessionName: childSessionName,
 			orchestratorIntercomTarget: ctx.orchestratorIntercomTarget,
 			runId: ctx.id,
 			childAgentName: step.agent,
@@ -2189,6 +2196,7 @@ async function runSingleStepInner(
 
 	const result: StepResult & { completionGuardTriggered?: boolean } = omitUndefinedProperties({
 		agent: step.agent,
+		...(childSessionName ? { sessionName: childSessionName } : {}),
 		context: step.context,
 		...(step.agentContract ? { agentContract: step.agentContract } : {}),
 		launchContractDigest: actualLaunchContractDigest,
@@ -2548,8 +2556,10 @@ async function runSubagent(
 			for (const task of step.parallel) {
 				const taskFlatIndex = flatStepCount;
 				const transcriptPath = resolveAsyncStepTranscriptPath(omitUndefinedProperties({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: taskFlatIndex, flatStepCount: initialFlatStepCount }));
+				const taskSessionName = task.sessionName ?? deriveChildSessionName({ agent: task.agent, task: task.task, label: task.label });
 				initialStatusSteps.push(omitUndefinedProperties({
 					agent: task.agent,
+					...(taskSessionName ? { sessionName: taskSessionName } : {}),
 					...(externalRunnerStatus(task.runner) ? { runner: externalRunnerStatus(task.runner) } : {}),
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
 					...(task.context ? { context: task.context } : {}),
@@ -2599,8 +2609,10 @@ async function runSubagent(
 		} else {
 			const stepFlatIndex = flatStepCount;
 			const transcriptPath = resolveAsyncStepTranscriptPath(omitUndefinedProperties({ artifactsDir, artifactConfig, runId: id, agent: step.agent, flatIndex: stepFlatIndex, flatStepCount: initialFlatStepCount }));
+			const stepSessionName = step.sessionName ?? deriveChildSessionName({ agent: step.agent, task: step.task, label: step.label });
 			initialStatusSteps.push(omitUndefinedProperties({
 				agent: step.agent,
+				...(stepSessionName ? { sessionName: stepSessionName } : {}),
 				...(externalRunnerStatus(step.runner) ? { runner: externalRunnerStatus(step.runner) } : {}),
 				...(statusStepDescription(step.task) ? { description: statusStepDescription(step.task) } : {}),
 				...(step.context ? { context: step.context } : {}),
@@ -2824,6 +2836,7 @@ async function runSubagent(
 			stopped: state === "stopped" ? true : undefined,
 			results: statusPayload.steps.map((step) => omitUndefinedProperties({
 				agent: step.agent,
+				...(step.sessionName ? { sessionName: step.sessionName } : {}),
 				output: step.status === "complete" || step.status === "completed" ? "" : step.error ?? summary,
 				error: step.error,
 				success: statusResultSuccess(state, step),
@@ -2925,7 +2938,7 @@ async function runSubagent(
 	};
 	const childStopResult = (index: number, agent: string, context?: "fresh" | "fork"): SingleStepResult => {
 		markChildStopped(index);
-		return stoppedStepResult(agent, context);
+		return stoppedStepResult(agent, context, requiredStatusStep(statusPayload, index).sessionName);
 	};
 	const stopChildStep = (request: StopRequest): void => {
 		if (request.targetIndex === undefined) {
@@ -3077,23 +3090,26 @@ async function runSubagent(
 			}
 		}
 	};
-	const pausedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => omitUndefinedProperties({
+	const pausedStepResult = (agent: string, context?: "fresh" | "fork", sessionName?: string): SingleStepResult => omitUndefinedProperties({
 		agent,
+		sessionName,
 		context,
 		output: "Paused after interrupt. Waiting for explicit next action.",
 		exitCode: 0,
 		interrupted: true,
 	});
-	const timedOutStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => omitUndefinedProperties({
+	const timedOutStepResult = (agent: string, context?: "fresh" | "fork", sessionName?: string): SingleStepResult => omitUndefinedProperties({
 		agent,
+		sessionName,
 		context,
 		output: timeoutMessage ?? "Subagent timed out.",
 		error: timeoutMessage ?? "Subagent timed out.",
 		exitCode: 1,
 		timedOut: true,
 	});
-	const stoppedStepResult = (agent: string, context?: "fresh" | "fork"): SingleStepResult => omitUndefinedProperties({
+	const stoppedStepResult = (agent: string, context?: "fresh" | "fork", sessionName?: string): SingleStepResult => omitUndefinedProperties({
 		agent,
+		sessionName,
 		context,
 		output: stopMessage,
 		error: stopMessage,
@@ -3996,10 +4012,12 @@ async function runSubagent(
 					: step.parallel.outputPath;
 				const taskText = task.task ?? step.parallel.task;
 				const materializedTask = step.parallel.namespaceOutputPath ? injectSingleOutputInstruction(taskText, outputPath, step.parallel) : taskText;
+				const sessionName = deriveChildSessionName({ agent: step.parallel.agent, task: materializedTask, label: task.label ?? step.parallel.label });
 				return omitUndefinedProperties({
 					...step.parallel,
 					runFanoutPath: `chain[${stepIndex}].expand[${itemIndex}]`,
 					task: materializedTask,
+					...(sessionName ? { sessionName } : {}),
 					effectiveAcceptance: resolveEffectiveAcceptance(omitUndefinedProperties({
 						explicit: step.parallel.acceptanceInput,
 						agentName: step.parallel.agent,
@@ -4030,6 +4048,7 @@ async function runSubagent(
 				const transcriptPath = resolveAsyncStepTranscriptPath(omitUndefinedProperties({ artifactsDir, artifactConfig, runId: id, agent: task.agent, flatIndex: groupStartFlatIndex + itemIndex, flatStepCount: dynamicFlatStepCount }));
 				return omitUndefinedProperties({
 					agent: task.agent,
+					...(task.sessionName ? { sessionName: task.sessionName } : {}),
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
 					...(task.context ? { context: task.context } : {}),
 					...(task.phase ?? step.phase ? { phase: task.phase ?? step.phase } : {}),
@@ -4113,12 +4132,12 @@ async function runSubagent(
 					usageBudgetExceeded = true;
 					writeStatusPayload();
 					appendJsonl(eventsPath, JSON.stringify({ type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: 1, durationMs: 0 }));
-					return omitUndefinedProperties({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
+					return omitUndefinedProperties({ agent: task.agent, ...(task.sessionName ? { sessionName: task.sessionName } : {}), context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
 				}
-				if (timedOut) return timedOutStepResult(task.agent, task.context);
-				if (stopped) return stoppedStepResult(task.agent, task.context);
+				if (timedOut) return timedOutStepResult(task.agent, task.context, task.sessionName);
+				if (stopped) return stoppedStepResult(task.agent, task.context, task.sessionName);
 				if (childStopRequests.has(fi)) return childStopResult(fi, task.agent, task.context);
-				if (interrupted) return pausedStepResult(task.agent, task.context);
+				if (interrupted) return pausedStepResult(task.agent, task.context, task.sessionName);
 				if (aborted && failFast) {
 					const skippedAt = Date.now();
 					requiredStatusStep(statusPayload, fi).status = "failed";
@@ -4129,7 +4148,7 @@ async function runSubagent(
 					requiredStatusStep(statusPayload, fi).exitCode = -1;
 					statusPayload.lastUpdate = skippedAt;
 					writeStatusPayload();
-					return omitUndefinedProperties({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
+					return omitUndefinedProperties({ agent: task.agent, ...(task.sessionName ? { sessionName: task.sessionName } : {}), context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
 				}
 				const taskStartTime = Date.now();
 				statusPayload.currentStep = fi;
@@ -4200,6 +4219,7 @@ async function runSubagent(
 				if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 				if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 				if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
+				setOptionalProperty(requiredStatusStep(statusPayload, fi), "sessionName", singleResult.sessionName);
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "model", singleResult.model);
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "thinking", resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking));
 				setOptionalProperty(requiredStatusStep(statusPayload, fi), "attemptedModels", singleResult.attemptedModels);
@@ -4251,6 +4271,7 @@ async function runSubagent(
 			for (const pr of parallelResults) {
 				results.push(omitUndefinedProperties({
 					agent: pr.agent,
+					...(pr.sessionName ? { sessionName: pr.sessionName } : {}),
 					context: pr.context,
 					agentContract: pr.agentContract,
 					launchContractDigest: pr.launchContractDigest,
@@ -4493,12 +4514,12 @@ async function runSubagent(
 							appendJsonl(eventsPath, JSON.stringify({
 								type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: 1, durationMs: 0,
 							}));
-							return omitUndefinedProperties({ agent: task.agent, context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
+							return omitUndefinedProperties({ agent: task.agent, ...(task.sessionName ? { sessionName: task.sessionName } : {}), context: task.context, output: message, error: message, exitCode: 1 as number | null, skipped: true });
 						}
-						if (timedOut) return timedOutStepResult(task.agent, task.context);
-						if (stopped) return stoppedStepResult(task.agent, task.context);
+						if (timedOut) return timedOutStepResult(task.agent, task.context, task.sessionName);
+						if (stopped) return stoppedStepResult(task.agent, task.context, task.sessionName);
 						if (childStopRequests.has(fi)) return childStopResult(fi, task.agent, task.context);
-						if (interrupted) return pausedStepResult(task.agent, task.context);
+						if (interrupted) return pausedStepResult(task.agent, task.context, task.sessionName);
 						if (aborted && failFast) {
 							const skippedAt = Date.now();
 							requiredStatusStep(statusPayload, fi).status = "failed";
@@ -4513,7 +4534,7 @@ async function runSubagent(
 							appendJsonl(eventsPath, JSON.stringify({
 								type: "subagent.step.failed", ts: skippedAt, runId: id, stepIndex: fi, agent: task.agent, exitCode: -1, durationMs: 0,
 							}));
-							return omitUndefinedProperties({ agent: task.agent, context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
+							return omitUndefinedProperties({ agent: task.agent, ...(task.sessionName ? { sessionName: task.sessionName } : {}), context: task.context, output: "(skipped — fail-fast)", exitCode: -1 as number | null, skipped: true });
 						}
 
 						const taskStartTime = Date.now();
@@ -4602,6 +4623,7 @@ async function runSubagent(
 						if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 						if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 						if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
+						setOptionalProperty(requiredStatusStep(statusPayload, fi), "sessionName", singleResult.sessionName);
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "model", singleResult.model);
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "thinking", resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, fi).thinking));
 						setOptionalProperty(requiredStatusStep(statusPayload, fi), "attemptedModels", singleResult.attemptedModels);
@@ -4826,12 +4848,12 @@ async function runSubagent(
 		} else {
 			const seqStep = step as SubagentStep;
 			if (timedOut) {
-				results.push(timedOutStepResult(seqStep.agent, seqStep.context));
+				results.push(timedOutStepResult(seqStep.agent, seqStep.context, seqStep.sessionName));
 				flatIndex++;
 				continue;
 			}
 			if (stopped) {
-				results.push(stoppedStepResult(seqStep.agent, seqStep.context));
+				results.push(stoppedStepResult(seqStep.agent, seqStep.context, seqStep.sessionName));
 				flatIndex++;
 				continue;
 			}
@@ -4841,7 +4863,7 @@ async function runSubagent(
 				continue;
 			}
 			if (interrupted) {
-				results.push(pausedStepResult(seqStep.agent, seqStep.context));
+				results.push(pausedStepResult(seqStep.agent, seqStep.context, seqStep.sessionName));
 				flatIndex++;
 				continue;
 			}
@@ -4944,6 +4966,7 @@ async function runSubagent(
 			const childStopped = singleResult.stopped === true;
 			results.push(omitUndefinedProperties({
 				agent: singleResult.agent,
+				...(singleResult.sessionName ? { sessionName: singleResult.sessionName } : {}),
 				context: singleResult.context,
 				agentContract: singleResult.agentContract,
 				launchContractDigest: singleResult.launchContractDigest,
@@ -5046,6 +5069,7 @@ async function runSubagent(
 			if (singleResult.turnBudget) statusPayload.turnBudget = singleResult.turnBudget;
 			if (singleResult.turnBudgetExceeded) statusPayload.turnBudgetExceeded = true;
 			if (singleResult.wrapUpRequested) statusPayload.wrapUpRequested = true;
+			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "sessionName", singleResult.sessionName);
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "model", singleResult.model);
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "thinking", resolveEffectiveThinking(singleResult.model, requiredStatusStep(statusPayload, flatIndex).thinking));
 			setOptionalProperty(requiredStatusStep(statusPayload, flatIndex), "attemptedModels", singleResult.attemptedModels);
@@ -5309,6 +5333,7 @@ async function runSubagent(
 			...(stopped ? { stopped: true, error: stopMessage } : timedOut ? { timedOut: true, error: timeoutMessage ?? "Subagent timed out." } : usageBudgetExceeded ? { error: statusPayload.error ?? "Usage budget exhausted." } : {}),
 			results: results.map((r) => omitUndefinedProperties({
 				agent: r.agent,
+				...(r.sessionName ? { sessionName: r.sessionName } : {}),
 				context: r.context,
 				output: r.output,
 				outputState: r.outputState,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -332,7 +332,7 @@ async function runSingleAttempt(
 	// Display name for the child session: applied inside the child via
 	// PI_SUBAGENT_SESSION_NAME and echoed back on the result payload so hosts
 	// can label this run without reading the child's session file.
-	const childSessionName = deriveChildSessionName({ agent: agent.name, task });
+	const childSessionName = deriveChildSessionName({ agent: agent.name, task: shared.originalTask ?? task });
 	const watchdogConfig = resolveWatchdogConfig(options.cwd ?? runtimeCwd);
 	const childWatchdog = watchdogConfig.ok
 		? resolveChildWatchdogConfig({

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -67,6 +67,7 @@ import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-prog
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { resolvePermissionRules } from "../shared/permissions.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
+import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV } from "../shared/capability-ceiling.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
@@ -328,6 +329,10 @@ async function runSingleAttempt(
 	assertThinkingWithinCeiling({ model: modelArg, configThinking: effectiveThinking, ceiling: options.thinkingCeiling, agent: agent.name, runId: options.runId });
 	const expectedModelForVerification = shared.verifyModel ? modelArg : undefined;
 	const resolvedThinking = resolveEffectiveThinking(modelArg, effectiveThinking);
+	// Display name for the child session: applied inside the child via
+	// PI_SUBAGENT_SESSION_NAME and echoed back on the result payload so hosts
+	// can label this run without reading the child's session file.
+	const childSessionName = deriveChildSessionName({ agent: agent.name, task });
 	const watchdogConfig = resolveWatchdogConfig(options.cwd ?? runtimeCwd);
 	const childWatchdog = watchdogConfig.ok
 		? resolveChildWatchdogConfig({
@@ -364,6 +369,7 @@ async function runSingleAttempt(
 		cwd: options.cwd ?? runtimeCwd,
 		promptFileStem: agent.name,
 		intercomSessionName: options.intercomSessionName,
+		sessionName: childSessionName,
 		orchestratorIntercomTarget: options.orchestratorIntercomTarget,
 		runId: options.runId,
 		childAgentName: agent.name,
@@ -433,6 +439,7 @@ async function runSingleAttempt(
 			index: options.index ?? 0,
 			agent: agent.name,
 			task,
+			...(childSessionName ? { sessionName: childSessionName } : {}),
 			messages: [],
 			finalOutput: "",
 			exitCode: 1,
@@ -473,6 +480,7 @@ async function runSingleAttempt(
 		index: options.index ?? 0,
 		agent: agent.name,
 		task: shared.originalTask ?? task,
+		...(childSessionName ? { sessionName: childSessionName } : {}),
 		...(options.agentContract ? { agentContract: options.agentContract } : {}),
 		launchContractDigest,
 		launchResolvedExtensions,
@@ -514,6 +522,7 @@ async function runSingleAttempt(
 	const progress: AgentProgress = {
 		index: options.index ?? 0,
 		agent: agent.name,
+		...(childSessionName ? { sessionName: childSessionName } : {}),
 		status: "running",
 		task,
 		skills: shared.resolvedSkillNames,
@@ -1505,6 +1514,7 @@ async function runSingleAttempt(
 	}
 
 	result.progressSummary = {
+		...(childSessionName ? { sessionName: childSessionName } : {}),
 		toolCount: progress.toolCount,
 		tokens: progress.tokens,
 		durationMs: progress.durationMs,
@@ -1656,6 +1666,7 @@ async function runSyncCompletionInner(
 		...options,
 		capabilityCeiling: intersectSubagentCapabilityCeilings(options.capabilityCeiling ?? resolveCurrentSubagentCapabilityCeiling(options.parentSessionId), decodeSubagentCapabilityCeiling(process.env[SUBAGENT_CAPABILITY_CEILING_ENV])),
 	};
+	const childSessionName = deriveChildSessionName({ agent: agentName, task });
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
 		const diagnosticContext = options.unknownAgentDiagnosticContext
@@ -2074,6 +2085,7 @@ async function runSyncCompletionInner(
 	result.attemptedModels = attemptedModels.length > 0 ? attemptedModels : undefined;
 	result.modelAttempts = modelAttempts.length > 0 ? modelAttempts : undefined;
 	result.progressSummary = {
+		...(childSessionName ? { sessionName: childSessionName } : {}),
 		toolCount: totalToolCount,
 		tokens: aggregateUsage.input + aggregateUsage.output,
 		durationMs: totalDurationMs,

--- a/src/runs/foreground/foreground-control.ts
+++ b/src/runs/foreground/foreground-control.ts
@@ -18,6 +18,7 @@ interface BeginForegroundChildInput {
 
 function copyProgress(target: ForegroundChildControl, progress: AgentProgress | undefined): void {
 	if (!progress) return;
+	target.sessionName = progress.sessionName;
 	target.currentActivityState = progress.activityState;
 	target.lastActivityAt = progress.lastActivityAt;
 	target.currentTool = progress.currentTool;
@@ -36,6 +37,7 @@ function copyProgress(target: ForegroundChildControl, progress: AgentProgress | 
 
 function syncCurrentChild(control: ForegroundRunControl, child: ForegroundChildControl): void {
 	control.currentAgent = child.agent;
+	control.sessionName = child.sessionName;
 	control.currentIndex = child.index;
 	control.description = child.description;
 	control.currentActivityState = child.currentActivityState;
@@ -59,6 +61,7 @@ function syncCurrentChild(control: ForegroundRunControl, child: ForegroundChildC
 
 function clearCurrentChild(control: ForegroundRunControl): void {
 	control.currentAgent = undefined;
+	control.sessionName = undefined;
 	control.currentIndex = undefined;
 	control.currentActivityState = undefined;
 	control.lastActivityAt = undefined;

--- a/src/runs/foreground/foreground-history.ts
+++ b/src/runs/foreground/foreground-history.ts
@@ -29,6 +29,7 @@ function compactChild(child: ForegroundResumeChild): ForegroundResumeChild {
 	return {
 		agent: child.agent,
 		index: child.index,
+		...(child.sessionName ? { sessionName: child.sessionName } : {}),
 		...(child.context ? { context: child.context } : {}),
 		...(child.sessionFile ? { sessionFile: child.sessionFile } : {}),
 		...(child.model ? { model: child.model } : {}),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4900,6 +4900,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 										const step = status.steps?.find((candidate) => candidate.workflowKey === key);
 										if (step) {
 											step.agent = launch.agent;
+											if (launch.sessionName) step.sessionName = launch.sessionName;
 											step.sessionFile = launch.sessionFile;
 											step.async = launch.async;
 											if (launch.runId) step.runId = launch.runId;
@@ -4924,6 +4925,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 										step.toolCount = progress.toolCount;
 										step.model = progress.model;
 										step.thinking = progress.thinking;
+										if (progress.sessionName) step.sessionName = progress.sessionName;
 										step.error = progress.error;
 										projectWorkflowActivity();
 										persist({ tolerateStatusWriteFailure: true });

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -185,6 +185,7 @@ import {
 	wrapForkTask,
 	type ScheduleOrigin,
 } from "../../shared/types.ts";
+import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 
 const MUTATING_MANAGEMENT_ACTIONS = new Set(["create", "update", "delete", "eject", "disable", "enable", "reset", "grant-spawn-budget", "watchdog.configure", "mission.create", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "inspector.open", "inspector.close", "project.open", "project.close", "worktree.discard", "refine", "refine.rollback", "dismiss", "schedule.create", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"]);
 const DESTRUCTIVE_MANAGEMENT_ACTIONS = new Set(["delete", "eject", "disable", "reset", "mission.close", "worktree.discard", "refine.rollback", "inspector.close", "project.close", "stop", "interrupt", "schedule.delete"]);
@@ -694,6 +695,7 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 			const child = {
 				agent: result.agent,
 				index,
+				...(result.sessionName ? { sessionName: result.sessionName } : {}),
 				...(result.context ? { context: result.context } : {}),
 				status: resolveSubagentResultStatus(omitUndefinedProperties({
 					exitCode: result.exitCode,
@@ -2086,6 +2088,7 @@ async function resumeAsyncRun(input: {
 		const childResult: SingleResult = {
 			index: 0,
 			agent: completed.agent,
+			...(completed.sessionName ? { sessionName: completed.sessionName } : {}),
 			task: effectiveFollowUp,
 			exitCode: completed.exitCode,
 			usage: {
@@ -2232,6 +2235,7 @@ async function emitForegroundResultIntercom(input: {
 	if (!input.intercomBridge.active || !input.intercomBridge.resultDelivery || !input.intercomBridge.orchestratorTarget) return null;
 	const children = input.results.flatMap((result, index) => result.detached ? [] : [omitUndefinedProperties({
 		agent: result.agent,
+		...(result.sessionName ? { sessionName: result.sessionName } : {}),
 		status: foregroundResultIntercomStatus(result),
 		outputState: result.outputState ?? "unknown",
 		summary: resultSummaryForIntercom(result),
@@ -3106,6 +3110,7 @@ async function waitForWorkflowAsyncSingleResult(
 	const childResult: SingleResult = omitUndefinedProperties({
 		index: 0,
 		agent: completed.agent,
+		...(completed.sessionName ? { sessionName: completed.sessionName } : {}),
 		task: options.task,
 		exitCode: completed.exitCode,
 		usage: {
@@ -3925,7 +3930,7 @@ function duplicateSubagentCallResult(params: SubagentParamsLike): AgentToolResul
 	};
 }
 
-const workflowLaunchObservers = new WeakMap<object, (launch: { agent: string; sessionFile?: string; async: boolean; runId?: string }) => void>();
+const workflowLaunchObservers = new WeakMap<object, (launch: { agent: string; sessionName?: string; sessionFile?: string; async: boolean; runId?: string }) => void>();
 
 /**
  * Terminal-mission retention can remove a mission while its children still
@@ -4801,8 +4806,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (entry.durationMs === undefined) delete existing.durationMs;
 								else existing.durationMs = entry.durationMs;
 							} else {
+								const stepSessionName = deriveChildSessionName({ agent: entry.agent ?? entry.key, label: entryLabel ?? entry.key });
 								const step: NonNullable<AsyncStatus["steps"]>[number] = {
 									agent: entry.agent ?? entry.key,
+									...(stepSessionName ? { sessionName: stepSessionName } : {}),
 									label: entryLabel ?? entry.key,
 									workflowKey: entry.key,
 									parentWorkflowRunId: workflowRunId,
@@ -4970,7 +4977,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, workflowChildren, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, workflowChildren, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(status.error ? { error: status.error } : {}) });
@@ -5013,7 +5020,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, workflowChildren, ...(terminalOutcome ? { terminalOutcome } : {}), results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, workflowChildren, ...(terminalOutcome ? { terminalOutcome } : {}), results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(terminalOutcome ? { terminalOutcome } : {}), ...(status.error ? { error: status.error } : {}), ...(status.activityState ? { activityState: status.activityState } : {}) });
@@ -6283,6 +6290,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						mode: foregroundMode,
 						state,
 						agent: agentsForSummary[0],
+						...(details?.results.length === 1 && details.results[0]?.sessionName ? { sessionName: details.results[0].sessionName } : {}),
 						agents: agentsForSummary,
 						...(agentsForSummary.length === 1 && (type === "subagent.nested.started" ? startedLaunches[0]?.model : details?.results[0]?.model) ? { model: type === "subagent.nested.started" ? startedLaunches[0]?.model : details?.results[0]?.model } : {}),
 						...(agentsForSummary.length === 1 && (type === "subagent.nested.started" ? startedLaunches[0]?.thinking : details?.results[0]?.thinking) ? { thinking: type === "subagent.nested.started" ? startedLaunches[0]?.thinking : details?.results[0]?.thinking } : {}),
@@ -6301,6 +6309,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							: details?.results.length
 								? { steps: details.results.map((child) => ({
 									agent: child.agent,
+									...(child.sessionName ? { sessionName: child.sessionName } : {}),
 									status: child.interrupted || child.detached ? "paused" as const : child.exitCode === 0 ? "complete" as const : "failed" as const,
 									...(child.model ? { model: child.model } : {}),
 									...(child.thinking ? { thinking: child.thinking } : {}),
@@ -6324,10 +6333,15 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			}
 			if (workflowLaunchObserver) {
 				const singleTask = hasTasks && effectiveParams.tasks?.length === 1 ? effectiveParams.tasks[0] : undefined;
-				const launch = hasSingle
-					? { agent: effectiveParams.agent!, sessionFile: childSessionFileForTask(effectiveParams.agent!, 0, effectiveParams.model), async: effectiveAsync, ...(effectiveAsync ? { runId: asyncRunId } : {}) }
+				const singleSessionName = hasSingle
+					? deriveChildSessionName({ agent: effectiveParams.agent!, task: effectiveParams.task })
 					: singleTask
-						? { agent: singleTask.agent, sessionFile: childSessionFileForTask(singleTask.agent, 0, singleTask.model), async: effectiveAsync, ...(effectiveAsync ? { runId: asyncRunId } : {}) }
+						? deriveChildSessionName({ agent: singleTask.agent, task: singleTask.task })
+						: undefined;
+				const launch = hasSingle
+					? { agent: effectiveParams.agent!, ...(singleSessionName ? { sessionName: singleSessionName } : {}), sessionFile: childSessionFileForTask(effectiveParams.agent!, 0, effectiveParams.model), async: effectiveAsync, ...(effectiveAsync ? { runId: asyncRunId } : {}) }
+					: singleTask
+						? { agent: singleTask.agent, ...(singleSessionName ? { sessionName: singleSessionName } : {}), sessionFile: childSessionFileForTask(singleTask.agent, 0, singleTask.model), async: effectiveAsync, ...(effectiveAsync ? { runId: asyncRunId } : {}) }
 						: undefined;
 				if (launch) {
 					workflowLaunchObservers.delete(params);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4806,7 +4806,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (entry.durationMs === undefined) delete existing.durationMs;
 								else existing.durationMs = entry.durationMs;
 							} else {
-								const stepSessionName = deriveChildSessionName({ agent: entry.agent ?? entry.key, label: entryLabel ?? entry.key });
+								// Naming uses the explicit label only — never the workflow key — so the
+								// placeholder cannot diverge from the task-derived name the child
+								// session actually gets (launch/progress updates overwrite this).
+								const stepSessionName = deriveChildSessionName({ agent: entry.agent ?? entry.key, label: entryLabel });
 								const step: NonNullable<AsyncStatus["steps"]>[number] = {
 									agent: entry.agent ?? entry.key,
 									...(stepSessionName ? { sessionName: stepSessionName } : {}),

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -32,7 +32,7 @@ import {
 
 export function applyDetachedChildToPausedWorkflow(
 	status: AsyncStatus,
-	input: { childRunId: string; result: Pick<SingleResult, "exitCode" | "error" | "interrupted" | "sessionFile" | "stopped">; workflowKey?: string },
+	input: { childRunId: string; result: Pick<SingleResult, "exitCode" | "error" | "interrupted" | "sessionFile" | "sessionName" | "stopped">; workflowKey?: string },
 ): AsyncStatus | undefined {
 	return applyDetachedChildSettlement(status, input);
 }
@@ -62,6 +62,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 				...(result.interrupted || result.stopped ? { interrupted: true } : {}),
 				...(result.stopped ? { stopped: true } : {}),
 				...(terminalOutcome ? { terminalOutcome } : {}),
+				...(result.sessionName ? { sessionName: result.sessionName } : {}),
 				...(result.error ? { error: result.error } : {}),
 			};
 		});
@@ -69,6 +70,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 	return status.steps?.map((step: WorkflowStatusStep) => ({
 		workflowKey: step.workflowKey,
 		agent: step.agent,
+		...(step.sessionName ? { sessionName: step.sessionName } : {}),
 		runId: step.runId,
 		success: step.status === "completed" || step.status === "complete",
 		output: step.runId === childRunId ? output : "",

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -306,6 +306,7 @@ function sanitizeStep(input: unknown, depth: number): NestedStepSummary | undefi
 		status,
 		...(model ? { model } : {}),
 		...(thinking ? { thinking } : {}),
+		...(stringValue(raw.sessionName, 256) ? { sessionName: stringValue(raw.sessionName, 256) } : {}),
 		...(stringValue(raw.sessionFile, 2048) ? { sessionFile: stringValue(raw.sessionFile, 2048) } : {}),
 		...(raw.activityState === "active_long_running" || raw.activityState === "needs_attention" ? { activityState: raw.activityState } : {}),
 		...(clampNumber(raw.lastActivityAt) !== undefined ? { lastActivityAt: clampNumber(raw.lastActivityAt) } : {}),
@@ -1005,6 +1006,7 @@ export function nestedSummaryFromAsyncStatus(status: AsyncStatus, asyncDir: stri
 		mode: status.mode ?? fallback.mode,
 		...(status.steps?.length === 1 && status.steps[0]?.model ? { model: status.steps[0].model } : {}),
 		...(status.steps?.length === 1 && status.steps[0]?.thinking ? { thinking: status.steps[0].thinking } : {}),
+		...(status.steps?.length === 1 && status.steps[0]?.sessionName ? { sessionName: status.steps[0].sessionName } : {}),
 		...(status.processTerminal ? { processTerminal: sanitizeProcessTerminal(status.processTerminal, { runId: status.runId || fallback.id, runnerProcessInstanceId: status.processTerminal.runnerProcessInstanceId }, `${asyncDir}/status.json`) } : {}),
 		...(status.launchResolvedExtensions ? { launchResolvedExtensions: status.launchResolvedExtensions } : {}),
 		...runtimeAcknowledgedEntry(status.runtimeAcknowledgedExtensions),
@@ -1035,6 +1037,7 @@ export function nestedSummaryFromAsyncStatus(status: AsyncStatus, asyncDir: stri
 		...(status.sessionFile ? { sessionFile: status.sessionFile } : {}),
 		...(status.steps?.length ? { steps: status.steps.map((step, index) => ({
 			agent: step.agent,
+			...(step.sessionName ? { sessionName: step.sessionName } : {}),
 			status: step.status,
 			...(step.model ? { model: step.model } : {}),
 			...(step.thinking ? { thinking: step.thinking } : {}),

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -347,6 +347,7 @@ export function sanitizeSummary(input: unknown, depth = 0): NestedRunSummary | u
 		depth: Math.min(Math.max(0, clampNumber(raw.depth) ?? 0), MAX_DEPTH),
 		path: pathParts,
 		state: sanitizeState(raw.state, "running"),
+		...(stringValue(raw.sessionName, 256) ? { sessionName: stringValue(raw.sessionName, 256) } : {}),
 		...(stringValue(raw.model) ? { model: stringValue(raw.model) } : {}),
 		...(THINKING_LEVELS.find((level) => level === raw.thinking) ? { thinking: THINKING_LEVELS.find((level) => level === raw.thinking) } : {}),
 		...(stringValue(raw.asyncDir, 2048) ? { asyncDir: stringValue(raw.asyncDir, 2048) } : {}),

--- a/src/runs/shared/nested-render.ts
+++ b/src/runs/shared/nested-render.ts
@@ -50,6 +50,7 @@ export function formatNestedAggregate(children: NestedRunSummary[] | undefined):
 }
 
 function nestedRunLabel(run: NestedRunSummary): string {
+	if (run.sessionName?.trim()) return run.sessionName.trim();
 	if (run.agent) return run.agent;
 	if (run.agents?.length) return run.agents.length === 1 ? run.agents[0]! : `${run.agents.slice(0, 2).join(", ")}${run.agents.length > 2 ? ` +${run.agents.length - 2}` : ""}`;
 	return run.id;
@@ -106,7 +107,7 @@ function formatNestedRunLines(children: NestedRunSummary[] | undefined, options:
 				if (lines.length >= options.maxLines) return;
 				const stepActivity = step.status === "running" ? formatNestedActivity(step) : undefined;
 				const stepModelThinking = formatModelThinking(step.model, step.thinking);
-				lines.push(`${indent}  ${stepIndex + 1}. ${step.agent} ${step.status}${stepModelThinking ? ` | ${stepModelThinking}` : ""}${stepActivity ? ` | ${stepActivity}` : ""}${step.error ? ` | error: ${step.error}` : ""}`);
+				lines.push(`${indent}  ${stepIndex + 1}. ${step.sessionName?.trim() || step.agent} ${step.status}${stepModelThinking ? ` | ${stepModelThinking}` : ""}${stepActivity ? ` | ${stepActivity}` : ""}${step.error ? ` | error: ${step.error}` : ""}`);
 				append(step.children, depth + 1, `${indent}    `);
 			}
 			append(child.children, depth + 1, `${indent}  `);

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -6,6 +6,8 @@ export interface RunnerSubagentStep {
 	/** Resolved opt-in rules for native Pi child tool calls. */
 	permissionRules?: import("./permissions.ts").PermissionRules;
 	agent: string;
+	/** Human-readable display name for the child session, derived internally at launch. */
+	sessionName?: string;
 	task: string;
 	runner?: ResolvedRunnerConfig;
 	externalJobFollowUp?: {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -170,6 +170,11 @@ export interface BuildPiArgsInput {
 	cwd?: string;
 	promptFileStem?: string;
 	intercomSessionName?: string;
+	/** Human-readable display name for the child session (agent + task excerpt,
+	 *  derived by the caller). Passed to the child as PI_SUBAGENT_SESSION_NAME;
+	 *  the prompt runtime applies it via pi.setSessionName unless an intercom
+	 *  target takes precedence. */
+	sessionName?: string;
 	orchestratorIntercomTarget?: string;
 	runId?: string;
 	childAgentName?: string;
@@ -887,6 +892,9 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	env[PI_INTERCOM_SESSION_ID_ENV] = undefined;
 	if (input.intercomSessionName) {
 		env.PI_SUBAGENT_INTERCOM_SESSION_NAME = input.intercomSessionName;
+	}
+	if (input.sessionName?.trim()) {
+		env.PI_SUBAGENT_SESSION_NAME = input.sessionName.trim();
 	}
 	if (input.orchestratorIntercomTarget) {
 		env[SUBAGENT_ORCHESTRATOR_TARGET_ENV] = input.orchestratorIntercomTarget;

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -32,6 +32,9 @@ import { drainOutstandingWork } from "../background/auto-drain.ts";
 const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
 const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
 export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
+/** Human-readable child display name (agent + task excerpt) set by the parent
+ *  at launch; applied via pi.setSessionName when no intercom target exists. */
+export const SUBAGENT_SESSION_NAME_ENV = "PI_SUBAGENT_SESSION_NAME";
 const STEERING_LEGACY_SETTLE_FALLBACK_MS = 1000;
 const STEERING_SAFETY_POLL_INTERVAL_MS = 5000;
 
@@ -756,9 +759,14 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	onRuntimeEvent("before_agent_start", async (event: unknown) => {
 		if (!event || typeof event !== "object" || !("systemPrompt" in event) || typeof event.systemPrompt !== "string") return undefined;
 		registerNativeSupervisorClientOnce();
+		// The intercom target is a routing address and always wins; the display
+		// name (agent + task excerpt, computed by the parent at launch) only
+		// applies when the bridge is not addressing this child.
 		const intercomSessionName = process.env[SUBAGENT_INTERCOM_SESSION_NAME_ENV]?.trim();
-		if (intercomSessionName && typeof pi.setSessionName === "function") {
-			pi.setSessionName(intercomSessionName);
+		const displaySessionName = process.env[SUBAGENT_SESSION_NAME_ENV]?.trim();
+		const childSessionName = intercomSessionName || displaySessionName;
+		if (childSessionName && typeof pi.setSessionName === "function") {
+			pi.setSessionName(childSessionName);
 		}
 
 		const inheritProjectContext = readBooleanEnv(SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV);

--- a/src/shared/child-session-name.ts
+++ b/src/shared/child-session-name.ts
@@ -1,0 +1,46 @@
+import { previewDisplayText } from "./display-text.ts";
+import { PROMPT_REDACTED } from "./utils.ts";
+
+/**
+ * Human-readable display name for a child session, derived at launch time from
+ * the agent name and its task (or workflow node label). The parent computes it
+ * once and threads it two ways:
+ *
+ *  1. Into the child process via `PI_SUBAGENT_SESSION_NAME`, where the prompt
+ *     runtime calls `pi.setSessionName(...)` so the child's own session file
+ *     is identifiable in `pi --resume` and host session browsers.
+ *  2. Into the `sessionName` field of result/progress payloads, so hosts
+ *     rendering the parent stream can label each child row.
+ *
+ * The name is display-only metadata. When the intercom bridge is active the
+ * child keeps its machine intercom target as the session name instead — that
+ * name is a routing address and must win (see subagent-prompt-runtime).
+ */
+
+/** Longest task excerpt kept in the name; the full string is capped below. */
+const TASK_EXCERPT_MAX_CHARS = 60;
+/** Hard cap on the final name so host UI rows stay one line. */
+export const CHILD_SESSION_NAME_MAX_CHARS = 80;
+
+export function deriveChildSessionName(input: {
+	agent?: string;
+	task?: string;
+	/** Workflow node label; preferred over the task excerpt when present. */
+	label?: string;
+}): string | undefined {
+	const agent = input.agent?.trim() ?? "";
+	const rawLabel = input.label?.trim() ?? "";
+	const rawTask = input.task?.trim() ?? "";
+	// Never build a name from redacted text — the excerpt would be meaningless
+	// and the redaction marker itself carries no information.
+	const excerptSource =
+		rawLabel && rawLabel !== PROMPT_REDACTED
+			? rawLabel
+			: rawTask && rawTask !== PROMPT_REDACTED
+				? rawTask
+				: "";
+	const excerpt = excerptSource ? previewDisplayText(excerptSource, TASK_EXCERPT_MAX_CHARS) : "";
+	const base = agent && excerpt ? `${agent}: ${excerpt}` : agent || excerpt;
+	if (!base) return undefined;
+	return previewDisplayText(base, CHILD_SESSION_NAME_MAX_CHARS);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1851,6 +1851,8 @@ export interface ForegroundResumeRun {
 export interface ForegroundChildControl {
 	index: number;
 	agent: string;
+	/** Human-readable display name for the child's session, when derived at launch. */
+	sessionName?: string;
 	description?: string;
 	startedAt: number;
 	updatedAt: number;
@@ -1888,6 +1890,8 @@ export interface ForegroundRunControl {
 	/** Effective working directory used to resolve live transcript artifacts. */
 	cwd?: string;
 	currentAgent?: string;
+	/** Human-readable display name for the current child session, when derived at launch. */
+	sessionName?: string;
 	currentIndex?: number;
 	/** Short caller-facing task/goal shown in fleet surfaces when available. */
 	description?: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,6 +100,8 @@ export interface WorkflowChildSummaryV1 {
 		childId: string;
 		runId?: string;
 		agent?: string;
+		/** Human-readable display name for the child session, when derived at launch. */
+		sessionName?: string;
 		model?: string;
 		thinking?: string;
 		state: "pending" | "running" | "completed" | "failed" | "paused" | "stopped" | "rejected" | "detached";
@@ -677,7 +679,7 @@ export interface SteeringRecoveryDescriptor {
 
 export type PublicNestedStepSummary = Pick<
 	NestedStepSummary,
-	"agent" | "status" | "model" | "thinking" | "sessionFile" | "transcriptPath" | "transcriptError" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "startedAt" | "endedAt" | "error" | "timedOut" | "stopped"
+	"agent" | "sessionName" | "status" | "model" | "thinking" | "sessionFile" | "transcriptPath" | "transcriptError" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "startedAt" | "endedAt" | "error" | "timedOut" | "stopped"
 > & {
 	children?: PublicNestedRunSummary[];
 };
@@ -690,7 +692,7 @@ export type CostSummary = {
 
 export type PublicNestedRunSummary = Pick<
 	NestedRunSummary,
-	"id" | "parentRunId" | "parentStepIndex" | "parentAgent" | "depth" | "path" | "asyncDir" | "sessionId" | "sessionFile" | "intercomTarget" | "ownerIntercomTarget" | "leafIntercomTarget" | "ownerState" | "mode" | "state" | "agent" | "agents" | "model" | "thinking" | "currentStep" | "chainStepCount" | "parallelGroups" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "totalTokens" | "totalCost" | "startedAt" | "endedAt" | "lastUpdate" | "error" | "timeoutMs" | "deadlineAt" | "timedOut" | "stopped" | "turnBudget" | "turnBudgetExceeded" | "wrapUpRequested"
+	"id" | "parentRunId" | "parentStepIndex" | "parentAgent" | "depth" | "path" | "asyncDir" | "sessionId" | "sessionFile" | "intercomTarget" | "ownerIntercomTarget" | "leafIntercomTarget" | "ownerState" | "mode" | "state" | "agent" | "sessionName" | "agents" | "model" | "thinking" | "currentStep" | "chainStepCount" | "parallelGroups" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "totalTokens" | "totalCost" | "startedAt" | "endedAt" | "lastUpdate" | "error" | "timeoutMs" | "deadlineAt" | "timedOut" | "stopped" | "turnBudget" | "turnBudgetExceeded" | "wrapUpRequested"
 > & {
 	steps?: PublicNestedStepSummary[];
 	children?: PublicNestedRunSummary[];
@@ -698,6 +700,8 @@ export type PublicNestedRunSummary = Pick<
 
 export interface SubagentResultIntercomChild {
 	agent: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	/** Process/lifecycle status. It does not establish semantic task completion. */
 	status: SubagentResultStatus;
 	/** Whether the child produced substantive output before its process ended. */
@@ -746,6 +750,8 @@ export interface ChildWatchdogProgress {
 export interface AgentProgress {
 	index: number;
 	agent: string;
+	/** Human-readable display name for the child's session, when derived at launch. */
+	sessionName?: string;
 	status: "pending" | "running" | "completed" | "failed" | "detached";
 	activityState?: ActivityState;
 	task: string;
@@ -781,6 +787,8 @@ export interface ToolCallSummary {
 interface ProgressSummary {
 	index?: number;
 	agent?: string;
+	/** Human-readable display name for the child's session, when derived at launch. */
+	sessionName?: string;
 	status?: AgentProgress["status"];
 	activityState?: ActivityState;
 	skills?: string[];
@@ -1041,6 +1049,9 @@ export interface SingleResult {
 	index: number;
 	agent: string;
 	task: string;
+	/** Human-readable display name for the child's own session (agent + task
+	 *  excerpt), when the launcher derived one. Display metadata only. */
+	sessionName?: string;
 	/** Resolved launch context for this child. */
 	context?: "fresh" | "fork";
 	exitCode: number;
@@ -1319,6 +1330,8 @@ export interface NestedRunAddress {
 
 export interface NestedStepSummary {
 	agent: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	status: "pending" | "running" | "complete" | "completed" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 	model?: string;
 	thinking?: string;
@@ -1370,6 +1383,8 @@ export interface NestedRunSummary extends NestedRunAddress {
 	capabilityAudit?: SubagentCapabilityAudit;
 	state: NestedRunState;
 	agent?: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	agents?: string[];
 	model?: string;
 	thinking?: string;
@@ -1616,6 +1631,8 @@ export interface AsyncStatus {
 		/** Stable caller-facing child identity for inspect/status/stop. */
 		childId?: string;
 		agent: string;
+		/** Human-readable display name for the child session, when derived at launch. */
+		sessionName?: string;
 		runner?: ExternalCliRunnerStatus | ExternalJobRunnerStatus;
 		externalProcess?: ExternalProcessStatus;
 		externalJob?: ExternalJobStatus;
@@ -1769,6 +1786,8 @@ export interface AsyncJobState {
 
 export interface ForegroundResumeChild {
 	agent: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	index: number;
 	context?: "fresh" | "fork";
 	sessionFile?: string;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -338,6 +338,7 @@ function compactCompletedProgress(progress: AgentProgress): AgentProgress {
 	return {
 		index: progress.index,
 		agent: progress.agent,
+		...(progress.sessionName ? { sessionName: progress.sessionName } : {}),
 		status: progress.status,
 		activityState: progress.activityState,
 		task: "[prompt redacted]",

--- a/src/slash/slash-live-state.ts
+++ b/src/slash/slash-live-state.ts
@@ -2,6 +2,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Message } from "@earendil-works/pi-ai";
 import type { SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
 import { previewSimpleWorkflowRun } from "../workflows/scripted-workflow.ts";
+import { deriveChildSessionName } from "../shared/child-session-name.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
 import { type Details, type SingleResult, type Usage, SLASH_RESULT_TYPE } from "../shared/types.ts";
 
@@ -54,9 +55,11 @@ function createPlaceholderResult(
 	status: "pending" | "running",
 	index: number,
 ): SingleResult {
+	const sessionName = deriveChildSessionName({ agent, task });
 	return {
 		agent,
 		task,
+		...(sessionName ? { sessionName } : {}),
 		index,
 		exitCode: 0,
 		messages: EMPTY_MESSAGES,
@@ -64,6 +67,7 @@ function createPlaceholderResult(
 		progress: {
 			index,
 			agent,
+			...(sessionName ? { sessionName } : {}),
 			status,
 			task,
 			recentTools: [],
@@ -84,17 +88,21 @@ function buildParallelInitialResult(params: SubagentParamsLike): AgentToolResult
 			...(params.async ? { background: true } : {}),
 			...(params.context === "fresh" || params.context === "fork" ? { context: params.context } : {}),
 			results: tasks.map((task, index) => createPlaceholderResult(task.agent, task.task, "running", index)),
-			progress: tasks.map((task, index) => ({
-				index,
-				agent: task.agent,
-				status: "running" as const,
-				task: task.task,
-				recentTools: [],
-				recentOutput: [],
-				toolCount: 0,
-				tokens: 0,
-				durationMs: 0,
-			})),
+			progress: tasks.map((task, index) => {
+				const sessionName = deriveChildSessionName({ agent: task.agent, task: task.task });
+				return {
+					index,
+					agent: task.agent,
+					...(sessionName ? { sessionName } : {}),
+					status: "running" as const,
+					task: task.task,
+					recentTools: [],
+					recentOutput: [],
+					toolCount: 0,
+					tokens: 0,
+					durationMs: 0,
+				};
+			}),
 		},
 	};
 }
@@ -143,6 +151,7 @@ function buildChainInitialResult(params: SubagentParamsLike): AgentToolResult<De
 			progress: results.map((result, index) => ({
 				index,
 				agent: result.agent,
+				...(result.sessionName ? { sessionName: result.sessionName } : {}),
 				status: index === 0 ? "running" as const : "pending" as const,
 				task: result.task,
 				recentTools: [],
@@ -162,6 +171,7 @@ function buildSingleInitialResult(params: SubagentParamsLike): AgentToolResult<D
 	const preview = previewSimpleWorkflowRun(params.workflowScript) ?? {};
 	const agent = params.agent ?? preview.agent ?? "subagent";
 	const task = params.task ?? preview.task ?? "";
+	const sessionName = deriveChildSessionName({ agent, task });
 	return {
 		content: [{ type: "text", text: task }],
 		details: {
@@ -172,6 +182,7 @@ function buildSingleInitialResult(params: SubagentParamsLike): AgentToolResult<D
 			progress: [{
 				index: 0,
 				agent,
+				...(sessionName ? { sessionName } : {}),
 				status: "running",
 				task,
 				recentTools: [],

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -727,6 +727,7 @@ function widgetStepRenderKey(step: AsyncJobStep, index: number, expanded = false
 	return [
 		step.index ?? index,
 		step.agent,
+		step.sessionName,
 		step.workflowKey,
 		step.phase,
 		step.label,
@@ -766,6 +767,7 @@ function nestedRenderKey(children: NestedRunSummary[] | undefined, expanded = fa
 		child.id,
 		child.state,
 		child.agent,
+		child.sessionName,
 		child.model,
 		child.thinking,
 		child.activityState,
@@ -963,7 +965,7 @@ function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded =
 		const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
 		const label = compactTaskText(step.description, step.label);
-		const display = label ? `${label} (${step.agent})` : step.agent;
+		const display = step.sessionName?.trim() || (label ? `${label} (${step.agent})` : step.agent);
 		lines.push(`  ${theme.fg("dim", `${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${display} · ${widgetStepStatus(step.status, theme)}${modelDisplay}${activity ? ` · ${activity}` : ""}`)}`);
 		const lane = projectAsyncLane(job, step);
 		if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "    "));
@@ -1092,12 +1094,13 @@ function buildChainRenderEntries(details: Details, label: MultiProgressLabel): C
 			continue;
 		}
 		for (let index = span.start; index < span.start + span.count; index++) {
+			const result = details.results[index];
 			entries.push({
 				kind: "result",
 				resultIndex: index,
 				rowNumber: index + 1,
 				rowLabel: span.isParallel ? `Agent ${index - span.start + 1}/${span.count}` : `Step ${span.stepIndex + 1}`,
-				agentName: details.results[index]?.agent ?? details.chainAgents?.[span.stepIndex] ?? `step-${span.stepIndex + 1}`,
+				agentName: result?.sessionName?.trim() || result?.agent || details.chainAgents?.[span.stepIndex] || `step-${span.stepIndex + 1}`,
 			});
 		}
 	}
@@ -1282,6 +1285,7 @@ function widgetOutputPath(job: AsyncJobState, step: NonNullable<AsyncJobState["s
 }
 
 function nestedRunName(run: NestedRunSummary): string {
+	if (run.sessionName?.trim()) return run.sessionName.trim();
 	if (run.agent) return run.agent;
 	if (run.agents?.length) return formatWidgetAgents(run.agents);
 	return run.id;
@@ -1364,7 +1368,7 @@ function formatNestedWidgetLines(children: NestedRunSummary[] | undefined, theme
 			const activity = nestedActivity(step, state, snapshotNow ?? fallback);
 			const timestamp = "status" in step ? nestedStepTimestamp(step, fallback) : formatClockTime(nestedRunEventTime(step));
 			const error = step.error ? ` · ${step.error}` : "";
-			const name = "status" in step ? step.agent : nestedRunName(step);
+			const name = "status" in step ? childDisplayName(step) : nestedRunName(step);
 			rows.push({
 				prefix,
 				text: `${nestedTimestampPrefix(timestamp)}${nestedStatusGlyph(state, theme)} ${name} · ${state}${modelThinking ? ` · ${modelThinking}` : ""}${activity ? ` · ${activity}` : ""}${error}`,
@@ -1426,7 +1430,7 @@ function formatNestedWidgetLines(children: NestedRunSummary[] | undefined, theme
 			for (const step of child.steps ?? []) {
 				if (lines.length >= lineBudget) return;
 				const modelThinking = formatModelThinking(step.model, step.thinking);
-				lines.push(theme.fg("dim", `${prefix}  ↳ ${nestedTimestampPrefix(nestedStepTimestamp(step, child.lastUpdate))}${nestedStatusGlyph(step.status, theme)} ${step.agent} · ${step.status}${modelThinking ? ` · ${modelThinking}` : ""} · ${nestedActivity(step, step.status, snapshotNow ?? child.lastUpdate)}`));
+				lines.push(theme.fg("dim", `${prefix}  ↳ ${nestedTimestampPrefix(nestedStepTimestamp(step, child.lastUpdate))}${nestedStatusGlyph(step.status, theme)} ${childDisplayName(step)} · ${step.status}${modelThinking ? ` · ${modelThinking}` : ""} · ${nestedActivity(step, step.status, snapshotNow ?? child.lastUpdate)}`));
 				append(step.children, depth + 1, `${prefix}    `);
 			}
 			append(child.children, depth + 1, `${prefix}  `);
@@ -1450,7 +1454,7 @@ function foregroundStyleWidgetStepLines(
 	const status = widgetStepStatus(step.status, theme);
 	const stats = widgetStepStats(theme, step);
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
-	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${itemTitle} ${index}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
+	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${itemTitle} ${index}/${total}: ${themeBold(theme, childDisplayName(step))}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
 	const lane = projectAsyncLane(job, step);
 	if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "    "));
 	const task = compactTaskText(step.description, step.label);
@@ -1531,7 +1535,7 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
 		const task = compactTaskText(step.description, step.label);
 		const taskSuffix = task ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", `task: ${task}`)}` : "";
-		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, step.agent)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${taskSuffix}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
+		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, childDisplayName(step))}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${taskSuffix}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
 		const lane = projectAsyncLane(job, step);
 		if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "  "));
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, 6)) lines.push(`    ${nestedLine}`);
@@ -2056,7 +2060,8 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 		const r = d.results[i];
 		const fallbackLabel = itemTitle.toLowerCase();
 		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? childDisplayName(r, `${fallbackLabel}-${rowNumber}`) : (d.chainAgents![i] || childDisplayName(r, `${fallbackLabel}-${rowNumber}`)) };
+		const fallbackAgent = useResultsDirectly ? (r?.agent || `${fallbackLabel}-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `${fallbackLabel}-${rowNumber}`);
+		return { kind: "result", resultIndex: i, rowNumber, agentName: r?.sessionName?.trim() || fallbackAgent };
 	});
 	for (const entry of renderEntries) {
 		if (entry.kind === "placeholder") {
@@ -2356,6 +2361,7 @@ export function renderSubagentResult(
 		? d.chainAgents
 				.map((agent, i) => {
 					const result = d.results[i];
+					const displayName = result?.sessionName?.trim() || agent;
 					const isCurrent = i === (d.currentStepIndex ?? d.results.length);
 					const stepPresentation = result
 						? styledResultPresentation(resultPresentation(result, getSingleResultOutput(result), isCurrent && hasRunning && !hasTerminalResultFlag(result)), theme)
@@ -2363,7 +2369,7 @@ export function renderSubagentResult(
 					const stepStatus = stepPresentation
 						? `${stepPresentation.glyph} ${stepPresentation.label}`
 						: theme.fg("dim", "◦ pending");
-					return `${stepStatus} ${agent}${contextModeBadge(theme, result?.context)}`;
+					return `${stepStatus} ${displayName}${contextModeBadge(theme, result?.context)}`;
 				})
 				.join(theme.fg("dim", " → "))
 		: null;
@@ -2390,7 +2396,8 @@ export function renderSubagentResult(
 		const i = displayStart + offset;
 		const r = d.results[i];
 		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? childDisplayName(r, `step-${rowNumber}`) : (d.chainAgents![i] || childDisplayName(r, `step-${rowNumber}`)) };
+		const fallbackAgent = useResultsDirectly ? (r?.agent || `step-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `step-${rowNumber}`);
+		return { kind: "result", resultIndex: i, rowNumber, agentName: r?.sessionName?.trim() || fallbackAgent };
 	});
 
 	c.addChild(new Spacer(1));
@@ -2430,7 +2437,7 @@ export function renderSubagentResult(
 		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
 		const contextBadge = contextModeBadge(theme, r.context);
 		const stepHeader = rRunning
-			? `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`
+			? `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(theme.fg("warning", childDisplayName(r)))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`
 			: `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(childDisplayName(r))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`;
 		const toolCallLines = getToolCallLines(r, expanded);
 		c.addChild(new Text(fit(stepHeader), 0, 0));

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -266,6 +266,12 @@ function oneLine(text: string): string {
 
 const COMPACT_TASK_MAX_CHARS = 96;
 
+/** Display label for a child run: the derived session name (agent + task
+ *  excerpt) when the launcher provided one, else the bare agent name. */
+function childDisplayName(result: { agent?: string; sessionName?: string } | undefined, fallback = "subagent"): string {
+	return result?.sessionName?.trim() || result?.agent || fallback;
+}
+
 export function compactTaskText(task: string | undefined, label?: string): string | undefined {
 	const taskText = task?.trim();
 	const labelText = label?.trim();
@@ -1909,7 +1915,7 @@ function renderSingleCompact(
 	const detailIndent = mainWindowIndent(layout, 1);
 	const continuationIndent = mainWindowIndent(layout, 2) + (layout.horizontalSpacing > 0 ? " " : "");
 	const modelDisplay = modelThinkingBadge(theme, r.model ?? r.progress?.model, r.thinking ?? r.progress?.thinking);
-	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(r.agent))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
+	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(childDisplayName(r)))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
 
 	if (isRunning && r.progress) {
 		const task = compactTaskText(r.task);
@@ -2050,7 +2056,7 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 		const r = d.results[i];
 		const fallbackLabel = itemTitle.toLowerCase();
 		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? (r?.agent || `${fallbackLabel}-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `${fallbackLabel}-${rowNumber}`) };
+		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? childDisplayName(r, `${fallbackLabel}-${rowNumber}`) : (d.chainAgents![i] || childDisplayName(r, `${fallbackLabel}-${rowNumber}`)) };
 	});
 	for (const entry of renderEntries) {
 		if (entry.kind === "placeholder") {
@@ -2141,7 +2147,7 @@ export function renderSubagentSummary(
 				? theme.fg("error", "✗")
 				: theme.fg("warning", "■");
 	const label = details?.mode === "single" && results.length === 1
-		? results[0]?.agent || "subagent"
+		? childDisplayName(results[0])
 		: details?.mode || "subagent";
 	return new Text(
 		truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(label))} ${theme.fg("dim", "·")} ${theme.fg(state === "failed" ? "error" : state === "completed" ? "success" : state === "running" ? "accent" : "warning", state)}`, getTermWidth() - 4),
@@ -2211,7 +2217,7 @@ export function renderSubagentResult(
 		const fit = (text: string) => expanded ? text : truncLine(text, w);
 		const toolCallLines = getToolCallLines(r, expanded);
 		const c = new Container();
-		c.addChild(new Text(fit(`${presentation.glyph} ${theme.fg("toolTitle", theme.bold(r.agent))}${contextBadge}${progressInfo} ${theme.fg("dim", "·")} ${presentation.label}`), 0, 0));
+		c.addChild(new Text(fit(`${presentation.glyph} ${theme.fg("toolTitle", theme.bold(childDisplayName(r)))}${contextBadge}${progressInfo} ${theme.fg("dim", "·")} ${presentation.label}`), 0, 0));
 		c.addChild(new Spacer(1));
 		const taskMaxLen = Math.max(20, w - 8);
 		const taskPreview = expanded || r.task.length <= taskMaxLen
@@ -2384,7 +2390,7 @@ export function renderSubagentResult(
 		const i = displayStart + offset;
 		const r = d.results[i];
 		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? (r?.agent || `step-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `step-${rowNumber}`) };
+		return { kind: "result", resultIndex: i, rowNumber, agentName: useResultsDirectly ? childDisplayName(r, `step-${rowNumber}`) : (d.chainAgents![i] || childDisplayName(r, `step-${rowNumber}`)) };
 	});
 
 	c.addChild(new Spacer(1));
@@ -2425,7 +2431,7 @@ export function renderSubagentResult(
 		const contextBadge = contextModeBadge(theme, r.context);
 		const stepHeader = rRunning
 			? `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(theme.fg("warning", r.agent))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`
-			: `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(r.agent)}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`;
+			: `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(childDisplayName(r))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`;
 		const toolCallLines = getToolCallLines(r, expanded);
 		c.addChild(new Text(fit(stepHeader), 0, 0));
 

--- a/src/workflows/workflow-child-summary.ts
+++ b/src/workflows/workflow-child-summary.ts
@@ -38,6 +38,7 @@ export function workflowChildSummary(input: {
 			state,
 			...(bounded(entry.runId, 256) ? { runId: bounded(entry.runId, 256) } : {}),
 			...(previous?.agent ? { agent: previous.agent } : {}),
+			...(previous?.sessionName ? { sessionName: previous.sessionName } : {}),
 			...(previous?.model ? { model: previous.model } : {}),
 			...(previous?.thinking ? { thinking: previous.thinking } : {}),
 		});
@@ -57,6 +58,7 @@ export function workflowChildSummary(input: {
 			state,
 			...(bounded(step.runId, 256) ? { runId: bounded(step.runId, 256) } : {}),
 			...(launchResolved && bounded(step.agent, 256) ? { agent: bounded(step.agent, 256) } : {}),
+			...(bounded(step.sessionName, 256) ? { sessionName: bounded(step.sessionName, 256) } : {}),
 			...(bounded(step.model, 256) ? { model: bounded(step.model, 256) } : {}),
 			...(bounded(step.thinking, 32) ? { thinking: bounded(step.thinking, 32) } : {}),
 		});
@@ -70,6 +72,7 @@ export function workflowChildSummary(input: {
 			state,
 			...(bounded(child.runId, 256) ? { runId: bounded(child.runId, 256) } : {}),
 			...(bounded(child.agent, 256) ? { agent: bounded(child.agent, 256) } : {}),
+			...(bounded(result?.sessionName, 256) ? { sessionName: bounded(result?.sessionName, 256) } : {}),
 			...(bounded(result?.model, 256) ? { model: bounded(result?.model, 256) } : {}),
 			...(bounded(result?.thinking, 32) ? { thinking: bounded(result?.thinking, 32) } : {}),
 		});
@@ -101,14 +104,14 @@ export function parseWorkflowChildSummary(value: unknown): WorkflowChildSummaryV
 	const children = input.children.map((row): WorkflowChildSummaryV1["children"][number] => {
 		if (!row || typeof row !== "object" || Array.isArray(row)) throw new Error("workflowChildren child row is invalid.");
 		const child = row as Record<string, unknown>;
-		if (Object.keys(child).some((key) => !["childId", "runId", "agent", "model", "thinking", "state"].includes(key))) throw new Error("workflowChildren child row has unsupported fields.");
+		if (Object.keys(child).some((key) => !["childId", "runId", "agent", "sessionName", "model", "thinking", "state"].includes(key))) throw new Error("workflowChildren child row has unsupported fields.");
 		if (typeof child.childId !== "string" || !KEY_PATTERN.test(child.childId)) throw new Error("workflowChildren childId is invalid.");
 		const state = child.state;
 		if (state !== "pending" && state !== "running" && state !== "completed" && state !== "failed" && state !== "paused" && state !== "stopped" && state !== "rejected" && state !== "detached") throw new Error("workflowChildren child state is invalid.");
-		for (const [field, maxBytes] of [["runId", 256], ["agent", 256], ["model", 256], ["thinking", 32]] as const) {
+		for (const [field, maxBytes] of [["runId", 256], ["agent", 256], ["sessionName", 256], ["model", 256], ["thinking", 32]] as const) {
 			if (child[field] !== undefined && bounded(child[field], maxBytes) === undefined) throw new Error(`workflowChildren child ${field} is invalid.`);
 		}
-		return { childId: child.childId, state, ...(child.runId ? { runId: child.runId as string } : {}), ...(child.agent ? { agent: child.agent as string } : {}), ...(child.model ? { model: child.model as string } : {}), ...(child.thinking ? { thinking: child.thinking as string } : {}) };
+		return { childId: child.childId, state, ...(child.runId ? { runId: child.runId as string } : {}), ...(child.agent ? { agent: child.agent as string } : {}), ...(child.sessionName ? { sessionName: child.sessionName as string } : {}), ...(child.model ? { model: child.model as string } : {}), ...(child.thinking ? { thinking: child.thinking as string } : {}) };
 	});
 	if (new Set(children.map((child) => child.childId)).size !== children.length) throw new Error("workflowChildren has duplicate childId values.");
 	if (typeof input.parentToolCallId !== "string") throw new Error("workflowChildren.parentToolCallId is invalid.");

--- a/src/workflows/workflow-settlement.ts
+++ b/src/workflows/workflow-settlement.ts
@@ -19,6 +19,8 @@ export type WorkflowStatusStep = NonNullable<AsyncStatus["steps"]>[number] & {
 export interface WorkflowPublicChild {
 	workflowKey?: string;
 	agent?: string;
+	/** Human-readable display name for the child session, when derived at launch. */
+	sessionName?: string;
 	runId?: string;
 	output: string;
 	outputState: "present" | "absent";
@@ -92,7 +94,7 @@ export function promoteSettledPausedWorkflow(status: AsyncStatus, now = Date.now
 
 export function applyDetachedChildSettlement(
 	status: AsyncStatus,
-	input: { childRunId: string; result: { exitCode: number | null; error?: string; interrupted?: boolean; sessionFile?: string; stopped?: boolean }; workflowKey?: string; now?: number },
+	input: { childRunId: string; result: { exitCode: number | null; error?: string; interrupted?: boolean; sessionFile?: string; sessionName?: string; stopped?: boolean }; workflowKey?: string; now?: number },
 ): AsyncStatus | undefined {
 	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
 	const next = cloneWorkflowStatus(status);
@@ -114,6 +116,7 @@ export function applyDetachedChildSettlement(
 	delete step.currentTool;
 	delete step.currentToolStartedAt;
 	if (input.result.sessionFile) step.sessionFile = input.result.sessionFile;
+	if (input.result.sessionName) step.sessionName = input.result.sessionName;
 	if (succeeded) {
 		delete step.error;
 		delete step.interrupted;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -80,7 +80,7 @@ interface AsyncResultPayload {
 	totalTokens?: { input: number; output: number; total: number };
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
 	usageBudget?: UsageBudgetState;
-	results: Array<{ agent?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; timeoutRecovery?: { changedFiles?: string[]; message?: string; warning?: string }; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean; message?: string }; settlementDiagnostic?: { finalTextPresent?: boolean; mutation?: { expected?: boolean; attempted?: boolean; observed?: boolean }; requiredOutput?: { kind?: string; path?: string; missing?: boolean }; afterCompactionSettlement?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string; transcriptPath?: string }; outputSaveError?: string; metadataSaveError?: string; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
+	results: Array<{ agent?: string; sessionName?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; timeoutRecovery?: { changedFiles?: string[]; message?: string; warning?: string }; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean; message?: string }; settlementDiagnostic?: { finalTextPresent?: boolean; mutation?: { expected?: boolean; attempted?: boolean; observed?: boolean }; requiredOutput?: { kind?: string; path?: string; missing?: boolean }; afterCompactionSettlement?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string; transcriptPath?: string }; outputSaveError?: string; metadataSaveError?: string; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
 	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
 	parallelHandoff?: { version?: number; path?: string; groupCount?: number; childCount?: number; changedPatches?: number; cleanupState?: string };
@@ -116,6 +116,8 @@ interface AsyncStatusPayload {
 	capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] };
 	capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean };
 	steps?: Array<{
+		agent?: string;
+		sessionName?: string;
 		label?: string;
 		phase?: string;
 		outputName?: string;
@@ -2387,7 +2389,6 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 					parallel: {
 						agent: "reviewer",
 						task: "Review {target.path}",
-						label: "Review {target.path}",
 						outputSchema: { type: "object" },
 				},
 				collect: { as: "reviews" },
@@ -2412,6 +2413,8 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(readMockPiArgs(mockPi, 1).at(-1) ?? "", /Review src\/a\.ts/);
 		assert.match(readMockPiArgs(mockPi, 2).at(-1) ?? "", /Review src\/b\.ts/);
 		assert.match(readMockPiArgs(mockPi, 3).at(-1) ?? "", /"key":"src\/a\.ts"/);
+		assert.deepEqual(status.steps?.slice(1, 3).map((step) => step.sessionName), ["reviewer: Review src/a.ts", "reviewer: Review src/b.ts"]);
+		assert.deepEqual(payload.results.slice(1, 3).map((result) => result.sessionName), ["reviewer: Review src/a.ts", "reviewer: Review src/b.ts"]);
 		const collected = payload.outputs?.reviews?.structured as Array<{ key: string; structured: unknown }>;
 		assert.deepEqual(collected.map((item) => item.key), ["src/a.ts", "src/b.ts"]);
 		assert.deepEqual(collected.map((item) => item.structured), [{ ok: "a" }, { ok: "b" }]);

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -142,7 +142,7 @@ describe("async status helpers", () => {
 				startedAt: 100,
 				lastUpdate: 200,
 				steps: [
-					{ agent: "scout", context: "fresh", status: "running" },
+					{ agent: "scout", sessionName: "  scout: Scan the auth flow  ", context: "fresh", status: "running" },
 					{ agent: "worker", context: "fork", status: "running" },
 				],
 			});
@@ -152,7 +152,7 @@ describe("async status helpers", () => {
 			assert.deepEqual(runs[0]?.steps.map((step) => step.context), ["fresh", "fork"]);
 			const text = formatAsyncRunList(runs);
 			assert.match(text, /run-context \| running .* \| parallel \[mixed\]/);
-			assert.match(text, /1\. scout \[fresh\] \| running/);
+			assert.match(text, /1\. scout: Scan the auth flow \[fresh\] \| running/);
 			assert.match(text, /2\. worker \[fork\] \| running/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -1441,7 +1441,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 		assert.doesNotMatch(statusText, /Async run not found/);
 		assert.match(statusText, /State: remembered foreground/);
-		assert.match(statusText, /a completed/);
+		assert.match(statusText, /a: ask supervisor completed/);
 		assert.match(statusText, /final recovered answer/);
 
 		const transcript = await executor.execute(

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -833,6 +833,30 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(expanded, /reviewer \(gpt-5\.5 · thinking high\)/);
 	});
 
+	it("prefers session names in expanded running multi-result rows", () => {
+		const sessionName = "reviewer: Review the diff";
+		const widget = renderSubagentResult!({
+			content: [{ type: "text", text: "(running...)" }],
+			details: {
+				mode: "parallel",
+				totalSteps: 1,
+				results: [{
+					agent: "reviewer",
+					sessionName,
+					task: "Review the diff",
+					exitCode: 0,
+					messages: [],
+					usage: emptyUsage,
+					progress: { index: 0, agent: "reviewer", sessionName, status: "running", task: "Review the diff", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 0 },
+				}],
+			},
+		}, { expanded: true }, theme);
+
+		const text = widget.render(160).join("\n");
+		assert.match(text, /Agent 1\/1: reviewer: Review the diff[^\n]* · running/);
+		assert.doesNotMatch(text, /Agent 1\/1: reviewer · running/);
+	});
+
 	it("keeps running compact result output stable when progress is unchanged", async () => {
 		const result = {
 			content: [{ type: "text" as const, text: "(running...)" }],
@@ -1059,6 +1083,7 @@ describe("renderSubagentResult fork indicator", () => {
 				chainAgents: ["[scout+reviewer+worker]", "planner", "writer"],
 				results: [{
 					agent: "scout",
+					sessionName: "  scout: Scan the repository  ",
 					task: "scan",
 					exitCode: 0,
 					messages: [],
@@ -1078,7 +1103,7 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /chain · step 1\/3 · parallel group: 2 agents running · 0\/3 done/);
-		assert.match(text, /Agent 1\/3: scout/);
+		assert.match(text, /Agent 1\/3: scout: Scan the repository/);
 		assert.match(text, /Agent 2\/3: reviewer/);
 		assert.doesNotMatch(text, /Step 1: scout/);
 	});
@@ -1144,6 +1169,7 @@ describe("renderSubagentResult fork indicator", () => {
 				chainAgents: ["planner", "[scout+reviewer]", "writer"],
 				results: progress.map((entry) => ({
 					agent: entry.agent,
+					...(entry.agent === "scout" ? { sessionName: "  scout: Scan completed targets  " } : {}),
 					task: entry.task,
 					exitCode: 0,
 					messages: [],
@@ -1157,7 +1183,7 @@ describe("renderSubagentResult fork indicator", () => {
 		const text = widget.render(120).join("\n");
 		assert.match(text, /chain · step 3\/3/);
 		assert.match(text, /Step 1: planner/);
-		assert.match(text, /Agent 1\/2: scout/);
+		assert.match(text, /Agent 1\/2: scout: Scan completed targets/);
 		assert.match(text, /Agent 2\/2: reviewer/);
 		assert.match(text, /Step 3: writer/);
 		assert.doesNotMatch(text, /step 4\/4/);

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -697,7 +697,7 @@ describe("subagent async widget rendering", () => {
 				stepsTotal: 3,
 				updatedAt: now,
 				steps: [
-					{ agent: "reviewer", status: "running", lastActivityAt: now, toolCount: 2 },
+					{ agent: "reviewer", sessionName: "  reviewer: Inspect the first row  ", status: "running", lastActivityAt: now, toolCount: 2 },
 					{ agent: "reviewer", status: "running", currentTool: "read", currentToolStartedAt: now - 2000 },
 					{ agent: "reviewer", status: "complete", tokens: { input: 1000, output: 500, cache: 0, total: 1500 } },
 				],
@@ -707,11 +707,39 @@ describe("subagent async widget rendering", () => {
 		const text = lines.join("\n");
 		assert.match(text, /async subagent parallel \(3\) · background/);
 		assert.match(text, /parallel · 2 agents running · 1\/3 done/);
-		assert.match(text, /Agent 1\/3: reviewer · running · 2 tool uses/);
+		assert.match(text, /Agent 1\/3: reviewer: Inspect the first row · running · 2 tool uses/);
 		assert.match(text, /⎿  active now/);
 		assert.match(text, /Agent 2\/3: reviewer · running\n\s+⎿  read \| 2\.0s/);
 		assert.match(text, /Press configured-expand-key for live detail/);
 		assert.match(text, /Agent 3\/3: reviewer · complete · 1\.5k token/);
+	});
+
+	it("prefers session names in multi-job widget step rows", () => {
+		const text = buildWidgetLines([
+			{
+				asyncId: "run-multi-a",
+				asyncDir: "/tmp/multi-a",
+				status: "running",
+				mode: "parallel",
+				agents: ["reviewer"],
+				stepsTotal: 1,
+				runningSteps: 1,
+				completedSteps: 0,
+				steps: [{ index: 0, agent: "reviewer", sessionName: "  reviewer: Inspect the multi-job row  ", status: "running" }],
+			},
+			{
+				asyncId: "run-multi-b",
+				asyncDir: "/tmp/multi-b",
+				status: "complete",
+				mode: "single",
+				agents: ["worker"],
+				stepsTotal: 1,
+				steps: [{ index: 0, agent: "worker", status: "complete" }],
+			},
+		], theme, 180).join("\n");
+
+		assert.match(text, /Agent 1\/1: reviewer: Inspect the multi-job row · running/);
+		assert.doesNotMatch(text, /Agent 1\/1: reviewer · running/);
 	});
 
 	it("shows async job and step context badges", () => {
@@ -1002,6 +1030,7 @@ describe("subagent async widget rendering", () => {
 				{
 					index: 0,
 					agent: "worker",
+					sessionName: "  worker: Read the widget  ",
 					status: "running",
 					currentTool: "read",
 					currentToolArgs: "src/tui/render.ts",
@@ -1013,7 +1042,7 @@ describe("subagent async widget rendering", () => {
 
 		const collapsedText = buildWidgetLines([job], theme, 180).join("\n");
 		assert.match(collapsedText, /async subagent worker · background/);
-		assert.match(collapsedText, /Step 1\/1: worker · running/);
+		assert.match(collapsedText, /Step 1\/1: worker: Read the widget · running/);
 		assert.match(collapsedText, /⎿  read: src\/tui\/render\.ts \| 2\.0s/);
 		assert.match(collapsedText, /Press configured-expand-key for live detail/);
 		assert.match(collapsedText, outputPathPattern("/tmp/single-run/output-0.log"));

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -408,6 +408,19 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(output, "Hello from mock agent");
 	});
 
+	it("derives a child session name and passes it to the child env", async () => {
+		mockPi.onCall({ echoEnv: ["PI_SUBAGENT_SESSION_NAME"] });
+		const agents = makeAgentConfigs(["echo"]);
+
+		const result = await runSync(tempDir, agents, "echo", "Say hello to the world", {});
+
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.sessionName, "echo: Say hello to the world");
+		assert.equal(result.progressSummary?.sessionName, "echo: Say hello to the world");
+		const echoed = JSON.parse(getFinalOutput(result.messages));
+		assert.equal(echoed.PI_SUBAGENT_SESSION_NAME, "echo: Say hello to the world");
+	});
+
 	it("rejects invalid foreground cwd before spawning Pi", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const executor = makeExecutor([makeAgent("echo")]);
 		const requestedCwd = "missing-local-cwd";

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -939,7 +939,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.existsSync(path.join(DIRS.async, toolCallId)), false);
 		assert.match(result.content[0]?.text ?? "", /Async workflow/);
 		const statusPath = path.join(result.details.asyncDir!, "status.json");
-		let status: { runId?: string; toolCallId?: string; cwd?: string; sessionRoot?: string; state?: string; steps?: Array<{ agent?: string; label?: string; phase?: string; workflowKey?: string; parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; agent?: string; label?: string; phase?: string; state?: string }> } } = {};
+		let status: { runId?: string; toolCallId?: string; cwd?: string; sessionRoot?: string; state?: string; steps?: Array<{ agent?: string; sessionName?: string; label?: string; phase?: string; workflowKey?: string; parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; agent?: string; label?: string; phase?: string; state?: string }> } } = {};
 		for (let attempt = 0; attempt < 100; attempt++) {
 			status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
 			if (status.state === "complete" || status.state === "failed") break;
@@ -951,8 +951,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(status.cwd, workflowCwd);
 		assert.equal(status.sessionRoot, path.join(tempDir, ".pi/subagents", "sessions"));
 		assert.equal(status.steps?.length, 1);
-		assert.deepEqual(status.steps?.map(({ agent, label, phase, workflowKey }) => ({ agent, label, phase, workflowKey })), [
-			{ agent: "echo", label: "Run async child", phase: "Execution", workflowKey: "work" },
+		assert.deepEqual(status.steps?.map(({ agent, sessionName, label, phase, workflowKey }) => ({ agent, sessionName, label, phase, workflowKey })), [
+			{ agent: "echo", sessionName: "echo: Async work", label: "Run async child", phase: "Execution", workflowKey: "work" },
 		]);
 		assert.ok(status.steps?.every((step) => step.parentWorkflowRunId === workflowRunId));
 		assert.deepEqual(status.workflow?.value, { answer: 42 });
@@ -971,14 +971,14 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			{ key: "work", state: "completed" },
 		]);
 		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
-		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown; receipt?: unknown }; workflowReceipt?: { path?: string; receipt?: { workflowRunId?: string; entries?: Record<string, { key?: string; agent?: string; latestRunId?: string; resumability?: { state?: string; reason?: string }; continuation?: { runIds?: string[] } }> } }; results?: Array<{ agent?: string; workflowKey?: string; runId?: string; output?: string }> };
+		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown; receipt?: unknown }; workflowReceipt?: { path?: string; receipt?: { workflowRunId?: string; entries?: Record<string, { key?: string; agent?: string; latestRunId?: string; resumability?: { state?: string; reason?: string }; continuation?: { runIds?: string[] } }> } }; results?: Array<{ agent?: string; sessionName?: string; workflowKey?: string; runId?: string; output?: string }> };
 		assert.equal(persistedResult.id, workflowRunId);
 		assert.equal(persistedResult.runId, workflowRunId);
 		assert.equal(persistedResult.toolCallId, toolCallId);
 		assert.equal(persistedResult.agent, "workflow");
 		assert.equal(persistedResult.cwd, workflowCwd);
-		assert.deepEqual(persistedResult.results?.map(({ agent, workflowKey }) => ({ agent, workflowKey })), [
-			{ agent: "echo", workflowKey: "work" },
+		assert.deepEqual(persistedResult.results?.map(({ agent, sessionName, workflowKey }) => ({ agent, sessionName, workflowKey })), [
+			{ agent: "echo", sessionName: "echo: Async work", workflowKey: "work" },
 		]);
 		const steeringEnv = JSON.parse(persistedResult.results?.[0]?.output ?? "null") as Record<string, string | null>;
 		assert.match(steeringEnv[SUBAGENT_STEER_INBOX_ENV] ?? "", /control[/\\]workflow-foreground[/\\].+[/\\]control[/\\]steer-targets[/\\]0$/);

--- a/test/unit/child-session-name.test.ts
+++ b/test/unit/child-session-name.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	CHILD_SESSION_NAME_MAX_CHARS,
+	deriveChildSessionName,
+} from "../../src/shared/child-session-name.ts";
+import { PROMPT_REDACTED } from "../../src/shared/utils.ts";
+
+describe("deriveChildSessionName", () => {
+	it("combines agent and task excerpt", () => {
+		assert.equal(
+			deriveChildSessionName({ agent: "reviewer", task: "Review the diff since main" }),
+			"reviewer: Review the diff since main",
+		);
+	});
+
+	it("prefers a workflow label over the task", () => {
+		assert.equal(
+			deriveChildSessionName({ agent: "scout", label: "find-callers", task: "ignored task text" }),
+			"scout: find-callers",
+		);
+	});
+
+	it("falls back to the bare agent when no task or label is usable", () => {
+		assert.equal(deriveChildSessionName({ agent: "worker" }), "worker");
+		assert.equal(deriveChildSessionName({ agent: "worker", task: "   " }), "worker");
+	});
+
+	it("never builds a name from a redacted prompt", () => {
+		assert.equal(deriveChildSessionName({ agent: "worker", task: PROMPT_REDACTED }), "worker");
+		assert.equal(deriveChildSessionName({ task: PROMPT_REDACTED }), undefined);
+	});
+
+	it("collapses newlines and control characters into a single line", () => {
+		const name = deriveChildSessionName({ agent: "scout", task: "line one\nline two" });
+		assert.equal(name, "scout: line one line two");
+		assert.doesNotMatch(name!, /[\n]/);
+	});
+
+	it("caps the final name at CHILD_SESSION_NAME_MAX_CHARS", () => {
+		const name = deriveChildSessionName({ agent: "worker", task: "x".repeat(500) });
+		assert.ok(name);
+		assert.ok(name.length <= CHILD_SESSION_NAME_MAX_CHARS);
+		assert.ok(name.endsWith("..."));
+	});
+
+	it("returns undefined when there is nothing to name", () => {
+		assert.equal(deriveChildSessionName({}), undefined);
+	});
+});

--- a/test/unit/foreground-control.test.ts
+++ b/test/unit/foreground-control.test.ts
@@ -15,6 +15,7 @@ function progress(index: number, agent: string, tokens: number): AgentProgress {
 	return {
 		index,
 		agent,
+		sessionName: `  ${agent}: named task  `,
 		status: "running",
 		task: `${agent} task`,
 		recentTools: [],
@@ -69,6 +70,8 @@ describe("foreground child control", () => {
 		assert.equal(control.currentIndex, 1);
 		updateForegroundChild(control, 0, progress(0, "reviewer", 120));
 		assert.equal(control.currentIndex, 0);
+		assert.equal(control.sessionName, "  reviewer: named task  ");
+		assert.equal(control.activeChildren?.get(0)?.sessionName, "  reviewer: named task  ");
 		assert.equal(control.tokens, 120);
 		assert.equal(control.inputTokens, 100);
 		assert.equal(control.outputTokens, 20);
@@ -93,6 +96,7 @@ describe("foreground child control", () => {
 		finishForegroundChild(control, 0);
 		assert.equal(control.activeChildren?.size, 0);
 		assert.equal(control.currentIndex, undefined);
+		assert.equal(control.sessionName, undefined);
 		assert.equal(control.model, undefined);
 		assert.equal(control.inputTokens, undefined);
 		assert.equal(control.outputTokens, undefined);

--- a/test/unit/nested-events.test.ts
+++ b/test/unit/nested-events.test.ts
@@ -472,3 +472,21 @@ describe("nested event parsing and projection", () => {
 		assert.equal(secondProjection.children[0]?.state, "complete");
 	});
 });
+
+describe("nested session-name projection", () => {
+	it("keeps bounded root and step session names from async status", () => {
+		const summary = nestedSummaryFromAsyncStatus({
+			runId: "child-run",
+			mode: "single",
+			state: "running",
+			startedAt: 1,
+			steps: [{
+				agent: "reviewer",
+				sessionName: "reviewer: Inspect the changed auth middleware",
+				status: "running",
+			}],
+		}, "/tmp/child-run", { id: "child-run", parentRunId: "root-run", depth: 1, ts: 1 });
+		assert.equal(summary.sessionName, "reviewer: Inspect the changed auth middleware");
+		assert.equal(summary.steps?.[0]?.sessionName, "reviewer: Inspect the changed auth middleware");
+	});
+});

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -325,6 +325,31 @@ describe("buildPiArgs session wiring", () => {
 		assert.equal(env[SUBAGENT_PARENT_SESSION_ENV], "direct-parent");
 	});
 
+	it("passes the child display session name through as PI_SUBAGENT_SESSION_NAME", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			sessionName: "worker: Fix the flaky test",
+		});
+
+		assert.equal(env.PI_SUBAGENT_SESSION_NAME, "worker: Fix the flaky test");
+	});
+
+	it("omits PI_SUBAGENT_SESSION_NAME when no session name is provided", () => {
+		const { env } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		assert.equal(env.PI_SUBAGENT_SESSION_NAME, undefined);
+	});
+
 	it("falls back to inherited parent session env for permission forwarding", () => {
 		process.env.PI_SUBAGENT_PARENT_SESSION = "inherited-parent";
 		const { env } = buildPiArgs({

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -360,6 +360,20 @@ test("static sequential and static parallel chain rendering keep existing labels
 	assert.match(parallel, /Step 3: writer/);
 });
 
+test("expanded simple chain summaries prefer result session names", () => {
+	const expanded = componentText(renderSubagentResult({
+		content: [{ type: "text", text: "done" }],
+		details: {
+			mode: "chain",
+			chainAgents: ["chain-label"],
+			totalSteps: 1,
+			results: [{ ...result("worker", "done"), sessionName: "  worker: named task  " }],
+		},
+	}, { expanded: true }, theme as any));
+	assert.match(expanded, /Step 1: worker: named task/);
+	assert.doesNotMatch(expanded, /Step 1: chain-label/);
+});
+
 test("main-window renderer config removes compact result indentation without changing status glyphs", () => {
 	const component = renderSubagentResult({
 		content: [{ type: "text", text: "done" }],

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -171,7 +171,7 @@ describe("async run status inspection", () => {
 				chainStepCount: 1,
 				parallelGroups: [{ start: 0, count: 3, stepIndex: 0 }],
 				steps: [
-					{ agent: "reviewer", status: "running", startedAt: 100, model: "openai-codex/gpt-5.5:high" },
+					{ agent: "reviewer", sessionName: "  reviewer: Inspect the first result  ", status: "running", startedAt: 100, model: "openai-codex/gpt-5.5:high" },
 					{ agent: "reviewer", status: "running", startedAt: 100, model: "anthropic/claude-haiku-4-5", thinking: "low" },
 					{ agent: "reviewer", status: "pending" },
 				],
@@ -189,7 +189,7 @@ describe("async run status inspection", () => {
 			assert.match(text, /Error: top-level async status error/);
 			assert.match(text, /Progress: 2 agents running · 0\/3 done/);
 			assert.match(text, new RegExp(`Output: ${runOutputPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
-			assert.match(text, /Agent 1\/3: reviewer running \(gpt-5\.5 · thinking high\)/);
+			assert.match(text, /Agent 1\/3: reviewer: Inspect the first result running \(gpt-5\.5 · thinking high\)/);
 			assert.match(text, /Agent 2\/3: reviewer running \(claude-haiku-4-5 · thinking low\)/);
 			assert.match(text, /Agent 3\/3: reviewer pending/);
 			assert.doesNotMatch(text, /openai-codex\/gpt-5\.5/);
@@ -216,7 +216,7 @@ describe("async run status inspection", () => {
 				startedAt: 100,
 				lastUpdate: 200,
 				currentStep: 0,
-				steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+				steps: [{ agent: "worker", sessionName: "  worker: Read the transcript  ", status: "running", startedAt: 100 }],
 			}, null, 2), "utf-8");
 
 			const result = inspectSubagentStatus({ id: "run-transcript", view: "transcript", lines: 2 }, {
@@ -229,7 +229,7 @@ describe("async run status inspection", () => {
 			const text = textContent(result);
 			assert.equal(result.isError, undefined);
 			assert.match(text, /Run: run-transcript/);
-			assert.match(text, /Step: 0 \(worker\) \| running/);
+			assert.match(text, /Step: 0 \(worker: Read the transcript\) \| running/);
 			assert.match(text, new RegExp(`Transcript tail from ${outputPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\(tail truncated\\):`));
 			assert.doesNotMatch(text, /first line/);
 			assert.match(text, /second line/);
@@ -465,7 +465,7 @@ describe("async run status inspection", () => {
 				chainStepCount: 1,
 				parallelGroups: [{ start: 0, count: 2, stepIndex: 0 }],
 				steps: [
-					{ agent: "worker", status: "running", startedAt: 100 },
+					{ agent: "worker", sessionName: "  worker: Inspect fleet  ", label: "Fleet check", status: "running", startedAt: 100 },
 					{ agent: "reviewer", status: "pending" },
 				],
 			}, null, 2), "utf-8");
@@ -477,6 +477,7 @@ describe("async run status inspection", () => {
 					startedAt: 100,
 					updatedAt: 250,
 					currentAgent: "scout",
+					sessionName: "  foreground: Inspect fleet  ",
 					currentIndex: 0,
 					lastActivityAt: 240,
 				}]]),
@@ -494,8 +495,10 @@ describe("async run status inspection", () => {
 			assert.equal(result.isError, undefined);
 			assert.match(text, /Subagent fleet: 2 tracked/);
 			assert.match(text, /Foreground runs:/);
-			assert.match(text, /fg-run \| running \| scout/);
+			assert.match(text, /fg-run \| running \| foreground: Inspect fleet/);
+			assert.doesNotMatch(text, /fg-run \| running \| scout/);
 			assert.match(text, /Async runs:/);
+			assert.match(text, /0\. worker: Inspect fleet \| running/);
 			assert.match(text, /run-fleet \| running .*\| parallel \| 1 agent running · 0\/2 done/);
 			assert.match(text, /transcript: subagent\(\{ action: "status", id: "run-fleet", view: "transcript" \}\)/);
 			assert.match(text, /transcript: subagent\(\{ action: "status", id: "run-fleet", index: 0, view: "transcript" \}\)/);
@@ -735,6 +738,7 @@ describe("async run status inspection", () => {
 					path: [{ runId: "run-nested-root", stepIndex: 0, agent: "orchestrator" }],
 					state: "running",
 					agent: "reviewer",
+					sessionName: "  reviewer: Read the status  ",
 					currentTool: "read",
 					lastUpdate: 150,
 				},
@@ -750,7 +754,7 @@ describe("async run status inspection", () => {
 			const text = textContent(result);
 			assert.equal(result.isError, undefined);
 			assert.match(text, /Step 1: orchestrator running/);
-			assert.match(text, /↳ reviewer \[nested-status-child\] running \| tool read/);
+			assert.match(text, /↳ reviewer: Read the status \[nested-status-child\] running \| tool read/);
 			assert.match(text, /Status: subagent\(\{ action: "status", id: "nested-status-child" \}\)/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/widget-nested-render.test.ts
+++ b/test/unit/widget-nested-render.test.ts
@@ -39,13 +39,13 @@ function job(child: NestedRunSummary): AsyncJobState {
 
 describe("nested widget rendering", () => {
 	it("renders a bounded collapsed tree and full child rows when expanded", () => {
-		const child = nested("nested-reviewer", "root-run", "running", { currentTool: "read", model: "gpt-5.6-luna:medium", thinking: "medium" });
+		const child = nested("nested-reviewer", "root-run", "running", { sessionName: "  nested-reviewer: Review nested run  ", currentTool: "read", model: "gpt-5.6-luna:medium", thinking: "medium" });
 		const collapsed = buildWidgetLines([job(child)], theme as any, 120, false).join("\n");
-		assert.match(collapsed, /↳ └─ \[\d{2}:\d{2}:\d{2}\] . nested-reviewer · running · gpt-5.6-luna · thinking medium · read/);
+		assert.match(collapsed, /↳ └─ \[\d{2}:\d{2}:\d{2}\] . nested-reviewer: Review nested run · running · gpt-5.6-luna · thinking medium · read/);
 		assert.equal((collapsed.match(/thinking medium/g) ?? []).length, 1);
 
 		const expanded = buildWidgetLines([job(child)], theme as any, 120, true).join("\n");
-		assert.match(expanded, /↳ \[\d{2}:\d{2}:\d{2}\] . nested-reviewer · running · gpt-5.6-luna · thinking medium · read/);
+		assert.match(expanded, /↳ \[\d{2}:\d{2}:\d{2}\] . nested-reviewer: Review nested run · running · gpt-5.6-luna · thinking medium · read/);
 
 		const epoch = buildWidgetLines([job(nested("epoch", "root-run", "running", { lastUpdate: 0, startedAt: 0 }))], theme as any, 120, false).join("\n");
 		assert.match(epoch, /↳ └─ \[\d{2}:\d{2}:\d{2}\] . epoch · running/);
@@ -122,7 +122,7 @@ describe("nested widget rendering", () => {
 	it("timestamps every nested lifecycle state and completed steps", () => {
 		const states: NestedRunSummary["state"][] = ["queued", "running", "complete", "failed", "paused", "stopped"];
 		const root = nested("matrix-root", "root-run", "running", {
-			steps: [{ agent: "completed-step", status: "completed", endedAt: 2_000 }],
+			steps: [{ agent: "completed-step", sessionName: "  completed-step: Finalize report  ", status: "completed", endedAt: 2_000 }],
 			children: states.map((state, index) => nested(`child-${state}`, "matrix-root", state, {
 				parentStepIndex: undefined,
 				startedAt: 1_000 + index,
@@ -133,7 +133,7 @@ describe("nested widget rendering", () => {
 		for (const state of states) {
 			assert.match(expanded, new RegExp(`\\[\\d{2}:\\d{2}:\\d{2}\\] . child-${state} · ${state}`));
 		}
-		assert.match(expanded, /\[\d{2}:\d{2}:\d{2}\] . completed-step · completed/);
+		assert.match(expanded, /\[\d{2}:\d{2}:\d{2}\] . completed-step: Finalize report · completed/);
 	});
 
 	it("keeps event-time timestamps stable instead of advancing with wall time", async () => {
@@ -147,6 +147,8 @@ describe("nested widget rendering", () => {
 	it("rerenders when only nested state changes", () => {
 		const first = job(nested("nested-reviewer", "root-run", "running"));
 		const second = job(nested("nested-reviewer", "root-run", "complete"));
+		const renamed = job(nested("nested-reviewer", "root-run", "running", { sessionName: "nested-reviewer: Review nested run" }));
 		assert.notEqual(widgetRenderKey(first), widgetRenderKey(second));
+		assert.notEqual(widgetRenderKey(first), widgetRenderKey(renamed));
 	});
 });

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -321,3 +321,39 @@ describe("workflow receipts", () => {
 		);
 	});
 });
+
+describe("workflow child session names", () => {
+	it("persists a bounded child session name from async status", () => {
+		const summary = workflowChildSummary({
+			parentToolCallId: "tool-call",
+			workflowRunId: "workflow-1",
+			workflowState: "completed",
+			inventoryComplete: true,
+			steps: [{
+				agent: "reviewer",
+				sessionName: "reviewer: Inspect the changed auth middleware",
+				workflowKey: "review",
+				status: "complete",
+			}],
+		});
+		assert.equal(summary.children[0]?.sessionName, "reviewer: Inspect the changed auth middleware");
+	});
+
+	it("rejects unbounded session names in persisted workflow summaries", () => {
+		const root = tempRoot();
+		const asyncDir = path.join(root, "workflow-1");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		writeWorkflowReceipt(asyncDir, {
+			...buildWorkflowReceipt({ workflowRunId: "workflow-1", state: "complete", children: [] }),
+			workflowChildren: {
+				version: 1,
+				parentToolCallId: "tool",
+				workflowRunId: "workflow-1",
+				inventoryComplete: true,
+				workflowState: "completed",
+				children: [{ childId: "review", state: "completed", sessionName: "x".repeat(257) }],
+			},
+		});
+		assert.throws(() => readWorkflowReceipt(root, "workflow-1"), /sessionName is invalid/);
+	});
+});


### PR DESCRIPTION
# feat: human-readable child session names

## Motivation

Every subagent child runs its own Pi session, but that session is unnamed: nothing calls
`pi.setSessionName()` for a normal child, so the session shows up as an anonymous file in
`pi --resume` and host session browsers. The only exception is the intercom bridge, which
sets a *machine* name (`subagent-<agent>-<runId>-<n>`) that exists for routing, not display.

Hosts rendering the parent stream (the Pi TUI, and GUI hosts consuming the tool `details`
payload) have the same problem: `details.results[]` identifies a child only by its agent
type, so three parallel `worker` children are indistinguishable without expanding each one.

## What this PR does

1. **Derives a display name at launch** — `deriveChildSessionName({ agent, task, label })`
   in `src/shared/child-session-name.ts`, e.g. `reviewer: Review the diff since main`.
   One line, terminal-control-sanitized (reuses `previewDisplayText`), hard-capped at 80
   chars. Workflow node labels are preferred over the task excerpt. Redacted prompts
   (`PROMPT_REDACTED`) never contribute text — the name falls back to the bare agent name.

2. **Names the child's actual session** — the name travels to the child as
   `PI_SUBAGENT_SESSION_NAME` (set by `buildPiArgs`), and the prompt runtime applies it via
   `pi.setSessionName()` in `before_agent_start`. The intercom target keeps precedence:
   it is a routing address, not a display name, and overriding it would break intercom
   delivery. So an intercom-enabled child's *persisted* session name may differ from the
   payload `sessionName` — the payload field is the parent-computed display name.

3. **Echoes the name on every payload** — optional `sessionName` on `SingleResult`,
   `AgentProgress`, `ProgressSummary`, async `status.json` step rows, workflow child
   summaries, nested run summaries, and intercom completion children. Strict projections
   and allowlists (nested-event sanitizers, workflow child parser, public `Pick`s) admit
   the key explicitly.

4. **Prefers the name in the TUI** — child rows/headers in `render.ts` show the session
   name when present, falling back to the agent name exactly as before.

## Compatibility

- All wire/type changes are additive optional fields; older hosts ignore them and older
  children simply omit them (hosts fall back to `agent`).
- No new configuration; naming is always-on and cost-free (one env var, one
  `setSessionName` call).
- Privacy: the name is derived from the task text, which already travels in the same
  payloads (`SingleResult.task`); `compactCompletedProgress` keeps redacting the task
  field itself. Public input boundaries (`public-execution.ts`) do **not** accept a
  caller-provided `sessionName` — it is always derived internally.

## Testing

- `test/unit/child-session-name.test.ts`: derivation rules (excerpt, label preference,
  redaction, sanitization, length cap).
- Projection tests for the previously lossy allowlists (nested events, workflow child
  summary parser, foreground history compaction).
- `tsc --noEmit` clean; unit suite at baseline (the 32 pre-existing failures on main are
  unchanged).
