### PR TITLE
fix: allow long background-work session ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Accept path-like Pi session ids up to 4,096 characters when snapshotting background work. Thanks to [@dvishoot](https://github.com/dvishoot) for #1616.
 - Accept bare leaf model ids reported by provider drivers when verifying provider-qualified launch candidates. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.
 - Resume compaction-induced child aborts once when retained state is safe, and report the exact recovery blocker otherwise.
 - Report aborted or signalled no-output child runs with their terminal stop, stderr, or process signal before missing-output handoff diagnostics.

--- a/src/api/background-work.ts
+++ b/src/api/background-work.ts
@@ -4,7 +4,11 @@ export const BACKGROUND_WORK_REGISTRY_KEY = "pi-subagents.background-work.v1";
 const MAX_PROVIDER_NAME_LENGTH = 128;
 const MAX_PROVIDERS = 100;
 const MAX_ITEM_ID_LENGTH = 256;
-const MAX_SESSION_ID_LENGTH = 256;
+/**
+ * A Pi session id is the session file path, which routinely exceeds a short
+ * identity budget in nested worktrees, so it is bounded like the other paths.
+ */
+const MAX_SESSION_ID_LENGTH = 4_096;
 const MAX_WAKE_CHANNEL_LENGTH = 256;
 const MAX_ITEMS_PER_PROVIDER = 10_000;
 

--- a/test/unit/background-work.test.ts
+++ b/test/unit/background-work.test.ts
@@ -127,6 +127,29 @@ describe("background-work provider protocol", () => {
 		assert.throws(() => snapshotBackgroundWork("session-a"), /duplicate item 'job'/);
 	});
 
+	it("accepts path-like session ids up to the bound and rejects longer ids", () => {
+		const longSessionId = `${"/nested/".repeat(511)}xsession`;
+		const overBoundSessionId = `${longSessionId}x`;
+		assert.equal(longSessionId.length, 4_096);
+
+		registerBackgroundWorkProvider({
+			name: "patty",
+			listActiveWork: () => [{ id: "job", sessionId: longSessionId }],
+		});
+		assert.deepEqual(snapshotBackgroundWork(longSessionId), {
+			providers: ["patty"],
+			items: [{ provider: "patty", id: "job", sessionId: longSessionId }],
+		});
+		assert.throws(() => snapshotBackgroundWork(overBoundSessionId), /at most 4096 characters/);
+
+		clearRegistry();
+		registerBackgroundWorkProvider({
+			name: "patty",
+			listActiveWork: () => [{ id: "job", sessionId: overBoundSessionId }],
+		});
+		assert.throws(() => snapshotBackgroundWork("session-a"), /at most 4096 characters/);
+	});
+
 	it("preserves list and reconcile errors with provider context", () => {
 		registerBackgroundWorkProvider({
 			name: "broken-reconcile",


### PR DESCRIPTION
## Summary

Fixes #1616 by raising the background-work session ID validation bound from 256 to 4,096 characters, matching the existing external-runs precedent for path-derived Pi session IDs.

The change stays at the API validation boundary. It does not add polling, filesystem scans, recovery behavior, public API, or configuration.

Thanks to [@dvishoot](https://github.com/dvishoot) for #1616.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/background-work.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
