### PR TITLE
fix: format million-scale context limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Format million-scale context limits as `1M` instead of `1000k` in live status displays.
 - Accept path-like Pi session ids up to 4,096 characters when snapshotting background work. Thanks to [@dvishoot](https://github.com/dvishoot) for #1616.
 - Accept bare leaf model ids reported by provider drivers when verifying provider-qualified launch candidates. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.
 - Resume compaction-induced child aborts once when retained state is safe, and report the exact recovery blocker otherwise.

--- a/src/shared/formatters.ts
+++ b/src/shared/formatters.ts
@@ -11,10 +11,13 @@ import { previewDisplayText, sanitizeDisplayText } from "./display-text.ts";
 import { splitKnownThinkingSuffix, THINKING_LEVELS } from "./model-info.ts";
 
 /**
- * Format token count with k suffix for large numbers
+ * Format token count for compact display.
  */
 export function formatTokens(n: number): string {
-	return n < 1000 ? String(n) : n < 10000 ? `${(n / 1000).toFixed(1)}k` : `${Math.round(n / 1000)}k`;
+	if (n < 1000) return String(n);
+	if (n < 10000) return `${(n / 1000).toFixed(1)}k`;
+	if (n < 999_500) return `${Math.round(n / 1000)}k`;
+	return `${Number((n / 1_000_000).toFixed(1))}M`;
 }
 
 export function formatTokenUsage(usage: TokenUsage, legacyLabel = "tok"): string {

--- a/test/unit/formatters.test.ts
+++ b/test/unit/formatters.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatContextUsage, formatTokens } from "../../src/shared/formatters.ts";
+
+test("formats million-scale token values with an M suffix", () => {
+	assert.equal(formatTokens(999_499), "999k");
+	assert.equal(formatTokens(999_500), "1M");
+	assert.equal(formatTokens(1_000_000), "1M");
+	assert.equal(formatTokens(1_250_000), "1.3M");
+});
+
+test("formats million-scale context limits clearly", () => {
+	assert.equal(formatContextUsage({ window: 93_000 }, 1_000_000), "ctx 93k/1M (9%)");
+});


### PR DESCRIPTION
## Summary

Fixes #1627.

This changes shared context-limit formatting so million-scale context windows render as `1M` instead of `1000k`. It keeps the existing sub-million `k` display and leaves context usage math unchanged.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/formatters.test.ts`
- `npm run typecheck`
- `npm test`
- `git diff --check origin/main...HEAD`

Fresh review found no release risks at `d1b5d91d8a73e13d19254ffbe3fe8710ab73cc03`.
