### PR TITLE
fix: handle stale contexts during reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Stop stale extension and slash-command contexts from escaping during reload or session replacement.
 - Format million-scale context limits as `1M` instead of `1000k` in live status displays.
 - Accept path-like Pi session ids up to 4,096 characters when snapshotting background work. Thanks to [@dvishoot](https://github.com/dvishoot) for #1616.
 - Accept bare leaf model ids reported by provider drivers when verifying provider-qualified launch candidates. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -293,7 +293,9 @@ function isSlashResultError(result: { details?: Details }): boolean {
 }
 
 function isStaleExtensionContextError(error: unknown): boolean {
-	return error instanceof Error && error.message.includes("Extension context no longer active");
+	return error instanceof Error
+		&& (error.message.includes("This extension ctx is stale")
+			|| error.message.includes("Extension context no longer active"));
 }
 
 function rebuildSlashResultContainer(
@@ -756,7 +758,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 	});
 
-	registerSlashCommands(pi, state, {
+	const disposeSlashCommands = registerSlashCommands(pi, state, {
 		fleetKeybindings: config.fleetKeybindings,
 		foregroundDetachShortcut: config.foregroundDetachShortcut,
 	});
@@ -940,6 +942,13 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			if (runtimeCleaned) return;
 			runtimeCleaned = true;
 			const shuttingDownParentSession = parentSessionEnvValue;
+			// Workflow continuations retain their launch context; abort them before
+			// teardown so a reload cannot launch through a stale context.
+			for (const controller of state.workflowControllers?.values() ?? []) {
+				if (!controller.signal.aborted) controller.abort(new Error("Workflow stopped because the extension session was replaced or reloaded."));
+			}
+			state.workflowControllers?.clear();
+			state.workflowChildStops?.clear();
 			clearRuntimeAgentsForPi(pi);
 			clearTimeout(resultIndexCleanupTimer);
 			clearTimeout(asyncRetentionTimer);
@@ -963,6 +972,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 					// Best effort cleanup during shutdown or reload.
 				}
 			}
+			disposeSlashCommands.dispose();
 			slashBridge.cancelAll();
 			slashBridge.dispose();
 			promptTemplateBridge.cancelAll();

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4751,7 +4751,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					const { action: _action, agent: _agent, task: _task, resume: _resume, tasks: _tasks, chain: _chain, concurrency: _concurrency, foregroundOnly: _foregroundOnly, clarify: _clarify, timeoutMs: _timeoutMs, maxRuntimeMs: _maxRuntimeMs, usageBudget: _usageBudget, missionId: _missionId, mission: _mission, ...workflowChildDefaults } = workflowRequest;
 					const workflowOutput = typeof workflowChildDefaults.output === "string" || typeof workflowChildDefaults.output === "boolean" ? workflowChildDefaults.output : undefined;
 					const configuredOutputBaseDir = resolveConfiguredSingleRunOutputBaseDir(deps);
-					const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, ctx.cwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, workflowRunId));
+					const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, parentCwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, workflowRunId));
 					const claimedOutputPaths = new Map<string, string>();
 					const childOutputOverrides = new Map<string, string>();
 					const producedChildOutputPaths = new Set<string>();
@@ -4864,7 +4864,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							...(workflowState ? { state: workflowState } : {}),
 							onTrace: updateTrace,
 							admit: (calls) => {
-								const outputClaims = workflowChildOutputClaims({ ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, state: deps.state, claimedOutputPaths, entries: calls });
+								const outputClaims = workflowChildOutputClaims({ ctxCwd: parentCwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, state: deps.state, claimedOutputPaths, entries: calls });
 								if (outputClaims.error) throw new Error(outputClaims.error);
 								status.runFanoutBudget = claimRunFanoutBatch(workflowFanoutBudget, calls.map(({ key }) => `workflow[${key}]`));
 								if (outputClaims.claims) applyWorkflowChildOutputClaims(claimedOutputPaths, outputClaims.claims);
@@ -4892,7 +4892,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								});
 								const result = await runMissionWorkflowChild(missionBinding, workflowRunId, key, childPhase, () => {
 									const childRequest = bindMissionWorkflowChildAsyncLaunch(
-										{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: workflowRunId, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), options: { missionDetached: detachWorkflowChildMissions, runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt, capabilityCeiling: workflowCapabilityCeiling } }), runFanoutAdmitted: admission.admitted },
+										{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: workflowRunId, workflowKey: key, ctxCwd: parentCwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), options: { missionDetached: detachWorkflowChildMissions, runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt, capabilityCeiling: workflowCapabilityCeiling } }), runFanoutAdmitted: admission.admitted },
 										missionBinding,
 										deps.asyncByDefault,
 									);

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -449,50 +449,76 @@ function getProfileWorkerModel(profile: { subagents?: { agentOverrides?: Record<
 	return typeof model === "string" && model.trim() ? model.trim() : undefined;
 }
 
+function isStaleExtensionContextError(error: unknown): boolean {
+	return error instanceof Error
+		&& (error.message.includes("This extension ctx is stale")
+			|| error.message.includes("Extension context no longer active"));
+}
+
+function slashHasUI(ctx: ExtensionContext): boolean | undefined {
+	try {
+		return ctx.hasUI;
+	} catch (error) {
+		if (isStaleExtensionContextError(error)) return undefined;
+		throw error;
+	}
+}
+
 
 async function requestSlashRun(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	requestId: string,
 	params: SubagentParamsLike,
+	signal?: AbortSignal,
 ): Promise<SlashSubagentResponse> {
 	return new Promise((resolve, reject) => {
 		let done = false;
 		let started = false;
-
-		const startTimeoutMs = 15_000;
-		const startTimeout = setTimeout(() => {
-			finish(() => reject(new Error(
-				"Slash subagent bridge did not start within 15s. Ensure the extension is loaded correctly.",
-			)));
-		}, startTimeoutMs);
+		let startTimeout: ReturnType<typeof setTimeout> | undefined;
 
 		const onStarted = (data: unknown) => {
-			if (done || !data || typeof data !== "object") return;
+			if (done || signal?.aborted || !data || typeof data !== "object") return;
 			if ((data as { requestId?: unknown }).requestId !== requestId) return;
 			started = true;
-			clearTimeout(startTimeout);
-			if (ctx.hasUI) ctx.ui.setStatus("subagent-slash", "running...");
+			if (startTimeout) clearTimeout(startTimeout);
+			try {
+				if (ctx.hasUI) ctx.ui.setStatus("subagent-slash", "running...");
+			} catch (error) {
+				if (isStaleExtensionContextError(error)) {
+					finish(() => reject(error));
+					return;
+				}
+				throw error;
+			}
 		};
 
 		const onResponse = (data: unknown) => {
-			if (done || !data || typeof data !== "object") return;
+			if (done || signal?.aborted || !data || typeof data !== "object") return;
 			const response = data as Partial<SlashSubagentResponse>;
 			if (response.requestId !== requestId) return;
-			clearTimeout(startTimeout);
+			if (startTimeout) clearTimeout(startTimeout);
 			finish(() => resolve(response as SlashSubagentResponse));
 		};
 
 		const onUpdate = (data: unknown) => {
-			if (done || !data || typeof data !== "object") return;
+			if (done || signal?.aborted || !data || typeof data !== "object") return;
 			const update = data as SlashSubagentUpdate;
 			if (update.requestId !== requestId) return;
 			applySlashUpdate(requestId, update);
-			if (!ctx.hasUI) return;
-			const tool = update.currentTool ? ` ${update.currentTool}` : "";
-			const count = update.toolCount ?? 0;
-			const liveDetailKey = keyText("app.tools.expand");
-			ctx.ui.setStatus("subagent-slash", `${count} tools${tool} | ${liveDetailKey} live detail`);
+			try {
+				if (!ctx.hasUI) return;
+				const tool = update.currentTool ? ` ${update.currentTool}` : "";
+				const count = update.toolCount ?? 0;
+				const liveDetailKey = keyText("app.tools.expand");
+				ctx.ui.setStatus("subagent-slash", `${count} tools${tool} | ${liveDetailKey} live detail`);
+			} catch (error) {
+				if (isStaleExtensionContextError(error)) {
+					finish(() => reject(error));
+					return;
+				}
+				throw error;
+			}
 		};
 
 		const onTerminalInput = ctx.hasUI
@@ -508,18 +534,43 @@ async function requestSlashRun(
 		const unsubResponse = pi.events.on(SLASH_SUBAGENT_RESPONSE_EVENT, onResponse);
 		const unsubUpdate = pi.events.on(SLASH_SUBAGENT_UPDATE_EVENT, onUpdate);
 
+		let onAbort: () => void;
 		const finish = (next: () => void) => {
 			if (done) return;
 			done = true;
-			clearTimeout(startTimeout);
+			if (startTimeout) clearTimeout(startTimeout);
 			unsubStarted();
 			unsubResponse();
 			unsubUpdate();
-			onTerminalInput?.();
+			try {
+				onTerminalInput?.();
+			} catch (error) {
+				if (!isStaleExtensionContextError(error)) throw error;
+			}
+			signal?.removeEventListener("abort", onAbort);
 			next();
 		};
+		onAbort = () => finish(() => reject(new Error("Slash subagent request canceled during session replacement or reload.")));
+		startTimeout = setTimeout(() => {
+			finish(() => reject(new Error(
+				"Slash subagent bridge did not start within 15s. Ensure the extension is loaded correctly.",
+			)));
+		}, 15_000);
 
-		pi.events.emit(SLASH_SUBAGENT_REQUEST_EVENT, { requestId, params, ctx });
+		if (signal?.aborted) {
+			onAbort();
+			return;
+		}
+		signal?.addEventListener("abort", onAbort, { once: true });
+		try {
+			pi.events.emit(SLASH_SUBAGENT_REQUEST_EVENT, { requestId, params, ctx });
+		} catch (error) {
+			if (isStaleExtensionContextError(error)) {
+				finish(() => reject(error));
+				return;
+			}
+			throw error;
+		}
 
 		// Bridge emits STARTED synchronously during REQUEST emit.
 		// If not started, no bridge received the request.
@@ -585,62 +636,74 @@ async function runSlashSubagent(
 	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	params: SubagentParamsLike,
+	signal?: AbortSignal,
 ): Promise<void> {
-	if (ctx.hasUI) ctx.ui.setToolsExpanded(false);
+	if (signal?.aborted) return;
+	const initialHasUI = slashHasUI(ctx);
+	if (initialHasUI === undefined) return;
+	try {
+		if (initialHasUI) ctx.ui.setToolsExpanded(false);
+	} catch (error) {
+		if (isStaleExtensionContextError(error)) return;
+		throw error;
+	}
 	const requestId = randomUUID();
 	const initialDetails = buildSlashInitialResult(requestId, params);
 	const initialText = extractSlashMessageText(initialDetails.result.content) || "Running subagent...";
-	pi.sendMessage({
-		customType: SLASH_RESULT_TYPE,
-		content: initialText,
-		display: true,
-		details: initialDetails,
-	});
+	try {
+		pi.sendMessage({
+			customType: SLASH_RESULT_TYPE,
+			content: initialText,
+			display: true,
+			details: initialDetails,
+		});
+	} catch (error) {
+		if (isStaleExtensionContextError(error)) return;
+		throw error;
+	}
 	persistSlashSessionSnapshot(ctx);
 
 	try {
-		const response = await requestSlashRun(pi, ctx, requestId, params);
+		const response = await requestSlashRun(pi, ctx, requestId, params, signal);
+		if (signal?.aborted) return;
+		const hasUI = slashHasUI(ctx);
+		if (hasUI === undefined) return;
 		const finalDetails = finalizeSlashResult(response);
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: buildSlashExportText(response),
-			display: !ctx.hasUI,
+			display: !hasUI,
 			details: finalDetails,
 		});
 		persistSlashSessionSnapshot(ctx);
-		if (ctx.hasUI) {
+		if (hasUI) {
 			ctx.ui.setStatus("subagent-slash", undefined);
 		}
-		if (response.isError && ctx.hasUI) {
+		if (response.isError && hasUI) {
 			ctx.ui.notify(response.errorText || "Subagent failed", "error");
 		}
 	} catch (error) {
+		if (signal?.aborted || isStaleExtensionContextError(error)) return;
 		const message = error instanceof Error ? error.message : String(error);
+		const hasUI = slashHasUI(ctx);
+		if (hasUI === undefined) return;
 		const failedDetails = failSlashResult(requestId, params, message);
 		pi.sendMessage({
 			customType: SLASH_RESULT_TYPE,
 			content: `## Subagent result\n\n${message}`,
-			display: !ctx.hasUI,
+			display: !hasUI,
 			details: failedDetails,
 		});
 		persistSlashSessionSnapshot(ctx);
-		if (ctx.hasUI) {
+		if (hasUI) {
 			ctx.ui.setStatus("subagent-slash", undefined);
 		}
 		if (message === "Cancelled") {
-			if (ctx.hasUI) ctx.ui.notify("Cancelled", "warning");
+			if (hasUI) ctx.ui.notify("Cancelled", "warning");
 			return;
 		}
-		if (ctx.hasUI) ctx.ui.notify(message, "error");
+		if (hasUI) ctx.ui.notify(message, "error");
 	}
-}
-
-function launchSlashSubagent(
-	pi: ExtensionAPI,
-	ctx: ExtensionContext,
-	params: SubagentParamsLike,
-): void {
-	void runSlashSubagent(pi, ctx, params);
 }
 
 function slashRunWorkflowScript(key: string, child: Record<string, unknown>): string {
@@ -651,12 +714,23 @@ export function registerSlashCommands(
 	pi: ExtensionAPI,
 	state: SubagentState,
 	options: { fleetKeybindings?: FleetKeybindingsConfig; foregroundDetachShortcut?: string } = {},
-): void {
+): { dispose: () => void } {
 	let fleetOpen = false;
+	let disposed = false;
+	const pendingRequests = new Set<AbortController>();
+	const runCommand = (ctx: ExtensionContext, params: SubagentParamsLike): Promise<void> => {
+		if (disposed) return Promise.resolve();
+		const controller = new AbortController();
+		pendingRequests.add(controller);
+		return runSlashSubagent(pi, ctx, params, controller.signal).finally(() => pendingRequests.delete(controller));
+	};
+	const launchCommand = (ctx: ExtensionContext, params: SubagentParamsLike): void => {
+		void runCommand(ctx, params);
+	};
 	const showFleet = async (ctx: ExtensionContext) => {
 		state.lastUiContext = ctx;
 		if (!ctx.hasUI) {
-			await runSlashSubagent(pi, ctx, { action: "status", view: "fleet" });
+			await runCommand(ctx, { action: "status", view: "fleet" });
 			return;
 		}
 		if (fleetOpen) {
@@ -712,7 +786,7 @@ export function registerSlashCommands(
 			if (inline.skill !== undefined) child.skill = inline.skill;
 			if (inline.model) child.model = inline.model;
 			if (fork) child.context = "fork";
-			launchSlashSubagent(pi, ctx, { workflowScript: slashRunWorkflowScript("run", child), async: bg ? true : false });
+			launchCommand(ctx, { workflowScript: slashRunWorkflowScript("run", child), async: bg ? true : false });
 		},
 	});
 
@@ -726,7 +800,7 @@ export function registerSlashCommands(
 	pi.registerCommand("subagents-doctor", {
 		description: "Show subagent diagnostics",
 		handler: async (_args, ctx) => {
-			await runSlashSubagent(pi, ctx, { action: "doctor" });
+			await runCommand(ctx, { action: "doctor" });
 		},
 	});
 
@@ -758,7 +832,7 @@ export function registerSlashCommands(
 				ctx.ui.notify("Usage: /subagents-guide [topic]", "error");
 				return;
 			}
-			await runSlashSubagent(pi, ctx, { action: "guide", ...(topic ? { topic } : {}) });
+			await runCommand(ctx, { action: "guide", ...(topic ? { topic } : {}) });
 		},
 	});
 
@@ -771,7 +845,7 @@ export function registerSlashCommands(
 				ctx.ui.notify("Usage: /subagents-refine <agent>", "error");
 				return;
 			}
-			await runSlashSubagent(pi, ctx, { action: "refine", agent: parts[0] });
+			await runCommand(ctx, { action: "refine", agent: parts[0] });
 		},
 	});
 
@@ -830,7 +904,7 @@ export function registerSlashCommands(
 				return;
 			}
 			if (id) {
-				await runSlashSubagent(pi, ctx, childId ? { action: "stop", id, childId } : { action: "stop", id });
+				await runCommand(ctx, childId ? { action: "stop", id, childId } : { action: "stop", id });
 				return;
 			}
 
@@ -862,10 +936,10 @@ export function registerSlashCommands(
 			);
 			if (!result?.confirmed || !result.target) return;
 			if (result.target.kind === "scheduled") {
-				await runSlashSubagent(pi, ctx, { action: "schedule.pause", id: result.target.id });
+				await runCommand(ctx, { action: "schedule.pause", id: result.target.id });
 				return;
 			}
-			await runSlashSubagent(pi, ctx, { action: "stop", id: result.target.id });
+			await runCommand(ctx, { action: "stop", id: result.target.id });
 		},
 	});
 
@@ -920,7 +994,7 @@ export function registerSlashCommands(
 				else if (resolution.child.step.runId) targetId = resolution.child.step.runId;
 				else childIndex = resolution.child.index;
 			}
-			await runSlashSubagent(pi, ctx, {
+			await runCommand(ctx, {
 				action: "steer",
 				id: targetId,
 				message,
@@ -936,17 +1010,17 @@ export function registerSlashCommands(
 	registerPromptWorkflowCommands({
 		pi,
 		run: async (params, ctx) => {
-			launchSlashSubagent(pi, ctx, params);
+			launchCommand(ctx, params);
 		},
 	});
 
 	pi.registerCommand("subagents-models", {
 		description: "Show runtime-loaded builtin subagent models",
 		getArgumentCompletions: makeBuiltinAgentNameCompletions(),
-		handler: async (args, ctx) => {
-			const trimmed = args.trim();
-			if (!trimmed) {
-				await runSlashSubagent(pi, ctx, { action: "models" });
+			handler: async (args, ctx) => {
+				const trimmed = args.trim();
+				if (!trimmed) {
+					await runCommand(ctx, { action: "models" });
 				return;
 			}
 			const parts = trimmed.split(/\s+/).filter(Boolean);
@@ -959,7 +1033,7 @@ export function registerSlashCommands(
 				ctx.ui.notify(`Unknown builtin agent: ${agent}`, "error");
 				return;
 			}
-			await runSlashSubagent(pi, ctx, { action: "models", agent });
+			await runCommand(ctx, { action: "models", agent });
 		},
 	});
 
@@ -1132,4 +1206,14 @@ export function registerSlashCommands(
 		},
 	});
 
+	return {
+		dispose: () => {
+			if (disposed) return;
+			disposed = true;
+			// A reload revokes the command context; do not let delayed responses
+			// resume a command against the old Pi context.
+			for (const controller of pendingRequests) controller.abort();
+			pendingRequests.clear();
+		},
+	};
 }

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -59,7 +59,7 @@ interface RegisterSlashCommandsModule {
 			resultFileCoalescer: { schedule(file: string, delayMs?: number): boolean; clear(): void };
 		},
 		options?: { foregroundDetachShortcut?: string },
-	) => void;
+	) => { dispose(): void };
 }
 
 interface SlashLiveStateModule {
@@ -896,6 +896,87 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		assert.match((sent[1] as { content?: string }).content ?? "", /Commit finished/);
 		assert.equal(sessionManager.rewrites, 2);
 		assert.equal(sessionManager.flushed, true);
+	});
+
+	it("/run abandons captured context when commands are disposed during reload", async () => {
+		const sent: unknown[] = [];
+		const commands = new Map<string, { handler(args: string, ctx: unknown): Promise<void> }>();
+		const events = createEventBus();
+		let deliverResponse: (() => void) | undefined;
+		events.on(SLASH_SUBAGENT_REQUEST_EVENT, (data) => {
+			const requestId = (data as { requestId: string }).requestId;
+			events.emit(SLASH_SUBAGENT_STARTED_EVENT, { requestId });
+			deliverResponse = () => events.emit(SLASH_SUBAGENT_RESPONSE_EVENT, {
+				requestId,
+				result: {
+					content: [{ type: "text", text: "late result" }],
+					details: { mode: "single", results: [] },
+				},
+				isError: false,
+			});
+		});
+
+		const pi = {
+			events,
+			registerCommand(name: string, spec: { handler(args: string, ctx: unknown): Promise<void> }) {
+				commands.set(name, spec);
+			},
+			registerShortcut() {},
+			sendMessage(message: unknown) { sent.push(message); },
+		};
+		const disposer = registerSlashCommands!(pi, createState(process.cwd()));
+		let stale = false;
+		const ctx = createCommandContext({ hasUI: true });
+		Object.defineProperty(ctx, "hasUI", {
+			get() {
+				if (stale) throw new Error("This extension ctx is stale after session replacement or reload.");
+				return true;
+			},
+		});
+
+		await commands.get("run")!.handler("scout Inspect this", ctx);
+		assert.equal(sent.length, 1);
+		stale = true;
+		disposer.dispose();
+		deliverResponse?.();
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.equal(sent.length, 1, "disposed slash work must not use the stale context for a final message");
+	});
+
+	it("/run handles a start timeout without an uninitialized finish callback", async () => {
+		const sent: unknown[] = [];
+		const commands = new Map<string, RegisteredSlashCommand>();
+		const pi = {
+			events: createEventBus(),
+			registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+			registerShortcut() {},
+			sendMessage(message: unknown) { sent.push(message); },
+		};
+		const disposer = registerSlashCommands!(pi, createState(process.cwd()));
+		const realSetTimeout = globalThis.setTimeout;
+		let timeoutCalls = 0;
+		const immediateTimeout = (...args: Parameters<typeof setTimeout>): ReturnType<typeof setTimeout> => {
+			const [handler, delay, ...rest] = args;
+			if (delay === 15_000) {
+				timeoutCalls += 1;
+				(handler as (...values: unknown[]) => void)(...rest);
+				return 0 as ReturnType<typeof setTimeout>;
+			}
+			return realSetTimeout(...args);
+		};
+		globalThis.setTimeout = immediateTimeout;
+		try {
+			await commands.get("run")!.handler("scout Inspect this", createCommandContext());
+			await new Promise<void>((resolve) => setImmediate(resolve));
+		} finally {
+			globalThis.setTimeout = realSetTimeout;
+			disposer.dispose();
+		}
+
+		assert.equal(timeoutCalls, 1);
+		assert.equal(sent.length, 2);
+		assert.match((sent[1] as { content?: string }).content ?? "", /did not start within 15s/);
 	});
 
 	it("/run reports discovery evidence for a missing agent", async () => {

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -1003,6 +1003,54 @@ describe("subagent extension child mode", () => {
 		}
 	});
 
+	it("ignores the current stale UI context during runtime reload cleanup", () => {
+		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-stale-ui-reload-"));
+		const configDir = path.join(agentDir, "extensions", "subagent");
+		fs.mkdirSync(configDir, { recursive: true });
+		fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ asyncWidget: false, fleetView: false }), "utf-8");
+		const script = String.raw`
+			import registerSubagentExtension from "./index.ts";
+			const handlers = new Map();
+			const events = { on() { return () => {}; }, emit() {} };
+			const fakePi = new Proxy({
+				events,
+				on(channel, handler) { handlers.set(channel, handler); },
+				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage() {}, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			let stale = false;
+			const ctx = {
+				cwd: process.cwd(),
+				get hasUI() {
+					if (stale) throw new Error("This extension ctx is stale after session replacement or reload.");
+					return true;
+				},
+				ui: {
+					setWidget() {}, requestRender() {}, setToolsExpanded() {}, getToolsExpanded() { return false; },
+					theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } },
+				},
+				sessionManager: { getSessionId() { return "stale-ui-session"; }, getSessionFile() { return null; }, getEntries() { return []; } },
+				modelRegistry: { getAvailable() { return []; } },
+			};
+			registerSubagentExtension(fakePi);
+			handlers.get("session_start")({ reason: "startup" }, ctx);
+			stale = true;
+			handlers.get("session_shutdown")({ reason: "reload" });
+		`;
+
+		try {
+			const env = parentToolEnv(agentDir);
+			env.PI_CODING_AGENT_DIR = agentDir;
+			execFileSync(
+				process.execPath,
+				["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script],
+				{ cwd: projectRoot, env, stdio: "pipe" },
+			);
+		} finally {
+			fs.rmSync(agentDir, { recursive: true, force: true });
+		}
+	});
+
 	it("claims the explicit predecessor session during session replacement", () => {
 		const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-session-transition-"));
 		const configDir = path.join(agentDir, "extensions", "subagent");


### PR DESCRIPTION
Fixes #1625.

This change fails closed when a reload or session replacement makes an extension context stale while slash commands or in-process workflow controllers are still active.

It disposes pending slash command requests, aborts live workflow controllers during runtime cleanup, handles the current stale-context error text, and uses the captured parent cwd in delayed async workflow paths instead of reading a stale command context.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/slash-commands.test.ts --test-name-pattern 'reload|start timeout'`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/index-child-registration.test.ts --test-name-pattern 'stale UI context|session replacement'`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review found no issues on `d42013e502a9482c8fbe3cfdc05896d967d8478a`.
