### PR TITLE
fix: restore workflow children after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixed
 - Stop stale extension and slash-command contexts from escaping during reload or session replacement.
 - Format million-scale context limits as `1M` instead of `1000k` in live status displays.
+- Restore active workflow children under their workflow parent in Fleet Status after reload, while keeping unmatched shell rows visible.
 - Accept path-like Pi session ids up to 4,096 characters when snapshotting background work. Thanks to [@dvishoot](https://github.com/dvishoot) for #1616.
 - Accept bare leaf model ids reported by provider drivers when verifying provider-qualified launch candidates. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.
 - Resume compaction-induced child aborts once when retained state is safe, and report the exact recovery blocker otherwise.

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -248,6 +248,25 @@ function foregroundDescription(control: { parentWorkflowRunId?: string; workflow
 	return description ? `${workflow} · ${description}` : workflow;
 }
 
+function workflowIdentityCandidates(step: Pick<AsyncJobStep, "workflowKey" | "runId">): string[] {
+	return [...new Set([step.workflowKey, step.runId].filter((value): value is string => typeof value === "string" && value.length > 0))];
+}
+
+function asyncJobIdentityCandidates(job: AsyncJobState): string[] {
+	return [...new Set([job.workflowKey, job.asyncId].filter((value): value is string => typeof value === "string" && value.length > 0))];
+}
+
+function linkedWorkflowParentKey(parentWorkflowRunId: string | undefined, activeWorkflowKeys: ReadonlySet<string>): string | undefined {
+	if (!parentWorkflowRunId) return undefined;
+	const parentKey = `async:${parentWorkflowRunId}`;
+	return activeWorkflowKeys.has(parentKey) ? parentKey : undefined;
+}
+
+function workflowStepsWithoutMaterializedChildren(steps: AsyncJobStep[] | undefined, materializedChildIds: ReadonlySet<string> | undefined): AsyncJobStep[] | undefined {
+	if (!steps?.length || !materializedChildIds?.size) return steps;
+	return steps.filter((step) => !workflowIdentityCandidates(step).some((identity) => materializedChildIds.has(identity)));
+}
+
 function activeLeafAgentCount(entries: FleetStatusEntry[]): number {
 	return entries.filter((entry) => !entry.workflowWrapper && !entry.surface).length;
 }
@@ -282,9 +301,17 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 	const activeWorkflowKeys = new Set([...state.asyncJobs.values()]
 		.filter((job) => job.mode === "workflow" && isActiveState(job.status))
 		.map((job) => `async:${job.asyncId}`));
+	const materializedChildrenByWorkflow = new Map<string, Set<string>>();
+	for (const job of state.asyncJobs.values()) {
+		if (!isActiveState(job.status) || !job.parentWorkflowRunId) continue;
+		const parentKey = linkedWorkflowParentKey(job.parentWorkflowRunId, activeWorkflowKeys);
+		if (!parentKey) continue;
+		const childIds = materializedChildrenByWorkflow.get(parentKey) ?? new Set<string>();
+		for (const identity of asyncJobIdentityCandidates(job)) childIds.add(identity);
+		materializedChildrenByWorkflow.set(parentKey, childIds);
+	}
 	for (const control of state.foregroundControls.values()) {
-		const parentKey = control.parentWorkflowRunId ? `async:${control.parentWorkflowRunId}` : undefined;
-		const linkedParentKey = parentKey && activeWorkflowKeys.has(parentKey) ? parentKey : undefined;
+		const linkedParentKey = linkedWorkflowParentKey(control.parentWorkflowRunId, activeWorkflowKeys);
 		if (control.activeChildren) {
 			for (const child of [...control.activeChildren.values()].sort((left, right) => left.index - right.index)) {
 				const modelThinking = formatModelThinking(child.model, child.thinking) || undefined;
@@ -323,10 +350,13 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 	for (const job of state.asyncJobs.values()) {
 		if (!isActiveState(job.status)) continue;
 		const startedAt = job.startedAt ?? job.updatedAt ?? Date.now();
+		const linkedParentKey = linkedWorkflowParentKey(job.parentWorkflowRunId, activeWorkflowKeys);
 		if (job.mode === "workflow") {
 			const latestEmit = job.workflow?.emits?.length ? formatWorkflowJsonPreview(job.workflow.emits.at(-1), 120) : undefined;
+			const workflowSteps = workflowStepsWithoutMaterializedChildren(job.steps, materializedChildrenByWorkflow.get(`async:${job.asyncId}`));
 			entries.push({
 				key: `async:${job.asyncId}`,
+				...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
 				workflowWrapper: true,
 				agent: "workflow",
 				description: latestEmit !== undefined ? `latest emit: ${latestEmit}` : job.description,
@@ -334,7 +364,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				tokens: job.totalTokens?.total ?? 0,
 				...(job.totalTokens?.window !== undefined ? { window: job.totalTokens.window } : {}),
 				state: job.status,
-				...(job.steps?.length ? { workflowRows: projectAsyncWorkflowRows(job.steps) } : {}),
+				...(workflowSteps?.length ? { workflowRows: projectAsyncWorkflowRows(workflowSteps) } : {}),
 				...(job.nestedChildren?.length ? { nestedChildren: job.nestedChildren } : {}),
 			});
 			continue;
@@ -349,6 +379,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 		if (!steps?.length) {
 			entries.push({
 				key: `async:${job.asyncId}`,
+				...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
 				agent: job.mode ?? "subagent",
 				description: job.description,
 				startedAt,
@@ -366,6 +397,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
 			entries.push({
 				key: `async:${job.asyncId}:${index}`,
+				...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
 				agent: step.label ? `${step.label} (${step.agent})` : step.agent,
 				...(modelThinking ? { modelThinking } : {}),
 				description: step.description ?? job.description,

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -834,6 +834,128 @@ describe("below-editor subagent FleetView", () => {
 		}
 	});
 
+	it("attaches active async workflow children and removes matching shell rows", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("workflow-1", {
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			status: "running",
+			mode: "workflow",
+			startedAt: 10,
+			updatedAt: 20,
+			steps: [
+				{ agent: "reviewer", workflowKey: "review", runId: "child-review", status: "running" },
+				{ agent: "worker", workflowKey: "worker", runId: "child-worker", status: "running" },
+			],
+		});
+		state.asyncJobs.set("child-review", {
+			asyncId: "child-review",
+			asyncDir: "/tmp/child-review",
+			status: "running",
+			mode: "single",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "review",
+			startedAt: 11,
+			updatedAt: 20,
+			steps: [{ agent: "reviewer", status: "running" }],
+		});
+
+		const entries = collectFleetStatusEntries(state);
+		const workflow = entries.find((entry) => entry.key === "async:workflow-1");
+		const child = entries.find((entry) => entry.key === "async:child-review:0");
+		assert.equal(child?.parentKey, "async:workflow-1");
+		assert.deepEqual(workflow?.workflowRows?.map((row) => row.name), ["worker (worker)"]);
+	});
+
+	it("preserves sibling shell rows when a materialized child has nested step identities", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("workflow-1", {
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			status: "running",
+			mode: "workflow",
+			startedAt: 10,
+			updatedAt: 20,
+			steps: [
+				{ agent: "reviewer", workflowKey: "a", status: "running" },
+				{ agent: "worker", workflowKey: "b", status: "running" },
+			],
+		});
+		state.asyncJobs.set("child-a", {
+			asyncId: "child-a",
+			asyncDir: "/tmp/child-a",
+			status: "running",
+			mode: "single",
+			parentWorkflowRunId: "workflow-1",
+			workflowKey: "a",
+			startedAt: 11,
+			updatedAt: 20,
+			steps: [{ agent: "nested", workflowKey: "b", status: "running" }],
+		});
+
+		const entries = collectFleetStatusEntries(state);
+		const workflow = entries.find((entry) => entry.key === "async:workflow-1");
+		const child = entries.find((entry) => entry.key === "async:child-a:0");
+		assert.equal(child?.parentKey, "async:workflow-1");
+		assert.deepEqual(workflow?.workflowRows?.map((row) => row.name), ["b (worker)"]);
+	});
+
+	it("keeps async workflow children top-level when the parent is missing or terminal", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("missing-child", {
+			asyncId: "missing-child",
+			asyncDir: "/tmp/missing-child",
+			status: "running",
+			mode: "single",
+			parentWorkflowRunId: "missing-parent",
+			workflowKey: "missing",
+			startedAt: 10,
+			updatedAt: 20,
+			steps: [{ agent: "reviewer", status: "running" }],
+		});
+		state.asyncJobs.set("terminal-child", {
+			asyncId: "terminal-child",
+			asyncDir: "/tmp/terminal-child",
+			status: "running",
+			mode: "single",
+			parentWorkflowRunId: "terminal-parent",
+			workflowKey: "terminal",
+			startedAt: 11,
+			updatedAt: 20,
+			steps: [{ agent: "worker", status: "running" }],
+		});
+		state.asyncJobs.set("terminal-parent", {
+			asyncId: "terminal-parent",
+			asyncDir: "/tmp/terminal-parent",
+			status: "complete",
+			mode: "workflow",
+			startedAt: 12,
+			updatedAt: 20,
+		});
+
+		const entries = collectFleetStatusEntries(state);
+		assert.deepEqual(entries.map((entry) => [entry.key, entry.parentKey]), [
+			["async:missing-child:0", undefined],
+			["async:terminal-child:0", undefined],
+		]);
+	});
+
+	it("keeps workflow shell rows when no materialized child is present", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("workflow-1", {
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			status: "running",
+			mode: "workflow",
+			startedAt: 10,
+			updatedAt: 20,
+			steps: [{ agent: "reviewer", workflowKey: "review", runId: "child-review", status: "running" }],
+		});
+
+		const workflow = collectFleetStatusEntries(state).find((entry) => entry.key === "async:workflow-1");
+		assert.deepEqual(workflow?.workflowRows?.map((row) => row.name), ["review (reviewer)"]);
+	});
+
 	it("renders bounded workflow progress rows under the workflow parent", () => {
 		const state = stateForTest();
 		const workflowJob = {


### PR DESCRIPTION
Fixes #1605.

This restores active workflow children under their workflow parent in Fleet Status after reload or resume, while leaving unmatched shell rows visible as fallback.

The change is projection-only. It uses the restored in-memory `parentWorkflowRunId`, `workflowKey`, and run id fields. It does not change persistence, active-run indexing, RPC, Herdr, or reload lifecycle code, and it does not add render-time filesystem or Git scans.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/fleet-status.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review found no issues on `b267030976adf1a41c40040660ec5b673912ddfd`.
