### PR TITLE
fix: show workspace context in async lane rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Include saved workflow child output paths and bounded inline previews in completion notices (#1629).
 - Format million-scale context limits as `1M` instead of `1000k` in live status displays.
 - Restore active workflow children under their workflow parent in Fleet Status after reload, while keeping unmatched shell rows visible.
+- Prefer loaded workspace context over repeated internal workflow keys in async TUI lane rows (#1619).
 - Accept path-like Pi session ids up to 4,096 characters when snapshotting background work. Thanks to [@dvishoot](https://github.com/dvishoot) for #1616.
 - Accept bare leaf model ids reported by provider drivers when verifying provider-qualified launch candidates. Thanks to [@lallenlowe](https://github.com/lallenlowe) for #1609.
 - Resume compaction-induced child aborts once when retained state is safe, and report the exact recovery blocker otherwise.

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -292,6 +292,7 @@ export interface AsyncLaneProjection {
 	gate?: string;
 	next?: string;
 	output?: string;
+	workspace?: string;
 	ref: string;
 	chips: string[];
 }
@@ -357,9 +358,10 @@ function isTerminalLaneState(state: AsyncJobState["status"]): boolean {
 /** Project already-loaded async status facts into one bounded, render-only lane row. */
 export function projectAsyncLane(job: AsyncJobState, selectedStep = laneStepForJob(job)): AsyncLaneProjection | undefined {
 	const trace = laneTraceForJob(job);
+	const workspace = job.cwd ? boundedLaneValue(shortenPath(job.cwd)) : undefined;
 	const label = compactTaskText(selectedStep?.description, selectedStep?.label)
 		?? boundedLaneValue(trace?.label)
-		?? boundedLaneValue(selectedStep?.workflowKey ?? job.workflowKey);
+		?? (workspace ? undefined : boundedLaneValue(selectedStep?.workflowKey ?? job.workflowKey));
 	const role = boundedLaneValue(selectedStep?.agent ?? trace?.agent ?? job.agents?.[0] ?? widgetJobName(job), 32) ?? "subagent";
 	const phase = boundedLaneValue(selectedStep?.phase ?? trace?.phase);
 	const gate = laneGate(selectedStep);
@@ -376,7 +378,7 @@ export function projectAsyncLane(job: AsyncJobState, selectedStep = laneStepForJ
 	const state = isTerminalLaneState(job.status) ? job.status : selectedStep?.status ?? job.status;
 	const next = laneNextAction(state, selectedStep, output, gate);
 	if (!label && !phase && !gate && !output && !selectedStep?.workflowKey && !job.workflowKey && !trace?.label && !trace?.phase) return undefined;
-	return { ...(label ? { label } : {}), role, ...(phase ? { phase } : {}), state, ...(gate ? { gate } : {}), ...(next ? { next } : {}), ...(output ? { output } : {}), ref, chips };
+	return { ...(label ? { label } : {}), role, ...(phase ? { phase } : {}), state, ...(gate ? { gate } : {}), ...(next ? { next } : {}), ...(output ? { output } : {}), ...(workspace ? { workspace } : {}), ref, chips };
 }
 
 function laneStateLabel(state: AsyncLaneProjection["state"], theme: Theme): string {
@@ -406,7 +408,7 @@ function formatLaneProjectionDetails(lane: AsyncLaneProjection, theme: Theme): s
 		lane.gate ? `gate:${lane.gate}` : undefined,
 		lane.next ? `next:${lane.next}` : undefined,
 		lane.output ? `out:${lane.output}` : undefined,
-		lane.ref ? `ref:${lane.ref}` : undefined,
+		lane.workspace ? `workspace:${lane.workspace}` : lane.ref ? `ref:${lane.ref}` : undefined,
 	].filter(Boolean);
 	const chips = lane.chips.map((chip) => formatLaneChip(chip, theme));
 	return [...(details.length ? [theme.fg("dim", details.join(" · "))] : []), ...chips].join(" · ") || undefined;
@@ -422,7 +424,7 @@ function formatLaneProjectionLines(lane: AsyncLaneProjection, theme: Theme, inde
 
 function laneRenderKey(job: AsyncJobState): unknown {
 	const lane = projectAsyncLane(job);
-	return lane ? [lane.label, lane.role, lane.phase, lane.state, lane.gate, lane.next, lane.output, lane.ref, lane.chips] : undefined;
+	return lane ? [lane.label, lane.role, lane.phase, lane.state, lane.gate, lane.next, lane.output, lane.workspace, lane.ref, lane.chips] : undefined;
 }
 
 function widgetLaneDetailLines(job: AsyncJobState, theme: Theme): string[] {
@@ -1678,7 +1680,7 @@ function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number, fra
 	const status = job.status === "complete" ? "done" : job.status;
 	const lane = projectAsyncLane(job);
 	const laneSummary = lane
-		? [lane.label ?? lane.role, lane.phase ? `phase:${lane.phase}` : undefined, lane.output ? `out:${lane.output}` : undefined, `ref:${lane.ref}`].filter(Boolean).join(" · ")
+		? [lane.label ?? lane.role, lane.phase ? `phase:${lane.phase}` : undefined, lane.output ? `out:${lane.output}` : undefined, lane.workspace ? `workspace:${lane.workspace}` : `ref:${lane.ref}`].filter(Boolean).join(" · ")
 		: "";
 	const laneSignals = lane
 		? [lane.next ? `next:${lane.next}` : undefined, ...lane.chips.map((chip) => formatLaneChip(chip, theme))].filter(Boolean).join(" · ")

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -3,12 +3,13 @@ import { describe, it } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { extractToolArgsPreview } from "../../src/shared/utils.ts";
 
-const { buildWidgetLines, clearLegacyResultAnimationTimer, compactTaskText, projectAsyncLane, renderWidget } = await import("../../src/tui/render.ts") as {
+const { buildWidgetLines, clearLegacyResultAnimationTimer, compactTaskText, projectAsyncLane, renderWidget, widgetRenderKey } = await import("../../src/tui/render.ts") as {
 	buildWidgetLines: (jobs: Array<Record<string, unknown>>, theme: { fg(name: string, text: string): string; bold(text: string): string }, width?: number, expanded?: boolean, frame?: number) => string[];
 	clearLegacyResultAnimationTimer: (context: { state: { subagentResultAnimationTimer?: ReturnType<typeof setInterval> } }) => void;
 	compactTaskText: (task: string | undefined, label?: string) => string | undefined;
-	projectAsyncLane: (job: Record<string, unknown>) => { label?: string; role: string; phase?: string; state: string; gate?: string; next?: string; output?: string; ref: string; chips: string[] } | undefined;
+	projectAsyncLane: (job: Record<string, unknown>) => { label?: string; role: string; phase?: string; state: string; gate?: string; next?: string; output?: string; workspace?: string; ref: string; chips: string[] } | undefined;
 	renderWidget: (ctx: Record<string, unknown>, jobs: Array<Record<string, unknown>>) => void;
+	widgetRenderKey: (job: Record<string, unknown>, expanded?: boolean) => string;
 };
 
 const theme = {
@@ -133,10 +134,113 @@ describe("subagent async widget rendering", () => {
 		assert.match(text, /phase:implementation · next:await launch · out:fix\.md/);
 	});
 
+	it("prefers bounded loaded workspace context over repeated internal lane refs", () => {
+		const workspacePath = `/tmp/workspaces/${"project-".repeat(16)}`;
+		const job = {
+			asyncId: "workspace-run",
+			asyncDir: "/tmp/workspace-run",
+			cwd: workspacePath,
+			status: "running",
+			mode: "single",
+			agents: ["reviewer"],
+			workflowKey: "internal-workflow-key",
+			steps: [{ index: 0, agent: "reviewer", status: "running", workflowKey: "internal-workflow-key" }],
+		};
+
+		const lane = projectAsyncLane(job);
+		assert.equal(lane?.ref, "internal-workflow-key");
+		assert.ok(lane?.workspace);
+		assert.ok((lane.workspace?.length ?? 0) <= 48, "workspace display should stay bounded");
+		assert.match(lane?.workspace ?? "", /^\/tmp\/workspaces\/project-/);
+		assert.match(lane?.workspace ?? "", /\.\.\.$/);
+
+		const text = buildWidgetLines([job], theme, 180, true).join("\n");
+		assert.match(text, /workspace:\/tmp\/workspaces\/project-/);
+		assert.doesNotMatch(text, /ref:internal-workflow-key/);
+	});
+
+	it("shows workspace context in expanded single and parallel/chain rows", () => {
+		for (const mode of ["single", "parallel", "chain"] as const) {
+			const workflowKey = `${mode}-workflow-key`;
+			const workspace = `/tmp/${mode}-workspace`;
+			const job = {
+				asyncId: `${mode}-workspace-run`,
+				asyncDir: `/tmp/${mode}-workspace-run`,
+				cwd: workspace,
+				status: "running",
+				mode,
+				agents: ["worker"],
+				steps: [{ index: 0, agent: "worker", status: "running", workflowKey }],
+			};
+
+			const text = buildWidgetLines([job], theme, 180, true).join("\n");
+			assert.match(text, new RegExp(`workspace:${escapeRegExp(workspace)}`));
+			assert.doesNotMatch(text, new RegExp(`ref:${escapeRegExp(workflowKey)}`));
+		}
+	});
+
+	it("keeps the bounded workflow-key fallback when no workspace is loaded", () => {
+		const workflowKey = `internal-${"workflow-key-".repeat(8)}`;
+		const job = {
+			asyncId: "fallback-ref-run",
+			asyncDir: "/tmp/fallback-ref-run",
+			status: "running",
+			mode: "single",
+			agents: ["worker"],
+			workflowKey,
+		};
+
+		const lane = projectAsyncLane(job);
+		assert.equal(lane?.workspace, undefined);
+		assert.ok(lane?.ref);
+		assert.ok((lane.ref.length) <= 24, "workflow-key fallback should stay bounded");
+		const text = buildWidgetLines([job], theme, 180, true).join("\n");
+		assert.match(text, new RegExp(`ref:${escapeRegExp(lane?.ref ?? "")}`));
+	});
+
+	it("uses workspace context in compact progressive lane headers", () => {
+		resetWidgetLayout();
+		withStdoutSize(22, 120, () => {
+			const workspace = "/tmp/compact-workspace";
+			const job = {
+				asyncId: "compact-workspace-run",
+				asyncDir: "/tmp/compact-workspace-run",
+				cwd: workspace,
+				status: "running",
+				mode: "single",
+				agents: ["worker"],
+				workflowKey: "compact-workflow-key",
+				currentTool: "read",
+			};
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, [job]);
+			const text = renderWidgetLines(ui.widgets.at(-1)).join("\n");
+			assert.match(text, new RegExp(`workspace:${escapeRegExp(workspace)}`));
+			assert.doesNotMatch(text, /ref:compact-workflow-key/);
+		});
+		resetWidgetLayout();
+	});
+
+	it("refreshes widget render keys when loaded workspace changes", () => {
+		const base = {
+			asyncId: "render-key-workspace-run",
+			asyncDir: "/tmp/render-key-workspace-run",
+			status: "running",
+			mode: "single",
+			agents: ["worker"],
+			workflowKey: "render-key-workflow",
+		};
+		assert.notEqual(
+			widgetRenderKey({ ...base, cwd: "/tmp/workspace-one" }),
+			widgetRenderKey({ ...base, cwd: "/tmp/workspace-two" }),
+		);
+	});
+
 	it("keeps simple one-off async rows on the existing fallback projection", () => {
 		const job = {
 			asyncId: "simple-run",
 			asyncDir: "/tmp/simple-run",
+			cwd: "/repo/simple",
 			status: "running",
 			mode: "single",
 			agents: ["scout"],


### PR DESCRIPTION
Fixes #1619.

This updates the async TUI lane rows to prefer the already-loaded workspace path over repeated internal workflow keys. It keeps `workflowKey`, `runId`, and `asyncId` identity unchanged, and keeps metadata-free one-off async rows on the existing fallback path.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review found no issues on `8a15c1883f88db3b48a72e7aa30669f49be7c33a`.
