### PR TITLE
feat: add typed host monitor workflow steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add bounded, provider-agnostic host-owned CI and gate workflow rows with explicit monitor kinds, terminal verdicts, stale freshness, report pointers, and fail-closed status/receipt projection.
 - Give every subagent child session a human-readable display name (`agent: task excerpt`, workflow node label preferred): applied to the child's own Pi session via `pi.setSessionName` (intercom routing targets keep precedence) and echoed as an optional `sessionName` field across result, live-progress, async status, workflow, nested, and intercom payloads so hosts can label child runs without reading child session files. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1615.
 - Add `/subagents-steer <run-id> [--child <child-id>] <message>`, a host bridge for steering live async runs from non-TUI sessions and RPC hosts, with fail-closed child-id resolution and pause-and-revive recovery disabled so callers keep exact-child authority. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1608.
 - Add explicit `allowNestedSubagents` agent authorization for nested fanout without replacing inherited tools or extensions. Thanks to [@tutu359](https://github.com/tutu359) for #1587.

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -25,6 +25,7 @@ import { listAsyncRuns, type AsyncRunSummary } from "./async-status.ts";
 import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequests } from "../shared/external-job-bridge.ts";
 import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summary.ts";
+import { validHostStepNodes } from "../shared/host-step-status.ts";
 
 interface AsyncJobTrackerOptions {
 	completionRetentionMs?: number;
@@ -147,6 +148,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			currentStep: run.currentStep,
 			chainStepCount: run.chainStepCount,
 			parallelGroups: groups,
+			hostSteps: run.hostSteps,
 			steps: visibleSteps,
 			stepsTotal: visibleSteps.length,
 			runningSteps: visibleSteps.filter((step) => step.status === "running").length,
@@ -400,6 +402,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				job.parentWorkflowRunId = status.parentWorkflowRunId ?? job.parentWorkflowRunId;
 				job.workflowKey = status.workflowKey ?? job.workflowKey;
 				job.workflow = status.workflow ?? job.workflow;
+				job.hostSteps = validHostStepNodes(status.workflowGraph);
 				const workflowChildren = parseWorkflowChildSummary(status.workflowChildren);
 				if (workflowChildren && workflowChildren.workflowRunId !== status.runId) throw new Error("workflowChildren.workflowRunId does not match async status runId.");
 				job.workflowChildren = workflowChildren ?? job.workflowChildren;

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -12,6 +12,7 @@ import { resultFilePath, resultPayloadPathForIndexedRun } from "./result-files.t
 import { canScanAsyncRunPrefix, MIN_SAFE_ASYNC_RUN_PREFIX_LENGTH } from "./run-id-query.ts";
 import { parallelHandoffPath, resolveRetainedWorktreeCwd } from "../shared/parallel-handoff.ts";
 import { intersectThinkingCeilings, parseThinkingLevel, type ThinkingLevel } from "../../shared/thinking-ceiling.ts";
+import { assertWorkflowGraphHostSteps } from "../shared/host-step-status.ts";
 
 export interface AsyncResumeParams {
 	id?: string;
@@ -260,6 +261,7 @@ function resultState(result: AsyncResultFile): AsyncStatus["state"] {
 function validateStatusForResume(status: AsyncStatus | null, source: string): void {
 	if (!status) return;
 	if (typeof status.runId !== "string") throw new Error(`Invalid async status '${source}': runId must be a string.`);
+	assertWorkflowGraphHostSteps(status.workflowGraph, source, status.runId);
 	if (status.sessionId !== undefined && typeof status.sessionId !== "string") throw new Error(`Invalid async status '${source}': sessionId must be a string.`);
 	if (status.cwd !== undefined && typeof status.cwd !== "string") throw new Error(`Invalid async status '${source}': cwd must be a string.`);
 	if (status.sessionFile !== undefined && typeof status.sessionFile !== "string") throw new Error(`Invalid async status '${source}': sessionFile must be a string.`);

--- a/src/runs/background/async-status-snapshot.ts
+++ b/src/runs/background/async-status-snapshot.ts
@@ -14,6 +14,7 @@ export {
 export type {
 	AsyncStatusSnapshotActivityV1,
 	AsyncStatusSnapshotCapsV1,
+	AsyncStatusSnapshotHostStepV1,
 	AsyncStatusSnapshotKind,
 	AsyncStatusSnapshotNodeV1,
 	AsyncStatusSnapshotOmittedV1,

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../../shared/formatters.ts";
 import { formatActivityLabel, formatParallelOutcome } from "../../shared/status-format.ts";
-import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TokenUsage, type TurnBudgetState, type UsageBudgetState } from "../../shared/types.ts";
+import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type HostStepNodeV1, type HostStepState, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TokenUsage, type TurnBudgetState, type UsageBudgetState } from "../../shared/types.ts";
 import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../shared/capability-ceiling.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { attachRootChildrenToSteps, buildNestedRouteIndex, findNestedRouteForRootId, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
@@ -17,6 +17,8 @@ import { readRecentTerminalRunIndex, TERMINAL_RUN_INDEX_DIR } from "./terminal-r
 import { canScanAsyncRunPrefix } from "./run-id-query.ts";
 import { asyncStatusChildIdentity } from "../shared/child-identity.ts";
 import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summary.ts";
+import { assertWorkflowGraphHostSteps, hostStepReportName, hostStepVerdictLabel, validHostStepNodes } from "../shared/host-step-status.ts";
+import { projectAsyncWorkflowRows } from "../shared/async-status-projection.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -108,6 +110,7 @@ export interface AsyncRunSummary {
 	chainStepCount?: number;
 	pendingAppends?: number;
 	parallelGroups?: AsyncParallelGroupStatus[];
+	hostSteps?: HostStepNodeV1[];
 	steps: AsyncRunStepSummary[];
 	sessionDir?: string;
 	outputFile?: string;
@@ -237,6 +240,8 @@ function deriveAsyncActivityState(asyncDir: string, status: AsyncStatus): { acti
 function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string }, nestedWarnings: string[] = [], nestedRoute?: NestedRoute): AsyncRunSummary {
 	const workflowChildren = parseWorkflowChildSummary(status.workflowChildren);
 	if (workflowChildren && workflowChildren.workflowRunId !== status.runId) throw new Error(`Invalid async status '${path.join(asyncDir, "status.json")}': workflowChildren.workflowRunId does not match.`);
+	assertWorkflowGraphHostSteps(status.workflowGraph, path.join(asyncDir, "status.json"), status.runId);
+	const hostSteps = validHostStepNodes(status.workflowGraph);
 	if (status.sessionId !== undefined && typeof status.sessionId !== "string") {
 		throw new Error(`Invalid async status '${path.join(asyncDir, "status.json")}': sessionId must be a string.`);
 	}
@@ -364,6 +369,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		...(status.chainStepCount !== undefined ? { chainStepCount: status.chainStepCount } : {}),
 		...(status.pendingAppends !== undefined ? { pendingAppends: status.pendingAppends } : {}),
 		...(parallelGroups.length ? { parallelGroups } : {}),
+		...(hostSteps.length ? { hostSteps } : {}),
 		steps: summarizedSteps,
 		...(nestedChildren.length ? { nestedChildren } : {}),
 		...(nestedWarnings.length ? { nestedWarnings } : {}),
@@ -539,6 +545,21 @@ function formatStepLine(step: AsyncRunStepSummary): string {
 	return parts.join(" | ");
 }
 
+function formatHostStepLine(row: ReturnType<typeof projectAsyncWorkflowRows>[number]): string {
+	if (!row.kind) return "";
+	const state = hostStepVerdictLabel(row.state as HostStepState, row.verdict);
+	const details = [
+		row.provider ? `provider:${row.provider}` : undefined,
+		row.role ? `role:${row.role}` : undefined,
+		row.target,
+		row.detail,
+		row.reasonCode ? `reason:${row.reasonCode}` : undefined,
+		row.freshness?.stale ? "stale" : row.freshness?.observedRef ? `ref:${row.freshness.observedRef}` : undefined,
+		row.reportPath ? `out:${hostStepReportName(row.reportPath)}` : undefined,
+	].filter((value): value is string => Boolean(value));
+	return `host ${row.kind}: ${row.name} | ${state}${details.length ? ` | ${details.join(" | ")}` : ""}`;
+}
+
 export function formatAsyncRunOutputPath(run: Pick<AsyncRunSummary, "asyncDir" | "outputFile">): string | undefined {
 	if (!run.outputFile) return undefined;
 	return path.isAbsolute(run.outputFile) ? run.outputFile : path.join(run.asyncDir, run.outputFile);
@@ -583,6 +604,10 @@ export function formatAsyncRunList(runs: AsyncRunSummary[], heading = "Active as
 		for (const step of run.steps) {
 			lines.push(`  ${formatStepLine(step)}`);
 			lines.push(...formatNestedRunStatusLines(step.children, { indent: "    ", maxLines: 12 }));
+		}
+		for (const row of projectAsyncWorkflowRows([], run.hostSteps)) {
+			const line = formatHostStepLine(row);
+			if (line) lines.push(`  ${line}`);
 		}
 		const attached = new Set(run.steps.flatMap((step) => step.children?.map((child) => child.id) ?? []));
 		const unattached = run.nestedChildren?.filter((child) => !attached.has(child.id)) ?? [];

--- a/src/runs/background/stale-run-reconciler.ts
+++ b/src/runs/background/stale-run-reconciler.ts
@@ -8,6 +8,7 @@ import { DIRS, type AsyncParallelGroupStatus, type AsyncStatus, type NestedRunSu
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { normalizeParallelGroups } from "./parallel-groups.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent, type NestedRoute } from "../shared/nested-events.ts";
+import { assertWorkflowGraphHostSteps } from "../shared/host-step-status.ts";
 
 export type PidLiveness = "alive" | "dead" | "unknown";
 
@@ -357,6 +358,7 @@ export function reconcileAsyncRun(asyncDir: string, options: ReconcileAsyncRunOp
 	const startedStatus = !status && options.startedRun ? buildStartedStatus(asyncDir, options.startedRun, now) : undefined;
 	const effectiveStatus = status ?? startedStatus;
 	if (!effectiveStatus) return { status: null, repaired: false };
+	assertWorkflowGraphHostSteps(effectiveStatus.workflowGraph, path.join(asyncDir, "status.json"), effectiveStatus.runId);
 	const statusPath = path.join(asyncDir, "status.json");
 	for (const [index, step] of (effectiveStatus.steps ?? []).entries()) {
 		const stepRecord = step as Record<string, unknown>;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -125,6 +125,7 @@ import { handleHerdrInspectorAction, HERDR_INSPECTOR_ACTIONS } from "../../inspe
 import { handleHerdrProjectPaneAction, HERDR_PROJECT_PANE_ACTIONS } from "../../inspectors/herdr/project-panes.ts";
 import { previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError, type WorkflowReceiptResumeReference, type WorkflowScriptChildResult, type WorkflowSteerOptions, type WorkflowSteerResult } from "../../workflows/scripted-workflow.ts";
 import { buildWorkflowReceipt, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
+import { validHostStepNodes } from "../shared/host-step-status.ts";
 import { workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { resolveWorkflowChatProgress, type WorkflowChatProgressProjection } from "../../workflows/chat-progress.ts";
 import { claimWorkflowChildPermit, validateWorkflowChildPermitRoot, type WorkflowChildPermit, type WorkflowChildPermitContext } from "../../shared/workflow-child-permit.ts";
@@ -4146,8 +4147,9 @@ function terminalWorkflowReceipt(
 	children: WorkflowScriptChildResult[],
 	workflowChildren?: WorkflowReceipt["workflowChildren"],
 	terminalOutcome?: WorkflowTerminalOutcome,
+	hostSteps?: WorkflowReceipt["hostSteps"],
 ): WorkflowReceipt {
-	return buildWorkflowReceipt({ workflowRunId, state, children, workflowChildren, terminalOutcome });
+	return buildWorkflowReceipt({ workflowRunId, state, children, workflowChildren, terminalOutcome, hostSteps });
 }
 
 function workflowFailureTerminalOutcome(error: unknown, _children: WorkflowScriptChildResult[], usageBudget: ReturnType<typeof usageBudgetState>): WorkflowTerminalOutcome | undefined {
@@ -4988,7 +4990,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const workflowUsage = sumResultsUsage(workflowResults);
 						const workflowChildren = workflowChildSummary({ parentToolCallId: toolCallId, workflowRunId, workflowState: "completed", inventoryComplete: true, trace: workflow.trace, children: workflow.children, steps: status.steps });
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: workflow.trace, emits: workflow.emits, console: workflow.console }, workflowChildren, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
-						const receipt = terminalWorkflowReceipt(workflowRunId, "complete", workflow.children, workflowChildren);
+						const receipt = terminalWorkflowReceipt(workflowRunId, "complete", workflow.children, workflowChildren, undefined, validHostStepNodes(status.workflowGraph));
 						let workflowReceipt: { path: string; receipt: WorkflowReceipt } | undefined;
 						try {
 							workflowReceipt = { path: writeWorkflowReceipt(asyncDir, receipt), receipt };
@@ -5031,7 +5033,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const resultSummary = appendWorkflowOutputWarning(terminalSummary, outputWarning);
 						const receiptState: WorkflowReceiptState = status.state === "complete" ? "complete" : status.state === "paused" ? "paused" : status.state === "stopped" ? "stopped" : "failed";
 						const terminalOutcome = workflowFailureTerminalOutcome(error, partial.children, usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)));
-						const receipt = terminalWorkflowReceipt(workflowRunId, receiptState, partial.children, workflowChildren, terminalOutcome);
+						const receipt = terminalWorkflowReceipt(workflowRunId, receiptState, partial.children, workflowChildren, terminalOutcome, validHostStepNodes(status.workflowGraph));
 						let workflowReceipt: { path: string; receipt: WorkflowReceipt } | undefined;
 						try {
 							workflowReceipt = { path: writeWorkflowReceipt(asyncDir, receipt), receipt };

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -1,6 +1,7 @@
 import { sanitizeDisplayText, truncateDisplayText } from "../../shared/display-text.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
-import type { AsyncJobState, AsyncJobStep, NestedRunSummary, NestedStepSummary, SubagentRunMode } from "../../shared/types.ts";
+import type { AsyncJobState, AsyncJobStep, HostStepFreshnessV1, HostStepMonitorKind, HostStepNodeV1, HostStepState, HostStepVerdict, NestedRunSummary, NestedStepSummary, SubagentRunMode, WorkflowGraphSnapshot } from "../../shared/types.ts";
+import { HOST_STEP_MAX_COUNT, HOST_STEP_MAX_DETAIL_CHARS, HOST_STEP_MAX_LABEL_CHARS, HOST_STEP_MAX_PROVIDER_CHARS, HOST_STEP_MAX_REASON_CHARS, HOST_STEP_MAX_REF_CHARS, HOST_STEP_MAX_ROLE_CHARS, HOST_STEP_MAX_TARGET_CHARS, hostStepReportName, parseHostStepNode, validHostStepNodes } from "./host-step-status.ts";
 
 export const ASYNC_STATUS_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
 export const ASYNC_STATUS_SNAPSHOT_VERSION = 1;
@@ -23,15 +24,29 @@ export interface AsyncStatusSnapshotActivityV1 {
 	toolCount?: number;
 }
 
+export interface AsyncStatusSnapshotHostStepV1 {
+	kind: HostStepMonitorKind;
+	provider?: string;
+	role?: string;
+	state: HostStepState;
+	verdict?: HostStepVerdict;
+	reasonCode?: string;
+	detail?: string;
+	target?: string;
+	stale?: boolean;
+	report?: string;
+}
+
 export interface AsyncStatusSnapshotNodeV1 {
 	id: string;
-	kind: AsyncStatusSnapshotKind;
+	kind: AsyncStatusSnapshotKind | "host-step";
 	label: string;
 	state: AsyncStatusSnapshotState;
 	startedAt?: number;
 	updatedAt?: number;
 	endedAt?: number;
 	activity?: AsyncStatusSnapshotActivityV1;
+	hostStep?: AsyncStatusSnapshotHostStepV1;
 	children?: AsyncStatusSnapshotNodeV1[];
 }
 
@@ -69,18 +84,41 @@ export interface AsyncStatusSnapshotOptions {
 
 export interface AsyncStatusWorkflowRow {
 	name: string;
-	state: AsyncJobStep["status"];
+	state: AsyncJobStep["status"] | HostStepState;
+	/** Present only for typed host-owned monitor rows; legacy child rows omit it. */
+	kind?: HostStepMonitorKind;
 	modelThinking?: string;
 	activity?: string;
 	startedAt?: number;
 	tokens?: number;
 	window?: number;
 	overflow?: number;
+	provider?: string;
+	role?: string;
+	verdict?: HostStepVerdict;
+	reasonCode?: string;
+	detail?: string;
+	target?: string;
+	freshness?: HostStepFreshnessV1;
+	reportPath?: string;
 }
 
 interface ProjectionContext {
 	caps: AsyncStatusSnapshotCapsV1;
 	omitted: AsyncStatusSnapshotOmittedV1;
+}
+
+function validHostStepList(source: readonly HostStepNodeV1[] | WorkflowGraphSnapshot | undefined): HostStepNodeV1[] {
+	if (source && "nodes" in source) return validHostStepNodes(source);
+	const hostSteps: HostStepNodeV1[] = [];
+	for (const [index, value] of (source ?? []).slice(0, HOST_STEP_MAX_COUNT).entries()) {
+		try {
+			hostSteps.push(parseHostStepNode(value, `hostSteps[${index}]`));
+		} catch {
+			// Renderers must not turn malformed host data into a fake child row.
+		}
+	}
+	return hostSteps;
 }
 
 function resolveCaps(options: AsyncStatusSnapshotOptions): AsyncStatusSnapshotCapsV1 {
@@ -219,6 +257,41 @@ function projectNestedRun(child: NestedRunSummary, index: number, depth: number,
 	return node;
 }
 
+function hostStepSnapshotState(state: HostStepState, verdict: HostStepVerdict | undefined): AsyncStatusSnapshotState {
+	if (state === "pending") return "queued";
+	if (state === "running") return "running";
+	if (state === "cancelled") return "stopped";
+	if (state === "error" || verdict === "fail") return "failed";
+	return verdict === "inconclusive" ? "partial" : "complete";
+}
+
+function projectHostStep(hostStep: HostStepNodeV1, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
+	const state = hostStepSnapshotState(hostStep.state, hostStep.verdict);
+	const detail = publicOptionalText(hostStep.detail, ctx.caps.maxStringLength);
+	const report = publicOptionalText(hostStepReportName(hostStep.reportPath), ctx.caps.maxStringLength);
+	const hostMetadata: AsyncStatusSnapshotHostStepV1 = {
+		kind: hostStep.monitorKind,
+		state: hostStep.state,
+		...(hostStep.provider ? { provider: publicText(hostStep.provider, "provider", ctx.caps.maxStringLength) } : {}),
+		...(hostStep.role ? { role: publicText(hostStep.role, "role", ctx.caps.maxStringLength) } : {}),
+		...(hostStep.verdict ? { verdict: hostStep.verdict } : {}),
+		...(hostStep.reasonCode ? { reasonCode: publicText(hostStep.reasonCode, "reason", ctx.caps.maxStringLength) } : {}),
+		...(detail ? { detail } : {}),
+		...(hostStep.target ? { target: publicText(hostStep.target, "target", ctx.caps.maxStringLength) } : {}),
+		...(hostStep.freshness?.stale !== undefined ? { stale: hostStep.freshness.stale } : {}),
+		...(report ? { report } : {}),
+	};
+	return {
+		id: publicText(hostStep.id, "host-step", ctx.caps.maxStringLength),
+		kind: "host-step",
+		label: publicText(hostStep.label, "host step", ctx.caps.maxStringLength),
+		state,
+		updatedAt: hostStep.updatedAt,
+		...(terminalState(state) ? { endedAt: hostStep.updatedAt } : {}),
+		hostStep: hostMetadata,
+	};
+}
+
 function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
 	const state = normalizeState(job.status);
 	const startedAt = publicTime(job.startedAt);
@@ -237,11 +310,12 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnap
 	if (ctx.caps.maxDepth > 0) {
 		const stepChildren = job.steps?.map((step, index) => projectStep(step, step.index ?? index, 1, ctx)) ?? [];
 		const nestedChildren = job.nestedChildren?.map((child, index) => projectNestedRun(child, index, 1, ctx)) ?? [];
+		const hostStepChildren = validHostStepList(job.hostSteps).map((hostStep) => projectHostStep(hostStep, ctx));
 		const bounded: AsyncStatusSnapshotNodeV1[] = [];
-		appendBoundedChildren(bounded, [...stepChildren, ...nestedChildren], ctx);
+		appendBoundedChildren(bounded, [...stepChildren, ...nestedChildren, ...hostStepChildren], ctx);
 		if (bounded.length) node.children = bounded;
 	} else {
-		ctx.omitted.children += (job.steps?.length ?? 0) + (job.nestedChildren?.length ?? 0);
+		ctx.omitted.children += (job.steps?.length ?? 0) + (job.nestedChildren?.length ?? 0) + validHostStepList(job.hostSteps).length;
 	}
 	return node;
 }
@@ -285,9 +359,32 @@ function workflowStepName(step: AsyncJobStep, index: number): string {
 	return `${phase}${key}${label} (${step.agent})`;
 }
 
+function hostStepRow(hostStep: HostStepNodeV1): AsyncStatusWorkflowRow {
+	const freshness = hostStep.freshness
+		? {
+			expectedRef: publicText(hostStep.freshness.expectedRef, "ref", HOST_STEP_MAX_REF_CHARS),
+			...(hostStep.freshness.observedRef ? { observedRef: publicText(hostStep.freshness.observedRef, "ref", HOST_STEP_MAX_REF_CHARS) } : {}),
+			...(hostStep.freshness.stale !== undefined ? { stale: hostStep.freshness.stale } : {}),
+		}
+		: undefined;
+	return {
+		name: publicText(hostStep.label, "host step", HOST_STEP_MAX_LABEL_CHARS),
+		kind: hostStep.monitorKind,
+		state: hostStep.state,
+		...(hostStep.role ? { role: publicText(hostStep.role, "role", HOST_STEP_MAX_ROLE_CHARS) } : {}),
+		...(hostStep.provider ? { provider: publicText(hostStep.provider, "provider", HOST_STEP_MAX_PROVIDER_CHARS) } : {}),
+		...(hostStep.verdict ? { verdict: hostStep.verdict } : {}),
+		...(hostStep.reasonCode ? { reasonCode: publicText(hostStep.reasonCode, "reason", HOST_STEP_MAX_REASON_CHARS) } : {}),
+		...(hostStep.detail ? { detail: publicText(hostStep.detail, "detail", HOST_STEP_MAX_DETAIL_CHARS) } : {}),
+		...(hostStep.target ? { target: publicText(hostStep.target, "target", HOST_STEP_MAX_TARGET_CHARS) } : {}),
+		...(freshness ? { freshness } : {}),
+		...(hostStep.reportPath ? { reportPath: hostStepReportName(hostStep.reportPath) } : {}),
+	};
+}
+
 /** Project loaded workflow child facts into compact rows; visibility bounds and rendering remain caller-owned. */
-export function projectAsyncWorkflowRows(steps: readonly AsyncJobStep[] | undefined): AsyncStatusWorkflowRow[] {
-	return (steps ?? []).map((step, index) => {
+export function projectAsyncWorkflowRows(steps: readonly AsyncJobStep[] | undefined, hostSteps?: readonly HostStepNodeV1[] | WorkflowGraphSnapshot): AsyncStatusWorkflowRow[] {
+	const childRows = (steps ?? []).map((step, index) => {
 		const modelThinking = formatModelThinking(step.model, step.thinking) || undefined;
 		const activity = workflowStepActivity(step);
 		return {
@@ -300,6 +397,7 @@ export function projectAsyncWorkflowRows(steps: readonly AsyncJobStep[] | undefi
 			...(step.tokens?.window !== undefined ? { window: step.tokens.window } : {}),
 		};
 	});
+	return [...childRows, ...validHostStepList(hostSteps).map(hostStepRow)];
 }
 
 /** Project already-loaded async status facts into the bounded public snapshot shape. */

--- a/src/runs/shared/host-step-status.ts
+++ b/src/runs/shared/host-step-status.ts
@@ -1,0 +1,226 @@
+import type {
+	AsyncStatus,
+	HostStepNodeV1,
+	HostStepState,
+	HostStepVerdict,
+	WorkflowGraphNode,
+	WorkflowGraphSnapshot,
+	WorkflowNodeStatus,
+} from "../../shared/types.ts";
+
+export const HOST_STEP_MAX_ID_CHARS = 128;
+export const HOST_STEP_MAX_LABEL_CHARS = 80;
+export const HOST_STEP_MAX_ROLE_CHARS = 32;
+export const HOST_STEP_MAX_PROVIDER_CHARS = 64;
+export const HOST_STEP_MAX_REASON_CHARS = 64;
+export const HOST_STEP_MAX_DETAIL_CHARS = 200;
+export const HOST_STEP_MAX_TARGET_CHARS = 128;
+export const HOST_STEP_MAX_REF_CHARS = 128;
+export const HOST_STEP_MAX_REPORT_PATH_CHARS = 240;
+export const HOST_STEP_MAX_COUNT = 32;
+
+const HOST_STEP_FIELDS = new Set([
+	"version",
+	"kind",
+	"monitorKind",
+	"id",
+	"label",
+	"role",
+	"provider",
+	"state",
+	"verdict",
+	"reasonCode",
+	"detail",
+	"target",
+	"freshness",
+	"reportPath",
+	"updatedAt",
+	"deadlineAt",
+]);
+
+const FRESHNESS_FIELDS = new Set(["expectedRef", "observedRef", "stale"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertBoundedString(value: unknown, field: string, maxChars: number, source: string, required = false): asserts value is string {
+	if (value === undefined && !required) return;
+	if (typeof value !== "string" || !value.trim()) throw new Error(`Invalid host step '${source}': ${field} must be a non-empty string.`);
+	if (value.length > maxChars) throw new Error(`Invalid host step '${source}': ${field} exceeds ${maxChars} characters.`);
+	if (/\r|\n/.test(value)) throw new Error(`Invalid host step '${source}': ${field} must be single-line.`);
+}
+
+function assertTimestamp(value: unknown, field: string, source: string, required = false): asserts value is number {
+	if (value === undefined && !required) return;
+	if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) throw new Error(`Invalid host step '${source}': ${field} must be a non-negative safe integer.`);
+}
+
+function assertFreshness(value: unknown, source: string): asserts value is HostStepNodeV1["freshness"] {
+	if (!isRecord(value)) throw new Error(`Invalid host step '${source}': freshness must be an object.`);
+	const unknownFields = Object.keys(value).filter((field) => !FRESHNESS_FIELDS.has(field));
+	if (unknownFields.length > 0) throw new Error(`Invalid host step '${source}': freshness has unsupported fields: ${unknownFields.join(", ")}.`);
+	assertBoundedString(value.expectedRef, "freshness.expectedRef", HOST_STEP_MAX_REF_CHARS, source, true);
+	assertBoundedString(value.observedRef, "freshness.observedRef", HOST_STEP_MAX_REF_CHARS, source);
+	if (value.stale !== undefined && typeof value.stale !== "boolean") throw new Error(`Invalid host step '${source}': freshness.stale must be a boolean.`);
+}
+
+/**
+ * Validate the persisted host-step contract. This deliberately rejects unknown
+ * fields and unbounded values so status and receipt loaders fail closed.
+ */
+export function assertHostStepNode(value: unknown, source = "status"): asserts value is HostStepNodeV1 {
+	if (!isRecord(value)) throw new Error(`Invalid host step '${source}': expected an object.`);
+	const unknownFields = Object.keys(value).filter((field) => !HOST_STEP_FIELDS.has(field));
+	if (unknownFields.length > 0) throw new Error(`Invalid host step '${source}': unsupported fields: ${unknownFields.join(", ")}.`);
+	if (value.version !== 1) throw new Error(`Invalid host step '${source}': version must be 1.`);
+	if (value.kind !== "host-step") throw new Error(`Invalid host step '${source}': kind must be 'host-step'.`);
+	if (value.monitorKind !== "ci" && value.monitorKind !== "gate") throw new Error(`Invalid host step '${source}': monitorKind must be 'ci' or 'gate'.`);
+	assertBoundedString(value.id, "id", HOST_STEP_MAX_ID_CHARS, source, true);
+	assertBoundedString(value.label, "label", HOST_STEP_MAX_LABEL_CHARS, source, true);
+	assertBoundedString(value.role, "role", HOST_STEP_MAX_ROLE_CHARS, source);
+	assertBoundedString(value.provider, "provider", HOST_STEP_MAX_PROVIDER_CHARS, source);
+	if (value.state !== "pending" && value.state !== "running" && value.state !== "done" && value.state !== "cancelled" && value.state !== "error") {
+		throw new Error(`Invalid host step '${source}': state is invalid.`);
+	}
+	if (value.verdict !== undefined && value.verdict !== "pass" && value.verdict !== "fail" && value.verdict !== "inconclusive") {
+		throw new Error(`Invalid host step '${source}': verdict is invalid.`);
+	}
+	if (value.state === "done" && value.verdict === undefined) throw new Error(`Invalid host step '${source}': done state requires a verdict.`);
+	if (value.state !== "done" && value.verdict !== undefined) throw new Error(`Invalid host step '${source}': verdict is only valid for done state.`);
+	assertBoundedString(value.reasonCode, "reasonCode", HOST_STEP_MAX_REASON_CHARS, source);
+	assertBoundedString(value.detail, "detail", HOST_STEP_MAX_DETAIL_CHARS, source);
+	assertBoundedString(value.target, "target", HOST_STEP_MAX_TARGET_CHARS, source);
+	if (value.freshness !== undefined) assertFreshness(value.freshness, source);
+	if (value.freshness && value.freshness.stale === true && (value.state !== "done" || value.verdict !== "inconclusive")) {
+		throw new Error(`Invalid host step '${source}': stale freshness requires done/inconclusive state.`);
+	}
+	assertBoundedString(value.reportPath, "reportPath", HOST_STEP_MAX_REPORT_PATH_CHARS, source);
+	const reportName = hostStepReportName(value.reportPath);
+	if (value.reportPath !== undefined && (!reportName || reportName === "." || reportName === "..")) throw new Error(`Invalid host step '${source}': reportPath must name a report.`);
+	assertTimestamp(value.updatedAt, "updatedAt", source, true);
+	assertTimestamp(value.deadlineAt, "deadlineAt", source);
+}
+
+export function parseHostStepNode(value: unknown, source = "status"): HostStepNodeV1 {
+	assertHostStepNode(value, source);
+	return {
+		...value,
+		...(value.freshness ? { freshness: { ...value.freshness } } : {}),
+	};
+}
+
+export function assertUniqueHostStepIds(hostSteps: readonly HostStepNodeV1[], source = "status"): void {
+	const ids = new Set<string>();
+	for (const hostStep of hostSteps) {
+		if (ids.has(hostStep.id)) throw new Error(`Invalid host step '${source}': duplicate host step id '${hostStep.id}'.`);
+		ids.add(hostStep.id);
+	}
+}
+
+/** Return only valid host nodes so an untrusted in-memory projection fails closed. */
+export function validHostStepNodes(graph: WorkflowGraphSnapshot | undefined): HostStepNodeV1[] {
+	const nodes = graph?.nodes ?? [];
+	const nodeIdCounts = new Map<string, number>();
+	for (const node of nodes) nodeIdCounts.set(node.id, (nodeIdCounts.get(node.id) ?? 0) + 1);
+	const hostSteps: HostStepNodeV1[] = [];
+	for (const [index, node] of nodes.entries()) {
+		if (node.kind !== "host-step") continue;
+		try {
+			const hostStep = parseHostStepNode(node.hostStep, `workflowGraph.nodes[${index}].hostStep`);
+			if (node.id !== hostStep.id || node.label !== hostStep.label) continue;
+			if (nodeIdCounts.get(hostStep.id) !== 1) continue;
+			hostSteps.push(hostStep);
+		} catch {
+			// Renderers must not turn malformed host data into a fake child row.
+		}
+	}
+	return hostSteps.slice(0, HOST_STEP_MAX_COUNT);
+}
+
+export function assertWorkflowGraphHostSteps(graph: WorkflowGraphSnapshot | undefined, source = "status", expectedRunId?: string): void {
+	if (!graph) return;
+	if (expectedRunId !== undefined && graph.runId !== expectedRunId) throw new Error(`Invalid host step '${source}': workflowGraph.runId does not match the status run id.`);
+	const hostStepCount = graph.nodes.filter((node) => node.kind === "host-step").length;
+	if (hostStepCount > HOST_STEP_MAX_COUNT) throw new Error(`Invalid host step '${source}': workflowGraph contains more than ${HOST_STEP_MAX_COUNT} host steps.`);
+	const hostSteps: HostStepNodeV1[] = [];
+	for (const [index, node] of graph.nodes.entries()) {
+		if (node.kind !== "host-step") continue;
+		const hostStep = parseHostStepNode(node.hostStep, `${source}.workflowGraph.nodes[${index}].hostStep`);
+		if (node.id !== hostStep.id) throw new Error(`Invalid host step '${source}': workflowGraph.nodes[${index}].id does not match hostStep.id.`);
+		if (node.label !== hostStep.label) throw new Error(`Invalid host step '${source}': workflowGraph.nodes[${index}].label does not match hostStep.label.`);
+		hostSteps.push(hostStep);
+	}
+	assertUniqueHostStepIds(hostSteps, source);
+	for (const hostStep of hostSteps) {
+		if (graph.nodes.filter((node) => node.id === hostStep.id).length !== 1) throw new Error(`Invalid host step '${source}': workflowGraph id '${hostStep.id}' is not unique.`);
+	}
+}
+
+export function hostStepWorkflowNode(hostStep: HostStepNodeV1): WorkflowGraphNode {
+	assertHostStepNode(hostStep, hostStep.id);
+	return {
+		id: hostStep.id,
+		kind: "host-step",
+		label: hostStep.label,
+		status: workflowNodeStatus(hostStep),
+		hostStep: { ...hostStep, ...(hostStep.freshness ? { freshness: { ...hostStep.freshness } } : {}) },
+	};
+}
+
+function workflowNodeStatus(hostStep: HostStepNodeV1): WorkflowNodeStatus {
+	if (hostStep.state === "pending") return "pending";
+	if (hostStep.state === "running") return "running";
+	if (hostStep.state === "cancelled") return "stopped";
+	if (hostStep.state === "error") return "failed";
+	return hostStep.verdict === "fail" ? "failed" : "completed";
+}
+
+/**
+ * Host-only registration/update boundary. The caller supplies the existing
+ * status writer; monitor providers never receive a path or write status.json.
+ */
+export function upsertHostStep(input: {
+	status: AsyncStatus;
+	hostStep: HostStepNodeV1;
+	persist: (status: AsyncStatus) => void;
+}): AsyncStatus {
+	const hostStep = parseHostStepNode(input.hostStep, input.hostStep.id);
+	assertWorkflowGraphHostSteps(input.status.workflowGraph, "host-step", input.status.runId);
+	const graph: WorkflowGraphSnapshot = input.status.workflowGraph
+		? {
+			...input.status.workflowGraph,
+			nodes: [...input.status.workflowGraph.nodes],
+		}
+		: {
+			runId: input.status.runId,
+			mode: input.status.mode,
+			phases: [],
+			nodes: [],
+		};
+	const existingIndex = graph.nodes.findIndex((node) => node.id === hostStep.id);
+	const existing = existingIndex >= 0 ? graph.nodes[existingIndex] : undefined;
+	if (existing && existing.kind !== "host-step") throw new Error(`Host step '${hostStep.id}' conflicts with an existing workflow node.`);
+	if (existingIndex < 0 && graph.nodes.filter((candidate) => candidate.kind === "host-step").length >= HOST_STEP_MAX_COUNT) {
+		throw new Error(`Host step limit of ${HOST_STEP_MAX_COUNT} has been reached.`);
+	}
+	const node = hostStepWorkflowNode(hostStep);
+	if (existingIndex >= 0) graph.nodes[existingIndex] = node;
+	else graph.nodes.push(node);
+	const nextStatus: AsyncStatus = {
+		...input.status,
+		workflowGraph: graph,
+		lastUpdate: Math.max(input.status.lastUpdate ?? 0, hostStep.updatedAt),
+	};
+	input.persist(nextStatus);
+	return nextStatus;
+}
+
+export function hostStepVerdictLabel(state: HostStepState, verdict: HostStepVerdict | undefined): string {
+	return state === "done" ? verdict ?? "inconclusive" : state;
+}
+
+export function hostStepReportName(reportPath: string | undefined): string | undefined {
+	if (!reportPath) return undefined;
+	return reportPath.split(/[\\/]/).filter(Boolean).at(-1);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -42,9 +42,40 @@ export type ChainOutputMap = Record<string, ChainOutputMapEntry>;
 
 export type WorkflowNodeStatus = "pending" | "running" | "completed" | "failed" | "paused" | "stopped" | "detached" | "rejected";
 
+export type HostStepMonitorKind = "ci" | "gate";
+export type HostStepState = "pending" | "running" | "done" | "cancelled" | "error";
+export type HostStepVerdict = "pass" | "fail" | "inconclusive";
+
+export interface HostStepFreshnessV1 {
+	expectedRef: string;
+	observedRef?: string;
+	stale?: boolean;
+}
+
+/** Bounded, provider-agnostic status for a host-owned workflow monitor. */
+export interface HostStepNodeV1 {
+	version: 1;
+	kind: "host-step";
+	/** Explicit monitor category; never inferred from labels or commands. */
+	monitorKind: HostStepMonitorKind;
+	id: string;
+	label: string;
+	role?: string;
+	provider?: string;
+	state: HostStepState;
+	verdict?: HostStepVerdict;
+	reasonCode?: string;
+	detail?: string;
+	target?: string;
+	freshness?: HostStepFreshnessV1;
+	reportPath?: string;
+	updatedAt: number;
+	deadlineAt?: number;
+}
+
 export interface WorkflowGraphNode {
 	id: string;
-	kind: "step" | "parallel-group" | "dynamic-parallel-group" | "agent";
+	kind: "step" | "parallel-group" | "dynamic-parallel-group" | "agent" | "host-step";
 	agent?: string;
 	phase?: string;
 	label: string;
@@ -64,6 +95,7 @@ export interface WorkflowGraphNode {
 	structured?: boolean;
 	acceptanceStatus?: AcceptanceLedgerStatus;
 	error?: string;
+	hostStep?: HostStepNodeV1;
 }
 
 export interface WorkflowGraphSnapshot {
@@ -129,6 +161,7 @@ export interface WorkflowReceipt {
 	state: WorkflowReceiptState;
 	createdAt: number;
 	entries: Record<string, WorkflowReceiptEntry>;
+	hostSteps?: HostStepNodeV1[];
 	workflowChildren?: WorkflowChildSummaryV1;
 	workflowResolution?: WorkflowTerminalResolution;
 	terminalOutcome?: WorkflowTerminalOutcome;
@@ -1752,6 +1785,8 @@ export interface AsyncJobState {
 	currentStep?: number;
 	chainStepCount?: number;
 	parallelGroups?: AsyncParallelGroupStatus[];
+	/** Bounded host-owned CI/gate nodes loaded from the workflow status graph. */
+	hostSteps?: HostStepNodeV1[];
 	steps?: AsyncJobStep[];
 	stepsTotal?: number;
 	runningSteps?: number;

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -2,9 +2,10 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { type EditorComponent, isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { snapshotExternalRuns } from "../api/external-runs.ts";
 import { formatModelThinking } from "../shared/formatters.ts";
-import type { AsyncJobState, AsyncJobStep, FleetViewPlacement, HerdrProjectPaneSnapshot, NestedRunSummary, NestedStepSummary, SubagentState } from "../shared/types.ts";
+import type { AsyncJobState, AsyncJobStep, FleetViewPlacement, HerdrProjectPaneSnapshot, HostStepState, HostStepVerdict, NestedRunSummary, NestedStepSummary, SubagentState } from "../shared/types.ts";
 import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
+import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
 
@@ -106,12 +107,17 @@ function visibleWorkflowRows(rows: AsyncStatusWorkflowRow[] | undefined, visible
 	if (rows.length <= visibleLimit) return rows;
 	const selected = new Set<number>();
 	for (const [index, row] of rows.entries()) {
-		if (row.state !== "complete" && row.state !== "completed") selected.add(index);
+		if (!isWorkflowRowTerminal(row)) selected.add(index);
 		if (selected.size >= visibleLimit) break;
 	}
 	for (let index = rows.length - 1; index >= 0 && selected.size < visibleLimit; index--) selected.add(index);
 	const visible = [...selected].sort((left, right) => left - right).map((index) => rows[index]!);
 	return [{ name: `… +${rows.length - visible.length} hidden workflow steps`, state: "complete", overflow: rows.length - visible.length }, ...visible];
+}
+
+function isWorkflowRowTerminal(row: AsyncStatusWorkflowRow): boolean {
+	if (row.kind) return row.state === "done" || row.state === "cancelled" || row.state === "error";
+	return row.state === "complete" || row.state === "completed";
 }
 
 function nestedStatusGlyph(state: FleetNestedRow["state"], theme: Theme): string {
@@ -354,6 +360,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 		if (job.mode === "workflow") {
 			const latestEmit = job.workflow?.emits?.length ? formatWorkflowJsonPreview(job.workflow.emits.at(-1), 120) : undefined;
 			const workflowSteps = workflowStepsWithoutMaterializedChildren(job.steps, materializedChildrenByWorkflow.get(`async:${job.asyncId}`));
+			const workflowRows = projectAsyncWorkflowRows(workflowSteps, job.hostSteps);
 			entries.push({
 				key: `async:${job.asyncId}`,
 				...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
@@ -364,7 +371,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				tokens: job.totalTokens?.total ?? 0,
 				...(job.totalTokens?.window !== undefined ? { window: job.totalTokens.window } : {}),
 				state: job.status,
-				...(workflowSteps?.length ? { workflowRows: projectAsyncWorkflowRows(workflowSteps) } : {}),
+				...(workflowRows.length ? { workflowRows } : {}),
 				...(job.nestedChildren?.length ? { nestedChildren: job.nestedChildren } : {}),
 			});
 			continue;
@@ -692,16 +699,43 @@ export class SubagentFleetStatus {
 		return truncateToWidth(`${left}${theme.fg("dim", elapsed)}`, width);
 	}
 
+	private workflowRowGlyph(row: AsyncStatusWorkflowRow, theme: Theme): string {
+		if (!row.kind) return nestedStatusGlyph(row.state as FleetNestedRow["state"], theme);
+		const state = row.state as HostStepState;
+		if (state === "pending") return theme.fg("muted", "◦");
+		if (state === "running") return theme.fg("accent", "●");
+		if (state === "done") return row.verdict === "pass" ? theme.fg("success", "✓") : row.verdict === "fail" ? theme.fg("error", "✗") : theme.fg("warning", "■");
+		if (state === "error") return theme.fg("error", "✗");
+		return theme.fg("warning", "■");
+	}
+
+	private workflowRowStateLabel(row: AsyncStatusWorkflowRow, theme: Theme): string {
+		const state = row.kind ? hostStepVerdictLabel(row.state as HostStepState, row.verdict as HostStepVerdict | undefined) : row.state;
+		if (state === "running") return theme.fg("accent", state);
+		if (state === "pending" || state === "queued") return theme.fg("muted", state);
+		if (state === "pass" || state === "complete" || state === "completed") return theme.fg("success", state === "pass" ? "pass" : "complete");
+		if (state === "fail" || state === "failed" || state === "error") return theme.fg("error", state === "fail" ? "fail" : state);
+		return theme.fg("warning", state);
+	}
+
 	private renderWorkflowRow(row: AsyncStatusWorkflowRow, last: boolean, width: number, theme: Theme): string {
 		const marker = last ? "└─" : "├─";
 		const indent = "    ";
 		if (row.overflow !== undefined) return truncateToWidth(`${indent}${marker} ${theme.fg("dim", `+${row.overflow} hidden workflow steps`)}`, width);
 		const modelThinking = row.modelThinking ? ` (${row.modelThinking})` : "";
 		const activity = row.activity ? ` · ${row.activity}` : "";
-		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg("muted", `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
+		const kind = row.kind ? `${row.kind}: ` : "";
+		const left = `${indent}${marker} ${this.workflowRowGlyph(row, theme)} ${theme.fg("muted", `${kind}${row.name}${modelThinking}`)} · ${this.workflowRowStateLabel(row, theme)}${activity}`;
 		const details = [
 			row.startedAt !== undefined ? formatFleetElapsed(Date.now() - row.startedAt) : undefined,
 			row.tokens !== undefined ? formatFleetTokens(row.tokens, row.window) : undefined,
+			row.provider ? `provider:${row.provider}` : undefined,
+			row.role ? `role:${row.role}` : undefined,
+			row.target,
+			row.detail,
+			row.reasonCode ? `reason:${row.reasonCode}` : undefined,
+			row.freshness?.stale ? "stale" : row.freshness?.observedRef ? `ref:${row.freshness.observedRef}` : undefined,
+			row.reportPath ? `out:${hostStepReportName(row.reportPath)}` : undefined,
 		].filter(Boolean).join(" · ");
 		return truncateToWidth(`${left}${details ? theme.fg("dim", ` · ${details}`) : ""}`, width);
 	}
@@ -756,12 +790,21 @@ export class SubagentFleetStatus {
 					Math.round((now - entry.startedAt) / 1000),
 					entry.tokens,
 					visibleWorkflowRows(entry.workflowRows, entry.parentKey ? 2 : 4).map((row) => [
+						row.kind,
 						row.name,
 						row.state,
 						row.modelThinking,
 						row.activity,
 						row.startedAt,
 						row.tokens,
+						row.provider,
+						row.role,
+						row.verdict,
+						row.reasonCode,
+						row.detail,
+						row.target,
+						row.freshness,
+						row.reportPath,
 						row.overflow,
 					]),
 					nestedFleetRows(entry.nestedChildren, entry.parentKey ? 3 : 4).map((row) => [

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -13,6 +13,8 @@ import {
 	type AsyncJobStep,
 	type AsyncParallelGroupStatus,
 	type Details,
+	type HostStepState,
+	type HostStepVerdict,
 	type NestedRunSummary,
 	type NestedStepSummary,
 	type WorkflowNodeStatus,
@@ -31,6 +33,8 @@ import { aggregateStepStatus, formatActivityLabel, formatAgentRunningLabel, form
 import { contextModeBadge, contextModePrefix } from "../runs/shared/context-mode.ts";
 import { buildWorkflowChatProgressRows, type WorkflowChatProgressRow } from "../workflows/chat-progress.ts";
 import { encodeAsyncStatusSnapshotWidget } from "../runs/background/async-status-snapshot.ts";
+import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
+import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
 
 type Theme = ExtensionContext["ui"]["theme"];
 
@@ -789,6 +793,22 @@ function nestedRenderKey(children: NestedRunSummary[] | undefined, expanded = fa
 	]);
 }
 
+function hostStepRenderKey(row: AsyncStatusWorkflowRow): unknown[] {
+	return [
+		row.kind,
+		row.name,
+		row.state,
+		row.provider,
+		row.role,
+		row.verdict,
+		row.reasonCode,
+		row.detail,
+		row.target,
+		row.freshness,
+		row.reportPath,
+	];
+}
+
 export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 	return JSON.stringify({
 		asyncDir: job.asyncDir,
@@ -805,6 +825,7 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 		currentStep: job.currentStep,
 		chainStepCount: job.chainStepCount,
 		parallelGroups: job.parallelGroups,
+		workflowHostSteps: projectAsyncWorkflowRows([], job.hostSteps).map(hostStepRenderKey),
 		steps: job.steps?.map((step, index) => widgetStepRenderKey(step, index, expanded)),
 		nestedChildren: nestedRenderKey(job.nestedChildren, expanded),
 		lane: laneRenderKey(job),
@@ -1486,11 +1507,37 @@ function foregroundStyleWidgetStepLines(
 	return lines;
 }
 
+function hostStepWidgetLines(job: AsyncJobState, theme: Theme, indent: string): string[] {
+	const rows = projectAsyncWorkflowRows([], job.hostSteps).filter((row) => row.kind);
+	const visible = rows.slice(0, 8);
+	const lines = visible.map((row) => {
+		const state = hostStepVerdictLabel(row.state as HostStepState, row.verdict as HostStepVerdict | undefined);
+		const glyph = state === "running" ? theme.fg("accent", "●")
+			: state === "pending" ? theme.fg("muted", "◦")
+			: state === "pass" ? theme.fg("success", "✓")
+			: state === "fail" || state === "error" ? theme.fg("error", "✗")
+			: theme.fg("warning", "■");
+		const details = [
+			row.provider ? `provider:${row.provider}` : undefined,
+			row.role ? `role:${row.role}` : undefined,
+			row.target,
+			row.detail,
+			row.reasonCode ? `reason:${row.reasonCode}` : undefined,
+			row.freshness?.stale ? "stale" : row.freshness?.observedRef ? `ref:${row.freshness.observedRef}` : undefined,
+			row.reportPath ? `out:${hostStepReportName(row.reportPath)}` : undefined,
+		].filter(Boolean).join(" · ");
+		return `${indent}${glyph} ${row.kind}: ${row.name} · ${state}${details ? ` · ${details}` : ""}`;
+	});
+	if (rows.length > visible.length) lines.push(`${indent}${theme.fg("dim", `… +${rows.length - visible.length} host steps hidden`)}`);
+	return lines;
+}
+
 function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, frame?: number): string[] {
 	if (!job.steps?.length) {
 		const lane = projectAsyncLane(job);
 		return [
 			...(lane ? formatLaneProjectionLines(lane, theme, "  ") : []),
+			...hostStepWidgetLines(job, theme, "  "),
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
 			...formatNestedWidgetLines(job.nestedChildren, theme, width, expanded, job.updatedAt, expanded ? 12 : 6).map((line) => `  ${line}`),
 		];
@@ -1502,6 +1549,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 	for (const [index, step] of job.steps.entries()) {
 		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index + 1, total, expanded, width, frame));
 	}
+	lines.push(...hostStepWidgetLines(job, theme, "  "));
 	const attached = new Set(job.steps.flatMap((step) => step.children?.map((child) => child.id) ?? []));
 	const unattached = job.nestedChildren?.filter((child) => !attached.has(child.id)) ?? [];
 	for (const nestedLine of formatNestedWidgetLines(unattached, theme, width, expanded, job.updatedAt, expanded ? 12 : 6)) {
@@ -1542,6 +1590,7 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 		if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "  "));
 		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, 6)) lines.push(`    ${nestedLine}`);
 	}
+	lines.push(...hostStepWidgetLines(job, theme, "  "));
 	if (job.steps.some((step) => step.status === "running")) lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));
 	return lines.map((line) => truncLine(line, width));
 }

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -4,6 +4,7 @@ import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
 import type { ExternalCliReceiptMetadata, WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState, WorkflowRecoveryAction, WorkflowTerminalOutcome, WorkflowTerminalResolution } from "../shared/types.ts";
 import type { WorkflowReceiptResumeReference, WorkflowScriptChildResult } from "./scripted-workflow.ts";
 import { parseWorkflowChildSummary } from "./workflow-child-summary.ts";
+import { HOST_STEP_MAX_COUNT, assertUniqueHostStepIds, parseHostStepNode } from "../runs/shared/host-step-status.ts";
 
 export type { WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState } from "../shared/types.ts";
 
@@ -33,6 +34,7 @@ export function buildWorkflowReceipt(input: {
 	workflowRunId: string;
 	state: WorkflowReceiptState;
 	children: WorkflowScriptChildResult[];
+	hostSteps?: WorkflowReceipt["hostSteps"];
 	workflowChildren?: WorkflowReceipt["workflowChildren"];
 	terminalOutcome?: WorkflowTerminalOutcome;
 	createdAt?: number;
@@ -61,7 +63,10 @@ export function buildWorkflowReceipt(input: {
 			? { ...base, latestRunId: latestRunId!, resumability }
 			: { ...base, ...(latestRunId ? { latestRunId } : {}), resumability };
 	}
-	return { version: WORKFLOW_RECEIPT_VERSION, workflowRunId, state: input.state, createdAt: input.createdAt ?? Date.now(), entries, ...(input.workflowChildren ? { workflowChildren: input.workflowChildren } : {}), ...(input.terminalOutcome ? { terminalOutcome: input.terminalOutcome } : {}) };
+	if (input.hostSteps && input.hostSteps.length > HOST_STEP_MAX_COUNT) throw new Error(`Workflow receipt has more than ${HOST_STEP_MAX_COUNT} host steps.`);
+	const hostSteps = input.hostSteps?.map((hostStep, index) => parseHostStepNode(hostStep, `workflow receipt hostSteps[${index}]`));
+	if (hostSteps) assertUniqueHostStepIds(hostSteps, "workflow receipt");
+	return { version: WORKFLOW_RECEIPT_VERSION, workflowRunId, state: input.state, createdAt: input.createdAt ?? Date.now(), entries, ...(hostSteps?.length ? { hostSteps } : {}), ...(input.workflowChildren ? { workflowChildren: input.workflowChildren } : {}), ...(input.terminalOutcome ? { terminalOutcome: input.terminalOutcome } : {}) };
 }
 
 export function writeWorkflowReceipt(asyncDir: string, receipt: WorkflowReceipt): string {
@@ -254,10 +259,17 @@ export function readWorkflowReceipt(asyncDirRoot: string, workflowRunId: string)
 	for (const [key, entry] of Object.entries(receipt.entries as Record<string, unknown>)) entries[assertKey(key, "workflow receipt key")] = parseEntry(entry, key, receiptPath);
 	const workflowChildren = parseWorkflowChildSummary(receipt.workflowChildren);
 	if (workflowChildren && workflowChildren.workflowRunId !== workflowRunId) throw new Error(`Workflow receipt '${receiptPath}' is stale: workflowChildren.workflowRunId does not match.`);
+	let hostSteps: NonNullable<WorkflowReceipt["hostSteps"]> | undefined;
+	if (receipt.hostSteps !== undefined) {
+		if (!Array.isArray(receipt.hostSteps)) throw new Error(`Invalid workflow receipt '${receiptPath}': hostSteps must be an array.`);
+		if (receipt.hostSteps.length > HOST_STEP_MAX_COUNT) throw new Error(`Invalid workflow receipt '${receiptPath}': hostSteps exceeds ${HOST_STEP_MAX_COUNT} entries.`);
+		hostSteps = receipt.hostSteps.map((hostStep, index) => parseHostStepNode(hostStep, `${receiptPath} hostSteps[${index}]`));
+		assertUniqueHostStepIds(hostSteps, receiptPath);
+	}
 	const workflowResolution = parseWorkflowResolution(receipt.workflowResolution, receiptPath);
 	const terminalOutcome = parseTerminalOutcome(receipt.terminalOutcome, `Invalid workflow receipt '${receiptPath}': terminalOutcome`);
 	const recovery = parseRecovery(receipt.recovery, workflowRunId, entries, receiptPath);
-	return { version: 1, workflowRunId, state: receipt.state, createdAt: receipt.createdAt, entries, ...(workflowChildren ? { workflowChildren } : {}), ...(workflowResolution ? { workflowResolution } : {}), ...(terminalOutcome ? { terminalOutcome } : {}), ...(recovery ? { recovery } : {}) };
+	return { version: 1, workflowRunId, state: receipt.state, createdAt: receipt.createdAt, entries, ...(hostSteps?.length ? { hostSteps } : {}), ...(workflowChildren ? { workflowChildren } : {}), ...(workflowResolution ? { workflowResolution } : {}), ...(terminalOutcome ? { terminalOutcome } : {}), ...(recovery ? { recovery } : {}) };
 }
 
 export function resolveWorkflowReceiptResumeEntry(input: {

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -74,6 +74,70 @@ describe("async status helpers", () => {
 		}
 	});
 
+	it("loads typed host monitor nodes from workflow status without child identity", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-host-step-"));
+		try {
+			createAsyncDir(root, "workflow-host", {
+				runId: "workflow-host",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{ agent: "reviewer", workflowKey: "review", runId: "child-review", status: "running" }],
+				workflowGraph: {
+					runId: "workflow-host",
+					mode: "workflow",
+					phases: [],
+					nodes: [{
+						id: "ci-check",
+						kind: "host-step",
+						label: "CI",
+						status: "completed",
+						hostStep: {
+							version: 1,
+							kind: "host-step",
+							monitorKind: "ci",
+							id: "ci-check",
+							label: "CI",
+							provider: "local-tests",
+							state: "running",
+							detail: "waiting for checks",
+							updatedAt: 150,
+						},
+					}],
+				},
+			});
+
+			const runs = listAsyncRuns(root, { states: ["running"], reconcile: false });
+			assert.equal(runs[0]?.hostSteps?.[0]?.kind, "host-step");
+			assert.equal(runs[0]?.steps[0]?.workflowKey, "review");
+			assert.match(formatAsyncRunList(runs), /host ci: CI \| running \| provider:local-tests \| waiting for checks/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when a persisted host monitor node is malformed", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-host-step-invalid-"));
+		try {
+			createAsyncDir(root, "workflow-host-invalid", {
+				runId: "workflow-host-invalid",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				workflowGraph: {
+					runId: "workflow-host-invalid",
+					mode: "workflow",
+					phases: [],
+					nodes: [{ id: "bad", kind: "host-step", label: "bad", status: "running" }],
+				},
+			});
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false }), /host step.*expected an object/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves agent contract projections on step summaries", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-contract-"));
 		try {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -236,6 +236,48 @@ describe("subagent async widget rendering", () => {
 		);
 	});
 
+	it("renders loaded host CI and gate nodes without creating child lanes", () => {
+		const job = {
+			asyncId: "host-run",
+			asyncDir: "/tmp/host-run",
+			status: "running",
+			mode: "workflow",
+			agents: [],
+			hostSteps: [
+				{
+					version: 1,
+					kind: "host-step",
+					monitorKind: "ci",
+					id: "ci-1",
+					label: "CI checks",
+					provider: "local-tests",
+					state: "running",
+					target: "PR #1614",
+					updatedAt: 10,
+				},
+				{
+					version: 1,
+					kind: "host-step",
+					monitorKind: "gate",
+					id: "gate-1",
+					label: "Review gate",
+					provider: "opaque-provider",
+					state: "done",
+					verdict: "inconclusive",
+					reasonCode: "stale-head",
+					freshness: { expectedRef: "old", observedRef: "new", stale: true },
+					reportPath: "/tmp/reports/gate.json",
+					updatedAt: 20,
+				},
+			],
+		};
+
+		const text = buildWidgetLines([job], theme, 180).join("\n");
+		assert.match(text, /ci: CI checks · running · provider:local-tests · PR #1614/);
+		assert.match(text, /gate: Review gate · inconclusive · provider:opaque-provider · reason:stale-head · stale · out:gate.json/);
+		assert.doesNotMatch(text, /async subagent .*CI checks/);
+	});
+
 	it("keeps simple one-off async rows on the existing fallback projection", () => {
 		const job = {
 			asyncId: "simple-run",

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { AsyncJobState } from "../../src/shared/types.ts";
+import type { AsyncJobState, HostStepNodeV1 } from "../../src/shared/types.ts";
 import {
 	ASYNC_STATUS_SNAPSHOT_KIND,
 	ASYNC_STATUS_SNAPSHOT_VERSION,
@@ -13,6 +13,21 @@ function job(input: Partial<AsyncJobState> & Pick<AsyncJobState, "asyncId" | "st
 		asyncDir: `/tmp/${input.asyncId}`,
 		...input,
 	} as AsyncJobState;
+}
+
+function hostStep(overrides: Partial<HostStepNodeV1> = {}): HostStepNodeV1 {
+	return {
+		version: 1,
+		kind: "host-step",
+		monitorKind: "ci",
+		id: "ci-check",
+		label: "CI checks",
+		provider: "github-ci",
+		state: "done",
+		verdict: "pass",
+		updatedAt: 20,
+		...overrides,
+	};
 }
 
 describe("async status projection", () => {
@@ -82,5 +97,32 @@ describe("async status projection", () => {
 			tokens: 25,
 			window: 18,
 		}]);
+	});
+
+	it("projects typed CI and gate host rows without treating them as child agents", () => {
+		const rows = projectAsyncWorkflowRows([], {
+			runId: "workflow-1",
+			mode: "workflow",
+			phases: [],
+			nodes: [
+				{ id: "ci-check", kind: "host-step", label: "CI checks", status: "completed", hostStep: hostStep() },
+				{ id: "review-gate", kind: "host-step", label: "Review gate", status: "completed", hostStep: hostStep({ id: "review-gate", monitorKind: "gate", label: "Review gate", verdict: "inconclusive", reasonCode: "stale-head", detail: "head changed", target: "PR #1614", freshness: { expectedRef: "old-head", observedRef: "new-head", stale: true }, reportPath: "/tmp/reports/gate.json" }) },
+			],
+		});
+
+		assert.deepEqual(rows, [
+			{ name: "CI checks", kind: "ci", state: "done", provider: "github-ci", verdict: "pass" },
+			{ name: "Review gate", kind: "gate", state: "done", provider: "github-ci", verdict: "inconclusive", reasonCode: "stale-head", detail: "head changed", target: "PR #1614", freshness: { expectedRef: "old-head", observedRef: "new-head", stale: true }, reportPath: "gate.json" },
+		]);
+	});
+
+	it("omits malformed host nodes instead of rendering them as agents", () => {
+		const rows = projectAsyncWorkflowRows([], {
+			runId: "workflow-1",
+			mode: "workflow",
+			phases: [],
+			nodes: [{ id: "bad", kind: "host-step", label: "bad", status: "running" }],
+		});
+		assert.deepEqual(rows, []);
 	});
 });

--- a/test/unit/async-status-snapshot.test.ts
+++ b/test/unit/async-status-snapshot.test.ts
@@ -88,6 +88,48 @@ describe("async status snapshot", () => {
 		assert.equal(snapshot.runs[0]?.children?.[0]?.state, "queued");
 	});
 
+	it("projects loaded host CI/gate nodes with bounded provider-neutral metadata", () => {
+		const snapshot = buildAsyncStatusSnapshot([{
+			asyncId: "workflow-1",
+			asyncDir: "/tmp/workflow-1",
+			status: "running",
+			mode: "workflow",
+			agents: [],
+			hostSteps: [{
+				version: 1,
+				kind: "host-step",
+				monitorKind: "gate",
+				id: "gate-1",
+				label: "Gate",
+				provider: "opaque-provider",
+				state: "done",
+				verdict: "inconclusive",
+				reasonCode: "stale-head",
+				freshness: { expectedRef: "old", observedRef: "new", stale: true },
+				reportPath: "/private/reports/gate.json",
+				updatedAt: 100,
+			}],
+		}] as any, { generatedAt: 200 });
+
+		assert.deepEqual(snapshot.runs[0]?.children, [{
+			id: "gate-1",
+			kind: "host-step",
+			label: "Gate",
+			state: "partial",
+			updatedAt: 100,
+			endedAt: 100,
+			hostStep: {
+				kind: "gate",
+				provider: "opaque-provider",
+				state: "done",
+				verdict: "inconclusive",
+				reasonCode: "stale-head",
+				stale: true,
+				report: "gate.json",
+			},
+		}]);
+	});
+
 	it("applies run, child, depth, string, and byte caps", () => {
 		const jobs = Array.from({ length: 5 }, (_, runIndex) => ({
 			asyncId: `run-${runIndex}`,

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -1005,6 +1005,79 @@ describe("below-editor subagent FleetView", () => {
 		}
 	});
 
+	it("renders host CI and gate rows as typed workflow monitors", () => {
+		const state = stateForTest();
+		const workflowJob = {
+			asyncId: "workflow-host",
+			asyncDir: "/tmp/workflow-host",
+			sessionId: "session-current",
+			status: "running" as const,
+			mode: "workflow" as const,
+			startedAt: 10,
+			updatedAt: 20,
+			hostSteps: [
+				{
+					version: 1 as const,
+					kind: "host-step" as const,
+					monitorKind: "ci" as const,
+					id: "ci-check",
+					label: "CI checks",
+					provider: "github-ci",
+					state: "running" as const,
+					target: "PR #1614",
+					updatedAt: 20,
+				},
+				{
+					version: 1 as const,
+					kind: "host-step" as const,
+					monitorKind: "gate" as const,
+					id: "gate-check",
+					label: "Review gate",
+					provider: "greptile",
+					state: "done" as const,
+					verdict: "inconclusive" as const,
+					reasonCode: "stale-head",
+					freshness: { expectedRef: "old", observedRef: "new", stale: true },
+					reportPath: "/tmp/reports/gate.json",
+					updatedAt: 20,
+				},
+			],
+		};
+		state.asyncJobs.set(workflowJob.asyncId, workflowJob);
+		state.fleetJobs!.set(workflowJob.asyncId, workflowJob);
+
+		const workflow = collectFleetStatusEntries(state).find((entry) => entry.key === "async:workflow-host");
+		assert.deepEqual(workflow?.workflowRows?.map((row) => ({ kind: row.kind, state: row.state })), [
+			{ kind: "ci", state: "running" },
+			{ kind: "gate", state: "done" },
+		]);
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000, maxAgentRows: 8 });
+		try {
+			fleet.setContext(ctx);
+			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
+			const lines = component.render(160).join("\n");
+			assert.match(lines, /ci: CI checks · running · .*provider:github-ci.*PR #1614/);
+			assert.match(lines, /gate: Review gate · inconclusive · .*provider:greptile.*stale.*out:gate.json/);
+			assert.doesNotMatch(lines, /agent: CI checks/);
+		} finally {
+			fleet.dispose();
+		}
+	});
+
 	it("renders recursive nested runs and steps within the existing row budget", () => {
 		const state = stateForTest();
 		state.asyncJobs.set("supervisor", {

--- a/test/unit/host-step-status.test.ts
+++ b/test/unit/host-step-status.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AsyncStatus, HostStepNodeV1 } from "../../src/shared/types.ts";
+import {
+	HOST_STEP_MAX_LABEL_CHARS,
+	assertHostStepNode,
+	assertWorkflowGraphHostSteps,
+	hostStepWorkflowNode,
+	parseHostStepNode,
+	assertUniqueHostStepIds,
+	upsertHostStep,
+	validHostStepNodes,
+} from "../../src/runs/shared/host-step-status.ts";
+
+function hostStep(overrides: Partial<HostStepNodeV1> = {}): HostStepNodeV1 {
+	return {
+		version: 1,
+		kind: "host-step",
+		monitorKind: "gate",
+		id: "gate-ci",
+		label: "CI and review gate",
+		provider: "github-ci",
+		state: "running",
+		updatedAt: 10,
+		...overrides,
+	};
+}
+
+describe("host step status", () => {
+	it("validates the explicit CI/gate contract and maps terminal states to graph status", () => {
+		const running = parseHostStepNode(hostStep({ monitorKind: "ci" }), "fixture");
+		assert.equal(running.monitorKind, "ci");
+		assert.equal(hostStepWorkflowNode(running).status, "running");
+		assert.equal(hostStepWorkflowNode(hostStep({ state: "done", verdict: "pass" })).status, "completed");
+		assert.equal(hostStepWorkflowNode(hostStep({ state: "done", verdict: "inconclusive" })).status, "completed");
+		assert.equal(hostStepWorkflowNode(hostStep({ state: "done", verdict: "fail" })).status, "failed");
+		assert.equal(hostStepWorkflowNode(hostStep({ state: "cancelled" })).status, "stopped");
+		assert.equal(hostStepWorkflowNode(hostStep({ state: "error" })).status, "failed");
+	});
+
+	it("rejects unbounded or incomplete terminal data", () => {
+		assert.throws(() => assertHostStepNode(hostStep({ label: "x".repeat(HOST_STEP_MAX_LABEL_CHARS + 1) }), "fixture"), /label exceeds/);
+		assert.throws(() => assertHostStepNode(hostStep({ state: "done" }), "fixture"), /done state requires a verdict/);
+		assert.throws(() => assertHostStepNode(hostStep({ state: "running", verdict: "pass" }), "fixture"), /verdict is only valid/);
+		assert.throws(() => assertHostStepNode(hostStep({ state: "done", verdict: "inconclusive", freshness: {} as HostStepNodeV1["freshness"] }), "fixture"), /expected/);
+		assert.throws(() => assertHostStepNode(hostStep({ state: "done", verdict: "pass", freshness: { expectedRef: "head", stale: true } }), "fixture"), /stale freshness/);
+	});
+
+	it("upserts through the host-owned persistence callback without touching legacy child steps", () => {
+		const status: AsyncStatus = {
+			runId: "workflow-1",
+			mode: "workflow",
+			state: "running",
+			startedAt: 1,
+			steps: [{ agent: "reviewer", workflowKey: "review", runId: "child-1", status: "running" }],
+		};
+		const writes: AsyncStatus[] = [];
+		const next = upsertHostStep({ status, hostStep: hostStep({ state: "done", verdict: "pass", updatedAt: 20 }), persist: (value) => writes.push(value) });
+		assert.equal(writes.length, 1);
+		assert.deepEqual(next.steps, status.steps);
+		assert.equal(next.workflowGraph?.nodes[0]?.kind, "host-step");
+		assert.equal(next.workflowGraph?.nodes[0]?.hostStep?.monitorKind, "gate");
+		assert.equal(next.workflowGraph?.nodes[0]?.status, "completed");
+		assert.equal(next.lastUpdate, 20);
+
+		const replaced = upsertHostStep({ status: next, hostStep: hostStep({ state: "error", updatedAt: 30 }), persist: (value) => writes.push(value) });
+		assert.equal(replaced.workflowGraph?.nodes.length, 1);
+		assert.equal(replaced.workflowGraph?.nodes[0]?.status, "failed");
+		assert.equal(writes.length, 2);
+	});
+
+	it("fails closed for malformed graph nodes while strict loaders can reject them", () => {
+		const graph = {
+			runId: "workflow-1",
+			mode: "workflow" as const,
+			phases: [],
+			nodes: [{ id: "bad", kind: "host-step" as const, label: "bad", status: "running" as const }],
+		};
+		assert.deepEqual(validHostStepNodes(graph), []);
+		assert.throws(() => assertHostStepNode(graph.nodes[0]?.hostStep, "status"), /expected an object/);
+	});
+
+	it("rejects ambiguous host-step identities", () => {
+		const duplicate = hostStep({ id: "duplicate" });
+		assert.throws(() => assertUniqueHostStepIds([duplicate, duplicate], "receipt"), /duplicate host step id/);
+		const graph = {
+			runId: "workflow-1",
+			mode: "workflow" as const,
+			phases: [],
+			nodes: [hostStepWorkflowNode(duplicate), hostStepWorkflowNode(duplicate)],
+		};
+		assert.deepEqual(validHostStepNodes(graph), []);
+		assert.throws(() => assertWorkflowGraphHostSteps(graph, "status", "workflow-1"), /duplicate host step id/);
+	});
+});

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, it } from "node:test";
 import { buildWorkflowReceipt, readWorkflowReceipt, resolveWorkflowReceiptResume, workflowReceiptPath, writeWorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
 import { externalCliReceiptMetadata, resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
 import type { WorkflowScriptChildResult } from "../../src/workflows/scripted-workflow.ts";
+import type { HostStepNodeV1 } from "../../src/shared/types.ts";
 import { workflowChildSummary } from "../../src/workflows/workflow-child-summary.ts";
 
 const roots: string[] = [];
@@ -38,6 +39,20 @@ function child(key: string, overrides: Partial<WorkflowScriptChildResult> = {}):
 	};
 }
 
+function hostStep(overrides: Partial<HostStepNodeV1> = {}): HostStepNodeV1 {
+	return {
+		version: 1,
+		kind: "host-step",
+		monitorKind: "gate",
+		id: "gate-1",
+		label: "Review gate",
+		state: "done",
+		verdict: "pass",
+		updatedAt: 10,
+		...overrides,
+	};
+}
+
 describe("workflow receipts", () => {
 	it("reads old receipt-v1 files without external adapter metadata", () => {
 		const asyncRoot = tempRoot();
@@ -52,6 +67,31 @@ describe("workflow receipts", () => {
 		}));
 
 		assert.equal(readWorkflowReceipt(asyncRoot, "workflow-old").entries.advisor?.externalAdapter, undefined);
+	});
+
+	it("round-trips bounded host CI/gate state in terminal receipts", () => {
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-host");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		const receipt = buildWorkflowReceipt({
+			workflowRunId: "workflow-host",
+			state: "complete",
+			children: [],
+			hostSteps: [hostStep({ monitorKind: "ci", id: "ci-1", label: "CI checks", provider: "opaque-provider", state: "done", verdict: "inconclusive", reasonCode: "stale-head", freshness: { expectedRef: "old", observedRef: "new", stale: true }, reportPath: "/private/report.json" })],
+			createdAt: 10,
+		});
+		writeWorkflowReceipt(asyncDir, receipt);
+		assert.deepEqual(readWorkflowReceipt(asyncRoot, "workflow-host").hostSteps, receipt.hostSteps);
+		assert.equal(JSON.stringify(receipt).includes("/private/report.json"), true);
+	});
+
+	it("rejects malformed host monitor receipt state", () => {
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-host-invalid");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		const receipt = buildWorkflowReceipt({ workflowRunId: "workflow-host-invalid", state: "complete", children: [] });
+		fs.writeFileSync(workflowReceiptPath(asyncRoot, "workflow-host-invalid"), JSON.stringify({ ...receipt, hostSteps: [{ ...hostStep(), state: "done", verdict: undefined }] }));
+		assert.throws(() => readWorkflowReceipt(asyncRoot, "workflow-host-invalid"), /done state requires a verdict/);
 	});
 
 	it("reads legacy Grok receipt metadata after the active profile is removed", () => {


### PR DESCRIPTION
Fixes #1614.

This adds bounded, typed host monitor rows for CI and gate evidence in workflow status. Host rows use explicit `monitorKind` values and loaded status or receipt data only. They do not infer type from labels or run provider work from render/status paths.

The change stays internal. It adds host-owned status validation and projection, keeps child `workflowKey` and `runId` identity separate, and does not add provider adapters, a `runs.gate` API, or render-time Git/GitHub/filesystem scans.

Validation:
- focused host-step/status/projection/snapshot/receipt/Fleet/widget tests: 143 passed
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- fresh exact-head review: no issues found
