### PR TITLE
feat: persist workflow lane metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add bounded, provider-agnostic host-owned CI and gate workflow rows with explicit monitor kinds, terminal verdicts, stale freshness, report pointers, and fail-closed status/receipt projection.
+- Persist bounded workflow lane metadata across child status, terminal receipts, and existing worktree handoff manifests, including display-only worktree paths and branches without adding a lane registry or cleanup authority; write pending worktree ownership evidence before creation to avoid crash orphan gaps.
 - Give every subagent child session a human-readable display name (`agent: task excerpt`, workflow node label preferred): applied to the child's own Pi session via `pi.setSessionName` (intercom routing targets keep precedence) and echoed as an optional `sessionName` field across result, live-progress, async status, workflow, nested, and intercom payloads so hosts can label child runs without reading child session files. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1615.
 - Add `/subagents-steer <run-id> [--child <child-id>] <message>`, a host bridge for steering live async runs from non-TUI sessions and RPC hosts, with fail-closed child-id resolution and pause-and-revive recovery disabled so callers keep exact-child authority. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1608.
 - Add explicit `allowNestedSubagents` agent authorization for nested fanout without replacing inherited tools or extensions. Thanks to [@tutu359](https://github.com/tutu359) for #1587.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -305,6 +305,33 @@ A top-level `{ workflowScript, worktree: true }` makes isolation the default for
 
 Configure the worktree base directory and setup hook in [configuration.md](configuration.md).
 
+### Lane metadata lifecycle
+
+Workflow children may declare a bounded `lane` object (`version`, `key`, optional
+`mode`, opaque `sourceRef`, advisory `claims`, and advisory `outputPaths`). The
+lane key must match the `runs.run`/`runs.all` workflow key. These fields are
+display and triage hints only: they do not grant tools, authorization, or
+cleanup permission, and `sourceRef` is never resolved over the network while
+rendering status. Worktree paths and branches copied into status are also
+display-only; the handoff manifest remains the deletion authority.
+
+| Durable file | Owner | Pending / running / finalized / cleanup states | Release predicate | Rollback predicate | Stale-head behavior | Fail-closed cases |
+| --- | --- | --- | --- | --- | --- | --- |
+| `status.json` | Async runner and workflow status projector | Child step starts `pending`, becomes `running`, then terminal `complete`/`failed`/`paused`/`stopped`; worktree path and branch are copied at launch | Status is terminal and the existing active-run/process proof can release the run marker; lane metadata alone never releases a worktree | Setup or persistence failure keeps the lane unknown; only the existing verified setup rollback may remove a newly created worktree | Recorded status is retained; a base/head mismatch is not repaired or inferred from render-time Git calls | Missing, malformed, or key-mismatched lane data; only one of `worktreePath`/`branch`; unverified process state |
+| `handoffs/<run-id>.json` | Existing parallel handoff writer and cleanup engine | Group is `partial` with preserved cleanup tasks while pending/running; finalized groups contain child identity, patch, and cleanup evidence; cleanup is `partial` or `complete` | Only the existing cleanup engine's fresh Git checks and recorded task evidence can release a worktree/branch; #1621 adds no deletion path | Missing diff, failed capture, or cleanup error preserves the task and records the reason | `baseCommit` is retained as evidence; stale or changed heads remain unknown/preserved until an explicit later reconciliation | Missing/invalid manifest, mismatched run/key/task identity, duplicate identity, dirty or uncaptured work |
+| `workflow-receipt.json` | Workflow terminal settlement | No receipt while `pending`/`running`; terminal receipt is finalized with one optional lane block per keyed child | Receipt publication is complete only after every included child entry is serialized; it does not authorize cleanup | Receipt write failure leaves status/handoff evidence authoritative and the workflow reports the missing receipt | Existing receipt is not backfilled or rewritten from a newer head | Invalid version/state, mismatched entry key or lane key, stale continuation lineage |
+| `.active-runs` marker | Existing active-run index | `pending`/`running` while the runner is live; terminal marker remains until observed process proof | Marker removal requires the existing exact-run process-terminal proof | Unknown proof keeps the marker and lane retained for inspection | Marker state is not inferred from Git head or timestamps alone | Missing/unknown process proof, active marker, or foreign run identity |
+
+Older runs without lane metadata remain readable and retain their existing
+handoff/cleanup behavior. Missing lane, receipt, or handoff metadata is
+unknown—not eligible for destructive cleanup.
+
+For managed worktree launches, the runner writes the pending handoff and the
+display-only status path/branch from the deterministic setup plan before the
+first `git worktree add`. If setup then fails or is interrupted, that pending
+ownership record remains preserved evidence; cleanup still rechecks the actual
+worktree state before any removal.
+
 ## Supervisor coordination (child asks parent)
 
 Child agents can talk back to the parent Pi session without installing `pi-intercom`. `pi-subagents` provides the child-facing `contact_supervisor` tool and the parent-facing `subagent_supervisor({ action: "reply" })` path natively. Generic `intercom` remains available only when an explicitly loaded external provider supplies it.

--- a/src/extension/public-execution.ts
+++ b/src/extension/public-execution.ts
@@ -14,6 +14,7 @@ export interface PublicSubagentExecutionParams {
 	workflowScriptPath?: unknown;
 	isolation?: unknown;
 	worktree?: unknown;
+	lane?: unknown;
 	async?: unknown;
 	output?: unknown;
 	resume?: unknown;

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -101,6 +101,15 @@ const ChainGateOverride = Type.String({
 	description: "For chain steps with agentContract, choose whether the chain advances on execution success or acceptance success. Defaults to execution.",
 });
 
+const WorkflowLaneMetadata = Type.Object({
+	version: Type.Integer({ minimum: 1, maximum: 1 }),
+	key: Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$" }),
+	mode: Type.Optional(Type.String({ enum: ["mutation", "review", "scout", "gate"] })),
+	sourceRef: Type.Optional(Type.String({ minLength: 1, maxLength: 128 })),
+	claims: Type.Optional(Type.Array(Type.String({ minLength: 1, maxLength: 160 }), { maxItems: 20 })),
+	outputPaths: Type.Optional(Type.Array(Type.String({ minLength: 1, maxLength: 256 }), { maxItems: 10 })),
+}, { additionalProperties: false, description: "Optional bounded child lane metadata. Display/triage only; sourceRef is opaque and never resolved during status rendering." });
+
 const ToolBudgetBlock = Type.Unsafe({
 	anyOf: [
 		{ type: "array", minItems: 1, items: { type: "string", minLength: 1 } },
@@ -312,6 +321,7 @@ const SubagentParamProperties = {
 	chatProgress: Type.Optional(Type.String({ enum: ["auto", "off", "live-card"], description: "WorkflowScript chat progress projection. auto shows a live in-chat card only for watched foreground workflows in the same Git repository; it is off otherwise. Explicit live-card requires same-repository async:false; async workflows should omit chatProgress or use auto/off." })),
 	isolation: Type.Optional(Type.String({ enum: ["none", "worktree"], description: "Workflow child isolation. none runs in the shared cwd; worktree requires managed git worktree isolation." })),
 	worktree: Type.Optional(Type.Boolean({ description: "Managed child isolation. true gives each workflow child a separate git worktree; an individual runs.run/runs.all item can override a workflow default with worktree:false." })),
+	lane: Type.Optional(WorkflowLaneMetadata),
 	context: Type.Optional(Type.String({
 		enum: ["fresh", "fork", "profile"],
 		description: "'fresh' or 'fork' to branch from parent session, or 'profile' to require the selected agent's declared defaultContext. Explicit fresh/fork overrides every child; profile ignores config defaultSubagentContext and fails when an agent has no defaultContext. If omitted, config defaultSubagentContext wins over each agent defaultContext; implicit fork needs a persisted parent session and leaf, else fresh. Config forkContext may prune resolved forks before spawn without adding another context value.",

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -55,6 +55,7 @@ import {
 	type ToolBudgetConfig,
 	type SubagentRunMode,
 	type SteeringRecoveryDescriptor,
+	type WorkflowLaneMetadata,
 	type UsageBudgetConfig,
 	DIRS,
 	SUBAGENT_ASYNC_STARTED_EVENT,
@@ -77,6 +78,7 @@ import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling,
 import { agentDefinitionDigest, launchBindingDigest } from "../../shared/launch-contract.ts";
 import { resolvePermissionRules, type PermissionConfig } from "../shared/permissions.ts";
 import { normalizeExtensionBindings, omitExtensionBindingsEnv, type ExtensionBindings } from "../shared/extension-bindings.ts";
+import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "../shared/lane-metadata.ts";
 
 const require = createRequire(import.meta.url);
 const piPackageRoot = resolvePiPackageRoot();
@@ -199,6 +201,7 @@ interface AsyncChainParams {
 	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
+	lane?: WorkflowLaneMetadata;
 	activeAsyncCapacity?: ActiveAsyncCapacityHandle;
 }
 
@@ -264,6 +267,7 @@ interface AsyncSingleParams {
 	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
+	lane?: WorkflowLaneMetadata;
 	workflowAwaitAsync?: boolean;
 	activeAsyncCapacity?: ActiveAsyncCapacityHandle;
 	externalJobFollowUp?: {
@@ -1484,6 +1488,13 @@ export function executeAsyncSingle(
 		childIntercomTarget,
 		nestedRoute,
 	} = params;
+	let lane: WorkflowLaneMetadata | undefined;
+	try {
+		lane = normalizeWorkflowLaneMetadata(params.lane, "lane");
+		assertWorkflowLaneKey(lane, params.workflowKey, "lane");
+	} catch (error) {
+		return formatAsyncStartError("single", error instanceof Error ? error.message : String(error));
+	}
 	const task = params.task ?? "";
 	let extensionBindings: ExtensionBindings | undefined;
 	try {
@@ -1706,6 +1717,7 @@ export function executeAsyncSingle(
 	const recoveryAgentConfig = params.recoveryAgentConfig ?? agentConfig;
 	const recoveryDescriptor: SteeringRecoveryDescriptor = {
 		version: 1,
+		...(lane ? { lane } : {}),
 		launchContractDigest,
 		...(extensionBindings ? { extensionBindings } : {}),
 		runFanoutBudget,
@@ -1821,6 +1833,7 @@ export function executeAsyncSingle(
 						...(params.structuredOutputSchema ? { structuredOutputSchema: params.structuredOutputSchema } : {}),
 						...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
 						...(params.worktree === true ? { worktree: true } : {}),
+						...(lane ? { lane } : {}),
 					},
 				],
 				resultPath: params.parentWorkflowRunId !== undefined && (params.revivalLease !== undefined || params.workflowAwaitAsync === true)
@@ -1856,6 +1869,7 @@ export function executeAsyncSingle(
 				runFanoutBudget,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
+				...(lane ? { lane } : {}),
 				...(params.revivalLease ? { revivalLease: params.revivalLease } : {}),
 				nestedRoute: nestedRoute ?? inheritedNestedRoute,
 				nestedSelf: inheritedNestedRoute && nestedAddress ? {
@@ -1878,7 +1892,8 @@ export function executeAsyncSingle(
 				lastUpdate: initialStatusAt,
 				currentStep: 0,
 				chainStepCount: 1,
-				steps: [{ agent, status: "pending", ...(model ? { model } : {}), ...(contextLimit !== undefined ? { contextLimit } : {}) }],
+				...(lane ? { lane } : {}),
+				steps: [{ agent, status: "pending", ...(lane ? { lane } : {}), ...(model ? { model } : {}), ...(contextLimit !== undefined ? { contextLimit } : {}) }],
 			},
 			path.join(asyncDir, "status.json"),
 			(proof) => emitProcessTerminalEvent(ctx, proof),

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -401,6 +401,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				job.mode = status.mode;
 				job.parentWorkflowRunId = status.parentWorkflowRunId ?? job.parentWorkflowRunId;
 				job.workflowKey = status.workflowKey ?? job.workflowKey;
+				job.lane = status.lane ?? job.lane;
 				job.workflow = status.workflow ?? job.workflow;
 				job.hostSteps = validHostStepNodes(status.workflowGraph);
 				const workflowChildren = parseWorkflowChildSummary(status.workflowChildren);

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { DIRS, type AcceptanceInput, type AsyncStatus, type SteeringRecoveryDescriptor, type SubagentRunMode } from "../../shared/types.ts";
 import type { AgentConfig } from "../../agents/agents.ts";
 import { normalizeExtensionBindings } from "../shared/extension-bindings.ts";
+import { normalizeWorkflowLaneMetadata } from "../shared/lane-metadata.ts";
 import { validateAcceptanceInput } from "../shared/acceptance.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { intersectSubagentCapabilityCeilings, parseSubagentCapabilityCeiling, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
@@ -317,7 +318,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		"subagentOnlyExtensions", "mcpDirectTools", "mutationTools", "systemPrompt", "systemPromptMode", "inheritProjectContext", "inheritGlobalContext", "inheritSkills", "skills",
 		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "structuredOutputSchema", "acceptance", "sessionDir", "artifactConfig",
 		"artifactsDir", "maxOutput", "controlConfig", "context", "intercomBridge", "absoluteDeadlineAt", "initialTurnBudget", "initialToolBudget", "maxSubagentDepth", "share", "capabilityCeiling",
-		"launchResolvedExtensions", "runFanoutBudget",
+		"launchResolvedExtensions", "runFanoutBudget", "lane",
 		"extensionBindings",
 	]);
 	for (const field of Object.keys(parsed)) {
@@ -336,6 +337,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 	if (parsed.capabilityCeiling !== undefined) parsed.capabilityCeiling = parseSubagentCapabilityCeiling(parsed.capabilityCeiling, `async recovery descriptor '${descriptorPath}' capabilityCeiling`);
 	if (parsed.thinkingCeiling !== undefined) parsed.thinkingCeiling = parseThinkingLevel(parsed.thinkingCeiling, `async recovery descriptor '${descriptorPath}' thinkingCeiling`);
 	if (parsed.extensionBindings !== undefined) parsed.extensionBindings = normalizeExtensionBindings(parsed.extensionBindings)!.value;
+	if (parsed.lane !== undefined) parsed.lane = normalizeWorkflowLaneMetadata(parsed.lane, `Invalid async recovery descriptor '${descriptorPath}': lane`);
 	if (parsed.agentContract !== undefined) {
 		if (!parsed.agentContract || typeof parsed.agentContract !== "object" || Array.isArray(parsed.agentContract)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': agentContract must be an object.`);
 		const contract = parsed.agentContract as Record<string, unknown>;

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -19,6 +19,7 @@ import { asyncStatusChildIdentity } from "../shared/child-identity.ts";
 import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { assertWorkflowGraphHostSteps, hostStepReportName, hostStepVerdictLabel, validHostStepNodes } from "../shared/host-step-status.ts";
 import { projectAsyncWorkflowRows } from "../shared/async-status-projection.ts";
+import { validateAsyncStatusLaneMetadata } from "../shared/lane-metadata.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -31,6 +32,9 @@ interface AsyncRunStepSummary {
 	description?: string;
 	phase?: string;
 	workflowKey?: string;
+	lane?: AsyncJobStep["lane"];
+	worktreePath?: string;
+	branch?: string;
 	runId?: string;
 	outputName?: string;
 	structured?: boolean;
@@ -128,6 +132,7 @@ export interface AsyncRunSummary {
 	capabilityAudit?: SubagentCapabilityAudit;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
+	lane?: AsyncStatus["lane"];
 	workflow?: Details["workflow"];
 	workflowChildren?: Details["workflowChildren"];
 }
@@ -238,6 +243,7 @@ function deriveAsyncActivityState(asyncDir: string, status: AsyncStatus): { acti
 }
 
 function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string }, nestedWarnings: string[] = [], nestedRoute?: NestedRoute): AsyncRunSummary {
+	validateAsyncStatusLaneMetadata(status, `Invalid async status '${path.join(asyncDir, "status.json")}'`);
 	const workflowChildren = parseWorkflowChildSummary(status.workflowChildren);
 	if (workflowChildren && workflowChildren.workflowRunId !== status.runId) throw new Error(`Invalid async status '${path.join(asyncDir, "status.json")}': workflowChildren.workflowRunId does not match.`);
 	assertWorkflowGraphHostSteps(status.workflowGraph, path.join(asyncDir, "status.json"), status.runId);
@@ -284,6 +290,9 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 			...(step.description ? { description: step.description } : {}),
 			...(step.phase ? { phase: step.phase } : {}),
 			...(step.workflowKey ? { workflowKey: step.workflowKey } : {}),
+			...(step.lane ? { lane: step.lane } : {}),
+			...(step.worktreePath ? { worktreePath: step.worktreePath } : {}),
+			...(step.branch ? { branch: step.branch } : {}),
 			...(step.runId ? { runId: step.runId } : {}),
 			...(step.outputName ? { outputName: step.outputName } : {}),
 			...(step.structured ? { structured: step.structured } : {}),
@@ -382,6 +391,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		...(status.capabilityAudit ? { capabilityAudit: status.capabilityAudit } : {}),
 		...(status.parentWorkflowRunId ? { parentWorkflowRunId: status.parentWorkflowRunId } : {}),
 		...(status.workflowKey ? { workflowKey: status.workflowKey } : {}),
+		...(status.lane ? { lane: status.lane } : {}),
 		...(status.workflow ? { workflow: status.workflow } : {}),
 		...(workflowChildren ? { workflowChildren } : {}),
 		...(status.sessionDir ? { sessionDir: status.sessionDir } : {}),
@@ -542,6 +552,8 @@ function formatStepLine(step: AsyncRunStepSummary): string {
 	if (modelThinking) parts.push(modelThinking);
 	if (step.durationMs !== undefined) parts.push(formatDuration(step.durationMs));
 	if (step.tokens) parts.push(`${formatTokens(step.tokens.total)} tok`);
+	if (step.lane) parts.push(`lane ${step.lane.key}`);
+	if (step.worktreePath) parts.push(`worktree ${shortenPath(step.worktreePath)} · branch ${step.branch ?? "unknown"}`);
 	return parts.join(" | ");
 }
 
@@ -592,7 +604,8 @@ function formatRunHeader(run: AsyncRunSummary): string {
 	const activity = formatActivityFacts(run);
 	const pending = run.pendingAppends ? ` | ${run.pendingAppends} pending append${run.pendingAppends === 1 ? "" : "s"}` : "";
 	const context = contextModeLabel(run.context);
-	return `${run.id} | ${run.state}${activity ? ` | ${activity}` : ""} | ${run.mode}${context ? ` ${context}` : ""} | ${stepLabel}${pending} | ${cwd}`;
+	const lane = run.lane ? ` | lane ${run.lane.key}` : "";
+	return `${run.id} | ${run.state}${activity ? ` | ${activity}` : ""} | ${run.mode}${context ? ` ${context}` : ""} | ${stepLabel}${pending}${lane} | ${cwd}`;
 }
 
 export function formatAsyncRunList(runs: AsyncRunSummary[], heading = "Active async runs"): string {

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -64,13 +64,14 @@ function formatCapacityOwner(inspect: ActiveAsyncCapacityInspection): string[] {
 }
 
 function formatWorkflowDebug(status: AsyncStatus): string[] {
-	if (status.mode !== "workflow" && !status.parentWorkflowRunId && !status.workflowKey) return [];
+	if (status.mode !== "workflow" && !status.parentWorkflowRunId && !status.workflowKey && !status.lane) return [];
 	const lines = [
 		status.parentWorkflowRunId ? `Workflow parent: ${status.parentWorkflowRunId}${status.workflowKey ? ` (${status.workflowKey})` : ""}` : undefined,
 		status.mode === "workflow" ? `Workflow children: ${(status.steps ?? []).length}` : undefined,
+		status.lane ? `Lane: ${status.lane.key}${status.lane.mode ? ` (${status.lane.mode})` : ""}` : undefined,
 	].filter((line): line is string => line !== undefined);
 	for (const [index, step] of (status.steps ?? []).entries()) {
-		lines.push(`  ${index + 1}. key ${step.workflowKey ?? "n/a"} · ${runStatusStepDisplayName(step)} · ${step.status} · async ${step.async === undefined ? "unknown" : step.async ? "yes" : "no"}${step.runId ? ` · run ${step.runId}` : ""}`);
+		lines.push(`  ${index + 1}. key ${step.workflowKey ?? "n/a"} · ${runStatusStepDisplayName(step)} · ${step.status} · async ${step.async === undefined ? "unknown" : step.async ? "yes" : "no"}${step.runId ? ` · run ${step.runId}` : ""}${step.lane ? ` · lane ${step.lane.key}` : ""}${step.worktreePath ? ` · worktree ${step.worktreePath} · branch ${step.branch ?? "unknown"}` : ""}`);
 	}
 	return lines;
 }
@@ -88,6 +89,7 @@ function formatRunLifecycleDebug(input: { status: AsyncStatus; asyncDir: string;
 		`Mode: ${status.mode}`,
 		status.parentWorkflowRunId ? `Workflow parent: ${status.parentWorkflowRunId}` : undefined,
 		status.workflowKey ? `Workflow key: ${status.workflowKey}` : undefined,
+		status.lane ? `Lane: ${status.lane.key}${status.lane.mode ? ` (${status.lane.mode})` : ""}` : undefined,
 		`Status process terminal: ${formatProcessTerminal(overlayProcessTerminal)}`,
 		`Sidecar process terminal: ${formatProcessTerminal(sidecarProcessTerminal)}`,
 		...formatCapacityOwner(capacity),

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -50,6 +50,7 @@ import {
 	type SteeringTargetState,
 	type SteeringTargetStatus,
 	type SubagentChildStatusEvent,
+	type WorkflowLaneMetadata,
 	DEFAULT_MAX_OUTPUT,
 	type MaxOutputConfig,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -217,6 +218,7 @@ interface SubagentRunConfig {
 	launchBarrierToken?: string;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
+	lane?: WorkflowLaneMetadata;
 }
 
 interface StepResult {
@@ -2304,6 +2306,11 @@ function requiredStatusStep(statusPayload: RunnerStatusPayload, index: number): 
 	return step;
 }
 
+function setStatusWorktreeReference(statusStep: RunnerStatusStep, worktree: WorktreeSetup["worktrees"][number]): void {
+	statusStep.worktreePath = worktree.path;
+	statusStep.branch = worktree.branch;
+}
+
 function markParallelGroupSetupFailure(input: {
 	statusPayload: RunnerStatusPayload;
 	results: StepResult[];
@@ -2522,6 +2529,8 @@ async function runSubagent(
 	const overallStartTime = Date.now();
 	const shareEnabled = config.share === true;
 	const asyncDir = config.asyncDir;
+	const handoffWorkflowKey = config.workflowKey;
+	const handoffChildRunId = handoffWorkflowKey ? id : undefined;
 	const statusPath = path.join(asyncDir, "status.json");
 	const eventsPath = path.join(asyncDir, "events.jsonl");
 	const logPath = path.join(asyncDir, `subagent-log-${id}.md`);
@@ -2561,6 +2570,7 @@ async function runSubagent(
 				const taskSessionName = task.sessionName ?? deriveChildSessionName({ agent: task.agent, task: task.task, label: task.label });
 				initialStatusSteps.push(omitUndefinedProperties({
 					agent: task.agent,
+					...(task.lane ? { lane: task.lane } : config.lane ? { lane: config.lane } : {}),
 					...(taskSessionName ? { sessionName: taskSessionName } : {}),
 					...(externalRunnerStatus(task.runner) ? { runner: externalRunnerStatus(task.runner) } : {}),
 					...(statusStepDescription(task.task) ? { description: statusStepDescription(task.task) } : {}),
@@ -2614,6 +2624,7 @@ async function runSubagent(
 			const stepSessionName = step.sessionName ?? deriveChildSessionName({ agent: step.agent, task: step.task, label: step.label });
 			initialStatusSteps.push(omitUndefinedProperties({
 				agent: step.agent,
+				...(step.lane ? { lane: step.lane } : config.lane ? { lane: config.lane } : {}),
 				...(stepSessionName ? { sessionName: stepSessionName } : {}),
 				...(externalRunnerStatus(step.runner) ? { runner: externalRunnerStatus(step.runner) } : {}),
 				...(statusStepDescription(step.task) ? { description: statusStepDescription(step.task) } : {}),
@@ -2691,6 +2702,7 @@ async function runSubagent(
 		...(config.runFanoutBudget ? { runFanoutBudget: getRunFanoutBudgetSnapshot(config.runFanoutBudget) } : {}),
 		...(config.parentWorkflowRunId ? { parentWorkflowRunId: config.parentWorkflowRunId } : {}),
 		...(config.workflowKey ? { workflowKey: config.workflowKey } : {}),
+		...(config.lane ? { lane: config.lane } : {}),
 		...(config.runnerProcessInstanceId ? { processTerminal: { version: 1 as const, state: "pending" as const, runId: id, runnerProcessInstanceId: config.runnerProcessInstanceId } } : {}),
 		steps: initialStatusSteps,
 		artifactsDir,
@@ -4444,6 +4456,23 @@ async function runSubagent(
 							? omitUndefinedProperties({ hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs })
 							: undefined,
 						baseDir: config.worktreeBaseDir,
+						beforeCreate: (plannedSetup) => {
+							for (const worktree of plannedSetup.worktrees) setStatusWorktreeReference(requiredStatusStep(statusPayload, groupStartFlatIndex + worktree.index), worktree);
+							const pendingHandoff = writePendingParallelHandoff({
+								manifestPath: parallelHandoffPath(asyncDir),
+								runId: id,
+								mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" : "chain",
+								source: "async",
+								cwd,
+								stepIndex,
+								flatStartIndex: groupStartFlatIndex,
+								setup: plannedSetup,
+								laneBindings: handoffWorkflowKey || config.lane ? [{ index: groupStartFlatIndex, taskIndex: 0, ...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}), ...(handoffChildRunId ? { runId: handoffChildRunId } : {}), ...(config.lane ? { lane: config.lane } : {}) }] : undefined,
+							});
+							statusPayload.parallelHandoff = pendingHandoff;
+							statusPayload.lastUpdate = Date.now();
+							writeStatusPayload();
+						},
 					}));
 				} catch (error) {
 					const setupError = error instanceof Error ? error.message : String(error);
@@ -4468,18 +4497,6 @@ async function runSubagent(
 			}
 
 			try {
-				if (worktreeSetup) {
-					writePendingParallelHandoff({
-						manifestPath: parallelHandoffPath(asyncDir),
-						runId: id,
-						mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" : "chain",
-						source: "async",
-						cwd,
-						stepIndex,
-						flatStartIndex: groupStartFlatIndex,
-						setup: worktreeSetup,
-					});
-				}
 				if (group.worktree) ensureParallelProgressFile(cwd, group);
 				const groupStartTime = Date.now();
 				markParallelGroupRunning({
@@ -4799,6 +4816,9 @@ async function runSubagent(
 						diffs: captured.diffs,
 						results: parallelResults.map((result) => ({
 							agent: result.agent,
+							...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}),
+							...(handoffChildRunId ? { runId: handoffChildRunId } : {}),
+							...(config.lane ? { lane: config.lane } : {}),
 							status: result.stopped || (result.exitCode !== 0 && isUnexplainedProcessSignal(omitUndefinedProperties({
 								processSignal: result.processSignal,
 								interrupted: result.interrupted,
@@ -4878,17 +4898,27 @@ async function runSubagent(
 							? omitUndefinedProperties({ hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs })
 							: undefined,
 						baseDir: config.worktreeBaseDir,
+						beforeCreate: (plannedSetup) => {
+							const worktree = plannedSetup.worktrees[0];
+							if (worktree) {
+								setStatusWorktreeReference(requiredStatusStep(statusPayload, flatIndex), worktree);
+							}
+							const pendingHandoff = writePendingParallelHandoff({
+								manifestPath: parallelHandoffPath(asyncDir),
+								runId: id,
+								mode: "single",
+								source: "async",
+								cwd,
+								stepIndex,
+								flatStartIndex: flatIndex,
+								setup: plannedSetup,
+								laneBindings: handoffWorkflowKey || config.lane ? [{ index: flatIndex, taskIndex: 0, ...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}), ...(handoffChildRunId ? { runId: handoffChildRunId } : {}), ...(config.lane ? { lane: config.lane } : {}) }] : undefined,
+							});
+							statusPayload.parallelHandoff = pendingHandoff;
+							statusPayload.lastUpdate = Date.now();
+							writeStatusPayload();
+						},
 					}));
-					writePendingParallelHandoff({
-						manifestPath: parallelHandoffPath(asyncDir),
-						runId: id,
-						mode: "single",
-						source: "async",
-						cwd,
-						stepIndex,
-						flatStartIndex: flatIndex,
-						setup: singleWorktreeSetup,
-					});
 				} catch (error) {
 					if (singleWorktreeSetup) cleanupWorktrees(singleWorktreeSetup);
 					throw error;
@@ -5132,6 +5162,9 @@ async function runSubagent(
 					diffs,
 					results: [{
 						agent: singleResult.agent,
+						...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}),
+						...(handoffChildRunId ? { runId: handoffChildRunId } : {}),
+						...(config.lane ? { lane: config.lane } : {}),
 						status: singleResult.stopped ? "stopped" as const : singleResult.interrupted ? "paused" as const : singleResult.exitCode === 0 ? "completed" as const : "failed" as const,
 						summary: singleResult.output || singleResult.error || "(no output)",
 						...(singleResult.artifactPaths?.outputPath ? { outputPath: singleResult.artifactPaths.outputPath } : {}),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -126,6 +126,7 @@ import { handleHerdrProjectPaneAction, HERDR_PROJECT_PANE_ACTIONS } from "../../
 import { previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError, type WorkflowReceiptResumeReference, type WorkflowScriptChildResult, type WorkflowSteerOptions, type WorkflowSteerResult } from "../../workflows/scripted-workflow.ts";
 import { buildWorkflowReceipt, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
 import { validHostStepNodes } from "../shared/host-step-status.ts";
+import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "../shared/lane-metadata.ts";
 import { workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { resolveWorkflowChatProgress, type WorkflowChatProgressProjection } from "../../workflows/chat-progress.ts";
 import { claimWorkflowChildPermit, validateWorkflowChildPermitRoot, type WorkflowChildPermit, type WorkflowChildPermitContext } from "../../shared/workflow-child-permit.ts";
@@ -311,6 +312,7 @@ export interface SubagentParamsLike {
 	/** Internal workflow ownership metadata; not part of the public schema. */
 	workflowParentRunId?: string;
 	workflowKey?: string;
+	lane?: import("../../shared/types.ts").WorkflowLaneMetadata;
 	/** Set by the scheduler so this run's completion can name the schedule that produced it. */
 	scheduleOrigin?: ScheduleOrigin;
 	workflowChildAsyncId?: string;
@@ -2028,6 +2030,7 @@ async function resumeAsyncRun(input: {
 		worktreeSetupHookTimeoutMs: input.deps.config.worktreeSetupHookTimeoutMs,
 		worktreeBaseDir: input.deps.config.worktreeBaseDir,
 		worktree: input.params.worktree === true,
+		lane: input.params.lane ?? recoveryDescriptor?.lane,
 		controlConfig: recoveryDescriptor?.controlConfig ?? resolveControlConfig(input.deps.config.control, input.params.control),
 		intercomBridge: input.params.intercomBridge ?? recoveryDescriptor?.intercomBridge,
 		controlIntercomTarget: intercomBridge.active ? intercomBridge.orchestratorTarget : undefined,
@@ -3288,6 +3291,7 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			runFanoutBudget: data.runFanoutBudget,
 			parentWorkflowRunId: params.workflowParentRunId,
 			workflowKey: params.workflowKey,
+			lane: params.lane,
 			workflowAwaitAsync: params.workflowAwaitAsync,
 		}));
 		return waitForWorkflowAsyncSingleResult(params, asyncResult, { runId: id, task: params.task ?? "", signal: data.signal, state: deps.state, kill: deps.kill });
@@ -3304,6 +3308,7 @@ function createSingleWorktreeSetup(
 	setupHook: ExtensionConfig["worktreeSetupHook"],
 	setupHookTimeoutMs: ExtensionConfig["worktreeSetupHookTimeoutMs"],
 	baseDir: ExtensionConfig["worktreeBaseDir"],
+	beforeCreate?: (setup: WorktreeSetup) => void,
 ): { setup?: WorktreeSetup; errorResult?: AgentToolResult<Details> } {
 	if (!enabled) return {};
 	try {
@@ -3314,6 +3319,7 @@ function createSingleWorktreeSetup(
 					? { hookPath: setupHook, ...(setupHookTimeoutMs === undefined ? {} : { timeoutMs: setupHookTimeoutMs }) }
 					: undefined,
 				baseDir,
+				beforeCreate,
 			})),
 		};
 	} catch (error) {
@@ -3505,6 +3511,8 @@ function finalizeSingleWorktreeHandoff(input: {
 	cwd: string;
 	agent: string;
 	result: SingleResult;
+	workflowKey?: string;
+	lane?: import("../../shared/types.ts").WorkflowLaneMetadata;
 }): { suffix: string; reference?: NonNullable<Details["parallelHandoff"]> } {
 	const diffsDir = path.join(input.artifactsDir, "worktree-diffs", input.runId);
 	const diffs = diffWorktrees(input.worktreeSetup, [input.agent], diffsDir);
@@ -3519,9 +3527,13 @@ function finalizeSingleWorktreeHandoff(input: {
 		stepIndex: 0,
 		flatStartIndex: 0,
 		setup: input.worktreeSetup,
+		laneBindings: input.workflowKey || input.lane ? [{ index: 0, taskIndex: 0, ...(input.workflowKey ? { workflowKey: input.workflowKey } : {}), runId: input.workflowKey ? input.runId : undefined, ...(input.lane ? { lane: input.lane } : {}) }] : undefined,
 		diffs,
 		results: [{
 			agent: input.result.agent,
+			...(input.workflowKey ? { workflowKey: input.workflowKey } : {}),
+			...(input.workflowKey ? { runId: input.runId } : {}),
+			...(input.lane ? { lane: input.lane } : {}),
 			status: resolveSubagentResultStatus(omitUndefinedProperties({
 				exitCode: input.result.exitCode,
 				interrupted: input.result.interrupted,
@@ -3571,6 +3583,13 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		controlConfig,
 		contextPolicy,
 	} = data;
+	let lane: import("../../shared/types.ts").WorkflowLaneMetadata | undefined;
+	try {
+		lane = normalizeWorkflowLaneMetadata(params.lane, "lane");
+		assertWorkflowLaneKey(lane, params.workflowKey, "lane");
+	} catch (error) {
+		return { content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }], isError: true, details: { mode: "single", results: [] } };
+	}
 	const onControlEvent = createForegroundControlNotifier(data, deps);
 	const childBridgeActive = intercomBridgeAppliesToAgent(data.intercomBridge, contextPolicy, params.agent!);
 	const childIntercomTarget = childBridgeActive ? resolveSubagentIntercomTarget(runId, params.agent!, 0) : undefined;
@@ -3611,6 +3630,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 
 
 	const sourceCwd = effectiveCwd;
+	let pendingHandoff: Details["parallelHandoff"];
 	const { setup: worktreeSetup, errorResult: worktreeSetupError } = createSingleWorktreeSetup(
 		params.worktree,
 		sourceCwd,
@@ -3619,12 +3639,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		deps.config.worktreeSetupHook,
 		deps.config.worktreeSetupHookTimeoutMs,
 		deps.config.worktreeBaseDir,
-	);
-	if (worktreeSetupError) return worktreeSetupError;
-	const singleCwd = worktreeSetup?.worktrees[0]?.agentCwd ?? sourceCwd;
-	let pendingHandoff: Details["parallelHandoff"];
-	if (worktreeSetup) {
-		try {
+		(plannedSetup) => {
 			pendingHandoff = writePendingParallelHandoff({
 				manifestPath: parallelHandoffPath(artifactsDir, runId),
 				runId,
@@ -3633,13 +3648,13 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				cwd: sourceCwd,
 				stepIndex: 0,
 				flatStartIndex: 0,
-				setup: worktreeSetup,
+				setup: plannedSetup,
+				laneBindings: params.workflowKey || lane ? [{ index: 0, taskIndex: 0, ...(params.workflowKey ? { workflowKey: params.workflowKey, runId } : {}), ...(lane ? { lane } : {}) }] : undefined,
 			});
-		} catch (error) {
-			cleanupWorktrees(worktreeSetup);
-			return { content: [{ type: "text", text: formatParallelHandoffError(error) }], isError: true, details: { mode: "single", results: [] } };
-		}
-	}
+		},
+	);
+	if (worktreeSetupError) return worktreeSetupError;
+	const singleCwd = worktreeSetup?.worktrees[0]?.agentCwd ?? sourceCwd;
 
 	const authoredTask = task;
 	if (shouldForkAgent(contextPolicy, params.agent!)) {
@@ -3770,7 +3785,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				}
 				try {
 					if (worktreeSetup) {
-						finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result });
+						finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result, workflowKey: params.workflowKey, lane });
 					}
 					try {
 						updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events, notify: true });
@@ -3830,7 +3845,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	if (worktreeSetup) {
 		worktreeHandoff = r.detached
 			? { suffix: pendingHandoff ? formatParallelHandoffReference(pendingHandoff) : "", reference: pendingHandoff }
-			: finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result: r });
+			: finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result: r, workflowKey: params.workflowKey, lane });
 	}
 
 	if (r.progress) allProgress.push(r.progress);
@@ -4076,9 +4091,12 @@ function workflowChildResult(
 	const externalProcess = externalResult?.externalProcess ?? externalStatusStep?.externalProcess;
 	const externalAdapter = externalRunner ? externalCliReceiptMetadata({ runner: externalRunner, externalProcess, outputReference }) : undefined;
 	if (externalAdapter) resumability = { state: "not-resumable", reason: externalAdapter.nonResumableReason };
+	const lane = normalizeWorkflowLaneMetadata(childParams.lane, `workflow child '${key}'.lane`);
+	assertWorkflowLaneKey(lane, key, `workflow child '${key}'.lane`);
 	return {
 		key,
 		ok,
+		...(lane ? { lane } : {}),
 		...(terminalOutcome ? { terminalOutcome } : {}),
 		...(resolvedAgents.length === 1 ? { agent: resolvedAgents[0] } : {}),
 		...(runId ? { runId } : {}),
@@ -4242,6 +4260,8 @@ export function prepareWorkflowLaunchParams(
 	options: { missionDetached?: boolean; suppressRoutineResultIntercom?: boolean; awaitDetachedChild?: boolean; runFanoutBudget?: RunFanoutBudgetDescriptor; parentDeadlineAt?: number; externalAsyncRequired?: boolean; capabilityCeiling?: ResolvedSubagentCapabilityCeiling } = {},
 ): SubagentParamsLike {
 	const capabilityCeiling = intersectSubagentCapabilityCeilings(workflowDefaults.capabilityCeiling, options.capabilityCeiling);
+	const lane = normalizeWorkflowLaneMetadata(Object.hasOwn(childParams, "lane") ? childParams.lane : workflowDefaults.lane, `workflow child '${workflowKey}'.lane`);
+	assertWorkflowLaneKey(lane, workflowKey, `workflow child '${workflowKey}'.lane`);
 	const parentTimeoutMs = options.parentDeadlineAt === undefined
 		|| childParams.timeoutMs !== undefined
 		|| childParams.maxRuntimeMs !== undefined
@@ -4276,6 +4296,7 @@ export function prepareWorkflowLaunchParams(
 			message: typeof childParams.task === "string" ? childParams.task.trim() : "",
 			workflowParentRunId: parentWorkflowRunId,
 			workflowKey,
+			...(lane ? { lane } : {}),
 			...(worktree !== undefined ? { worktree: worktree as boolean } : {}),
 			...(outputSchema !== undefined ? { outputSchema: outputSchema as JsonSchemaObject } : {}),
 			...(agentContract !== undefined ? { agentContract: agentContract as AgentContract } : {}),
@@ -4299,6 +4320,7 @@ export function prepareWorkflowLaunchParams(
 		workflowParentRunId: parentWorkflowRunId,
 		workflowKey,
 		...(options.awaitDetachedChild ? { workflowAwaitDetached: true } : {}),
+		...(lane ? { lane } : {}),
 		...(parentTimeoutMs !== undefined ? { workflowParentDeadlineAt: options.parentDeadlineAt } : {}),
 		...(options.runFanoutBudget ? { runFanoutBudget: { ...options.runFanoutBudget, parentPath: `${options.runFanoutBudget.parentPath ? `${options.runFanoutBudget.parentPath}/` : ""}workflow[${workflowKey}]` } } : {}),
 		...(options.suppressRoutineResultIntercom ? { suppressRoutineResultIntercom: true } : {}),
@@ -4905,12 +4927,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									...(childPhase ? { phase: childPhase } : {}),
 									heartbeat: { status: "running", ...(childPhase ? { phase: childPhase } : {}) },
 								});
+								let preparedChildParams: SubagentParamsLike | undefined;
 								const result = await runMissionWorkflowChild(missionBinding, workflowRunId, key, childPhase, () => {
 									const childRequest = bindMissionWorkflowChildAsyncLaunch(
 										{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: workflowRunId, workflowKey: key, ctxCwd: parentCwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), options: { missionDetached: detachWorkflowChildMissions, awaitDetachedChild: true, runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt, capabilityCeiling: workflowCapabilityCeiling } }), runFanoutAdmitted: admission.admitted },
 										missionBinding,
 										deps.asyncByDefault,
 									);
+									preparedChildParams = childRequest;
 									workflowLaunchObservers.set(childRequest, (launch) => {
 										const step = status.steps?.find((candidate) => candidate.workflowKey === key);
 										if (step) {
@@ -4919,6 +4943,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 											step.sessionFile = launch.sessionFile;
 											step.async = launch.async;
 											if (launch.runId) step.runId = launch.runId;
+											if (childRequest.lane) step.lane = childRequest.lane;
 											persist({ tolerateStatusWriteFailure: true });
 										}
 										recordMissionWorkflowChild(missionBinding, workflowRunId, key, { status: "running", agent: launch.agent, ...(launch.sessionFile ? { sessionPath: launch.sessionFile } : {}) });
@@ -4954,12 +4979,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								for (const childResult of result.details.results) {
 									if (childResult.savedOutputPath) producedChildOutputPaths.add(childResult.savedOutputPath);
 								}
-								const child = workflowChildResult(key, result, childParams, deps.state);
+								const child = workflowChildResult(key, result, preparedChildParams ? preparedChildParams as unknown as Record<string, unknown> : childParams, deps.state);
 								if (child.runId) workflowChildRunIds.set(key, child.runId);
 								const step = status.steps?.find((candidate) => candidate.workflowKey === key);
 								if (step) {
 									step.async = Boolean(result.details.asyncId || result.details.asyncDir);
 									if (child.runId) step.runId = child.runId;
+									if (child.lane) step.lane = child.lane;
 								}
 								if (result.details.asyncDir && missionBinding) writeMissionAsyncBinding(result.details.asyncDir, missionBinding);
 								const childStatus = missionWorkflowChildStatus(result);
@@ -5114,12 +5140,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							...(childPhase ? { phase: childPhase } : {}),
 							heartbeat: { status: "running", ...(childPhase ? { phase: childPhase } : {}) },
 						});
+						let preparedChildParams: SubagentParamsLike | undefined;
 						const result = await runMissionWorkflowChild(missionBinding, _id, key, childPhase, () => {
 							const childRequest = bindMissionWorkflowChildAsyncLaunch(
 								{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: _id, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), options: { missionDetached: detachWorkflowChildMissions, suppressRoutineResultIntercom: chatProgress.mode === "live-card", runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt, capabilityCeiling: workflowCapabilityCeiling } }), runFanoutAdmitted: admission.admitted },
 								missionBinding,
 								deps.asyncByDefault,
 							);
+							preparedChildParams = childRequest;
 							if (delegatedWorkflowPermit) {
 								if (childRequest.async !== false) throw new Error("Workflow child permit supports one foreground child only.");
 								const childCwd = resolveRequestedCwd(workflowCwd, childRequest.cwd);
@@ -5149,7 +5177,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							if (childResult.savedOutputPath) producedChildOutputPaths.add(childResult.savedOutputPath);
 						}
 						if (result.details.asyncDir && missionBinding) writeMissionAsyncBinding(result.details.asyncDir, missionBinding);
-						const child = workflowChildResult(key, result, childParams, deps.state);
+						const child = workflowChildResult(key, result, preparedChildParams ? preparedChildParams as unknown as Record<string, unknown> : childParams, deps.state);
 						if (child.runId) workflowChildRunIds.set(key, child.runId);
 						const childStatus = missionWorkflowChildStatus(result);
 						recordMissionWorkflowChild(missionBinding, _id, key, {

--- a/src/runs/shared/lane-metadata.ts
+++ b/src/runs/shared/lane-metadata.ts
@@ -1,0 +1,105 @@
+import type { AsyncStatus, WorkflowLaneMetadata, WorkflowLaneMode } from "../../shared/types.ts";
+
+export const WORKFLOW_LANE_KEY_MAX_BYTES = 128;
+export const WORKFLOW_LANE_SOURCE_REF_MAX_BYTES = 128;
+export const WORKFLOW_LANE_CLAIM_MAX_BYTES = 160;
+export const WORKFLOW_LANE_CLAIMS_MAX = 20;
+export const WORKFLOW_LANE_OUTPUT_PATH_MAX_BYTES = 256;
+export const WORKFLOW_LANE_OUTPUT_PATHS_MAX = 10;
+export const WORKTREE_STATUS_PATH_MAX_BYTES = 4096;
+export const WORKTREE_STATUS_BRANCH_MAX_BYTES = 256;
+
+const WORKFLOW_LANE_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const WORKFLOW_LANE_MODES = new Set<WorkflowLaneMode>(["mutation", "review", "scout", "gate"]);
+
+function byteLength(value: string): number {
+	return Buffer.byteLength(value, "utf8");
+}
+
+function boundedNonEmptyString(value: unknown, label: string, maxBytes: number): string {
+	if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must be a non-empty string.`);
+	const normalized = value.trim();
+	if (byteLength(normalized) > maxBytes) throw new Error(`${label} exceeds ${maxBytes} UTF-8 bytes.`);
+	if ([...normalized].some((character) => character === "\n" || character === "\r" || character === "\u0000")) throw new Error(`${label} must not contain newlines or NUL bytes.`);
+	return normalized;
+}
+
+function assertPlainObject(value: unknown, label: string): asserts value is Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value) || (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)) {
+		throw new Error(`${label} must be a plain JSON object.`);
+	}
+}
+
+function assertKnownFields(value: Record<string, unknown>, fields: readonly string[], label: string): void {
+	const unknown = Object.keys(value).filter((field) => !fields.includes(field));
+	if (unknown.length > 0) throw new Error(`${label} has unsupported fields: ${unknown.join(", ")}.`);
+}
+
+function boundedStringArray(value: unknown, label: string, maxItems: number, maxBytes: number): string[] {
+	if (!Array.isArray(value)) throw new Error(`${label} must be an array.`);
+	if (value.length > maxItems) throw new Error(`${label} supports at most ${maxItems} entries.`);
+	return value.map((entry, index) => {
+		if (!Object.hasOwn(value, index)) throw new Error(`${label} must not contain sparse entries.`);
+		return boundedNonEmptyString(entry, `${label}[${index}]`, maxBytes);
+	});
+}
+
+/** Normalize and validate launch-declared lane metadata. */
+export function normalizeWorkflowLaneMetadata(value: unknown, label = "lane"): WorkflowLaneMetadata | undefined {
+	if (value === undefined) return undefined;
+	assertPlainObject(value, label);
+	assertKnownFields(value, ["version", "key", "mode", "sourceRef", "claims", "outputPaths"], label);
+	if (value.version !== 1) throw new Error(`${label}.version must be 1.`);
+	const key = boundedNonEmptyString(value.key, `${label}.key`, WORKFLOW_LANE_KEY_MAX_BYTES);
+	if (!WORKFLOW_LANE_KEY_PATTERN.test(key)) throw new Error(`${label}.key is invalid.`);
+	const mode = value.mode;
+	if (mode !== undefined && (typeof mode !== "string" || !WORKFLOW_LANE_MODES.has(mode as WorkflowLaneMode))) throw new Error(`${label}.mode is invalid.`);
+	const sourceRef = value.sourceRef === undefined ? undefined : boundedNonEmptyString(value.sourceRef, `${label}.sourceRef`, WORKFLOW_LANE_SOURCE_REF_MAX_BYTES);
+	const claims = value.claims === undefined ? undefined : boundedStringArray(value.claims, `${label}.claims`, WORKFLOW_LANE_CLAIMS_MAX, WORKFLOW_LANE_CLAIM_MAX_BYTES);
+	const outputPaths = value.outputPaths === undefined ? undefined : boundedStringArray(value.outputPaths, `${label}.outputPaths`, WORKFLOW_LANE_OUTPUT_PATHS_MAX, WORKFLOW_LANE_OUTPUT_PATH_MAX_BYTES);
+	return {
+		version: 1,
+		key,
+		...(mode !== undefined ? { mode: mode as WorkflowLaneMode } : {}),
+		...(sourceRef !== undefined ? { sourceRef } : {}),
+		...(claims !== undefined ? { claims } : {}),
+		...(outputPaths !== undefined ? { outputPaths } : {}),
+	};
+}
+
+export function assertWorkflowLaneKey(lane: WorkflowLaneMetadata | undefined, workflowKey: string | undefined, label = "lane"): void {
+	if (!lane || workflowKey === undefined) return;
+	if (lane.key !== workflowKey) throw new Error(`${label}.key '${lane.key}' does not match workflow key '${workflowKey}'.`);
+}
+
+export interface WorktreeStatusReference {
+	worktreePath: string;
+	branch: string;
+}
+
+/** Validate the display-only worktree fields copied into status.json. */
+export function normalizeWorktreeStatusReference(value: unknown, label = "worktree status reference"): WorktreeStatusReference | undefined {
+	if (value === undefined) return undefined;
+	assertPlainObject(value, label);
+	assertKnownFields(value, ["worktreePath", "branch"], label);
+	return {
+		worktreePath: boundedNonEmptyString(value.worktreePath, `${label}.worktreePath`, WORKTREE_STATUS_PATH_MAX_BYTES),
+		branch: boundedNonEmptyString(value.branch, `${label}.branch`, WORKTREE_STATUS_BRANCH_MAX_BYTES),
+	};
+}
+
+/** Validate only the additive lane/worktree fields of a persisted async status. */
+export function validateAsyncStatusLaneMetadata(status: Pick<AsyncStatus, "runId" | "workflowKey" | "lane" | "steps">, label = "async status"): void {
+	const lane = normalizeWorkflowLaneMetadata(status.lane, `${label}.lane`);
+	assertWorkflowLaneKey(lane, status.workflowKey, `${label}.lane`);
+	if (lane) status.lane = lane;
+	for (const [index, step] of (status.steps ?? []).entries()) {
+		const stepLane = normalizeWorkflowLaneMetadata(step.lane, `${label}.steps[${index}].lane`);
+		assertWorkflowLaneKey(stepLane, step.workflowKey, `${label}.steps[${index}].lane`);
+		if (stepLane) step.lane = stepLane;
+		const hasPath = step.worktreePath !== undefined;
+		const hasBranch = step.branch !== undefined;
+		if (hasPath !== hasBranch) throw new Error(`${label}.steps[${index}] must include both worktreePath and branch.`);
+		if (hasPath) normalizeWorktreeStatusReference({ worktreePath: step.worktreePath, branch: step.branch }, `${label}.steps[${index}]`);
+	}
+}

--- a/src/runs/shared/parallel-handoff.ts
+++ b/src/runs/shared/parallel-handoff.ts
@@ -5,7 +5,9 @@ import type {
 	ParallelHandoffGroup,
 	ParallelHandoffManifest,
 	ParallelHandoffReference,
+	ParallelHandoffLaneBinding,
 	SubagentResultStatus,
+	WorkflowLaneMetadata,
 } from "../../shared/types.ts";
 import type {
 	WorktreeCleanupReport,
@@ -14,6 +16,7 @@ import type {
 	WorktreeCleanupIntent,
 } from "./worktree.ts";
 import { cleanupWorktrees } from "./worktree.ts";
+import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "./lane-metadata.ts";
 
 export interface ParallelHandoffResult {
 	agent: string;
@@ -23,15 +26,123 @@ export interface ParallelHandoffResult {
 	structuredOutput?: unknown;
 	structuredOutputPath?: string;
 	sessionPath?: string;
+	workflowKey?: string;
+	runId?: string;
+	lane?: WorkflowLaneMetadata;
+}
+
+function optionalIdentity(value: unknown, label: string): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must be a non-empty string.`);
+	return value.trim();
+}
+
+function nonNegativeIndex(value: unknown, label: string): number {
+	if (!Number.isSafeInteger(value) || (value as number) < 0) throw new Error(`${label} must be a non-negative integer.`);
+	return value as number;
+}
+
+function normalizeLaneBinding(value: unknown, label: string): ParallelHandoffLaneBinding {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
+	const binding = value as Record<string, unknown>;
+	const unknown = Object.keys(binding).filter((field) => !["index", "taskIndex", "workflowKey", "runId", "lane"].includes(field));
+	if (unknown.length > 0) throw new Error(`${label} has unsupported fields: ${unknown.join(", ")}.`);
+	const index = nonNegativeIndex(binding.index, `${label}.index`);
+	const taskIndex = nonNegativeIndex(binding.taskIndex, `${label}.taskIndex`);
+	const workflowKey = optionalIdentity(binding.workflowKey, `${label}.workflowKey`);
+	const runId = optionalIdentity(binding.runId, `${label}.runId`);
+	const lane = normalizeWorkflowLaneMetadata(binding.lane, `${label}.lane`);
+	assertWorkflowLaneKey(lane, workflowKey, `${label}.lane`);
+	return {
+		index,
+		taskIndex,
+		...(workflowKey ? { workflowKey } : {}),
+		...(runId ? { runId } : {}),
+		...(lane ? { lane } : {}),
+	};
+}
+
+function validateManifestIdentity(parsed: ParallelHandoffManifest, manifestPath: string): ParallelHandoffManifest {
+	if (parsed.version !== 1 || !Array.isArray(parsed.groups)) {
+		throw new Error(`Invalid parallel handoff manifest: ${manifestPath}`);
+	}
+	if (typeof parsed.runId !== "string" || !parsed.runId.trim()) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': runId must be a non-empty string.`);
+	parsed.runId = parsed.runId.trim();
+	const workflowKeys = new Set<string>();
+	const childRunIds = new Set<string>();
+	const childIndexes = new Set<number>();
+	for (const [groupIndex, group] of parsed.groups.entries()) {
+		if (!group || typeof group !== "object" || !Array.isArray(group.children) || !group.cleanup || !Array.isArray(group.cleanup.tasks)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}] is malformed.`);
+		if (group.laneBindings !== undefined) {
+			if (!Array.isArray(group.laneBindings)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].laneBindings must be an array.`);
+			const taskIndexes = new Set<number>();
+			const cleanupIndexes = new Set(group.cleanup.tasks.map((task) => task.index));
+			group.laneBindings = group.laneBindings.map((binding, bindingIndex) => {
+				const normalized = normalizeLaneBinding(binding, `Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].laneBindings[${bindingIndex}]`);
+				if (taskIndexes.has(normalized.taskIndex)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}] has duplicate lane binding taskIndex ${normalized.taskIndex}.`);
+				if (!cleanupIndexes.has(normalized.taskIndex)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].laneBindings[${bindingIndex}] has no cleanup task for taskIndex ${normalized.taskIndex}.`);
+				taskIndexes.add(normalized.taskIndex);
+				return normalized;
+			});
+		}
+		const taskIndexes = new Set<number>();
+		for (const [childIndex, child] of group.children.entries()) {
+			if (!child || typeof child !== "object" || !child.patch || typeof child.patch !== "object") throw new Error(`Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}] is malformed.`);
+			const childRecord = child as unknown as Record<string, unknown>;
+			const index = nonNegativeIndex(childRecord.index, `Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}].index`);
+			const taskIndex = nonNegativeIndex(childRecord.taskIndex, `Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}].taskIndex`);
+			if (taskIndexes.has(taskIndex)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}] has duplicate child taskIndex ${taskIndex}.`);
+			taskIndexes.add(taskIndex);
+			if (childIndexes.has(index)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': duplicate child index ${index}.`);
+			childIndexes.add(index);
+			if (!group.cleanup.tasks.some((task) => task.index === taskIndex)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}] has no cleanup task for taskIndex ${taskIndex}.`);
+			const workflowKey = optionalIdentity(childRecord.workflowKey, `Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}].workflowKey`);
+			const runId = optionalIdentity(childRecord.runId, `Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}].runId`);
+			const lane = normalizeWorkflowLaneMetadata(childRecord.lane, `Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}].lane`);
+			assertWorkflowLaneKey(lane, workflowKey, `Invalid parallel handoff manifest '${manifestPath}': groups[${groupIndex}].children[${childIndex}].lane`);
+			if (workflowKey && workflowKeys.has(workflowKey)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': duplicate workflow key '${workflowKey}'.`);
+			if (workflowKey) workflowKeys.add(workflowKey);
+			if (runId && childRunIds.has(runId)) throw new Error(`Invalid parallel handoff manifest '${manifestPath}': duplicate child run id '${runId}'.`);
+			if (runId) childRunIds.add(runId);
+			if (lane) childRecord.lane = lane;
+			if (workflowKey) childRecord.workflowKey = workflowKey;
+			if (runId) childRecord.runId = runId;
+			childRecord.index = index;
+			childRecord.taskIndex = taskIndex;
+		}
+	}
+	return parsed;
 }
 
 function readManifest(manifestPath: string): ParallelHandoffManifest | undefined {
 	if (!fs.existsSync(manifestPath)) return undefined;
 	const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as ParallelHandoffManifest;
-	if (parsed.version !== 1 || !Array.isArray(parsed.groups)) {
-		throw new Error(`Invalid parallel handoff manifest: ${manifestPath}`);
-	}
-	return parsed;
+	return validateManifestIdentity(parsed, manifestPath);
+}
+
+export function readParallelHandoffManifest(manifestPath: string): ParallelHandoffManifest | undefined {
+	return readManifest(manifestPath);
+}
+
+export function resolveParallelHandoffChild(input: {
+	manifestPath: string;
+	runId: string;
+	workflowKey?: string;
+	childRunId?: string;
+}): { group: ParallelHandoffGroup; child: ParallelHandoffGroup["children"][number] } | undefined {
+	const manifest = readManifest(input.manifestPath);
+	if (!manifest) return undefined;
+	if (manifest.runId !== input.runId) throw new Error(`Managed worktree handoff belongs to run '${manifest.runId}', not '${input.runId}'.`);
+	const workflowKey = input.workflowKey?.trim() || undefined;
+	const childRunId = input.childRunId?.trim() || undefined;
+	if (!workflowKey && !childRunId) throw new Error("Parallel handoff child resolution requires workflowKey or childRunId.");
+	const matches = manifest.groups.flatMap((group) => group.children.map((child) => ({ group, child }))).filter(({ child }) => {
+		if (workflowKey && child.workflowKey !== workflowKey) return false;
+		if (childRunId && child.runId !== childRunId) return false;
+		return true;
+	});
+	if (matches.length > 1) throw new Error(`Parallel handoff has multiple children matching workflow identity${workflowKey ? ` '${workflowKey}'` : ` '${childRunId}'`}.`);
+	return matches[0];
 }
 
 function resolveExistingPath(candidate: string): string {
@@ -125,6 +236,7 @@ export function writeParallelHandoffGroup(input: {
 	diffs: WorktreeDiff[];
 	cleanup?: WorktreeCleanupReport;
 	results: ParallelHandoffResult[];
+	laneBindings?: ParallelHandoffLaneBinding[];
 	now?: number;
 }): ParallelHandoffReference {
 	const now = input.now ?? Date.now();
@@ -132,11 +244,27 @@ export function writeParallelHandoffGroup(input: {
 	if (existing && (existing.runId !== input.runId || existing.mode !== input.mode || existing.source !== input.source)) {
 		throw new Error(`Parallel handoff manifest belongs to a different run: ${input.manifestPath}`);
 	}
+	const laneBindings = input.laneBindings?.map((binding, index) => normalizeLaneBinding(binding, `parallel handoff lane binding ${index}`));
+	if (laneBindings) {
+		const taskIndexes = new Set<number>();
+		for (const binding of laneBindings) {
+			if (taskIndexes.has(binding.taskIndex)) throw new Error(`Parallel handoff has duplicate lane binding taskIndex ${binding.taskIndex}.`);
+			if (!input.setup.worktrees.some((worktree) => worktree.index === binding.taskIndex)) throw new Error(`Parallel handoff lane binding taskIndex ${binding.taskIndex} has no managed worktree.`);
+			if (binding.index !== input.flatStartIndex + binding.taskIndex) throw new Error(`Parallel handoff lane binding index ${binding.index} does not match taskIndex ${binding.taskIndex}.`);
+			taskIndexes.add(binding.taskIndex);
+		}
+	}
+	const bindingForTask = (taskIndex: number): ParallelHandoffLaneBinding | undefined => laneBindings?.find((binding) => binding.taskIndex === taskIndex);
 	const group: ParallelHandoffGroup = {
 		stepIndex: input.stepIndex,
 		baseCommit: input.setup.baseCommit,
 		repoRoot: input.setup.cwd,
 		children: input.results.map((result, taskIndex) => {
+			const binding = bindingForTask(taskIndex);
+			const runId = optionalIdentity(result.runId ?? binding?.runId, `parallel handoff child ${taskIndex}.runId`);
+			const lane = normalizeWorkflowLaneMetadata(result.lane ?? binding?.lane, `parallel handoff child ${taskIndex}.lane`);
+			const workflowKey = optionalIdentity(result.workflowKey ?? binding?.workflowKey, `parallel handoff child ${taskIndex}.workflowKey`);
+			assertWorkflowLaneKey(lane, workflowKey, `parallel handoff child ${taskIndex}.lane`);
 			const diff = input.diffs[taskIndex] ?? missingDiff({
 				manifestPath: input.manifestPath,
 				stepIndex: input.stepIndex,
@@ -148,6 +276,9 @@ export function writeParallelHandoffGroup(input: {
 				index: input.flatStartIndex + taskIndex,
 				taskIndex,
 				agent: result.agent,
+				...(workflowKey ? { workflowKey } : {}),
+				...(runId ? { runId } : {}),
+				...(lane ? { lane } : {}),
 				status: result.status,
 				summary: result.summary,
 				...(result.outputPath ? { outputPath: result.outputPath } : {}),
@@ -166,6 +297,7 @@ export function writeParallelHandoffGroup(input: {
 				},
 			};
 		}),
+		...(laneBindings && laneBindings.length > 0 && input.results.length === 0 ? { laneBindings } : {}),
 		cleanup: input.cleanup ?? {
 			state: "partial",
 			pruned: false,
@@ -210,6 +342,7 @@ export function writePendingParallelHandoff(input: {
 	stepIndex: number;
 	flatStartIndex: number;
 	setup: WorktreeSetup;
+	laneBindings?: ParallelHandoffLaneBinding[];
 }): ParallelHandoffReference {
 	return writeParallelHandoffGroup({ ...input, diffs: [], results: [] });
 }

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -92,6 +92,8 @@ export interface RunnerSubagentStep {
 	runFanoutPath?: string;
 	/** Run this single child in one managed worktree. */
 	worktree?: boolean;
+	/** Bounded launch-declared lane metadata; display/triage only. */
+	lane?: import("../../shared/types.ts").WorkflowLaneMetadata;
 }
 
 export interface ParallelStepGroup {

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -77,6 +77,8 @@ interface CreateWorktreesOptions {
 	agents?: string[];
 	setupHook?: WorktreeSetupHookConfig;
 	baseDir?: string;
+	/** Called with deterministic ownership metadata before any worktree is created. */
+	beforeCreate?: (setup: WorktreeSetup) => void;
 }
 
 interface ResolvedWorktreeSetupHook {
@@ -680,6 +682,22 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 	const repo = resolveRepoState(cwd);
 	const setupHook = resolveWorktreeSetupHook(repo.toplevel, options?.setupHook);
 	const baseDir = resolveWorktreeBaseDir(options?.baseDir, repo.toplevel);
+	const plannedSetup: WorktreeSetup = {
+		cwd: repo.toplevel,
+		baseCommit: repo.baseCommit,
+		worktrees: Array.from({ length: count }, (_, index) => {
+			const worktreePath = buildWorktreePath(baseDir, runId, index);
+			return {
+				path: worktreePath,
+				agentCwd: repo.cwdRelative ? path.join(worktreePath, repo.cwdRelative) : worktreePath,
+				branch: buildWorktreeBranch(runId, index),
+				index,
+				nodeModulesLinked: false,
+				syntheticPaths: [],
+			};
+		}),
+	};
+	options?.beforeCreate?.(plannedSetup);
 	const worktrees: WorktreeInfo[] = [];
 
 	try {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -122,6 +122,22 @@ export interface WorkflowRecoveryAction {
 	taskRequired: true;
 }
 
+/**
+ * Bounded, launch-declared workflow lane metadata. This is display and
+ * triage information only; capability ceilings, authorization, and cleanup
+ * safety remain owned by their existing enforcement and handoff paths.
+ */
+export type WorkflowLaneMode = "mutation" | "review" | "scout" | "gate";
+
+export interface WorkflowLaneMetadata {
+	version: 1;
+	key: string;
+	mode?: WorkflowLaneMode;
+	sourceRef?: string;
+	claims?: string[];
+	outputPaths?: string[];
+}
+
 export interface WorkflowChildSummaryV1 {
 	version: 1;
 	parentToolCallId: string;
@@ -146,6 +162,7 @@ type WorkflowReceiptEntryResumability =
 
 export type WorkflowReceiptEntry = WorkflowReceiptEntryResumability & {
 	key: string;
+	lane?: WorkflowLaneMetadata;
 	terminalOutcome?: WorkflowTerminalOutcome;
 	agent?: string;
 	requestedContext?: "fresh" | "fork";
@@ -344,6 +361,11 @@ export interface ParallelHandoffChild {
 	index: number;
 	taskIndex: number;
 	agent: string;
+	/** Stable workflow identity used to join status/receipt metadata. */
+	workflowKey?: string;
+	/** Child run id when the worktree belongs to a workflow child. */
+	runId?: string;
+	lane?: WorkflowLaneMetadata;
 	status: SubagentResultStatus;
 	summary: string;
 	outputPath?: string;
@@ -351,6 +373,15 @@ export interface ParallelHandoffChild {
 	structuredOutputPath?: string;
 	sessionPath?: string;
 	patch: ParallelHandoffPatch;
+}
+
+/** Launch-time identity retained while a handoff group has no terminal child rows yet. */
+export interface ParallelHandoffLaneBinding {
+	index: number;
+	taskIndex: number;
+	workflowKey?: string;
+	runId?: string;
+	lane?: WorkflowLaneMetadata;
 }
 
 export interface ParallelHandoffCleanupTask {
@@ -369,6 +400,8 @@ export interface ParallelHandoffGroup {
 	baseCommit: string;
 	repoRoot: string;
 	children: ParallelHandoffChild[];
+	/** Optional launch identities for pending groups before child results settle. */
+	laneBindings?: ParallelHandoffLaneBinding[];
 	cleanup: {
 		state: "complete" | "partial";
 		tasks: ParallelHandoffCleanupTask[];
@@ -697,6 +730,7 @@ export interface SteeringRecoveryDescriptor {
 	context?: "fresh" | "fork";
 	/** Raw per-run bridge override. Omitted descriptors continue to use global config. */
 	intercomBridge?: IntercomBridgeConfig;
+	lane?: WorkflowLaneMetadata;
 	absoluteDeadlineAt?: number;
 	initialTurnBudget?: ResolvedTurnBudget;
 	initialToolBudget?: ResolvedToolBudget;
@@ -1658,6 +1692,7 @@ export interface AsyncStatus {
 	workflowChildren?: WorkflowChildSummaryV1;
 	parentWorkflowRunId?: string;
 	workflowKey?: string;
+	lane?: WorkflowLaneMetadata;
 	/** Set when a durable schedule launched this run, so completions can name their origin. */
 	scheduleOrigin?: ScheduleOrigin;
 	steps?: Array<{
@@ -1676,6 +1711,11 @@ export interface AsyncStatus {
 		phase?: string;
 		label?: string;
 		workflowKey?: string;
+		lane?: WorkflowLaneMetadata;
+		/** Display-only worktree path copied at launch; handoff remains authoritative. */
+		worktreePath?: string;
+		/** Display-only branch copied at launch; handoff remains authoritative. */
+		branch?: string;
 		/** Child run identity for workflow capacity reconciliation. */
 		runId?: string;
 		/** True only when this workflow child owns a detached async runner. */
@@ -1817,6 +1857,7 @@ export interface AsyncJobState {
 	workflowKey?: string;
 	workflow?: Details["workflow"];
 	workflowChildren?: WorkflowChildSummaryV1;
+	lane?: WorkflowLaneMetadata;
 }
 
 export interface ForegroundResumeChild {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -5,6 +5,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import { previewDisplayText, sanitizeDisplayText, truncateDisplayText } from "./display-text.ts";
 import { formatToolCall } from "./formatters.ts";
 import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, NestedRunSummary, SingleResult, ToolCallSummary, Usage } from "./types.ts";
+import { validateAsyncStatusLaneMetadata } from "../runs/shared/lane-metadata.ts";
 
 const DEFAULT_CONFIG_DIR_NAME = ".pi";
 const PI_CODING_AGENT_PACKAGE_NAME = "@earendil-works/pi-coding-agent";
@@ -180,6 +181,13 @@ export function readStatus(asyncDir: string): AsyncStatus | null {
 		status = JSON.parse(content) as AsyncStatus;
 	} catch (error) {
 		throw new Error(`Failed to parse async status file '${statusPath}': ${getErrorMessage(error)}`, {
+			cause: error instanceof Error ? error : undefined,
+		});
+	}
+	try {
+		validateAsyncStatusLaneMetadata(status, `Invalid async status '${statusPath}'`);
+	} catch (error) {
+		throw new Error(`Failed to validate async status file '${statusPath}': ${getErrorMessage(error)}`, {
 			cause: error instanceof Error ? error : undefined,
 		});
 	}

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -333,6 +333,25 @@ function validateExtensionBindings(value, label) {
   if (new TextEncoder().encode(stableRunJson(value)).byteLength > 16384) throw new Error(label + " extensionBindings canonical JSON exceeds 16384 bytes.");
 }
 
+function validateLaneMetadata(value, label, workflowKey) {
+  if (value === undefined) return;
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(label + " must be a plain JSON object.");
+  const fields = Object.keys(value);
+  const allowed = ["version", "key", "mode", "sourceRef", "claims", "outputPaths"];
+  const unknown = fields.filter((field) => !allowed.includes(field));
+  if (unknown.length > 0) throw new Error(label + " has unsupported fields: " + unknown.join(", ") + ".");
+  if (value.version !== 1) throw new Error(label + ".version must be 1.");
+  if (typeof value.key !== "string" || !value.key.trim() || !runKeyPattern.test(value.key.trim())) throw new Error(label + ".key is invalid.");
+  if (workflowKey !== undefined && value.key.trim() !== workflowKey) throw new Error(label + ".key must match workflow key '" + workflowKey + "'.");
+  if (value.mode !== undefined && !["mutation", "review", "scout", "gate"].includes(value.mode)) throw new Error(label + ".mode is invalid.");
+  const bounded = (entry, maxBytes) => typeof entry === "string" && entry.trim() && new TextEncoder().encode(entry.trim()).byteLength <= maxBytes && !/[\r\n\u0000]/.test(entry);
+  if (value.sourceRef !== undefined && !bounded(value.sourceRef, 128)) throw new Error(label + ".sourceRef is invalid.");
+  for (const [name, maxItems, maxLength] of [["claims", 20, 160], ["outputPaths", 10, 256]]) {
+    if (value[name] === undefined) continue;
+    if (!Array.isArray(value[name]) || value[name].length > maxItems || value[name].some((entry) => !bounded(entry, maxLength))) throw new Error(label + "." + name + " is invalid.");
+  }
+}
+
 function validateRunCall(key, params, label, fingerprints) {
   if (typeof key !== "string" || !runKeyPattern.test(key)) throw new Error(label + " has an invalid key.");
   if (!params || typeof params !== "object" || Array.isArray(params)) throw new Error(label + " requires a params object.");
@@ -342,6 +361,7 @@ function validateRunCall(key, params, label, fingerprints) {
   }
   if (Object.prototype.hasOwnProperty.call(params, "clarify")) throw new Error(label + " does not support clarify UI.");
   if (params.worktree !== undefined && typeof params.worktree !== "boolean") throw new Error(label + " worktree must be true or false.");
+  validateLaneMetadata(params.lane, label + " lane", key);
   if (params.gate !== undefined && (typeof params.gate !== "string" || !params.gate.trim())) throw new Error(label + " gate must be a non-empty command string.");
   if (params.gate !== undefined && params.acceptance !== undefined) throw new Error(label + " gate cannot be combined with acceptance; use one gate command or acceptance.verify.");
   if (params.gate !== undefined && params.resume !== undefined) throw new Error(label + " gate is not supported with retained resume.");
@@ -655,6 +675,7 @@ parentPort.on("message", async (message) => {
 export interface WorkflowScriptChildResult {
 	key: string;
 	ok: boolean;
+	lane?: import("../shared/types.ts").WorkflowLaneMetadata;
 	terminalOutcome?: import("../shared/types.ts").WorkflowTerminalOutcome;
 	stopped?: boolean;
 	/** Canonical child agent name when launch resolution produced one. */
@@ -687,6 +708,7 @@ export interface WorkflowScriptTraceEntry {
 	phase?: string;
 	label?: string;
 	error?: string;
+	lane?: import("../shared/types.ts").WorkflowLaneMetadata;
 }
 
 export interface WorkflowSteerOptions {
@@ -1114,7 +1136,7 @@ function resolveWorkflowParserEntry(): string {
 	}
 }
 
-const AUTO_RESUME_PARAM_KEYS = ["acceptance", "agentContract", "index", "intercomBridge", "label", "maxRuntimeMs", "output", "outputMode", "outputSchema", "phase", "skill", "skills", "task", "timeoutMs", "toolBudget", "worktree"] as const;
+const AUTO_RESUME_PARAM_KEYS = ["acceptance", "agentContract", "index", "intercomBridge", "label", "lane", "maxRuntimeMs", "output", "outputMode", "outputSchema", "phase", "skill", "skills", "task", "timeoutMs", "toolBudget", "worktree"] as const;
 
 function isZeroUsage(usage: unknown): boolean {
 	if (!isRecord(usage)) return false;

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -5,6 +5,7 @@ import type { ExternalCliReceiptMetadata, WorkflowReceipt, WorkflowReceiptEntry,
 import type { WorkflowReceiptResumeReference, WorkflowScriptChildResult } from "./scripted-workflow.ts";
 import { parseWorkflowChildSummary } from "./workflow-child-summary.ts";
 import { HOST_STEP_MAX_COUNT, assertUniqueHostStepIds, parseHostStepNode } from "../runs/shared/host-step-status.ts";
+import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "../runs/shared/lane-metadata.ts";
 
 export type { WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState } from "../shared/types.ts";
 
@@ -45,12 +46,15 @@ export function buildWorkflowReceipt(input: {
 	for (const child of input.children) {
 		const key = assertKey(child.key, "workflow receipt child key");
 		if (entries[key]) throw new Error(`Workflow receipt has duplicate child key '${key}'.`);
+		const lane = normalizeWorkflowLaneMetadata(child.lane, `workflow receipt child '${key}'.lane`);
+		assertWorkflowLaneKey(lane, key, `workflow receipt child '${key}'.lane`);
 		const runIds = [...new Set((child.continuation?.runIds ?? (child.runId ? [child.runId] : [])).filter((runId) => typeof runId === "string" && runId.trim()).map((runId) => runId.trim()))];
 		const latestRunId = runIds.at(-1);
 		const resumability = child.resumability ?? { state: "not-resumable", reason: child.runId ? "resumability was not recorded" : "child produced no run id" };
 		if (resumability.state === "resumable" && !latestRunId) throw new Error(`Workflow receipt child '${key}' is resumable but has no retained run id.`);
 		const base = {
 			key,
+			...(lane ? { lane } : {}),
 			...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}),
 			...(child.agent ? { agent: child.agent } : {}),
 			...(child.requestedContext ? { requestedContext: child.requestedContext } : {}),
@@ -207,7 +211,9 @@ function parseEntry(value: unknown, key: string, source: string): WorkflowReceip
 	if (state === "not-resumable" && (typeof reason !== "string" || !reason.trim())) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' non-resumable reason is missing.`);
 	const terminalOutcome = parseTerminalOutcome(entry.terminalOutcome, `Invalid workflow receipt '${source}': entry '${key}' terminalOutcome`);
 	parseExternalCliReceiptMetadata(entry.externalAdapter, key, source);
-	return { ...(value as WorkflowReceiptEntry), ...(terminalOutcome ? { terminalOutcome } : {}) };
+	const lane = normalizeWorkflowLaneMetadata(entry.lane, `Invalid workflow receipt '${source}': entry '${key}'.lane`);
+	assertWorkflowLaneKey(lane, key, `Invalid workflow receipt '${source}': entry '${key}'.lane`);
+	return { ...(value as WorkflowReceiptEntry), ...(lane ? { lane } : {}), ...(terminalOutcome ? { terminalOutcome } : {}) };
 }
 
 function parseWorkflowResolution(value: unknown, source: string): WorkflowTerminalResolution | undefined {

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -73,7 +73,6 @@ describe("async status helpers", () => {
 			if (budgetDirectory) fs.rmSync(budgetDirectory, { recursive: true, force: true });
 		}
 	});
-
 	it("loads typed host monitor nodes from workflow status without child identity", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-host-step-"));
 		try {
@@ -133,6 +132,52 @@ describe("async status helpers", () => {
 				},
 			});
 			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false }), /host step.*expected an object/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("projects bounded lane and display-only worktree metadata from status", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-lane-"));
+		try {
+			createAsyncDir(root, "run-lane", {
+				runId: "run-lane",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{
+					agent: "worker",
+					workflowKey: "writer",
+					lane: { version: 1, key: "writer", mode: "mutation", sourceRef: "owner/repo#1621" },
+					worktreePath: "/tmp/worktrees/run-lane-0",
+					branch: "pi-subagent/run-lane-0",
+					status: "running",
+				}],
+			});
+			const run = listAsyncRuns(root, { states: ["running"] })[0]!;
+			assert.deepEqual(run.steps[0]?.lane, { version: 1, key: "writer", mode: "mutation", sourceRef: "owner/repo#1621" });
+			assert.equal(run.steps[0]?.worktreePath, "/tmp/worktrees/run-lane-0");
+			assert.equal(run.steps[0]?.branch, "pi-subagent/run-lane-0");
+			assert.match(formatAsyncRunList([run]), /lane writer/);
+			assert.match(formatAsyncRunList([run]), /worktree .*run-lane-0 .*branch pi-subagent\/run-lane-0/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects malformed or mismatched lane identity in status", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-lane-invalid-"));
+		try {
+			const runDir = createAsyncDir(root, "run-lane-invalid", {
+				runId: "run-lane-invalid",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", workflowKey: "writer", lane: { version: 1, key: "other" }, status: "running" }],
+			});
+			assert.throws(() => listAsyncRuns(root, { states: ["running"] }), /does not match workflow key/);
+			assert.equal(fs.existsSync(path.join(runDir, "status.json")), true);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -1199,7 +1199,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			try {
 				const failed = await executor.execute(
 					"workflow-resume-start-failure",
-					{ workflowScript: `return await runs.run("resume-child", { resume: "${sourceRunId}", task: "Continue" });`, async: true },
+					{ workflowScript: `return await runs.run("resume-child", { resume: "${sourceRunId}", task: "Continue", lane: { version: 1, key: "resume-child", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["retained.txt"] } });`, async: true },
 					new AbortController().signal,
 					undefined,
 					ctx,
@@ -1208,11 +1208,12 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				assert.ok(workflowRunId, "expected async workflow id");
 				await waitForFile(path.join(RESULTS_DIR, `${workflowRunId}.json`));
 				const workflowStatusPath = path.join(ASYNC_DIR, workflowRunId, "status.json");
-				const workflowStatus = await waitForStatus(workflowStatusPath, (value) => value?.state === "failed") as { steps?: Array<{ async?: boolean; runId?: string }>; error?: string };
+				const workflowStatus = await waitForStatus(workflowStatusPath, (value) => value?.state === "failed") as { steps?: Array<{ async?: boolean; runId?: string; lane?: unknown }>; error?: string };
 				revivedRunId = workflowStatus.steps?.[0]?.runId;
 
 				assert.equal(workflowStatus.steps?.[0]?.async, true);
 				assert.ok(revivedRunId, "expected the workflow step to keep revived run identity");
+				assert.deepEqual(workflowStatus.steps?.[0]?.lane, { version: 1, key: "resume-child", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["retained.txt"] });
 				assert.match(workflowStatus.error ?? "", /already owned by run 'workflow-competing-revival'/);
 				assert.deepEqual(getActiveAsyncCapacitySnapshot(parentSessionId, 1), { used: 0, limit: 1 });
 			} finally {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1652,7 +1652,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const toolCallId = `scripted-workflow-parent-${Date.now()}`;
 		const started = await executor.execute(
 			toolCallId,
-			{ workflowScript: `const child = await runs.run("background", { agent: "echo", task: "Async child", async: true, worktree: true }); return child.runId;` },
+			{ workflowScript: `const child = await runs.run("background", { agent: "echo", task: "Async child", async: true, worktree: true, lane: { version: 1, key: "background", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature.txt"] } }); return child.runId;` },
 			new AbortController().signal,
 			undefined,
 			makeMinimalCtx(tempDir),
@@ -1672,10 +1672,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const workflowStatus = JSON.parse(fs.readFileSync(path.join(started.details.asyncDir!, "status.json"), "utf-8")) as AsyncStatus;
 		const workflowStepSessionFile = workflowStatus.steps?.[0]?.sessionFile ?? "";
 		assert.equal(workflowStatus.steps?.[0]?.agent, "echo");
+		assert.deepEqual(workflowStatus.steps?.[0]?.lane, { version: 1, key: "background", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature.txt"] });
 		assert.match(workflowStepSessionFile, /session\.jsonl$/);
 		const childDir = path.join(DIRS.async, childRunId);
 		const childStatusPath = path.join(childDir, "status.json");
-		let childStatus: { state?: string; mode?: string; parentWorkflowRunId?: string; workflowKey?: string; parallelHandoff?: { path?: string; changedPatches?: number } } = {};
+		let childStatus: { state?: string; mode?: string; parentWorkflowRunId?: string; workflowKey?: string; lane?: { key: string; mode?: string; sourceRef?: string; claims?: string[] }; steps?: Array<{ lane?: { key: string }; worktreePath?: string; branch?: string }>; parallelHandoff?: { path?: string; changedPatches?: number } } = {};
 		for (let attempt = 0; attempt < 200; attempt++) {
 			if (fs.existsSync(childStatusPath)) childStatus = JSON.parse(fs.readFileSync(childStatusPath, "utf-8"));
 			if (["complete", "failed", "stopped"].includes(childStatus.state ?? "")) break;
@@ -1684,10 +1685,17 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(childStatus.mode, "single");
 		assert.equal(childStatus.parentWorkflowRunId, workflowRunId);
 		assert.equal(childStatus.workflowKey, "background");
+		assert.deepEqual(childStatus.lane, { version: 1, key: "background", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature.txt"] });
+		assert.deepEqual(childStatus.steps?.[0]?.lane, childStatus.lane);
+		assert.equal(typeof childStatus.steps?.[0]?.worktreePath, "string");
+		assert.equal(typeof childStatus.steps?.[0]?.branch, "string");
 		assert.equal(typeof childStatus.parallelHandoff?.path, "string");
 		assert.equal(childStatus.parallelHandoff?.changedPatches, 1);
 		assert.equal(fs.existsSync(path.join(tempDir, "feature.txt")), false);
-		const handoff = JSON.parse(fs.readFileSync(childStatus.parallelHandoff!.path!, "utf-8")) as { groups?: Array<{ children?: Array<{ patch?: { changed?: boolean; filesChanged?: number } }>; cleanup?: { state?: string; tasks?: Array<{ path?: string; preserved?: boolean; worktreeRemoved?: boolean; reason?: string }> } }> };
+		const handoff = JSON.parse(fs.readFileSync(childStatus.parallelHandoff!.path!, "utf-8")) as { groups?: Array<{ children?: Array<{ workflowKey?: string; runId?: string; lane?: { key: string }; patch?: { changed?: boolean; filesChanged?: number } }>; cleanup?: { state?: string; tasks?: Array<{ path?: string; preserved?: boolean; worktreeRemoved?: boolean; reason?: string }> } }> };
+		assert.equal(handoff.groups?.[0]?.children?.[0]?.workflowKey, "background");
+		assert.equal(handoff.groups?.[0]?.children?.[0]?.runId, childRunId);
+		assert.equal(handoff.groups?.[0]?.children?.[0]?.lane?.key, "background");
 		assert.equal(handoff.groups?.[0]?.children?.[0]?.patch?.changed, true);
 		assert.equal(handoff.groups?.[0]?.children?.[0]?.patch?.filesChanged, 1);
 		assert.equal(handoff.groups?.[0]?.cleanup?.state, "partial");
@@ -1702,6 +1710,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const childResult = JSON.parse(fs.readFileSync(childResultPath, "utf-8")) as { parentWorkflowRunId?: string; workflowKey?: string };
 		assert.equal(childResult.parentWorkflowRunId, workflowRunId);
 		assert.equal(childResult.workflowKey, "background");
+		const workflowReceipt = JSON.parse(fs.readFileSync(path.join(started.details.asyncDir!, "workflow-receipt.json"), "utf-8")) as { entries?: Record<string, { lane?: { key: string; mode?: string } }> };
+		assert.deepEqual(workflowReceipt.entries?.background?.lane, { version: 1, key: "background", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature.txt"] });
 		assert.equal(fs.existsSync(workflowStepSessionFile), true);
 		const retainedCwd = handoff.groups?.[0]?.cleanup?.tasks?.[0]?.path;
 		assert.ok(retainedCwd);
@@ -3007,8 +3017,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 				async: false,
 				workflowScript: `
 					const children = await runs.all([
-						{ key: "feature-a", agent: "worker", task: "Implement A", worktree: true },
-						{ key: "feature-b", agent: "worker", task: "Implement B", worktree: true }
+						{ key: "feature-a", agent: "worker", task: "Implement A", worktree: true, lane: { version: 1, key: "feature-a", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature-a.txt"] } },
+						{ key: "feature-b", agent: "worker", task: "Implement B", worktree: true, lane: { version: 1, key: "feature-b", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature-b.txt"] } }
 					]);
 					return children.map(({ key, artifactPaths }) => ({ key, artifactPaths }));
 				`,
@@ -3018,8 +3028,10 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			makeMinimalCtx(tempDir),
 		);
 
-		assert.equal(result.isError, undefined);
-		assert.equal(mockPi.callCount(), 2, result.content[0]?.text ?? "workflow produced no output");
+			assert.equal(result.isError, undefined);
+			assert.equal(mockPi.callCount(), 2, result.content[0]?.text ?? "workflow produced no output");
+			assert.deepEqual(result.details.workflow?.receipt?.entries["feature-a"]?.lane, { version: 1, key: "feature-a", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature-a.txt"] });
+			assert.deepEqual(result.details.workflow?.receipt?.entries["feature-b"]?.lane, { version: 1, key: "feature-b", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["feature-b.txt"] });
 		assert.equal(fs.existsSync(path.join(tempDir, "feature-a.txt")), false);
 		assert.equal(fs.existsSync(path.join(tempDir, "feature-b.txt")), false);
 		const output = result.content[0]?.text ?? "";
@@ -3029,12 +3041,14 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		for (const handoffPath of handoffPaths) {
 			const handoff = JSON.parse(fs.readFileSync(handoffPath, "utf-8")) as {
 				groups: Array<{
-					children: Array<{ patch: { changed: boolean; path: string } }>;
+				children: Array<{ workflowKey: string; runId: string; lane: { key: string; mode: string; sourceRef: string; claims: string[] }; patch: { changed: boolean; path: string } }>;
 					cleanup: { state: string; tasks: Array<{ path: string; worktreeRemoved: boolean; branchRemoved: boolean }> };
 				}>;
 			};
 			assert.equal(handoff.groups.length, 1);
 			assert.equal(handoff.groups[0]?.children.length, 1);
+			assert.equal(handoff.groups[0]?.children[0]?.workflowKey, handoff.groups[0]?.children[0]?.lane.key);
+			assert.equal(handoff.groups[0]?.children[0]?.runId?.length > 0, true);
 			assert.equal(handoff.groups[0]?.children[0]?.patch.changed, true);
 			assert.equal(fs.existsSync(handoff.groups[0]!.children[0]!.patch.path), true);
 			assert.equal(handoff.groups[0]?.cleanup.state, "complete");

--- a/test/unit/parallel-handoff.test.ts
+++ b/test/unit/parallel-handoff.test.ts
@@ -5,6 +5,8 @@ import * as path from "node:path";
 import { describe, it } from "node:test";
 import {
 	formatParallelHandoffReference,
+	readParallelHandoffManifest,
+	resolveParallelHandoffChild,
 	writeParallelHandoffGroup,
 	writePendingParallelHandoff,
 } from "../../src/runs/shared/parallel-handoff.ts";
@@ -63,6 +65,7 @@ describe("parallel handoff", () => {
 					...setup("/repo", "base-1"),
 					worktrees: [{ path: "/tmp/worktree-0", agentCwd: "/tmp/worktree-0", branch: "branch-0", index: 0, nodeModulesLinked: false, syntheticPaths: [] }],
 				},
+				laneBindings: [{ index: 0, taskIndex: 0, workflowKey: "writer", runId: "run-pending", lane: { version: 1, key: "writer", mode: "mutation" } }],
 			});
 
 			assert.equal(reference.childCount, 0);
@@ -70,6 +73,7 @@ describe("parallel handoff", () => {
 			const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as ParallelHandoffManifest;
 			assert.equal(manifest.groups[0]?.cleanup.tasks[0]?.path, "/tmp/worktree-0");
 			assert.equal(manifest.groups[0]?.cleanup.tasks[0]?.preserved, true);
+			assert.deepEqual(manifest.groups[0]?.laneBindings?.[0], { index: 0, taskIndex: 0, workflowKey: "writer", runId: "run-pending", lane: { version: 1, key: "writer", mode: "mutation" } });
 			assert.match(manifest.groups[0]?.cleanup.tasks[0]?.reason ?? "", /cleanup pending/);
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
@@ -198,6 +202,65 @@ describe("parallel handoff", () => {
 				() => writeParallelHandoffGroup({ ...common, runId: "run-2" }),
 				/belongs to a different run/,
 			);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("round-trips lane identity and resolves a workflow child to its manifest task", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-parallel-handoff-lane-"));
+		try {
+			const manifestPath = path.join(dir, "handoff.json");
+			const lane = { version: 1 as const, key: "writer", mode: "mutation" as const, sourceRef: "nicobailon/pi-subagents#1621", claims: ["src/shared/types.ts"], outputPaths: ["reports/lane.md"] };
+			writeParallelHandoffGroup({
+				manifestPath,
+				runId: "workflow-run",
+				mode: "single",
+				source: "async",
+				cwd: "/repo",
+				stepIndex: 0,
+				flatStartIndex: 3,
+				setup: setup("/repo", "base-1"),
+				diffs: [diff(dir, 0, "writer", false)],
+				cleanup: cleanup(),
+				results: [{ agent: "worker", status: "completed", summary: "done", workflowKey: "writer", runId: "child-run", lane }],
+			});
+
+			const manifest = readParallelHandoffManifest(manifestPath);
+			assert.deepEqual(manifest?.groups[0]?.children[0]?.lane, lane);
+			assert.equal(manifest?.groups[0]?.children[0]?.workflowKey, "writer");
+			assert.equal(manifest?.groups[0]?.children[0]?.runId, "child-run");
+			const match = resolveParallelHandoffChild({ manifestPath, runId: "workflow-run", workflowKey: "writer", childRunId: "child-run" });
+			assert.equal(match?.child.taskIndex, 0);
+			assert.equal(match?.child.index, 3);
+			assert.equal(resolveParallelHandoffChild({ manifestPath, runId: "workflow-run", workflowKey: "missing" }), undefined);
+			assert.throws(() => resolveParallelHandoffChild({ manifestPath, runId: "other-run", workflowKey: "writer" }), /belongs to run/);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails closed when persisted lane identity does not match the workflow key", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-parallel-handoff-lane-invalid-"));
+		try {
+			const manifestPath = path.join(dir, "handoff.json");
+			writeParallelHandoffGroup({
+				manifestPath,
+				runId: "workflow-run",
+				mode: "single",
+				source: "async",
+				cwd: "/repo",
+				stepIndex: 0,
+				flatStartIndex: 0,
+				setup: setup("/repo", "base-1"),
+				diffs: [diff(dir, 0, "writer", false)],
+				cleanup: cleanup(),
+				results: [{ agent: "worker", status: "completed", summary: "done", workflowKey: "writer", lane: { version: 1, key: "writer" } }],
+			});
+			const raw = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as { groups: Array<{ children: Array<{ lane: { key: string } }> }> };
+			raw.groups[0]!.children[0]!.lane.key = "other";
+			fs.writeFileSync(manifestPath, JSON.stringify(raw), "utf-8");
+			assert.throws(() => readParallelHandoffManifest(manifestPath), /does not match workflow key/);
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -676,6 +676,30 @@ describe("scripted workflow runtime", () => {
 		]);
 	});
 
+	it("validates bounded lane metadata and passes it to child launch", async () => {
+		const launches: Array<{ key: string; lane: unknown }> = [];
+		await runWorkflowScript({
+			script: `return runs.run("writer", { agent: "worker", task: "write", lane: { version: 1, key: "writer", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["src/shared/types.ts"], outputPaths: ["reports/writer.md"] } });`,
+			timeoutMs: 2_000,
+			async launch(key, params) {
+				launches.push({ key, lane: params.lane });
+				return { key, ok: true, output: key, artifactPaths: [], results: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.deepEqual(launches, [{ key: "writer", lane: { version: 1, key: "writer", mode: "mutation", sourceRef: "owner/repo#1621", claims: ["src/shared/types.ts"], outputPaths: ["reports/writer.md"] } }]);
+
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return runs.run("writer", { agent: "worker", task: "write", lane: { version: 1, key: "other" } });`,
+				timeoutMs: 2_000,
+				async launch(key) { return { key, ok: true, output: "unexpected", artifactPaths: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /must match workflow key/.test(error.message),
+		);
+	});
+
 	it("passes distinct namespaced bindings to parallel children", async () => {
 		const launches: Array<{ key: string; bindings: unknown }> = [];
 		await runWorkflowScript({

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -206,6 +206,23 @@ describe("workflow receipts", () => {
 		assert.throws(() => buildWorkflowReceipt({ workflowRunId: "workflow-1", state: "complete", children: [], workflowChildren: summary }), /does not match its receipt/);
 	});
 
+	it("round-trips bounded lane metadata and rejects mismatched receipt identity", () => {
+		const lane = { version: 1 as const, key: "advisor", mode: "review" as const, sourceRef: "owner/repo#1621", claims: ["src/shared/types.ts"], outputPaths: ["reports/advisor.md"] };
+		const receipt = buildWorkflowReceipt({ workflowRunId: "workflow-lane", state: "complete", children: [child("advisor", { lane })], createdAt: 10 });
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-lane");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		writeWorkflowReceipt(asyncDir, receipt);
+		assert.deepEqual(readWorkflowReceipt(asyncRoot, "workflow-lane").entries.advisor?.lane, lane);
+		assert.throws(() => buildWorkflowReceipt({ workflowRunId: "workflow-lane", state: "complete", children: [child("advisor", { lane: { ...lane, key: "other" } })] }), /does not match workflow key/);
+
+		const receiptPath = workflowReceiptPath(asyncRoot, "workflow-lane");
+		const malformed = JSON.parse(fs.readFileSync(receiptPath, "utf-8")) as { entries: { advisor: { lane: { key: string } } } };
+		malformed.entries.advisor.lane.key = "other";
+		fs.writeFileSync(receiptPath, JSON.stringify(malformed), "utf-8");
+		assert.throws(() => readWorkflowReceipt(asyncRoot, "workflow-lane"), /does not match workflow key/);
+	});
+
 	it("rejects non-string workflow-child summary identifiers", () => {
 		const asyncRoot = tempRoot();
 		const asyncDir = path.join(asyncRoot, "workflow-1");

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -74,6 +74,27 @@ describe("worktree", () => {
 		}
 	});
 
+	it("invokes beforeCreate with deterministic ownership metadata before creating worktrees", () => {
+		const repoDir = createRepo("pi-worktree-before-create-");
+		let setup: WorktreeSetup | undefined;
+		let planned: WorktreeSetup | undefined;
+		try {
+			setup = createWorktrees(repoDir, "before-create", 1, {
+				beforeCreate: (candidate) => {
+					planned = candidate;
+					assert.equal(fs.existsSync(candidate.worktrees[0]!.path), false);
+					assert.equal(candidate.worktrees[0]!.branch, "pi-parallel-before-create-0");
+				},
+			});
+			assert.equal(planned?.baseCommit, setup.baseCommit);
+			assert.equal(planned?.worktrees[0]?.path, setup.worktrees[0]?.path);
+			assert.equal(fs.existsSync(setup.worktrees[0]!.path), true);
+		} finally {
+			if (setup) cleanupWorktrees(setup);
+			cleanupRepo(repoDir);
+		}
+	});
+
 	it("createWorktrees maps subdirectory cwd to each agentCwd", () => {
 		const repoDir = createRepo("pi-worktree-subdir-");
 		const nestedDir = path.join(repoDir, "packages", "app");


### PR DESCRIPTION
Fixes #1621.

This persists bounded workflow lane metadata through the existing async status, workflow receipt, and managed worktree handoff stores. It also records pending managed-worktree ownership before `git worktree add`, and keeps direct lane metadata from fabricating workflow-child identity.

The change is additive and fail-closed. It does not add a lane registry, cleanup apply path, merge evidence, preflight UI, monitor steps, render-time discovery, or new public result fields.

Validation:
- focused #1621/#1614 unit and async-status suite: 188 passed
- retained-resume async regression: 1 passed
- lane/worktree integration checks: 2 passed
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- fresh exact-head review: no issues found
