### PR TITLE
feat: add subagents.agentScanDirs — user/project settings extra agent scan dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add settings-driven extra agent scan directories with bounded wildcard expansion for user and project discovery. Thanks to [@mystery4f](https://github.com/mystery4f) for #1646.
 - Add bounded `runs.host(...)` command steps to `workflowScript`, with required timeouts, saved output, and host-step status/receipt evidence (#1648).
 - Add bounded, provider-agnostic host-owned CI and gate workflow rows with explicit monitor kinds, terminal verdicts, stale freshness, report pointers, and fail-closed status/receipt projection.
 - Persist bounded workflow lane metadata across child status, terminal receipts, and existing worktree handoff manifests, including display-only worktree paths and branches without adding a lane registry or cleanup authority; write pending worktree ownership evidence before creation to avoid crash orphan gaps.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -28,6 +28,7 @@ Discovery notes:
 - Project discovery also reads legacy `.agents/**/*.md` files. If both `.agents/` and the project config agents directory define the same parsed runtime agent name, the project config directory wins.
 - Nested subdirectories are discovered recursively. `.chain.md` files do not define agents.
 - Installed Pi packages can expose agent directories from either `{"pi-subagents":{"agents":["./agents"]}}` or `{"pi":{"subagents":{"agents":["./agents"]}}}` in their package manifest. Package agents load above builtins and below user/project agents.
+- Set `subagents.agentScanDirs` in user or project settings to add read-only agent-definition directories without copying files. Entries support a leading `~` and one wildcard path segment, such as `~/.pi/flow/*/agents`; user entries apply to user scope, project entries apply to project scope, and `both` includes both.
 - Use `agentScope: "user" | "project" | "both"` to control discovery. `both` is the default, and project definitions win runtime-name collisions.
 
 ## Builtin agents

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 `pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`. This page lists every key, plus the environment variables and the settings-file keys that affect config resolution.
 
-Settings-level keys (`subagents.defaultModel`, `defaultProvider`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. `modelScope.agents.<name>` adds per-agent restrictions, and `allow: ["inherit"]` permits the current parent model. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
+Settings-level keys (`subagents.agentScanDirs`, `defaultModel`, `defaultProvider`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. `modelScope.agents.<name>` adds per-agent restrictions, and `allow: ["inherit"]` permits the current parent model. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
 
 ## Project root resolution (settings)
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig } from "../shared/types.ts";
 import { CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL, isCodeOwnedExternalCliAdapterId, parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
+import { expandHomePath } from "../shared/settings.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
@@ -181,6 +182,7 @@ type ProjectRootResolution = "nearest" | "git-root";
 interface SubagentSettings {
 	overrides: Record<string, BuiltinAgentOverrideConfig>;
 	providerOverrides: Record<string, Record<string, BuiltinAgentOverrideConfig>>;
+	agentScanDirs?: string[];
 	defaultModel?: string;
 	defaultProvider?: string;
 	defaultThinking?: string;
@@ -1132,6 +1134,9 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		}
 		defaultExtensions = subagentsObject.defaultExtensions.map((item) => item.trim());
 	}
+	const agentScanDirs = Array.isArray(subagentsObject.agentScanDirs)
+		? subagentsObject.agentScanDirs.filter((item): item is string => typeof item === "string")
+		: undefined;
 	const modelScope = parseModelScopeConfig(subagentsObject.modelScope, { filePath });
 
 	const parsed: Record<string, BuiltinAgentOverrideConfig> = {};
@@ -1146,6 +1151,7 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		...(defaultThinking !== undefined ? { defaultThinking } : {}),
 		...(maxThinking !== undefined ? { maxThinking } : {}),
 		...(defaultExtensions !== undefined ? { defaultExtensions } : {}),
+		...(agentScanDirs !== undefined ? { agentScanDirs } : {}),
 		...(disableBuiltins !== undefined ? { disableBuiltins } : {}),
 		...(disableThinking !== undefined ? { disableThinking } : {}),
 		...(modelScope !== undefined ? { modelScope } : {}),
@@ -2278,6 +2284,43 @@ function extraUserAgentDirs(): string[] {
 		.filter((dir) => dir.length > 0);
 }
 
+// settings.json 的 subagents.agentScanDirs：额外 agent 扫描目录。
+// 支持 ~ 展开；仅最后一段通配（星号），例如 ~/.pi/flow/（星号）/agents。
+function settingsAgentScanDirs(settings: SubagentSettings): string[] {
+	const dirs = new Set<string>();
+	for (const entry of settings.agentScanDirs ?? []) {
+		for (const dir of expandAgentScanDirPattern(entry)) {
+			const resolved = path.resolve(expandHomePath(dir));
+			if (fs.existsSync(resolved)) dirs.add(resolved);
+		}
+	}
+	return [...dirs];
+}
+
+function expandAgentScanDirPattern(pattern: string): string[] {
+	const expanded = expandHomePath(pattern.trim());
+	if (!expanded) return [];
+	const wildcard = expanded.indexOf("*");
+	if (wildcard === -1) return [expanded];
+	// 定位通配段：段前斜杠（兼容正/反斜杠书写）与段后斜杠
+	const segmentStart = Math.max(expanded.lastIndexOf("/", wildcard), expanded.lastIndexOf("\\", wildcard));
+	if (segmentStart <= 0) return [];
+	const forwardSlashEnd = expanded.indexOf("/", wildcard);
+	const backslashEnd = expanded.indexOf("\\", wildcard);
+	const segmentEnd = forwardSlashEnd === -1
+		? backslashEnd
+		: backslashEnd === -1
+			? forwardSlashEnd
+			: Math.min(forwardSlashEnd, backslashEnd);
+	const base = expanded.slice(0, segmentStart);
+	const rest = segmentEnd === -1 ? "" : expanded.slice(segmentEnd + 1);
+	if (!fs.existsSync(base)) return [];
+	return fs
+		.readdirSync(base, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => path.join(base, entry.name, rest));
+}
+
 export function discoverAgents(cwd: string, scope: AgentScope, preferredModelProvider?: string): AgentDiscoveryResult {
 	const effectiveCwd = path.resolve(cwd);
 	const userDirOld = path.join(getAgentDir(), "agents");
@@ -2305,7 +2348,9 @@ export function discoverAgents(cwd: string, scope: AgentScope, preferredModelPro
 		userSettings, projectSettings, userSettingsPath, projectSettingsPath,
 	);
 
-	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), userDirOld, userDirNew].map((dir, discoveryPriority) => {
+	const userScanDirs = scope === "project" ? [] : settingsAgentScanDirs(userSettings);
+	const projectScanDirs = scope === "user" ? [] : settingsAgentScanDirs(projectSettings);
+	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), ...userScanDirs, userDirOld, userDirNew].map((dir, discoveryPriority) => {
 		const inspection = inspectAgentDefinitionDirectory(dir);
 		directories.push(reportAgentDefinitionDirectory("user", dir, inspection));
 		return loadAgentsFromDir(dir, "user", discoveryPriority, undefined, inspection);
@@ -2319,7 +2364,15 @@ export function discoverAgents(cwd: string, scope: AgentScope, preferredModelPro
 	// existing configured-root resolver found a root; never synthesize cwd paths.
 	const projectInspections = scope === "user" ? new Map<string, AgentDefinitionInspection>() : new Map(projectCandidateDirs.map((dir) => [dir, inspectAgentDefinitionDirectory(dir)]));
 	if (scope !== "user") for (const dir of projectCandidateDirs) directories.push(reportAgentDefinitionDirectory("project", dir, projectInspections.get(dir)!));
-	const projectLoaded = scope === "user" ? [] : projectAgentDirs.map((dir) => loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : 0, undefined, projectInspections.get(dir)!));
+	const projectScanLoaded = projectScanDirs.map((dir, discoveryPriority) => {
+		const inspection = inspectAgentDefinitionDirectory(dir);
+		directories.push(reportAgentDefinitionDirectory("project", dir, inspection));
+		return loadAgentsFromDir(dir, "project", discoveryPriority, undefined, inspection);
+	});
+	const projectLoaded = scope === "user" ? [] : [
+		...projectScanLoaded,
+		...projectAgentDirs.map((dir) => loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : 0, undefined, projectInspections.get(dir)!)),
+	];
 	const projectAgents = applyCustomAgentOverrides(
 		applySubagentDefaults(projectLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions),
 		userSettings, projectSettings, userSettingsPath, projectSettingsPath,
@@ -2389,7 +2442,7 @@ export function discoverAgentsAll(cwd: string, preferredModelProvider?: string):
 		userSettingsPath,
 		projectSettingsPath,
 	);
-	const userLoaded = [...extraUserAgentDirs(), userDirOld, userDirNew]
+	const userLoaded = [...extraUserAgentDirs(), ...settingsAgentScanDirs(userSettings), userDirOld, userDirNew]
 		.map((dir, discoveryPriority) => loadAgentsFromDir(dir, "user", discoveryPriority));
 	const user = applyCustomAgentOverrides(
 		applySubagentDefaults(userLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions),
@@ -2416,7 +2469,7 @@ export function discoverAgentsAll(cwd: string, preferredModelProvider?: string):
 	);
 	const projectMap = new Map<string, AgentConfig>();
 	const projectAgentDiagnostics: AgentDiscoveryDiagnostic[] = [];
-	for (const dir of projectDirs) {
+	for (const dir of [...settingsAgentScanDirs(projectSettings), ...projectDirs]) {
 		const loaded = loadAgentsFromDir(dir, "project", dir === projectDir ? 1 : 0);
 		projectAgentDiagnostics.push(...loaded.diagnostics);
 		for (const agent of loaded.agents) {

--- a/test/unit/agent-scan-dirs.test.ts
+++ b/test/unit/agent-scan-dirs.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { discoverAgents } from "../../src/agents/agents.ts";
+
+function tempDir(prefix: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "agent-scan-" + prefix + "-"));
+}
+
+describe("settings subagents.agentScanDirs", () => {
+	let agentDir: string;
+	let projectDir: string;
+	let scanRoot: string;
+	let previousAgentDir: string | undefined;
+
+	beforeEach(() => {
+		agentDir = tempDir("agent");
+		projectDir = tempDir("proj");
+		scanRoot = tempDir("scan");
+		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		fs.mkdirSync(path.join(agentDir, "agents"), { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".pi"), { recursive: true });
+	});
+
+	afterEach(() => {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	});
+
+	function writeAgent(dir: string, name: string): void {
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, name + ".md"), "---\nname: " + name + "\ndescription: scan dirs test\n---\nbody", "utf8");
+	}
+
+	function writeSettings(value: unknown): void {
+		fs.writeFileSync(path.join(agentDir, "settings.json"), JSON.stringify(value), "utf8");
+	}
+
+	function writeProjectSettings(value: unknown): void {
+		fs.writeFileSync(path.join(projectDir, ".pi", "settings.json"), JSON.stringify(value), "utf8");
+	}
+
+	it("discovers agents from subagents.agentScanDirs with last-segment glob", () => {
+		writeAgent(path.join(scanRoot, "tplA", "agents"), "writer");
+		writeSettings({ subagents: { agentScanDirs: [scanRoot.replaceAll("\\", "/") + "/*/agents"] } });
+		const result = discoverAgents(projectDir, "both");
+		assert.ok(
+			result.agents.some((agent) => agent.localName === "writer" || agent.name === "writer"),
+			"expected writer discovered, got: " + result.agents.map((a) => a.name).join(","),
+		);
+	});
+
+	it("keeps user and project scan directories scoped while both includes both", () => {
+		const userScanDir = path.join(scanRoot, "user-agents");
+		const projectScanDir = path.join(scanRoot, "project-agents");
+		writeAgent(userScanDir, "user-scan");
+		writeAgent(projectScanDir, "project-scan");
+		writeSettings({ subagents: { agentScanDirs: [userScanDir] } });
+		writeProjectSettings({ subagents: { agentScanDirs: [projectScanDir] } });
+
+		const userOnly = discoverAgents(projectDir, "user").agents;
+		assert.ok(userOnly.some((agent) => agent.name === "user-scan"));
+		assert.ok(!userOnly.some((agent) => agent.name === "project-scan"));
+
+		const projectOnly = discoverAgents(projectDir, "project").agents;
+		assert.ok(!projectOnly.some((agent) => agent.name === "user-scan"));
+		assert.ok(projectOnly.some((agent) => agent.name === "project-scan"));
+		assert.equal(projectOnly.find((agent) => agent.name === "project-scan")?.source, "project");
+
+		const both = discoverAgents(projectDir, "both").agents;
+		assert.ok(both.some((agent) => agent.name === "user-scan"));
+		assert.ok(both.some((agent) => agent.name === "project-scan"));
+	});
+
+	it("preserves the suffix after a backslash wildcard", () => {
+		writeAgent(path.join(scanRoot, "tplA", "agents"), "backslash");
+		writeSettings({ subagents: { agentScanDirs: [scanRoot + "\\*\\agents"] } });
+		const result = discoverAgents(projectDir, "user");
+		assert.ok(result.agents.some((agent) => agent.name === "backslash"));
+	});
+
+	it("does not discover agents when the setting is absent", () => {
+		writeAgent(path.join(scanRoot, "tplA", "agents"), "lonely");
+		const result = discoverAgents(projectDir, "both");
+		assert.ok(!result.agents.some((agent) => agent.localName === "lonely" || agent.name === "lonely"));
+	});
+
+	it("prefers user-dir copy over scan-dir same-name agent (eject semantics)", () => {
+		writeAgent(path.join(scanRoot, "tplA", "agents"), "writer");
+		writeAgent(path.join(agentDir, "agents"), "writer");
+		writeSettings({ subagents: { agentScanDirs: [scanRoot.replaceAll("\\", "/") + "/*/agents"] } });
+		const result = discoverAgents(projectDir, "both");
+		const agent = result.agents.find((a) => a.localName === "writer" || a.name === "writer");
+		assert.ok(agent, "writer should exist");
+		const filePath = String((agent as { filePath?: string }).filePath ?? "");
+		assert.ok(filePath.startsWith(path.join(agentDir, "agents")), "user-dir copy should win, got " + filePath);
+	});
+
+	it("supports plain directory entries without glob", () => {
+		writeAgent(scanRoot, "flat");
+		writeSettings({ subagents: { agentScanDirs: [scanRoot.replaceAll("\\", "/")] } });
+		const result = discoverAgents(projectDir, "both");
+		assert.ok(result.agents.some((agent) => agent.localName === "flat" || agent.name === "flat"));
+	});
+
+	it("ignores missing directories and malformed settings", () => {
+		writeSettings({ subagents: { agentScanDirs: [scanRoot.replaceAll("\\", "/") + "/missing/agents", 42] } });
+		const result = discoverAgents(projectDir, "both");
+		assert.ok(Array.isArray(result.agents));
+	});
+});


### PR DESCRIPTION
## Summary

- Read `subagents.agentScanDirs` from `~/.pi/agent/settings.json` and `<project>/.pi/settings.json`
- Support `~` expansion and last-segment glob (e.g. `~/.pi/flow/*/agents`), both slash styles on Windows
- Priority: env extra dirs > agentScanDirs > userDirOld > userDirNew — a user-dir copy (eject output) overrides a same-name agent from scan dirs
- Missing/malformed settings degrade gracefully (no throw; agents simply not discovered)

## Motivation

编排模板（如 flow 插件）将 agent 定义随模板目录分发（`flow/<模板>/agents/`），当前引擎不扫描这些目录。`agentScanDirs` 让用户在 settings 里声明这些目录即可被引擎发现，无需把 agent 复制进固定目录，也不需要插件侧做任何 import 或探测来源——兼容"能力"而非"来源"。

## Test

- New: `test/unit/agent-scan-dirs.test.ts` (5 cases: glob discovery / absent setting / eject override / plain dir / malformed tolerance)
- Existing `agent-*.test.ts` regression: no new failures
- **11 failures in `test/unit/agent-management.test.ts` reproduce identically on clean upstream baseline 36d3a28f (verified via detached dual-checkout comparison, 33 pass / 11 fail with identical failing-test names on both HEAD and baseline) — pre-existing, unrelated to this change.**
