### PR TITLE
fix: add direct resume hint for missing workflow receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Accept a child id on `/subagents-stop <run-id> <child-id>` so RPC hosts and non-TUI sessions can stop one child of a multi-child async run or workflow without stopping the whole run. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #1603.
 
 ### Changed
+- Include a direct resumable child id in missing workflow receipt guidance when retained status proves it is safe.
 - Clarify `workflowScript` contracts: each distinct retained resume pass needs a new stable workflow key, and durable child output paths should use explicit bindings plus returned path metadata.
 - Record attested merge or supersession evidence in existing worktree handoff manifests and render fail-closed cleanup eligibility without performing removal.
 - Show optional lane/work-item context in async status rows, including known phase, gate, next action, output, run reference, and stale/blocked signals without adding render-time I/O.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -127,7 +127,7 @@ import { previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, Wo
 import { buildWorkflowReceipt, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
 import { validHostStepNodes } from "../shared/host-step-status.ts";
 import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "../shared/lane-metadata.ts";
-import { workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
+import { parseWorkflowChildSummary, workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { resolveWorkflowChatProgress, type WorkflowChatProgressProjection } from "../../workflows/chat-progress.ts";
 import { annotateWorkflowPreflightTrace, formatWorkflowPreflight, formatWorkflowPreflightWarnings, normalizeWorkflowPreflight, workflowPreflightWarnings } from "../../workflows/workflow-preflight.ts";
 import { claimWorkflowChildPermit, validateWorkflowChildPermitRoot, type WorkflowChildPermit, type WorkflowChildPermitContext } from "../../shared/workflow-child-permit.ts";
@@ -4154,21 +4154,97 @@ function workflowSteerReceipt(key: string, result: AgentToolResult<Details>): Wo
 	};
 }
 
+const MAX_WORKFLOW_RESUME_HINT_BYTES = 1024;
+const MAX_WORKFLOW_CHILD_RUN_ID_BYTES = 256;
+const WORKFLOW_RESUME_HINT_PARENT_STATES = new Set(["complete", "failed", "partial"]);
+const WORKFLOW_STEP_STATES = new Set(["pending", "running", "complete", "completed", "failed", "partial", "paused", "stopped", "rejected"]);
+
+function isSafeWorkflowChildRunId(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	const runId = value.trim();
+	return value === runId
+		&& Boolean(runId)
+		&& Buffer.byteLength(runId, "utf8") <= MAX_WORKFLOW_CHILD_RUN_ID_BYTES
+		&& path.basename(runId) === runId
+		&& path.win32.basename(runId) === runId
+		&& !/[\\/]/.test(runId)
+		&& !runId.includes("..")
+		&& !/[\u0000-\u001f\u007f]/.test(runId);
+}
+
+function isMissingWorkflowReceiptDiagnostic(error: unknown, workflowRunId: string): error is Error {
+	return error instanceof Error
+		&& error.message.startsWith(`Workflow receipt '${workflowRunId}' is not available because the workflow may still be active or terminal receipt writing failed.`);
+}
+
+function missingWorkflowReceiptResumeHint(reference: WorkflowReceiptResumeReference, state: SubagentState): string | undefined {
+	try {
+		if (!state.currentSessionId) return undefined;
+		const workflowRunId = reference.workflowRunId.trim();
+		const workflowStatus = readStatus(path.join(DIRS.async, workflowRunId));
+		if (!workflowStatus
+			|| workflowStatus.runId !== workflowRunId
+			|| workflowStatus.mode !== "workflow"
+			|| workflowStatus.sessionId !== state.currentSessionId
+			|| typeof workflowStatus.startedAt !== "number"
+			|| !Number.isFinite(workflowStatus.startedAt)
+			|| !WORKFLOW_RESUME_HINT_PARENT_STATES.has(workflowStatus.state)
+			|| !Array.isArray(workflowStatus.steps)
+			|| workflowStatus.steps.some((step) => {
+				if (!step || typeof step !== "object" || Array.isArray(step)) return true;
+				const record = step as Record<string, unknown>;
+				return typeof record.agent !== "string"
+					|| typeof record.status !== "string"
+					|| !WORKFLOW_STEP_STATES.has(record.status)
+					|| (record.workflowKey !== undefined && typeof record.workflowKey !== "string")
+					|| (record.runId !== undefined && typeof record.runId !== "string");
+			})) return undefined;
+		const matchingSteps = workflowStatus.steps.filter((step) => step.workflowKey === reference.key);
+		if (matchingSteps.length !== 1) return undefined;
+		const childRunId = matchingSteps[0]?.runId;
+		if (!isSafeWorkflowChildRunId(childRunId)) return undefined;
+
+		const workflowChildren = parseWorkflowChildSummary(workflowStatus.workflowChildren);
+		if (workflowChildren) {
+			if (workflowChildren.workflowRunId !== workflowRunId) return undefined;
+			const matchingChildren = workflowChildren.children.filter((child) => child.childId === reference.key);
+			if (matchingChildren.length > 1 || (workflowChildren.inventoryComplete && matchingChildren.length !== 1)) return undefined;
+			if (matchingChildren.length === 1 && matchingChildren[0]?.runId !== childRunId) return undefined;
+		}
+
+		const target = resolveResumeTarget({ id: childRunId }, state, { asyncRequireSessionFile: true, exactOnly: true });
+		if (target.kind !== "revive") return undefined;
+		const hint = `Direct resumable child for workflow key '${reference.key}': subagent({ action: "resume", id: ${JSON.stringify(childRunId)}, message: "..." })`;
+		return Buffer.byteLength(hint, "utf8") <= MAX_WORKFLOW_RESUME_HINT_BYTES ? hint : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 function resolveKeyedWorkflowResume(
 	reference: WorkflowReceiptResumeReference,
 	state: SubagentState,
 ): { runId: string; runIds: string[] } {
-	const entry = resolveWorkflowReceiptResumeEntry({
-		reference,
-		asyncDirRoot: DIRS.async,
-		assertResumable(runId) {
-			const target = resolveResumeTarget({ id: runId }, state, { asyncRequireSessionFile: true, exactOnly: true });
-			if (target.kind !== "revive") throw new Error(`Workflow receipt child '${reference.key}' latest run '${runId}' is still running.`);
-		},
-	});
-	const runId = entry.latestRunId;
-	if (!runId) throw new Error(`Workflow receipt child '${reference.key}' has no retained run id.`);
-	return { runId, runIds: entry.continuation.runIds };
+	try {
+		const entry = resolveWorkflowReceiptResumeEntry({
+			reference,
+			asyncDirRoot: DIRS.async,
+			assertResumable(runId) {
+				const target = resolveResumeTarget({ id: runId }, state, { asyncRequireSessionFile: true, exactOnly: true });
+				if (target.kind !== "revive") throw new Error(`Workflow receipt child '${reference.key}' latest run '${runId}' is still running.`);
+			},
+		});
+		const runId = entry.latestRunId;
+		if (!runId) throw new Error(`Workflow receipt child '${reference.key}' has no retained run id.`);
+		return { runId, runIds: entry.continuation.runIds };
+	} catch (error) {
+		const workflowRunId = reference.workflowRunId.trim();
+		if (isMissingWorkflowReceiptDiagnostic(error, workflowRunId)) {
+			const hint = missingWorkflowReceiptResumeHint(reference, state);
+			if (hint) throw new Error(`${error.message} ${hint}`, { cause: error });
+		}
+		throw error;
+	}
 }
 
 function terminalWorkflowReceipt(

--- a/test/unit/workflow-resume-hint.test.ts
+++ b/test/unit/workflow-resume-hint.test.ts
@@ -1,0 +1,365 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { createSubagentExecutor } from "../../src/runs/foreground/subagent-executor.ts";
+import { resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
+import { DIRS, type AsyncStatus, type SubagentState } from "../../src/shared/types.ts";
+
+const cleanupRoots: string[] = [];
+
+function createState(sessionId: string | null): SubagentState {
+	return {
+		baseCwd: "",
+		currentSessionId: sessionId,
+		asyncJobs: new Map(),
+		foregroundRuns: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		pendingForegroundControlNotices: new Map(),
+		cleanupTimers: new Map(),
+		lastUiContext: null,
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
+function createExecutor(state: SubagentState, cwd: string) {
+	return createSubagentExecutor({
+		pi: { events: { emit() {}, on() { return () => {}; } }, getSessionName() { return "parent"; } } as never,
+		state,
+		config: { maxSubagentDepth: 2, control: {}, intercomBridge: {} } as never,
+		asyncByDefault: false,
+		tempArtifactsDir: cwd,
+		getSubagentSessionRoot: () => path.join(cwd, "sessions"),
+		expandTilde: (value) => value,
+		discoverAgents: () => ({ agents: [{ name: "worker" }] as never }),
+	});
+}
+
+function createContext(cwd: string) {
+	return {
+		cwd,
+		hasUI: false,
+		ui: {},
+		sessionManager: {
+			getSessionId() { return "session-1644"; },
+			getSessionFile() { return null; },
+		},
+		modelRegistry: { getAvailable() { return []; } },
+	} as never;
+}
+
+function makeIds(label: string): { parentRunId: string; childRunId: string } {
+	const suffix = `${label}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	return { parentRunId: `workflow-parent-${suffix}`, childRunId: `workflow-child-${suffix}` };
+}
+
+function writeRetainedChild(input: {
+	root: string;
+	childRunId: string;
+	sessionId: string;
+	state?: AsyncStatus["state"];
+	stepStatus?: NonNullable<AsyncStatus["steps"]>[number]["status"];
+	writeSession?: boolean;
+}): void {
+	const childDir = path.join(DIRS.async, input.childRunId);
+	fs.mkdirSync(childDir, { recursive: true });
+	const sessionFile = path.join(input.root, `${input.childRunId}.jsonl`);
+	if (input.writeSession !== false) fs.writeFileSync(sessionFile, "{}\n", "utf-8");
+	const state = input.state ?? "complete";
+	const stepStatus = input.stepStatus ?? "complete";
+	fs.writeFileSync(path.join(childDir, "status.json"), JSON.stringify({
+		runId: input.childRunId,
+		sessionId: input.sessionId,
+		mode: "single",
+		state,
+		startedAt: 100,
+		endedAt: state === "complete" ? 200 : undefined,
+		cwd: input.root,
+		sessionFile,
+		steps: [{ agent: "worker", status: stepStatus, sessionFile }],
+	}), "utf-8");
+}
+
+function writeWorkflowStatus(input: {
+	parentRunId: string;
+	childRunId: string;
+	key?: string;
+	sessionId?: string;
+	parentState?: AsyncStatus["state"];
+	steps?: Array<Record<string, unknown>>;
+	workflowChildren?: unknown;
+	malformed?: boolean;
+}): string {
+	const asyncDir = path.join(DIRS.async, input.parentRunId);
+	fs.mkdirSync(asyncDir, { recursive: true });
+	const statusPath = path.join(asyncDir, "status.json");
+	if (input.malformed) {
+		fs.writeFileSync(statusPath, "{not-json", "utf-8");
+	} else {
+		fs.writeFileSync(statusPath, JSON.stringify({
+			runId: input.parentRunId,
+			sessionId: input.sessionId ?? "session-1644",
+			mode: "workflow",
+			state: input.parentState ?? "complete",
+			startedAt: 100,
+			endedAt: 200,
+			steps: input.steps ?? [{ agent: "worker", workflowKey: input.key ?? "advisor", runId: input.childRunId, status: "complete" }],
+			...(input.workflowChildren === undefined ? {} : { workflowChildren: input.workflowChildren }),
+		}), "utf-8");
+	}
+	fs.writeFileSync(path.join(asyncDir, "events.jsonl"), `${JSON.stringify({ type: "subagent.workflow.child.completed", runId: input.parentRunId, childRunId: input.childRunId })}\n`, "utf-8");
+	return asyncDir;
+}
+
+async function runMissingReceiptResume(input: {
+	root: string;
+	parentRunId: string;
+	key?: string;
+	state?: SubagentState;
+}): Promise<string> {
+	const state = input.state ?? createState("session-1644");
+	const executor = createExecutor(state, input.root);
+	const key = input.key ?? "advisor";
+	const result = await executor.execute(
+		`resume-hint-request-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+		{
+			async: false,
+			mission: false,
+			workflowScript: `return runs.run("follow-up", { resume: { workflowRunId: ${JSON.stringify(input.parentRunId)}, key: ${JSON.stringify(key)}, latest: true }, task: "Continue" });`,
+		},
+		new AbortController().signal,
+		undefined,
+		createContext(input.root),
+	);
+	return result.content.map((part) => part.text ?? "").join("\n");
+}
+
+function cleanupRun(runId: string): void {
+	fs.rmSync(path.join(DIRS.async, runId), { recursive: true, force: true });
+}
+
+afterEach(() => {
+	for (const root of cleanupRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("workflow keyed resume recovery hint", () => {
+	it("names a directly resumable child when the parent receipt is missing", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-workflow-resume-hint-"));
+		cleanupRoots.push(root);
+		const { parentRunId, childRunId } = makeIds("positive");
+		writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+		const workflowChildren = {
+			version: 1,
+			parentToolCallId: "tool-call",
+			workflowRunId: parentRunId,
+			inventoryComplete: true,
+			workflowState: "completed",
+			children: [{ childId: "advisor", runId: childRunId, state: "completed" }],
+		};
+		writeWorkflowStatus({ parentRunId, childRunId, workflowChildren });
+
+		const text = await runMissingReceiptResume({ root, parentRunId });
+
+		assert.match(text, new RegExp(`Direct resumable child for workflow key 'advisor': subagent\\(\\{ action: "resume", id: ${JSON.stringify(childRunId)}, message: "\\.\\.\\." \\}\\)`));
+		assert.match(text, /terminal receipt writing failed/);
+		const target = resolveAsyncResumeTarget({ id: childRunId }, {}, { requireSessionFile: true, sessionId: "session-1644" });
+		assert.equal(target.kind, "revive");
+		assert.equal(target.runId, childRunId);
+		cleanupRun(parentRunId);
+		cleanupRun(childRunId);
+	});
+
+	it("does not hint when status proof or direct resumability is not safe", async () => {
+		const cases: Array<{
+			name: string;
+			configure: (root: string, parentRunId: string, childRunId: string) => SubagentState | undefined;
+		}> = [
+			{
+				name: "running parent",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, parentState: "running" });
+					return undefined;
+				},
+			},
+			{
+				name: "queued parent",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, parentState: "queued" });
+					return undefined;
+				},
+			},
+			{
+				name: "paused parent",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, parentState: "paused" });
+					return undefined;
+				},
+			},
+			{
+				name: "stopped parent",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, parentState: "stopped" });
+					return undefined;
+				},
+			},
+			{
+				name: "rejected parent",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, parentState: "rejected" });
+					return undefined;
+				},
+			},
+			{
+				name: "live child",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644", state: "running", stepStatus: "running" });
+					writeWorkflowStatus({ parentRunId, childRunId });
+					return undefined;
+				},
+			},
+			{
+				name: "pending child",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644", state: "running", stepStatus: "pending" });
+					writeWorkflowStatus({ parentRunId, childRunId });
+					return undefined;
+				},
+			},
+			{
+				name: "stopped child",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644", state: "stopped", stepStatus: "stopped" });
+					writeWorkflowStatus({ parentRunId, childRunId });
+					return undefined;
+				},
+			},
+			{
+				name: "missing session",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644", writeSession: false });
+					writeWorkflowStatus({ parentRunId, childRunId });
+					return undefined;
+				},
+			},
+			{
+				name: "foreign parent",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, sessionId: "other-session" });
+					return undefined;
+				},
+			},
+			{
+				name: "duplicate status key",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, steps: [
+						{ agent: "worker", workflowKey: "advisor", runId: childRunId, status: "complete" },
+						{ agent: "worker", workflowKey: "advisor", runId: childRunId, status: "complete" },
+					] });
+					return undefined;
+				},
+			},
+			{
+				name: "workflow child mismatch",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({
+						parentRunId,
+						childRunId,
+						workflowChildren: {
+							version: 1,
+							parentToolCallId: "tool-call",
+							workflowRunId: parentRunId,
+							inventoryComplete: true,
+							workflowState: "completed",
+							children: [{ childId: "advisor", runId: "other-child", state: "completed" }],
+						},
+					});
+					return undefined;
+				},
+			},
+			{
+				name: "complete summary missing key",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({
+						parentRunId,
+						childRunId,
+						workflowChildren: {
+							version: 1,
+							parentToolCallId: "tool-call",
+							workflowRunId: parentRunId,
+							inventoryComplete: true,
+							workflowState: "completed",
+							children: [],
+						},
+					});
+					return undefined;
+				},
+			},
+			{
+				name: "unsafe child id",
+				configure(root, parentRunId, childRunId) {
+					writeWorkflowStatus({
+						parentRunId,
+						childRunId,
+						steps: [{ agent: "worker", workflowKey: "advisor", runId: "../outside", status: "complete" }],
+					});
+					return undefined;
+				},
+			},
+			{
+				name: "whitespace child id",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({
+						parentRunId,
+						childRunId,
+						steps: [{ agent: "worker", workflowKey: "advisor", runId: `${childRunId} `, status: "complete" }],
+					});
+					return undefined;
+				},
+			},
+			{
+				name: "malformed receipt",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					const asyncDir = writeWorkflowStatus({ parentRunId, childRunId });
+					fs.writeFileSync(path.join(asyncDir, "workflow-receipt.json"), "{not-json", "utf-8");
+					return undefined;
+				},
+			},
+			{
+				name: "malformed parent status",
+				configure(root, parentRunId, childRunId) {
+					writeRetainedChild({ root, childRunId, sessionId: "session-1644" });
+					writeWorkflowStatus({ parentRunId, childRunId, malformed: true });
+					return undefined;
+				},
+			},
+		];
+
+		for (const testCase of cases) {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), `pi-workflow-resume-hint-${testCase.name.replaceAll(" ", "-")}-`));
+			cleanupRoots.push(root);
+			const { parentRunId, childRunId } = makeIds(testCase.name.replaceAll(" ", "-"));
+			const state = testCase.configure(root, parentRunId, childRunId);
+			const text = await runMissingReceiptResume({ root, parentRunId, state });
+			assert.doesNotMatch(text, /Direct resumable child for workflow key/);
+			cleanupRun(parentRunId);
+			cleanupRun(childRunId);
+		}
+	});
+});


### PR DESCRIPTION
Fixes #1644.

This keeps workflow-key resume on the terminal receipt path, but improves the missing-receipt recovery message. When the parent workflow status and existing direct resume checks prove that a child is safely revivable, the error now includes the exact direct `subagent({ action: "resume", id: ... })` command.

The hint stays fail-closed. It is not shown for nonterminal, stopped, foreign, malformed, duplicate, unsafe, or non-revivable state. It does not reconstruct from events, synthesize a receipt, or auto-resume from status.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-resume-hint.test.ts test/unit/workflow-receipt.test.ts test/unit/scripted-workflow.test.ts test/unit/async-resume.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
