### PR TITLE
fix: cover runs.lanes stages in preflight warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Avoid false preflight mismatch warnings for generated `runs.lanes(...)` stage keys (#1649).
 - Keep an async `workflowScript` continuation live while an awaited child coordinates with its supervisor, so sequential tail steps continue after the child settles (#1634).
 - Stop stale extension and slash-command contexts from escaping during reload or session replacement.
 - Include saved workflow child output paths and bounded inline previews in completion notices (#1629).

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1377,6 +1377,8 @@ export interface Details {
 			phase?: string;
 			label?: string;
 			durationMs?: number;
+			/** Internal provenance for a generated runs.lanes child key. */
+			generatedLaneKey?: string;
 			warning?: string;
 			error?: string;
 		}>;

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -254,11 +254,11 @@ function hostCall(method, args, observation) {
     : promise;
 }
 
-function runHostCall(key, params, collectFailure, batch) {
+function runHostCall(key, params, collectFailure, batch, generatedLaneKey) {
   const callId = ++nextCallId;
   const promise = new Promise((resolve, reject) => {
     pending.set(callId, { resolve, reject });
-    parentPort.postMessage({ type: "call", callId, method: "run", args: { key, params, ...(collectFailure ? { collectFailure: true } : {}), ...(batch ? { batch } : {}) } });
+    parentPort.postMessage({ type: "call", callId, method: "run", args: { key, params, ...(collectFailure ? { collectFailure: true } : {}), ...(batch ? { batch } : {}), ...(generatedLaneKey ? { generatedLaneKey } : {}) } });
   });
   return { key, callId, promise };
 }
@@ -375,9 +375,9 @@ function laneFailure(stageKey, error) {
   return { key: stageKey, ok: false, output: text, error: text, artifactPaths: [] };
 }
 
-function runCollected(key, params, observe) {
+function runCollected(key, params, observe, generatedLaneKey) {
   validateRunCall(key, params, "runs.lanes stage", runFingerprints);
-  const launched = runHostCall(key, params, true);
+  const launched = runHostCall(key, params, true, undefined, generatedLaneKey);
   observe([{ key, operation: "run", callId: launched.callId }]);
   return launched.promise.then(decorateWorkflowChildResult);
 }
@@ -470,7 +470,7 @@ function runLane(lane, firstResult, observe) {
     }
     let launched;
     try {
-      launched = runCollected(stage.generatedKey, params, observe);
+      launched = runCollected(stage.generatedKey, params, observe, lane.key);
     } catch (error) {
       const failed = laneFailure(stage.generatedKey, error);
       records.push(laneStageRecord(stage.key, failed));
@@ -500,7 +500,7 @@ function runLanes(laneSpecs) {
     return { key: first.generatedKey, ...first.params };
   });
   // Share the runs.all batch launcher while allowing each lane to advance independently.
-  const firstBatch = launchRunsAll(firstItems);
+  const firstBatch = launchRunsAll(firstItems, lanes.map((lane) => lane.key));
   const firstResults = firstBatch.launched.map(({ promise }) => promise.then(decorateWorkflowChildResult));
   let trackedAggregate;
   const observe = (observations) => trackRunObservation(observations, trackedAggregate);
@@ -609,7 +609,7 @@ function validateRunCall(key, params, label, fingerprints) {
   fingerprints.set(key, fingerprint);
 }
 
-function launchRunsAll(items) {
+function launchRunsAll(items, generatedLaneKeys) {
   if (!Array.isArray(items)) throw new Error("runs.all(items) requires an array.");
   const fingerprints = new Map(runFingerprints);
   const calls = [];
@@ -623,7 +623,7 @@ function launchRunsAll(items) {
   }
   runFingerprints = fingerprints;
   const batch = { id: "batch-" + (++nextCallId), calls };
-  const launched = calls.map(({ key, params }) => runHostCall(key, params, true, batch));
+  const launched = calls.map(({ key, params }, index) => runHostCall(key, params, true, batch, generatedLaneKeys?.[index]));
   return { calls, launched };
 }
 
@@ -939,6 +939,8 @@ export interface WorkflowScriptTraceEntry {
 	phase?: string;
 	label?: string;
 	error?: string;
+	/** Internal provenance for a generated runs.lanes child key. */
+	generatedLaneKey?: string;
 	lane?: import("../shared/types.ts").WorkflowLaneMetadata;
 	warning?: string;
 }
@@ -1423,7 +1425,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	const trace: WorkflowScriptTraceEntry[] = [];
 	const children = new Map<string, WorkflowScriptChildResult>();
 	const childOrder: string[] = [];
-	const launches = new Map<string, { fingerprint: string; promise: Promise<WorkflowScriptChildResult>; observed: boolean }>();
+	const launches = new Map<string, { fingerprint: string; promise: Promise<WorkflowScriptChildResult>; observed: boolean; generatedLaneKey?: string }>();
 	const steers = new Map<number, { key: string; promise: Promise<WorkflowSteerResult>; observed: boolean }>();
 	const stoppedLaunches = new Set<string>();
 	const childStopControllers = new Map<string, AbortController>();
@@ -1468,6 +1470,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			...(started?.agent ? { agent: started.agent } : {}),
 			...(started?.phase ? { phase: started.phase } : {}),
 			...(started?.label ? { label: started.label } : {}),
+			...(started?.generatedLaneKey ? { generatedLaneKey: started.generatedLaneKey } : {}),
 			error: message,
 		});
 		traceChanged();
@@ -1519,6 +1522,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 					...(started?.agent ? { agent: started.agent } : {}),
 					...(started?.phase ? { phase: started.phase } : {}),
 					...(started?.label ? { label: started.label } : {}),
+					...(started?.generatedLaneKey ? { generatedLaneKey: started.generatedLaneKey } : {}),
 					error: error.message,
 				});
 			}
@@ -1690,6 +1694,9 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			}
 			const params = message.args.params;
 			if (!isRecord(params)) return respond(Promise.reject(new Error(`runs.run('${key}', params) requires a params object.`)));
+			const generatedLaneKey = typeof message.args.generatedLaneKey === "string" && KEY_PATTERN.test(message.args.generatedLaneKey) && key.startsWith(`${message.args.generatedLaneKey}.`)
+				? message.args.generatedLaneKey
+				: undefined;
 			const collectFailure = message.args.collectFailure === true;
 			const callObserved = observedRunCalls.delete(message.callId);
 			const deliver = (promise: Promise<WorkflowScriptChildResult>) => collectFailure
@@ -1707,7 +1714,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (existing) {
 				if (existing.fingerprint !== fingerprint) return respond(Promise.reject(new Error(`Duplicate workflow key '${key}' used with incompatible launch params.`)));
 				if (callObserved) existing.observed = true;
-				trace.push({ operation: "run", key, state: "reused", ...workflowStringMetadata(params) });
+				trace.push({ operation: "run", key, state: "reused", ...workflowStringMetadata(params), ...(existing.generatedLaneKey ? { generatedLaneKey: existing.generatedLaneKey } : {}) });
 				traceChanged();
 				return respond(deliver(existing.promise), `runs.run('${key}') result`, (error) => children.set(key, responseBoundaryFailure(key, error)));
 			}
@@ -1805,7 +1812,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 					const autoResumeParams = setupAbortResumeParams(params, result, childSignal);
 					if (!autoResumeParams) return result;
 					resolvedResumeLineage = [...new Set([...(resolvedResumeLineage ?? []), result.runId!])];
-					trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(autoResumeParams), phase: "auto-resume", runId: result.runId });
+					trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(autoResumeParams), ...(generatedLaneKey ? { generatedLaneKey } : {}), phase: "auto-resume", runId: result.runId });
 					traceChanged();
 					return options.launch(key, autoResumeParams, childSignal, { admitted: true, batch: batch !== undefined });
 				} finally {
@@ -1820,7 +1827,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				if (stoppedLaunches.has(key)) return children.get(key) ?? normalized;
 				children.set(key, normalized);
 				const state = normalized.ok ? "completed" : normalized.stopped ? "stopped" : normalized.detached ? "detached" : "failed";
-				trace.push({ operation: "run", key, state, durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(normalized.agent ? { agent: normalized.agent } : {}), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });
+				trace.push({ operation: "run", key, state, durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(generatedLaneKey ? { generatedLaneKey } : {}), ...(normalized.agent ? { agent: normalized.agent } : {}), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });
 				traceChanged();
 				return normalized;
 			}, (error: unknown) => {
@@ -1829,13 +1836,13 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				childStopControllers.delete(key);
 				if (stoppedLaunches.has(key)) return children.get(key) ?? { ...failure, stopped: true };
 				children.set(key, failure);
-				trace.push({ operation: "run", key, state: "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), error: text });
+				trace.push({ operation: "run", key, state: "failed", durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(generatedLaneKey ? { generatedLaneKey } : {}), error: text });
 				traceChanged();
 				return failure;
 			});
-			launches.set(key, { fingerprint, promise, observed: callObserved });
+			launches.set(key, { fingerprint, promise, observed: callObserved, ...(generatedLaneKey ? { generatedLaneKey } : {}) });
 			childOrder.push(key);
-			trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(params) });
+			trace.push({ operation: "run", key, state: "started", ...workflowStringMetadata(params), ...(generatedLaneKey ? { generatedLaneKey } : {}) });
 			traceChanged();
 			respond(deliver(promise), `runs.run('${key}') result`, (error) => children.set(key, responseBoundaryFailure(key, error)));
 		});

--- a/src/workflows/workflow-preflight.ts
+++ b/src/workflows/workflow-preflight.ts
@@ -17,6 +17,7 @@ type WorkflowTraceLike = {
 	operation: string;
 	key: string;
 	phase?: string;
+	generatedLaneKey?: string;
 	warning?: string;
 };
 
@@ -141,15 +142,25 @@ function declaredKeys(preflight: WorkflowPreflightV1): Set<string> {
 	return new Set(preflight.lanes.map((lane) => lane.key));
 }
 
-function launchedKeys(trace: readonly WorkflowTraceLike[]): string[] {
-	const keys: string[] = [];
+function generatedByLane(entry: WorkflowTraceLike, laneKey: string): boolean {
+	return entry.generatedLaneKey === laneKey && entry.key.startsWith(`${laneKey}.`);
+}
+
+function keyCoveredByDeclaredLane(entry: WorkflowTraceLike, declared: ReadonlySet<string>): boolean {
+	if (declared.has(entry.key)) return true;
+	for (const laneKey of declared) if (generatedByLane(entry, laneKey)) return true;
+	return false;
+}
+
+function launchedEntries(trace: readonly WorkflowTraceLike[]): WorkflowTraceLike[] {
+	const entries: WorkflowTraceLike[] = [];
 	const seen = new Set<string>();
 	for (const entry of trace) {
 		if (entry.operation !== "run" || entry.phase === "auto-resume" || seen.has(entry.key)) continue;
 		seen.add(entry.key);
-		keys.push(entry.key);
+		entries.push(entry);
 	}
-	return keys;
+	return entries;
 }
 
 function undeclaredWarning(key: string): string {
@@ -168,11 +179,10 @@ export function workflowPreflightWarnings(
 ): string[] {
 	if (!preflight) return [];
 	const declared = declaredKeys(preflight);
-	const launched = launchedKeys(trace);
-	const messages = launched.filter((key) => !declared.has(key)).map(undeclaredWarning);
+	const launched = launchedEntries(trace);
+	const messages = launched.filter((entry) => !keyCoveredByDeclaredLane(entry, declared)).map((entry) => undeclaredWarning(entry.key));
 	if (options.settled === true) {
-		const launchedSet = new Set(launched);
-		for (const lane of preflight.lanes) if (!launchedSet.has(lane.key)) messages.push(unlaunchedWarning(lane.key));
+		for (const lane of preflight.lanes) if (!launched.some((entry) => entry.key === lane.key || generatedByLane(entry, lane.key))) messages.push(unlaunchedWarning(lane.key));
 	}
 	return warningLimit(messages);
 }
@@ -183,7 +193,7 @@ export function annotateWorkflowPreflightTrace<T extends WorkflowTraceLike>(trac
 	const declared = declaredKeys(preflight);
 	const warned = new Set<string>();
 	return trace.map((entry) => {
-		if (entry.operation !== "run" || entry.phase === "auto-resume" || declared.has(entry.key) || warned.has(entry.key)) return entry;
+		if (entry.operation !== "run" || entry.phase === "auto-resume" || keyCoveredByDeclaredLane(entry, declared) || warned.has(entry.key)) return entry;
 		warned.add(entry.key);
 		return { ...entry, warning: entry.warning ?? undeclaredWarning(entry.key) };
 	});

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -405,6 +405,11 @@ describe("scripted workflow runtime", () => {
 		assert.equal(alphaChallengeStartedBeforeBetaWriter, true, "a settled lane should advance without waiting for slower siblings");
 		assert.deepEqual(launches.map(({ key }) => key), ["alpha.writer", "beta.writer", "alpha.challenge", "beta.review"]);
 		assert.deepEqual(launches.find(({ key }) => key === "alpha.challenge")?.params, { resume: "run-alpha.writer", task: "alpha challenge" });
+		for (const lane of ["alpha", "beta"]) {
+			const stageTrace = result.trace.filter((entry) => entry.operation === "run" && entry.key.startsWith(`${lane}.`));
+			assert.ok(stageTrace.length > 0);
+			assert.equal(stageTrace.every((entry) => entry.generatedLaneKey === lane), true);
+		}
 		assert.deepEqual(result.value, [
 			{
 				key: "alpha",
@@ -423,6 +428,21 @@ describe("scripted workflow runtime", () => {
 				],
 			},
 		]);
+	});
+
+	it("marks only runs.lanes stages with generated lane provenance", async () => {
+		const result = await runWorkflowScript({
+			script: `const direct = await runs.run("audit.shadow", { agent: "worker", task: "direct" }); const lanes = await runs.lanes([{ key: "audit", stages: [{ key: "writer", agent: "worker", task: "generated" }] }]); return { direct: direct.output, lanes };`,
+			timeoutMs: 2_000,
+			async launch(key) { return { key, ok: true, runId: "run-" + key, output: key, artifactPaths: [], results: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		const directTrace = result.trace.filter((entry) => entry.operation === "run" && entry.key === "audit.shadow");
+		const generatedTrace = result.trace.filter((entry) => entry.operation === "run" && entry.key === "audit.writer");
+		assert.ok(directTrace.length > 0);
+		assert.equal(directTrace.every((entry) => entry.generatedLaneKey === undefined), true);
+		assert.ok(generatedTrace.length > 0);
+		assert.equal(generatedTrace.every((entry) => entry.generatedLaneKey === "audit"), true);
 	});
 
 	it("keeps a rejected first-stage result local to its lane", async () => {

--- a/test/unit/workflow-preflight.test.ts
+++ b/test/unit/workflow-preflight.test.ts
@@ -116,4 +116,38 @@ describe("workflow preflight metadata", () => {
 		assert.ok(workflowPreflightWarnings(manyLanes, [], { settled: true }).some((warning) => warning.includes("declared lane 'declared-0' was not launched")));
 		assert.ok(WORKFLOW_PREFLIGHT_MAX_CLAIMS > 0);
 	});
+
+	it("covers only proven generated runs.lanes stages", () => {
+		const lanes = normalizeWorkflowPreflight({
+			version: 1,
+			coverage: "complete",
+			lanes: [{ key: "audit" }],
+		});
+		const generatedTrace = [
+			{ operation: "run", key: "audit.writer", generatedLaneKey: "audit", state: "completed" as const },
+			{ operation: "run", key: "audit.review", generatedLaneKey: "audit", state: "completed" as const },
+		];
+		assert.deepEqual(workflowPreflightWarnings(lanes, generatedTrace, { settled: true }), []);
+		assert.equal(annotateWorkflowPreflightTrace(generatedTrace, lanes).some((entry) => entry.warning), false);
+
+		const directTrace = [
+			{ operation: "run", key: "audit.shadow", state: "started" as const },
+			{ operation: "run", key: "audit-other.writer", state: "started" as const },
+		];
+		assert.deepEqual(workflowPreflightWarnings(lanes, directTrace), [
+			"Preflight advisory: workflow key 'audit.shadow' launched without a declared lane.",
+			"Preflight advisory: workflow key 'audit-other.writer' launched without a declared lane.",
+		]);
+		assert.deepEqual(workflowPreflightWarnings(lanes, directTrace, { settled: true }), [
+			"Preflight advisory: workflow key 'audit.shadow' launched without a declared lane.",
+			"Preflight advisory: workflow key 'audit-other.writer' launched without a declared lane.",
+			"Preflight advisory: declared lane 'audit' was not launched.",
+		]);
+		const directAnnotated = annotateWorkflowPreflightTrace(directTrace, lanes);
+		assert.match(directAnnotated[0]?.warning ?? "", /without a declared lane/);
+		assert.match(directAnnotated[1]?.warning ?? "", /without a declared lane/);
+
+		const exactTrace = [{ operation: "run", key: "audit", state: "completed" as const }];
+		assert.deepEqual(workflowPreflightWarnings(lanes, exactTrace, { settled: true }), []);
+	});
 });


### PR DESCRIPTION
Fixes #1649.

This removes the false preflight mismatch warnings for generated `runs.lanes(...)` stage keys. A declared parent lane now covers generated stage keys only when the runtime trace carries bounded `generatedLaneKey` provenance from `runs.lanes`. Direct dotted keys such as `runs.run("audit.shadow", ...)` still warn when only `audit` was declared.

The change is display/advisory only. It does not change workflow execution, public preflight schema, launch authority, or render-time I/O.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-preflight.test.ts test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh exact-head review: no issues found
