### PR TITLE
fix: accept long workflow child tool call IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 - Avoid false preflight mismatch warnings for generated `runs.lanes(...)` stage keys (#1649).
+- Accept long host tool-call ids in workflow child summaries, matching the existing 4,096-byte session id bound. Thanks to [@SudoKillMe](https://github.com/SudoKillMe) for #1653.
 - Keep an async `workflowScript` continuation live while an awaited child coordinates with its supervisor, so sequential tail steps continue after the child settles (#1634).
 - Stop stale extension and slash-command contexts from escaping during reload or session replacement.
 - Include saved workflow child output paths and bounded inline previews in completion notices (#1629).

--- a/src/workflows/workflow-child-summary.ts
+++ b/src/workflows/workflow-child-summary.ts
@@ -3,6 +3,7 @@ import type { WorkflowScriptChildResult, WorkflowScriptTraceEntry } from "./scri
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const TERMINAL_STATES = new Set(["completed", "failed", "paused", "stopped", "rejected", "detached"]);
+const MAX_REQUIRED_ID_BYTES = 4_096;
 
 function bounded(value: unknown, maxBytes: number): string | undefined {
 	if (typeof value !== "string" || !value.trim() || Buffer.byteLength(value, "utf8") > maxBytes) return undefined;
@@ -10,8 +11,8 @@ function bounded(value: unknown, maxBytes: number): string | undefined {
 }
 
 function requiredId(value: string, label: string): string {
-	const id = bounded(value, 256);
-	if (!id) throw new Error(`${label} must be a non-empty identifier of at most 256 UTF-8 bytes.`);
+	const id = bounded(value, MAX_REQUIRED_ID_BYTES);
+	if (!id) throw new Error(`${label} must be a non-empty identifier of at most ${MAX_REQUIRED_ID_BYTES} UTF-8 bytes.`);
 	return id;
 }
 

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -7,7 +7,7 @@ import { buildWorkflowReceipt, readWorkflowReceipt, resolveWorkflowReceiptResume
 import { externalCliReceiptMetadata, resolveExternalCliRunnerStatus } from "../../src/runs/shared/external-cli-contract.ts";
 import type { WorkflowScriptChildResult } from "../../src/workflows/scripted-workflow.ts";
 import type { HostStepNodeV1 } from "../../src/shared/types.ts";
-import { workflowChildSummary } from "../../src/workflows/workflow-child-summary.ts";
+import { parseWorkflowChildSummary, workflowChildSummary } from "../../src/workflows/workflow-child-summary.ts";
 
 const roots: string[] = [];
 
@@ -181,6 +181,21 @@ describe("workflow receipts", () => {
 		fs.mkdirSync(asyncDir, { recursive: true });
 		writeWorkflowReceipt(asyncDir, receipt);
 		assert.deepEqual(readWorkflowReceipt(asyncRoot, "workflow-1").workflowChildren, summary);
+	});
+
+	it("round-trips long parent tool-call ids while rejecting ids over the summary bound", () => {
+		const parentToolCallId = `call_${"x".repeat(500)}`;
+		const summary = workflowChildSummary({ parentToolCallId, workflowRunId: "workflow-long-tool-call", workflowState: "completed", inventoryComplete: true });
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-long-tool-call");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		writeWorkflowReceipt(asyncDir, buildWorkflowReceipt({ workflowRunId: "workflow-long-tool-call", state: "complete", children: [], workflowChildren: summary, createdAt: 10 }));
+		assert.equal(readWorkflowReceipt(asyncRoot, "workflow-long-tool-call").workflowChildren?.parentToolCallId, parentToolCallId);
+
+		const overBoundParentToolCallId = `call_${"x".repeat(4_091)}`;
+		assert.equal(workflowChildSummary({ parentToolCallId: overBoundParentToolCallId, workflowRunId: "workflow-long-tool-call", workflowState: "completed", inventoryComplete: true }).parentToolCallId, overBoundParentToolCallId);
+		assert.throws(() => workflowChildSummary({ parentToolCallId: `${overBoundParentToolCallId}x`, workflowRunId: "workflow-long-tool-call", workflowState: "completed", inventoryComplete: true }), /at most 4096 UTF-8 bytes/);
+		assert.throws(() => parseWorkflowChildSummary({ ...summary, parentToolCallId: `${overBoundParentToolCallId}x` }), /at most 4096 UTF-8 bytes/);
 	});
 
 	it("uses workflow keys when flattened child indexes collide", () => {


### PR DESCRIPTION
## Summary

Fixes #1653 by raising the required `workflowChildren.parentToolCallId` and `workflowRunId` byte bound to 4,096 bytes. This lets GitHub Copilot Responses tool-call ids fit without aborting `workflowScript` admission.

Optional child metadata fields keep their existing smaller bounds, and the summary stays payload-free.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-receipt.test.ts test/unit/wait-completions.test.ts`
- `npm run typecheck`
- `git diff --check`
