### PR TITLE
fix(tui): remove lane prefix from async status rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Remove the remaining `lane:` prefix from operator-facing async status rows in the TUI (#1658).
 - Avoid false preflight mismatch warnings for generated `runs.lanes(...)` stage keys (#1649).
 - Accept long host tool-call ids in workflow child summaries, matching the existing 4,096-byte session id bound. Thanks to [@SudoKillMe](https://github.com/SudoKillMe) for #1653.
 - Keep an async `workflowScript` continuation live while an awaited child coordinates with its supervisor, so sequential tail steps continue after the child settles (#1634).

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -397,7 +397,7 @@ function laneStateLabel(state: AsyncLaneProjection["state"], theme: Theme): stri
 function formatLaneProjection(lane: AsyncLaneProjection, theme: Theme): string {
 	const label = boundedLaneValue(lane.label, 56);
 	const identity = [label, lane.role ? `role:${lane.role}` : undefined].filter(Boolean).join(" · ");
-	return `${theme.fg("dim", "lane:")} ${identity ? theme.bold(identity) : theme.bold(lane.role)} · ${laneStateLabel(lane.state, theme)}`;
+	return `${identity ? theme.bold(identity) : theme.bold(lane.role)} · ${laneStateLabel(lane.state, theme)}`;
 }
 
 function formatLaneChip(chip: string, theme: Theme): string {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -145,11 +145,12 @@ describe("subagent async widget rendering", () => {
 			chips: ["fresh"],
 		});
 		const text = buildWidgetLines([job], theme, 180).join("\n");
-		assert.match(text, /lane: Review #1610 — Inspect the current status surface · role:reviewer · running/);
+		assert.match(text, /Review #1610 — Inspect the current status surface · role:reviewer · running/);
 		assert.match(text, /phase:fresh-review · gate:review required · next:review output · out:review\.md · ref:review · \[fresh\]/);
-		assert.match(text, /lane: Fix candidate/);
-		assert.match(text, /lane: Fix candidate · role:writer · pending/);
+		assert.match(text, /Fix candidate/);
+		assert.match(text, /Fix candidate · role:writer · pending/);
 		assert.match(text, /phase:implementation · next:await launch · out:fix\.md/);
+		assert.doesNotMatch(text, /lane:/);
 	});
 
 	it("prefers bounded loaded workspace context over repeated internal lane refs", () => {


### PR DESCRIPTION
## Summary

Fixes #1658.

This removes the remaining `lane:` prefix from the operator-facing async TUI/widget row. It keeps the existing label, role, state, and detail fields, and does not add any render-time filesystem or Git probing.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`
