### PR TITLE
fix: allow schedule roots shared by git worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Fixed
 - Remove the remaining `lane:` prefix from operator-facing async status rows in the TUI (#1658).
+- Allow scheduled project roots shared through a registered Git worktree's `.pi` symlink while rejecting unrelated or unproven Git-layout escapes. Thanks to [@sususu98](https://github.com/sususu98) for #1656.
 - Avoid false preflight mismatch warnings for generated `runs.lanes(...)` stage keys (#1649).
 - Accept long host tool-call ids in workflow child summaries, matching the existing 4,096-byte session id bound. Thanks to [@SudoKillMe](https://github.com/SudoKillMe) for #1653.
 - Keep an async `workflowScript` continuation live while an awaited child coordinates with its supervisor, so sequential tail steps continue after the child settles (#1634).

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -11,6 +12,8 @@ import type { SubagentParamsLike } from "../foreground/subagent-executor.ts";
 import { validateExecutionAcceptance } from "../shared/acceptance.ts";
 import type { ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
 import { previewSimpleWorkflowRun } from "../../workflows/scripted-workflow.ts";
+import { resolveGitRepositoryIdentity } from "../../workflows/chat-progress.ts";
+import { getConfigDirName } from "../../shared/utils.ts";
 
 export const SCHEDULED_RUN_ACTIONS = [
 	"schedule.create",
@@ -142,9 +145,81 @@ function validateScheduleId(id: string): string {
 	return id;
 }
 
+function normalizedComparisonPath(value: string): string {
+	const absolute = path.resolve(value);
+	if (process.platform !== "win32") return absolute;
+	let normalized = absolute;
+	try { normalized = fs.realpathSync.native(absolute); } catch {}
+	normalized = normalized.replaceAll("/", "\\");
+	if (normalized.startsWith("\\\\?\\UNC\\")) normalized = `\\\\${normalized.slice(8)}`;
+	else if (normalized.startsWith("\\\\?\\")) normalized = normalized.slice(4);
+	normalized = path.win32.normalize(normalized).toLowerCase();
+	if (normalized.length > 3) normalized = normalized.replace(/[\\]+$/, "");
+	return normalized;
+}
+
 function pathWithin(root: string, candidate: string): boolean {
-	const relative = path.relative(root, candidate);
+	const relative = path.relative(normalizedComparisonPath(root), normalizedComparisonPath(candidate));
 	return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+function resolveGitCommonDirForCheckout(checkoutRoot: string): string | undefined {
+	const gitPath = path.join(checkoutRoot, ".git");
+	try {
+		const stat = fs.statSync(gitPath);
+		if (stat.isDirectory()) return fs.realpathSync.native(gitPath);
+		if (!stat.isFile()) return undefined;
+		const match = /^gitdir:[ \t]*([^\r\n]+)$/i.exec(fs.readFileSync(gitPath, "utf-8").trim());
+		return match?.[1] ? fs.realpathSync.native(path.resolve(checkoutRoot, match[1])) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function samePath(left: string, right: string): boolean {
+	return normalizedComparisonPath(left) === normalizedComparisonPath(right);
+}
+
+function resolveTrustedGitConfigRoot(checkoutRoot: string, commonDir: string): string | undefined {
+	const resolvedCommonDir = resolveGitCommonDirForCheckout(checkoutRoot);
+	if (!resolvedCommonDir || !samePath(resolvedCommonDir, commonDir)) return undefined;
+	const configRoot = path.join(checkoutRoot, getConfigDirName());
+	try {
+		const resolved = fs.realpathSync.native(configRoot);
+		return fs.statSync(resolved).isDirectory() && pathWithin(checkoutRoot, resolved) ? resolved : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function registeredGitWorktreeRoots(projectCwd: string): string[] {
+	const result = spawnSync("git", ["-C", projectCwd, "worktree", "list", "--porcelain"], { encoding: "utf-8", windowsHide: true });
+	if (result.status !== 0 || typeof result.stdout !== "string") return [];
+	const roots: string[] = [];
+	for (const line of result.stdout.split(/\r?\n/)) {
+		if (!line.startsWith("worktree ")) continue;
+		try { roots.push(fs.realpathSync.native(line.slice("worktree ".length).trim())); } catch {}
+	}
+	return roots;
+}
+
+function resolveSharedGitConfigRoot(projectCwd: string): string | undefined {
+	const repository = resolveGitRepositoryIdentity(projectCwd);
+	if (!repository) return undefined;
+	let projectConfigRoot: string;
+	try {
+		projectConfigRoot = fs.realpathSync.native(path.join(projectCwd, getConfigDirName()));
+	} catch {
+		return undefined;
+	}
+	// Git may report a separate-git-dir primary checkout as its common git
+	// directory, not as the checkout root. Without a registered checkout root,
+	// do not infer a shared config path from that unprovable layout.
+	for (const checkoutRoot of new Set(registeredGitWorktreeRoots(projectCwd))) {
+		const resolved = resolveTrustedGitConfigRoot(checkoutRoot, repository.commonDir);
+		if (resolved && samePath(resolved, projectConfigRoot)) return resolved;
+	}
+	return undefined;
 }
 
 function assertScheduleRoot(root: string, projectCwd: string | undefined, create: boolean): void {
@@ -154,7 +229,7 @@ function assertScheduleRoot(root: string, projectCwd: string | undefined, create
 	}
 	let projectPath: string;
 	try {
-		projectPath = fs.realpathSync(projectCwd);
+		projectPath = fs.realpathSync.native(projectCwd);
 	} catch (error) {
 		if (!create && (error as NodeJS.ErrnoException).code === "ENOENT") return;
 		throw error;
@@ -165,10 +240,14 @@ function assertScheduleRoot(root: string, projectCwd: string | undefined, create
 		if (parent === existing) break;
 		existing = parent;
 	}
-	if (!pathWithin(projectPath, fs.realpathSync(existing))) throw new Error(`Project schedule root '${root}' resolves outside the real project.`);
+	const existingPath = fs.realpathSync.native(existing);
+	const sharedGitConfigRoot = pathWithin(projectPath, existingPath) ? undefined : resolveSharedGitConfigRoot(projectCwd);
+	const isTrustedPath = (candidate: string): boolean => pathWithin(projectPath, candidate)
+		|| (sharedGitConfigRoot !== undefined && pathWithin(sharedGitConfigRoot, candidate));
+	if (!isTrustedPath(existingPath)) throw new Error(`Project schedule root '${root}' resolves outside the real project.`);
 	if (!create) return;
 	fs.mkdirSync(root, { recursive: true, mode: 0o700 });
-	if (!pathWithin(projectPath, fs.realpathSync(root))) throw new Error(`Project schedule root '${root}' resolves outside the real project.`);
+	if (!isTrustedPath(fs.realpathSync.native(root))) throw new Error(`Project schedule root '${root}' resolves outside the real project.`);
 }
 
 function scheduleDir(root: string, id: string, create = false, projectCwd?: string): string {
@@ -182,9 +261,9 @@ function scheduleDir(root: string, id: string, create = false, projectCwd?: stri
 		if (!create) return dir;
 		fs.mkdirSync(dir, { mode: 0o700 });
 	}
-	const rootPath = fs.realpathSync(root);
-	const dirPath = fs.realpathSync(dir);
-	if (dirPath !== path.join(rootPath, id)) throw new Error(`Schedule path '${dir}' escapes the project schedule root.`);
+	const rootPath = fs.realpathSync.native(root);
+	const dirPath = fs.realpathSync.native(dir);
+	if (!samePath(dirPath, path.join(rootPath, id))) throw new Error(`Schedule path '${dir}' escapes the project schedule root.`);
 	return dir;
 }
 

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -55,6 +56,10 @@ const roots: string[] = [];
 afterEach(() => {
 	for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
+
+function git(cwd: string, args: string[]): void {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+}
 
 function context(cwd: string, sessionId = "session-a"): ExtensionContext {
 	return {
@@ -381,6 +386,116 @@ describe("project schedule management", () => {
 		assert.equal(result.isError, true);
 		assert.match(text(result), /resolves outside the real project/);
 		assert.equal(fs.existsSync(path.join(outside, "schedules")), false);
+	});
+
+	it("allows a default project schedule root through a shared Git worktree .pi symlink", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-worktree-link-"));
+		roots.push(root);
+		const repository = path.join(root, "repository");
+		const worktree = path.join(repository, ".worktrees", "feature");
+		fs.mkdirSync(repository, { recursive: true });
+		git(repository, ["init"]);
+		git(repository, ["config", "user.email", "test@example.com"]);
+		git(repository, ["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(repository, "tracked.txt"), "base\n", "utf-8");
+		git(repository, ["add", "tracked.txt"]);
+		git(repository, ["commit", "-m", "base"]);
+		fs.mkdirSync(path.dirname(worktree), { recursive: true });
+		git(repository, ["worktree", "add", "-b", "feature", worktree]);
+		fs.mkdirSync(path.join(repository, ".pi"), { recursive: true });
+		fs.symlinkSync(path.join(repository, ".pi"), path.join(worktree, ".pi"), process.platform === "win32" ? "junction" : "dir");
+
+		const ctx = context(worktree);
+		const manager = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		manager.bindSession(ctx);
+		const result = await manager.handleToolCall({ action: "schedule.create", id: "shared", every: "1h", workflowScript: "return 1" }, ctx);
+		assert.equal(result.isError, undefined);
+		assert.equal(fs.existsSync(path.join(repository, ".pi", "subagents", "schedules", "shared", "schedule.json")), true);
+	});
+
+	it("rejects a Git worktree .pi symlink outside the shared config root", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-worktree-escape-"));
+		roots.push(root);
+		const repository = path.join(root, "repository");
+		const worktree = path.join(repository, ".worktrees", "feature");
+		const outside = path.join(root, "outside");
+		fs.mkdirSync(repository, { recursive: true });
+		git(repository, ["init"]);
+		git(repository, ["config", "user.email", "test@example.com"]);
+		git(repository, ["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(repository, "tracked.txt"), "base\n", "utf-8");
+		git(repository, ["add", "tracked.txt"]);
+		git(repository, ["commit", "-m", "base"]);
+		fs.mkdirSync(path.dirname(worktree), { recursive: true });
+		git(repository, ["worktree", "add", "-b", "feature", worktree]);
+		fs.mkdirSync(path.join(repository, ".pi"), { recursive: true });
+		fs.mkdirSync(outside);
+		fs.symlinkSync(outside, path.join(worktree, ".pi"), process.platform === "win32" ? "junction" : "dir");
+
+		const manager = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		assert.throws(() => manager.bindSession(context(worktree)), /resolves outside the real project/);
+		assert.equal(fs.existsSync(path.join(outside, "subagents")), false);
+	});
+
+	it("rejects separate-git-dir primary checkout sharing without a registered root", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-separate-git-dir-"));
+		roots.push(root);
+		const repository = path.join(root, "repository");
+		const gitDir = path.join(root, "git-data", "metadata");
+		const worktree = path.join(root, "worktree");
+		fs.mkdirSync(repository, { recursive: true });
+		fs.mkdirSync(path.dirname(gitDir), { recursive: true });
+		git(repository, ["init", "--separate-git-dir", gitDir]);
+		git(repository, ["config", "user.email", "test@example.com"]);
+		git(repository, ["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(repository, "tracked.txt"), "base\n", "utf-8");
+		git(repository, ["add", "tracked.txt"]);
+		git(repository, ["commit", "-m", "base"]);
+		git(repository, ["worktree", "add", "-b", "feature", worktree]);
+		const primaryConfig = path.join(repository, ".pi");
+		fs.mkdirSync(primaryConfig, { recursive: true });
+		fs.symlinkSync(primaryConfig, path.join(worktree, ".pi"), process.platform === "win32" ? "junction" : "dir");
+
+		const manager = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		assert.throws(() => manager.bindSession(context(worktree)), /resolves outside the real project/);
+		assert.equal(fs.existsSync(path.join(primaryConfig, "subagents")), false);
+	});
+
+	it("rejects an unregistered checkout ancestor with the same Git directory", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-schedule-unregistered-git-dir-"));
+		roots.push(root);
+		const repository = path.join(root, "repository");
+		const worktree = path.join(repository, ".worktrees", "feature");
+		const outside = path.join(root, "outside");
+		fs.mkdirSync(repository, { recursive: true });
+		git(repository, ["init"]);
+		git(repository, ["config", "user.email", "test@example.com"]);
+		git(repository, ["config", "user.name", "Test User"]);
+		fs.writeFileSync(path.join(repository, "tracked.txt"), "base\n", "utf-8");
+		git(repository, ["add", "tracked.txt"]);
+		git(repository, ["commit", "-m", "base"]);
+		fs.mkdirSync(path.dirname(worktree), { recursive: true });
+		git(repository, ["worktree", "add", "-b", "feature", worktree]);
+		const outsideConfig = path.join(outside, ".pi");
+		fs.mkdirSync(outsideConfig, { recursive: true });
+		fs.writeFileSync(path.join(outside, ".git"), `gitdir: ${path.join(repository, ".git")}\n`, "utf-8");
+		fs.symlinkSync(outsideConfig, path.join(worktree, ".pi"), process.platform === "win32" ? "junction" : "dir");
+
+		const manager = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		assert.throws(() => manager.bindSession(context(worktree)), /resolves outside the real project/);
+		assert.equal(fs.existsSync(path.join(outsideConfig, "subagents")), false);
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes #1656.

This allows a scheduled-run store root to pass through a linked-worktree `.pi` symlink only when the resolved target is the shared Git common checkout config root. It keeps the existing fail-closed checks for unrelated `.pi` targets, `.pi/subagents` escapes, and schedule-child symlinks.

Thanks to [@sususu98](https://github.com/sususu98) for the report.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/scheduled-runs.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^..HEAD`
