### PR TITLE
fix: account for async workflow child usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Give `runs.lanes(...)` stage-0 retained-resume validation actionable `runs.run(...)` guidance instead of a generic error (#1657).
 - Remove the remaining `lane:` prefix from operator-facing async status rows in the TUI (#1658).
 - Allow scheduled project roots shared through a registered Git worktree's `.pi` symlink while rejecting unrelated or unproven Git-layout escapes. Thanks to [@sususu98](https://github.com/sususu98) for #1656.
+- Include delegated child usage in subagent tool results and `/subagent-cost`, including completed async workflow children and parent compaction usage with persisted workflow-receipt recovery when needed (#1662, #1666). Thanks to [@Geraldo-Morais](https://github.com/Geraldo-Morais) for #1662 and [@jf88888](https://github.com/jf88888) for #1666.
 - Avoid false preflight mismatch warnings for generated `runs.lanes(...)` stage keys (#1649).
 - Accept long host tool-call ids in workflow child summaries, matching the existing 4,096-byte session id bound. Thanks to [@SudoKillMe](https://github.com/SudoKillMe) for #1653.
 - Keep an async `workflowScript` continuation live while an awaited child coordinates with its supervisor, so sequential tail steps continue after the child settles (#1634).

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { resultFilePath, resultPayloadPathForSessionRun } from "./result-files.ts";
-import type { AcceptanceLedger, ArtifactPaths, AsyncStatus, CostSummary, EffectsProjection, ExecutionProjection, ModelAttempt } from "../../shared/types.ts";
+import type { AcceptanceLedger, ArtifactPaths, AsyncStatus, CostSummary, EffectsProjection, ExecutionProjection, ModelAttempt, Usage } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 
 export interface ImportedAsyncRoot {
@@ -26,6 +26,7 @@ export interface ImportedAsyncRootResult {
 	modelAttempts?: ModelAttempt[];
 	contextOverflow?: boolean;
 	totalCost?: CostSummary;
+	usage?: Usage;
 	structuredOutput?: unknown;
 	structuredOutputPath?: string;
 	structuredOutputSchemaPath?: string;
@@ -64,6 +65,7 @@ interface AsyncResultFile {
 		modelAttempts?: ModelAttempt[];
 		contextOverflow?: boolean;
 		totalCost?: CostSummary;
+		usage?: Usage;
 		structuredOutput?: unknown;
 		structuredOutputPath?: string;
 		structuredOutputSchemaPath?: string;
@@ -77,6 +79,23 @@ interface AsyncResultFile {
 
 const TERMINAL_STATES = new Set(["complete", "failed", "partial", "paused", "stopped"]);
 const TERMINAL_STEP_STATUSES = new Set(["complete", "completed", "failed", "partial", "paused", "stopped"]);
+
+function usageFromAttempts(attempts: ModelAttempt[] | undefined): Usage | undefined {
+	if (!attempts?.length) return undefined;
+	const usage: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+	for (const attempt of attempts) {
+		if (!attempt.usage) continue;
+		usage.input += attempt.usage.input;
+		usage.output += attempt.usage.output;
+		usage.cacheRead += attempt.usage.cacheRead;
+		usage.cacheWrite += attempt.usage.cacheWrite;
+		usage.cost += attempt.usage.cost;
+		usage.turns += attempt.usage.turns;
+	}
+	return usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0 || usage.cost !== 0 || usage.turns !== 0
+		? usage
+		: undefined;
+}
 
 function readResultFile(resultPath: string): AsyncResultFile | undefined {
 	try {
@@ -127,6 +146,7 @@ function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, 
 	const execution = step?.execution ?? (partialStatus
 		? { status: "partial" as const, success: false, exitCode: 1, error: message }
 		: undefined);
+	const usage = usageFromAttempts(step?.modelAttempts);
 	return {
 		agent,
 		output: message,
@@ -142,6 +162,7 @@ function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, 
 		...(step?.modelAttempts ? { modelAttempts: step.modelAttempts } : {}),
 		...(step?.contextOverflow ? { contextOverflow: true } : {}),
 		...(step?.totalCost ? { totalCost: step.totalCost } : {}),
+		...(usage ? { usage } : {}),
 		...(step?.structuredOutput !== undefined ? { structuredOutput: step.structuredOutput } : {}),
 		...(step?.structuredOutputPath ? { structuredOutputPath: step.structuredOutputPath } : {}),
 		...(step?.structuredOutputSchemaPath ? { structuredOutputSchemaPath: step.structuredOutputSchemaPath } : {}),
@@ -154,6 +175,7 @@ function outputFromTerminalStatus(root: ImportedAsyncRoot, status: AsyncStatus, 
 
 function outputFromTimeout(root: ImportedAsyncRoot, status: AsyncStatus | null, message: string): ImportedAsyncRootResult {
 	const step = selectedStatusStep(status, root.index);
+	const usage = usageFromAttempts(step?.modelAttempts);
 	return {
 		agent: step?.agent ?? status?.steps?.[root.index]?.agent ?? "subagent",
 		output: message,
@@ -168,6 +190,7 @@ function outputFromTimeout(root: ImportedAsyncRoot, status: AsyncStatus | null, 
 		...(step?.modelAttempts ? { modelAttempts: step.modelAttempts } : {}),
 		...(step?.contextOverflow ? { contextOverflow: true } : {}),
 		...(step?.totalCost ? { totalCost: step.totalCost } : {}),
+		...(usage ? { usage } : {}),
 		...(step?.transcriptPath ? { transcriptPath: step.transcriptPath } : {}),
 	};
 }
@@ -183,6 +206,7 @@ function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null
 	const success = state === "complete" && !timedOut && !stopped;
 	const error = child?.error ?? (success ? undefined : stopped ? "Subagent stopped by user." : result.error ?? result.summary ?? status?.error ?? `Attached async root ${root.runId} did not complete successfully.`);
 	const execution = state ? { status: state === "complete" ? "completed" as const : state, success, exitCode: success ? 0 : 1, ...(error ? { error } : {}) } : undefined;
+	const usage = child?.usage ?? usageFromAttempts(step?.modelAttempts);
 	return {
 		agent,
 		output: success ? output : (output || error || ""),
@@ -199,6 +223,7 @@ function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null
 		...(child?.modelAttempts ?? step?.modelAttempts ? { modelAttempts: child?.modelAttempts ?? step?.modelAttempts } : {}),
 		...(child?.contextOverflow || step?.contextOverflow ? { contextOverflow: true } : {}),
 		...(child?.totalCost ?? step?.totalCost ? { totalCost: child?.totalCost ?? step?.totalCost } : {}),
+		...(usage ? { usage } : {}),
 		...(child?.structuredOutput !== undefined ? { structuredOutput: child.structuredOutput } : step?.structuredOutput !== undefined ? { structuredOutput: step.structuredOutput } : {}),
 		...(child?.structuredOutputPath ?? step?.structuredOutputPath ? { structuredOutputPath: child?.structuredOutputPath ?? step?.structuredOutputPath } : {}),
 		...(child?.structuredOutputSchemaPath ?? step?.structuredOutputSchemaPath ? { structuredOutputSchemaPath: child?.structuredOutputSchemaPath ?? step?.structuredOutputSchemaPath } : {}),

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -433,6 +433,23 @@ function costSummaryFromAttempts(attempts: ModelAttempt[] | undefined): CostSumm
 		: undefined;
 }
 
+function usageFromAttempts(attempts: ModelAttempt[] | undefined): Usage | undefined {
+	if (!attempts || attempts.length === 0) return undefined;
+	const usage = emptyUsage();
+	for (const attempt of attempts) {
+		if (!attempt.usage) continue;
+		usage.input += attempt.usage.input;
+		usage.output += attempt.usage.output;
+		usage.cacheRead += attempt.usage.cacheRead;
+		usage.cacheWrite += attempt.usage.cacheWrite;
+		usage.cost += attempt.usage.cost;
+		usage.turns += attempt.usage.turns;
+	}
+	return usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0 || usage.cost !== 0 || usage.turns !== 0
+		? usage
+		: undefined;
+}
+
 function appendRecentStepOutput(step: RunnerStatusStep, lines: string[]): void {
 	const nonEmpty = lines.filter((line) => line.trim());
 	if (nonEmpty.length === 0) return;
@@ -1379,6 +1396,7 @@ async function runSingleStepInner(
 				modelAttempts: imported.modelAttempts,
 				contextOverflow: imported.contextOverflow,
 				totalCost: imported.totalCost,
+				usage: imported.usage,
 				structuredOutput: timedOut || stopped ? undefined : imported.structuredOutput,
 				structuredOutputPath: timedOut || stopped ? undefined : imported.structuredOutputPath,
 				structuredOutputSchemaPath: timedOut || stopped ? undefined : imported.structuredOutputSchemaPath,
@@ -2177,6 +2195,7 @@ async function runSingleStepInner(
 		abortRecoveryDiagnostic: effectiveFinalExitCode !== 0 ? finalResult?.abortRecoveryDiagnostic : undefined,
 		requiredOutput: effectiveFinalExitCode !== 0 ? finalResult?.effects?.settlementDiagnostic?.requiredOutput : undefined,
 	});
+	const usage = usageFromAttempts(modelAttempts);
 
 	const artifactErrors = artifactPaths && ctx.artifactConfig?.enabled !== false
 		? persistStepArtifacts({
@@ -2196,6 +2215,7 @@ async function runSingleStepInner(
 				model: finalResult?.model,
 				attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
 				modelAttempts,
+				usage,
 				error: effectiveFinalError,
 				acceptance: effectiveAcceptance,
 				...(capabilityAudit ? { capabilityCeiling: capabilityAudit.ceiling, capabilityAudit } : {}),
@@ -2228,6 +2248,7 @@ async function runSingleStepInner(
 		modelAttempts,
 		contextOverflow: contextOverflow || undefined,
 		totalCost: costSummaryFromAttempts(modelAttempts),
+		usage,
 		artifactPaths,
 		outputSaveError: [resolvedOutput.saveError, artifactErrors.outputSaveError].filter(Boolean).join("\n") || undefined,
 		metadataSaveError: artifactErrors.metadataSaveError,
@@ -2871,6 +2892,7 @@ async function runSubagent(
 				model: step.model,
 				attemptedModels: step.attemptedModels,
 				modelAttempts: step.modelAttempts,
+				usage: usageFromAttempts(step.modelAttempts),
 				contextOverflow: step.contextOverflow,
 			})),
 			exitCode: state === "complete" || state === "paused" ? 0 : 1,
@@ -4326,6 +4348,7 @@ async function runSubagent(
 					modelAttempts: pr.modelAttempts,
 					contextOverflow: pr.contextOverflow,
 					totalCost: pr.totalCost,
+					usage: pr.usage,
 					artifactPaths: pr.artifactPaths,
 					transcriptPath: pr.transcriptPath,
 					transcriptError: pr.transcriptError,
@@ -4776,6 +4799,7 @@ async function runSubagent(
 						modelAttempts: pr.modelAttempts,
 						contextOverflow: pr.contextOverflow,
 						totalCost: pr.totalCost,
+						usage: pr.usage,
 						artifactPaths: pr.artifactPaths,
 						transcriptPath: pr.transcriptPath,
 						transcriptError: pr.transcriptError,
@@ -5030,6 +5054,7 @@ async function runSubagent(
 				modelAttempts: singleResult.modelAttempts,
 				contextOverflow: singleResult.contextOverflow,
 				totalCost: singleResult.totalCost,
+				usage: singleResult.usage,
 				artifactPaths: singleResult.artifactPaths,
 				transcriptPath: singleResult.transcriptPath,
 				transcriptError: singleResult.transcriptError,
@@ -5402,6 +5427,7 @@ async function runSubagent(
 				modelAttempts: r.modelAttempts,
 				contextOverflow: r.contextOverflow,
 				totalCost: r.totalCost,
+				usage: r.usage,
 				artifactPaths: r.artifactPaths,
 				outputSaveError: r.outputSaveError,
 				metadataSaveError: r.metadataSaveError,

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -58,9 +58,11 @@ import {
 	type Details,
 	type ForegroundResumeRun,
 	type SubagentState,
+	type Usage,
 	type WaitCompletion,
 } from "../../shared/types.ts";
 import { formatDuration, shortenPath } from "../../shared/formatters.ts";
+import { toAgentToolUsage } from "../../shared/utils.ts";
 import { collectWaitCompletions } from "./wait-completions.ts";
 import { formatResumeFirstFailedRunsNote } from "./resume-guidance.ts";
 export { WAIT_TOOL_DEFAULT_TIMEOUT_MS_ENV, WAIT_TOOL_ENABLED_ENV, resolveWaitToolConfig, type ResolvedWaitToolConfig } from "./wait-config.ts";
@@ -314,10 +316,31 @@ function summarizeTerminalRuns(runs: AsyncRunSummary[], providerFinishedCount = 
 	return parts.join(", ");
 }
 
+function completionUsage(completions: WaitCompletion[] | undefined): Usage | undefined {
+	if (!completions?.length) return undefined;
+	const usage: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 };
+	let projected = false;
+	for (const completion of completions) {
+		for (const child of completion.results ?? []) {
+			if (!child.usage || (child.usage.input === 0 && child.usage.output === 0 && child.usage.cacheRead === 0 && child.usage.cacheWrite === 0 && child.usage.cost === 0 && child.usage.turns === 0)) continue;
+			projected = true;
+			usage.input += child.usage.input;
+			usage.output += child.usage.output;
+			usage.cacheRead += child.usage.cacheRead;
+			usage.cacheWrite += child.usage.cacheWrite;
+			usage.cost += child.usage.cost;
+			usage.turns += child.usage.turns;
+		}
+	}
+	return projected ? usage : undefined;
+}
+
 function result(text: string, isError = false, completions?: WaitCompletion[]): AgentToolResult<Details> {
+	const usage = completionUsage(completions);
 	return {
 		content: [{ type: "text", text }],
 		...(isError ? { isError: true } : {}),
+		...(usage ? { usage: toAgentToolUsage(usage) } : {}),
 		details: {
 			mode: "management",
 			results: [],

--- a/src/runs/background/wait-completions.ts
+++ b/src/runs/background/wait-completions.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import type { ArtifactPaths, SubagentState, WaitCompletion, WaitCompletionChild } from "../../shared/types.ts";
+import type { ArtifactPaths, SubagentState, Usage, WaitCompletion, WaitCompletionChild } from "../../shared/types.ts";
 import type { AsyncRunSummary } from "./async-status.ts";
 import { readCompletionReplay, writeCompletionReplay } from "./completion-replay.ts";
 import { fallbackResultPayloadPathForSessionRun, resultFilePath, resultPayloadPathForSessionRun } from "./result-files.ts";
@@ -7,6 +7,23 @@ import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summar
 
 function asNonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value ? value : undefined;
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function projectedUsage(value: unknown): Usage | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	const input = nonNegativeNumber(record.input);
+	const output = nonNegativeNumber(record.output);
+	const cacheRead = nonNegativeNumber(record.cacheRead);
+	const cacheWrite = nonNegativeNumber(record.cacheWrite);
+	const cost = nonNegativeNumber(record.cost);
+	const turns = nonNegativeNumber(record.turns);
+	if (input === undefined || output === undefined || cacheRead === undefined || cacheWrite === undefined || cost === undefined || turns === undefined || !Number.isSafeInteger(turns)) return undefined;
+	return { input, output, cacheRead, cacheWrite, cost, turns };
 }
 
 function errorCode(error: unknown): string | undefined {
@@ -43,12 +60,16 @@ export function toWaitCompletion(data: Record<string, unknown>, runId: string): 
 				: undefined;
 			const agent = asNonEmptyString(child.agent);
 			const childRunId = asNonEmptyString(child.runId);
+			const usage = projectedUsage(child.usage);
+			const sessionFile = asNonEmptyString(child.sessionFile);
 			const error = asNonEmptyString(child.error);
 			const model = asNonEmptyString(child.model);
 			const contextOverflow = child.contextOverflow === true;
 			return [{
 				...(agent ? { agent } : {}),
 				...(childRunId ? { runId: childRunId } : {}),
+				...(usage ? { usage } : {}),
+				...(sessionFile ? { sessionFile } : {}),
 				...(typeof child.success === "boolean" ? { success: child.success } : {}),
 				...(outputState ? { outputState } : {}),
 				...(error ? { error } : {}),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -66,7 +66,7 @@ import { isAgentContractV1 } from "../shared/agent-contract.ts";
 import { normalizeExtensionBindings, type ExtensionBindings } from "../shared/extension-bindings.ts";
 import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOutputOverride, outputPathMappingFromTask, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { assertJsonSchemaObject, cleanupStructuredOutputRuntime, createStructuredOutputRuntime } from "../shared/structured-output.ts";
-import { compactForegroundDetails, getSingleResultOutput, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage } from "../../shared/utils.ts";
+import { compactForegroundDetails, getSingleResultOutput, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage, toAgentToolUsage } from "../../shared/utils.ts";
 import { createTaskMutationArbiter } from "../shared/llm-intent-arbiter.ts";
 import { discardPreservedWorktrees, formatParallelHandoffError, formatParallelHandoffReference, formatStoredParallelHandoffCleanup, parallelHandoffPath, readParallelHandoffManifest, recordParallelHandoffMerge, recordParallelHandoffSupersession, writeParallelHandoffGroup, writePendingParallelHandoff } from "../shared/parallel-handoff.ts";
 import { summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
@@ -158,6 +158,7 @@ import {
 	type SingleResult,
 	type SubagentChildStatusEvent,
 	type ToolBudgetConfig,
+	type Usage,
 	type UsageBudgetConfig,
 	type WorkflowTerminalOutcome,
 	type SubagentRunMode,
@@ -2091,21 +2092,14 @@ async function resumeAsyncRun(input: {
 			input.signal?.removeEventListener("abort", stopOnAbort);
 		}
 		fs.rmSync(resultPath, { force: true });
-		const totalCost = completed.totalCost;
+		const usage = importedAsyncRootUsage(completed);
 		const childResult: SingleResult = {
 			index: 0,
 			agent: completed.agent,
 			...(completed.sessionName ? { sessionName: completed.sessionName } : {}),
 			task: effectiveFollowUp,
 			exitCode: completed.exitCode,
-			usage: {
-				input: totalCost?.inputTokens ?? 0,
-				output: totalCost?.outputTokens ?? 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				cost: totalCost?.costUsd ?? 0,
-				turns: 0,
-			},
+			usage,
 			finalOutput: completed.output,
 			outputState: completed.output.trim() ? "present" : "absent",
 			...(completed.error ? { error: completed.error } : {}),
@@ -2823,6 +2817,14 @@ function withResolvedContext(
 	};
 }
 
+function withAggregatedToolUsage(result: AgentToolResult<Details>): AgentToolResult<Details> {
+	if (result.details.results.length === 0) return result;
+	const usage = sumResultsUsage(result.details.results);
+	return usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0 || usage.cost !== 0 || usage.turns !== 0
+		? { ...result, usage: toAgentToolUsage(usage) }
+		: result;
+}
+
 function withForkThinkingNotes(
 	result: AgentToolResult<Details>,
 	downgrades: Map<number, string>,
@@ -3024,6 +3026,18 @@ async function preflightForkSessionsForStaticTasks(
 	}
 }
 
+function importedAsyncRootUsage(completed: Awaited<ReturnType<typeof waitForImportedAsyncRoot>>): Usage {
+	const totalCost = completed.totalCost;
+	return completed.usage ?? {
+		input: totalCost?.inputTokens ?? 0,
+		output: totalCost?.outputTokens ?? 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		cost: totalCost?.costUsd ?? 0,
+		turns: 0,
+	};
+}
+
 async function waitForWorkflowAsyncSingleResult(
 	params: SubagentParamsLike,
 	launchResult: AgentToolResult<Details>,
@@ -3045,21 +3059,14 @@ async function waitForWorkflowAsyncSingleResult(
 		options.signal?.removeEventListener("abort", stopOnAbort);
 	}
 	fs.rmSync(resultPath, { force: true });
-	const totalCost = completed.totalCost;
+	const usage = importedAsyncRootUsage(completed);
 	const childResult: SingleResult = omitUndefinedProperties({
 		index: 0,
 		agent: completed.agent,
 		...(completed.sessionName ? { sessionName: completed.sessionName } : {}),
 		task: options.task,
 		exitCode: completed.exitCode,
-		usage: {
-			input: totalCost?.inputTokens ?? 0,
-			output: totalCost?.outputTokens ?? 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			cost: totalCost?.costUsd ?? 0,
-			turns: 0,
-		},
+		usage,
 		finalOutput: completed.output,
 		outputState: completed.output.trim() ? "present" as const : "absent" as const,
 		...(completed.error ? { error: completed.error } : {}),
@@ -4075,6 +4082,16 @@ function workflowChildResult(
 		continuation: { runIds: continuationRunIds },
 		artifactPaths: [...artifactPaths],
 		results: result.details.results,
+	};
+}
+
+function workflowChildAccountingFields(child: WorkflowScriptChildResult): { usage?: Usage; sessionFile?: string } {
+	if (!child.results?.length) return {};
+	const usage = sumResultsUsage(child.results);
+	const sessionFile = child.results.find((result) => result.sessionFile)?.sessionFile;
+	return {
+		...(usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0 || usage.cost !== 0 || usage.turns !== 0 ? { usage } : {}),
+		...(sessionFile ? { sessionFile } : {}),
 	};
 }
 
@@ -5102,7 +5119,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, workflowChildren, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, workflowChildren, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(status.error ? { error: status.error } : {}) });
@@ -5147,7 +5164,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
-						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, workflowChildren, ...(terminalOutcome ? { terminalOutcome } : {}), results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, workflowChildren, ...(terminalOutcome ? { terminalOutcome } : {}), results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
 						persist();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(terminalOutcome ? { terminalOutcome } : {}), ...(status.error ? { error: status.error } : {}), ...(status.activityState ? { activityState: status.activityState } : {}) });
@@ -6601,15 +6618,15 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 	): Promise<AgentToolResult<Details>> => {
 		const normalizedAction = typeof params.action === "string" ? params.action.trim() : params.action;
 		const requestParams = normalizedAction ? { ...params, action: normalizedAction } : params;
-		if (normalizedAction) return execute(id, requestParams, signal, onUpdate, ctx);
+		if (normalizedAction) return execute(id, requestParams, signal, onUpdate, ctx).then(withAggregatedToolUsage);
 		const { depth } = checkSubagentDepth(deps.config.maxSubagentDepth);
 		const dispatchParams = applyForceTopLevelAsyncOverride(requestParams, depth, deps.config.forceTopLevelAsync === true);
 		const runsForeground = dispatchParams.clarify === true || (dispatchParams.async ?? deps.asyncByDefault) !== true;
-		if (!runsForeground) return execute(id, requestParams, signal, onUpdate, ctx);
+		if (!runsForeground) return execute(id, requestParams, signal, onUpdate, ctx).then(withAggregatedToolUsage);
 		if (deps.state.subagentInProgress === true) return duplicateSubagentCallResult(requestParams);
 		deps.state.subagentInProgress = true;
 		try {
-			return await execute(id, requestParams, signal, onUpdate, ctx);
+			return withAggregatedToolUsage(await execute(id, requestParams, signal, onUpdate, ctx));
 		} finally {
 			deps.state.subagentInProgress = false;
 		}
@@ -6656,7 +6673,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		if (allowZeroToolBudget) delegatedZeroToolBudgets.add(delegatedParams);
 		if (workflowPermit) workflowPermitContexts.set(delegatedParams, { root: workflowPermit });
 		delegatedExecutions.add(delegatedParams);
-		return execute(id, delegatedParams, signal, onUpdate, ctx);
+		return withAggregatedToolUsage(await execute(id, delegatedParams, signal, onUpdate, ctx));
 	};
 
 	const executeScheduled = (

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -41,11 +41,18 @@ export function promotePausedWorkflowIfSettled(status: AsyncStatus): AsyncStatus
 	return promoteSettledPausedWorkflow(status);
 }
 
+function usageWithValue(usage: SingleResult["usage"] | undefined): SingleResult["usage"] | undefined {
+	return usage && (usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0 || usage.cost !== 0 || usage.turns !== 0)
+		? usage
+		: undefined;
+}
+
 function workflowResultChildren(status: AsyncStatus, childRunId: string, result: SingleResult, existingResults: unknown, receipt?: WorkflowReceipt): unknown {
 	const output = getSingleResultOutput(result);
 	const outputReference = result.savedOutputPath ?? result.outputReference?.path;
 	const outputPathMapping = outputPathMappingFromTask(result.task, outputReference);
 	const terminalOutcome = workflowTerminalOutcomeForResult(result);
+	const usage = usageWithValue(result.usage);
 	if (Array.isArray(existingResults)) {
 		return existingResults.map((entry) => {
 			if (!entry || typeof entry !== "object" || Array.isArray(entry)) return entry;
@@ -57,12 +64,14 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 				output,
 				outputState: output.trim() ? "present" : "absent",
 				detached: undefined,
+				...(usage ? { usage } : {}),
 				...(outputReference ? { outputReference } : {}),
 				...(outputPathMapping ? { outputPathMapping } : {}),
 				...(result.interrupted || result.stopped ? { interrupted: true } : {}),
 				...(result.stopped ? { stopped: true } : {}),
 				...(terminalOutcome ? { terminalOutcome } : {}),
 				...(result.sessionName ? { sessionName: result.sessionName } : {}),
+				...(result.sessionFile ? { sessionFile: result.sessionFile } : {}),
 				...(result.error ? { error: result.error } : {}),
 			};
 		});
@@ -75,6 +84,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 		success: step.status === "completed" || step.status === "complete",
 		output: step.runId === childRunId ? output : "",
 		outputState: step.runId === childRunId && output.trim() ? "present" : "absent",
+		...(step.runId === childRunId ? { ...(usage ? { usage } : {}), ...(result.sessionFile ? { sessionFile: result.sessionFile } : {}) } : {}),
 		...(step.runId === childRunId && outputReference ? { outputReference } : step.workflowKey && receipt?.entries[step.workflowKey]?.outputReference ? { outputReference: receipt.entries[step.workflowKey]!.outputReference } : {}),
 		...(step.runId === childRunId && outputPathMapping ? { outputPathMapping } : step.outputPathMapping ? { outputPathMapping: step.outputPathMapping } : {}),
 		...(step.interrupted ? { interrupted: true } : {}),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1263,6 +1263,10 @@ export interface WaitCompletionChild {
 	agent?: string;
 	/** Child run identity where the producer records one (workflow children); artifact files are keyed by it. */
 	runId?: string;
+	/** Bounded accounting projection used by /subagent-cost after async completion. */
+	usage?: Usage;
+	/** Persisted Pi child session when available. */
+	sessionFile?: string;
 	success?: boolean;
 	outputState?: SubagentOutputState;
 	error?: string;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Message } from "@earendil-works/pi-ai";
+import type { Message, Usage as PiUsage } from "@earendil-works/pi-ai";
 import { previewDisplayText, sanitizeDisplayText, truncateDisplayText } from "./display-text.ts";
 import { formatToolCall } from "./formatters.ts";
 import type { AgentProgress, AsyncStatus, Details, DisplayItem, ErrorInfo, NestedRunSummary, SingleResult, ToolCallSummary, Usage } from "./types.ts";
@@ -337,6 +337,17 @@ export function sumResultsUsage(results: SingleResult[]): Usage {
 		usage.turns += result.usage.turns;
 	}
 	return usage;
+}
+
+export function toAgentToolUsage(usage: Usage): PiUsage {
+	return {
+		input: usage.input,
+		output: usage.output,
+		cacheRead: usage.cacheRead,
+		cacheWrite: usage.cacheWrite,
+		totalTokens: usage.input + usage.output + usage.cacheRead + usage.cacheWrite,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: usage.cost },
+	};
 }
 
 function addNestedCost(total: NonNullable<Details["totalCost"]>, children: NestedRunSummary[] | undefined): void {

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -24,6 +24,8 @@ import { listScheduledRunSummaries } from "../runs/background/scheduled-runs.ts"
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
 import { resolveAsyncStatusChild } from "../runs/shared/child-identity.ts";
 import { readStatus } from "../shared/utils.ts";
+import { getArtifactPaths, getArtifactsDir } from "../shared/artifacts.ts";
+import { readWorkflowReceipt } from "../workflows/workflow-receipt.ts";
 import { FLEET_OPEN_SHORTCUT } from "../shared/shortcuts.ts";
 import type { SlashSubagentResponse, SlashSubagentUpdate } from "./slash-bridge.ts";
 import { registerPromptWorkflowCommands } from "./prompt-workflows.ts";
@@ -347,25 +349,60 @@ function usageHasValue(usage: Usage): boolean {
 	return usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0 || usage.cost !== 0 || usage.turns !== 0;
 }
 
+function nonNegativeNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function usageFromValue(value: unknown, turnsOverride?: number): Usage | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const record = value as Record<string, unknown>;
+	const costValue = typeof record.cost === "object" && record.cost !== null && !Array.isArray(record.cost)
+		? (record.cost as Record<string, unknown>).total
+		: record.cost;
+	const turnsValue = turnsOverride ?? record.turns;
+	const usage = {
+		input: nonNegativeNumber(record.input) ?? 0,
+		output: nonNegativeNumber(record.output) ?? 0,
+		cacheRead: nonNegativeNumber(record.cacheRead) ?? 0,
+		cacheWrite: nonNegativeNumber(record.cacheWrite) ?? 0,
+		cost: nonNegativeNumber(costValue) ?? 0,
+		turns: nonNegativeNumber(turnsValue) ?? 0,
+	};
+	return Number.isSafeInteger(usage.turns) ? usage : undefined;
+}
+
 function assistantUsageFromMessage(message: unknown): Usage | undefined {
 	if (!message || typeof message !== "object") return undefined;
 	const msg = message as { role?: unknown; usage?: unknown };
-	if (msg.role !== "assistant" || !msg.usage || typeof msg.usage !== "object") return undefined;
-	const usage = msg.usage as {
-		input?: unknown;
-		output?: unknown;
-		cacheRead?: unknown;
-		cacheWrite?: unknown;
-		cost?: { total?: unknown };
-	};
-	return {
-		input: typeof usage.input === "number" ? usage.input : 0,
-		output: typeof usage.output === "number" ? usage.output : 0,
-		cacheRead: typeof usage.cacheRead === "number" ? usage.cacheRead : 0,
-		cacheWrite: typeof usage.cacheWrite === "number" ? usage.cacheWrite : 0,
-		cost: typeof usage.cost?.total === "number" ? usage.cost.total : 0,
-		turns: 1,
-	};
+	return msg.role === "assistant" ? usageFromValue(msg.usage, 1) : undefined;
+}
+
+function compactionUsageFromEntry(entry: unknown): Usage | undefined {
+	if (!entry || typeof entry !== "object") return undefined;
+	const record = entry as { type?: unknown; usage?: unknown };
+	return record.type === "compaction" ? usageFromValue(record.usage, 0) : undefined;
+}
+
+const MAX_USAGE_METADATA_BYTES = 2 * 1024 * 1024;
+
+function readUsageMetadata(metadataPath: string): Record<string, unknown> | undefined {
+	let fd: number | undefined;
+	try {
+		fd = fs.openSync(metadataPath, "r");
+		const stat = fs.fstatSync(fd);
+		if (!stat.isFile() || stat.size > MAX_USAGE_METADATA_BYTES) return undefined;
+		const buffer = Buffer.allocUnsafe(stat.size);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const bytesRead = fs.readSync(fd, buffer, offset, buffer.length - offset, null);
+			if (bytesRead <= 0) return undefined;
+			offset += bytesRead;
+		}
+		const value: unknown = JSON.parse(buffer.toString("utf-8"));
+		return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+	} finally {
+		if (fd !== undefined) fs.closeSync(fd);
+	}
 }
 
 function isSubagentDetails(value: unknown): value is Details {
@@ -383,8 +420,30 @@ function detailsFromSessionEntry(entry: unknown): Details | undefined {
 	}
 	if (record.type !== "message" || !record.message || typeof record.message !== "object") return undefined;
 	const message = record.message as { role?: unknown; toolName?: unknown; details?: unknown };
-	if (message.role !== "toolResult" || message.toolName !== "subagent") return undefined;
+	if (message.role !== "toolResult" || (message.toolName !== "subagent" && message.toolName !== "subagent_wait")) return undefined;
 	return isSubagentDetails(message.details) ? message.details : undefined;
+}
+
+function metadataUsage(
+	artifactsDirs: string[],
+	input: { runId: string; agent: string },
+): Usage | undefined {
+	if (!/^[A-Za-z0-9._-]+$/.test(input.runId)) return undefined;
+	for (const artifactsDir of artifactsDirs) {
+		for (const index of [0, undefined] as const) {
+			const metadataPath = getArtifactPaths(artifactsDir, input.runId, input.agent, index).metadataPath;
+			try {
+				const metadata = readUsageMetadata(metadataPath);
+				if (!metadata) continue;
+				if (metadata.runId !== input.runId || metadata.agent !== input.agent) continue;
+				const usage = usageFromValue(metadata.usage);
+				if (usage && usageHasValue(usage)) return usage;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Failed to read subagent usage metadata '${metadataPath}':`, error);
+			}
+		}
+	}
+	return undefined;
 }
 
 function formatCostUsage(label: string, usage: Usage): string {
@@ -396,28 +455,94 @@ function formatCostUsage(label: string, usage: Usage): string {
 	return `${label}: ↑${formatTokens(usage.input)} ↓${formatTokens(usage.output)} $${usage.cost.toFixed(4)}${extras.length ? ` (${extras.join(", ")})` : ""}`;
 }
 
-function buildSubagentCostReport(ctx: ExtensionContext): string {
+function buildSubagentCostReport(ctx: ExtensionContext, state: SubagentState): string {
 	const parent = emptyUsage();
 	const childTotal = emptyUsage();
 	const total = emptyUsage();
 	const children: Array<{ label: string; usage: Usage; sessionFile?: string }> = [];
+	const seenChildren = new Set<string>();
+	const workflowRunIds = new Set<string>();
+	let unresolvedAsyncChildren = 0;
+
+	const addChild = (input: { agent?: string; runId?: string; usage?: Usage; sessionFile?: string }): boolean => {
+		if (!input.usage || !usageHasValue(input.usage)) return false;
+		const identity = input.runId ? `run:${input.runId}` : input.sessionFile ? `session:${input.sessionFile}` : undefined;
+		if (identity && seenChildren.has(identity)) return true;
+		if (identity) seenChildren.add(identity);
+		const usage = { ...input.usage };
+		children.push({
+			label: `Child ${children.length + 1} (${input.agent ?? "unknown"})`,
+			usage,
+			...(input.sessionFile ? { sessionFile: input.sessionFile } : {}),
+		});
+		addUsage(childTotal, usage);
+		return true;
+	};
+
 	for (const entry of ctx.sessionManager.getBranch()) {
 		const message = entry.type === "message" ? (entry as { message?: unknown }).message : undefined;
-		const parentUsage = assistantUsageFromMessage(message);
+		const parentUsage = assistantUsageFromMessage(message) ?? compactionUsageFromEntry(entry);
 		if (parentUsage) addUsage(parent, parentUsage);
 		const details = detailsFromSessionEntry(entry);
 		if (!details) continue;
+		if (details.mode === "workflow" && details.runId) workflowRunIds.add(details.runId);
 		for (const result of details.results) {
-			if (!usageHasValue(result.usage)) continue;
-			const usage = { ...result.usage };
-			children.push({
-				label: `Child ${children.length + 1} (${result.agent})`,
-				usage,
-				...(result.sessionFile ? { sessionFile: result.sessionFile } : {}),
-			});
-			addUsage(childTotal, usage);
+			const resultRunId = (result as SingleResult & { runId?: unknown }).runId;
+			addChild({ agent: result.agent, runId: typeof resultRunId === "string" ? resultRunId : undefined, usage: usageFromValue(result.usage), sessionFile: result.sessionFile });
+		}
+		for (const completion of details.completions ?? []) {
+			if (completion.mode === "workflow") workflowRunIds.add(completion.runId);
+			for (const result of completion.results ?? []) {
+				addChild({ agent: result.agent, runId: result.runId, usage: usageFromValue(result.usage), sessionFile: result.sessionFile });
+			}
 		}
 	}
+
+	let sessionFile: string | null = null;
+	try {
+		sessionFile = ctx.sessionManager.getSessionFile() ?? null;
+	} catch { /* an unpersisted session can still report direct child usage */ }
+	const artifactsDirs = new Set<string>();
+	const addArtifactsDir = (cwd: string | undefined): void => {
+		try {
+			artifactsDirs.add(getArtifactsDir(sessionFile, cwd, state.artifactDirPreference));
+		} catch { /* invalid or unavailable project roots are ignored */ }
+	};
+	addArtifactsDir(ctx.cwd);
+	addArtifactsDir(state.baseCwd);
+
+	for (const workflowRunId of workflowRunIds) {
+		try {
+			const status = readStatus(path.join(DIRS.async, workflowRunId));
+			addArtifactsDir(status?.cwd);
+			const receipt = readWorkflowReceipt(DIRS.async, workflowRunId);
+			const summaryChildren = new Map((receipt.workflowChildren?.children ?? []).map((child) => [child.childId, child]));
+			const refsByRunId = new Map<string, { runId: string; agent: string }>();
+			const addRef = (runId: string | undefined, agent: string | undefined): void => {
+				if (!runId || !agent || refsByRunId.has(runId)) return;
+				refsByRunId.set(runId, { runId, agent });
+			};
+			for (const [key, entry] of Object.entries(receipt.entries)) {
+				const summaryChild = summaryChildren.get(key);
+				const runIds = entry.continuation?.runIds?.length
+					? entry.continuation.runIds
+					: entry.latestRunId ? [entry.latestRunId] : summaryChild?.runId ? [summaryChild.runId] : [];
+				for (const runId of runIds) addRef(runId, entry.agent ?? summaryChild?.agent);
+			}
+			for (const child of receipt.workflowChildren?.children ?? []) {
+				if (!Object.hasOwn(receipt.entries, child.childId)) addRef(child.runId, child.agent);
+			}
+			const refs = [...refsByRunId.values()];
+			for (const ref of refs) {
+				if (seenChildren.has(`run:${ref.runId}`)) continue;
+				const usage = metadataUsage([...artifactsDirs], ref);
+				if (!usage || !addChild({ ...ref, usage })) unresolvedAsyncChildren += 1;
+			}
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") console.error(`Failed to resolve async subagent usage for '${workflowRunId}':`, error);
+		}
+	}
+
 	addUsage(total, parent);
 	addUsage(total, childTotal);
 	const lines = [
@@ -433,6 +558,7 @@ function buildSubagentCostReport(ctx: ExtensionContext): string {
 			if (child.sessionFile) lines.push(`  Session: ${child.sessionFile}`);
 		}
 	}
+	if (unresolvedAsyncChildren > 0) lines.push(`Async child usage unavailable: ${unresolvedAsyncChildren}.`);
 	lines.push("────────────────────────────", formatCostUsage("Children", childTotal), formatCostUsage("Total", total));
 	return lines.join("\n");
 }
@@ -792,7 +918,7 @@ export function registerSlashCommands(
 	pi.registerCommand("subagent-cost", {
 		description: "Show parent and subagent child usage cost for this session",
 		handler: async (_args, ctx) => {
-			sendSlashText(pi, buildSubagentCostReport(ctx));
+			sendSlashText(pi, buildSubagentCostReport(ctx, state));
 		},
 	});
 

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -11,6 +11,7 @@ export type { WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState } from
 
 export const WORKFLOW_RECEIPT_VERSION = 1;
 export const WORKFLOW_RECEIPT_FILE = "workflow-receipt.json";
+const MAX_WORKFLOW_RECEIPT_BYTES = 2 * 1024 * 1024;
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
@@ -77,6 +78,26 @@ export function writeWorkflowReceipt(asyncDir: string, receipt: WorkflowReceipt)
 	const receiptPath = path.join(asyncDir, WORKFLOW_RECEIPT_FILE);
 	writePrivateAtomicJson(receiptPath, receipt);
 	return receiptPath;
+}
+
+function readWorkflowReceiptFile(receiptPath: string): unknown {
+	let fd: number | undefined;
+	try {
+		fd = fs.openSync(receiptPath, "r");
+		const stat = fs.fstatSync(fd);
+		if (!stat.isFile()) throw new Error("workflow receipt is not a regular file.");
+		if (stat.size > MAX_WORKFLOW_RECEIPT_BYTES) throw new Error(`workflow receipt exceeds the ${MAX_WORKFLOW_RECEIPT_BYTES}-byte limit.`);
+		const buffer = Buffer.allocUnsafe(stat.size);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const bytesRead = fs.readSync(fd, buffer, offset, buffer.length - offset, null);
+			if (bytesRead <= 0) throw new Error("workflow receipt ended before its declared size.");
+			offset += bytesRead;
+		}
+		return JSON.parse(buffer.toString("utf-8")) as unknown;
+	} finally {
+		if (fd !== undefined) fs.closeSync(fd);
+	}
 }
 
 const EXTERNAL_CLI_CAPABILITIES = {
@@ -241,7 +262,7 @@ export function readWorkflowReceipt(asyncDirRoot: string, workflowRunId: string)
 	const receiptPath = workflowReceiptPath(asyncDirRoot, workflowRunId);
 	let value: unknown;
 	try {
-		value = JSON.parse(fs.readFileSync(receiptPath, "utf-8")) as unknown;
+		value = readWorkflowReceiptFile(receiptPath);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
 			const workflowDir = path.dirname(receiptPath);

--- a/src/workflows/workflow-settlement.ts
+++ b/src/workflows/workflow-settlement.ts
@@ -3,6 +3,7 @@ import type {
 	WorkflowRecoveryAction,
 	WorkflowTerminalOutcome,
 	WorkflowTerminalResolution,
+	Usage,
 } from "../shared/types.ts";
 import type { WorkflowReceipt } from "./workflow-receipt.ts";
 import { workflowChildSummary } from "./workflow-child-summary.ts";
@@ -22,6 +23,8 @@ export interface WorkflowPublicChild {
 	/** Human-readable display name for the child session, when derived at launch. */
 	sessionName?: string;
 	runId?: string;
+	usage?: Usage;
+	sessionFile?: string;
 	output: string;
 	outputState: "present" | "absent";
 	structuredOutput?: unknown;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -80,7 +80,7 @@ interface AsyncResultPayload {
 	totalTokens?: { input: number; output: number; total: number };
 	totalCost?: { inputTokens: number; outputTokens: number; costUsd: number };
 	usageBudget?: UsageBudgetState;
-	results: Array<{ agent?: string; sessionName?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; timeoutRecovery?: { changedFiles?: string[]; message?: string; warning?: string }; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean; message?: string }; settlementDiagnostic?: { finalTextPresent?: boolean; mutation?: { expected?: boolean; attempted?: boolean; observed?: boolean }; requiredOutput?: { kind?: string; path?: string; missing?: boolean }; afterCompactionSettlement?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string; transcriptPath?: string }; outputSaveError?: string; metadataSaveError?: string; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
+	results: Array<{ agent?: string; sessionName?: string; launchContractDigest?: string; launchResolvedExtensions?: LaunchResolvedExtensions; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedExtensions; output?: string; outputState?: "present" | "absent" | "unknown"; success?: boolean; error?: string; protocolError?: { code?: string; stream?: string; limitBytes?: number; observedBytes?: number }; timedOut?: boolean; timeoutRecovery?: { changedFiles?: string[]; message?: string; warning?: string }; stopped?: boolean; turnBudget?: { maxTurns: number; graceTurns: number; outcome: string; turnCount: number; wrapUpRequestedAtTurn?: number; terminationDeferredAtTurn?: number; exceededAtTurn?: number }; turnBudgetExceeded?: boolean; wrapUpRequested?: boolean; model?: string; attemptedModels?: string[]; modelAttempts?: Array<{ success?: boolean; error?: string }>; totalCost?: { inputTokens: number; outputTokens: number; costUsd: number }; usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number; turns: number }; structuredOutput?: unknown; agentContract?: { version: 1 }; execution?: { status?: string; success?: boolean; exitCode?: number }; effects?: { fileMutation?: { status?: string; expected?: boolean; attempted?: boolean; message?: string }; settlementDiagnostic?: { finalTextPresent?: boolean; mutation?: { expected?: boolean; attempted?: boolean; observed?: boolean }; requiredOutput?: { kind?: string; path?: string; missing?: boolean }; afterCompactionSettlement?: boolean } }; intercomTarget?: string; acceptance?: { status?: string; effectiveAcceptance?: { level?: string }; childReport?: unknown; runtimeChecks?: Array<{ id?: string; status?: string; message?: string }> }; artifactPaths?: { outputPath?: string; inputPath?: string; metadataPath?: string; transcriptPath?: string }; outputSaveError?: string; metadataSaveError?: string; capabilityCeiling?: { version?: number; allowedTools?: string[]; denyExtensions?: boolean; sources?: string[] }; capabilityAudit?: { effectiveTools?: string[]; removedTools?: string[]; extensionsDenied?: boolean } }>;
 	outputs?: Record<string, { text?: string; structured?: unknown }>;
 	workflowGraph?: { nodes?: Array<{ kind?: string; label?: string; phase?: string; status?: string; acceptanceStatus?: string; error?: string; outputName?: string; structured?: boolean; children?: Array<{ label?: string; outputName?: string; itemKey?: string; status?: string; acceptanceStatus?: string; error?: string }> }> };
 	parallelHandoff?: { version?: number; path?: string; groupCount?: number; childCount?: number; changedPatches?: number; cleanupState?: string };
@@ -561,6 +561,31 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
 		assert.equal(status.state, "complete");
 		assert.equal(status.endedAt !== undefined, true);
+	});
+
+	it("persists the bounded usage projection in async results and metadata", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({ output: "accounted output" });
+		const id = `async-usage-artifact-${Date.now().toString(36)}`;
+		const artifactsDir = path.join(tempDir, ".pi", "subagents", "artifacts");
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Persist usage",
+			agentConfig: makeAgent("worker", { completionGuard: false }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-usage-artifact" },
+			artifactConfig: { enabled: true, includeInput: false, includeOutput: true, includeJsonl: false, includeMetadata: true, cleanupDays: 7 },
+			artifactsDir,
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+
+		const payload = await readAsyncPayload(id);
+		const expectedUsage = { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.001, turns: 1 };
+		assert.deepEqual(payload.results[0]?.usage, expectedUsage);
+		const metadataPath = payload.results[0]?.artifactPaths?.metadataPath;
+		assert.ok(metadataPath);
+		const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as { usage?: unknown };
+		assert.deepEqual(metadata.usage, expectedUsage);
 	});
 
 	it("makes a launched async run immediately visible to exact status lookup", { skip: !isAsyncAvailable() || !resolveTargetedAsyncRun ? "jiti not available" : undefined }, async () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1227,7 +1227,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			{ key: "work", state: "completed" },
 		]);
 		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
-		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown; receipt?: unknown }; workflowReceipt?: { path?: string; receipt?: { workflowRunId?: string; entries?: Record<string, { key?: string; agent?: string; latestRunId?: string; resumability?: { state?: string; reason?: string }; continuation?: { runIds?: string[] } }> } }; results?: Array<{ agent?: string; sessionName?: string; workflowKey?: string; runId?: string; output?: string }> };
+		const persistedResult = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { id?: string; runId?: string; toolCallId?: string; agent?: string; cwd?: string; summary?: string; workflow?: { value?: unknown; receipt?: unknown }; workflowReceipt?: { path?: string; receipt?: { workflowRunId?: string; entries?: Record<string, { key?: string; agent?: string; latestRunId?: string; resumability?: { state?: string; reason?: string }; continuation?: { runIds?: string[] } }> } }; results?: Array<{ agent?: string; sessionName?: string; workflowKey?: string; runId?: string; output?: string; usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number; turns: number } }> };
 		assert.equal(persistedResult.id, workflowRunId);
 		assert.equal(persistedResult.runId, workflowRunId);
 		assert.equal(persistedResult.toolCallId, toolCallId);
@@ -1236,6 +1236,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(persistedResult.results?.map(({ agent, sessionName, workflowKey }) => ({ agent, sessionName, workflowKey })), [
 			{ agent: "echo", sessionName: "echo: Async work", workflowKey: "work" },
 		]);
+		assert.deepEqual(persistedResult.results?.[0]?.usage, { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.001, turns: 1 });
 		const steeringEnv = JSON.parse(persistedResult.results?.[0]?.output ?? "null") as Record<string, string | null>;
 		assert.match(steeringEnv[SUBAGENT_STEER_INBOX_ENV] ?? "", /control[/\\]workflow-foreground[/\\].+[/\\]control[/\\]steer-targets[/\\]0$/);
 		assert.match(steeringEnv[SUBAGENT_STEER_CAPABILITY_ENV] ?? "", /control[/\\]workflow-foreground[/\\].+[/\\]control[/\\]steer-capabilities[/\\]0\.json$/);
@@ -4548,6 +4549,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 
 		assert.equal(result.isError, undefined);
 		assert.deepEqual(result.details?.totalCost, { inputTokens: 100, outputTokens: 50, costUsd: 0.001 });
+		assert.deepEqual(result.usage, { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, totalTokens: 150, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 } });
 	});
 
 	it("ignores stale foreground control notification contexts after reload", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
@@ -4916,6 +4918,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const child = result.details.workflow?.value as { ok?: boolean; runId?: string; output?: string; continuation?: { runIds?: string[] } };
 		assert.equal(child.ok, true);
 		assert.match(child.output ?? "", /Recovered after workflow auto-resume/u);
+		assert.deepEqual(result.details.results[0]?.usage, { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.001, turns: 1 });
 		// The workflow-level setup recovery is a distinct launch, so its receipt
 		// retains both the failed source run and the resumed child run. The
 		// compaction planner no longer hides this source by resuming it first.

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -10,6 +10,7 @@ import { clearRuntimeAgentsForPi } from "../../src/agents/runtime-agent-registry
 import { scheduledRunStorePath } from "../../src/runs/background/scheduled-runs.ts";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { SUBAGENT_FANOUT_CHILD_ENV } from "../../src/runs/shared/pi-args.ts";
+import { getArtifactPaths, getArtifactsDir } from "../../src/shared/artifacts.ts";
 import { ASYNC_DIR, DIRS } from "../../src/shared/types.ts";
 import type { WatchdogReviewFunction } from "../../src/watchdog/runtime.ts";
 
@@ -496,6 +497,91 @@ describe("subagents watchdog slash command", { skip: !available ? "watchdog comm
 describe("slash command custom message delivery", { skip: !available ? "slash-commands.ts not importable" : undefined }, () => {
 	beforeEach(() => {
 		clearSlashSnapshots?.();
+	});
+
+	it("/subagent-cost recovers async workflow usage from receipts and metadata", async () => {
+		await withTempProject("pi-subagent-cost-async-", async (root) => {
+			const workflowRunId = `workflow-cost-${process.pid}-${Date.now()}`;
+			const earlierChildRunId = `child-cost-earlier-${process.pid}-${Date.now()}`;
+			const childRunId = `child-cost-${process.pid}-${Date.now()}`;
+			const asyncDir = path.join(DIRS.async, workflowRunId);
+			const sessionFile = path.join(root, "sessions", "parent.jsonl");
+			const artifactsDir = getArtifactsDir(sessionFile, root, "session");
+			const earlierMetadataPath = getArtifactPaths(artifactsDir, earlierChildRunId, "reviewer", 0).metadataPath;
+			const metadataPath = getArtifactPaths(artifactsDir, childRunId, "reviewer", 0).metadataPath;
+			fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+			fs.writeFileSync(sessionFile, "", "utf-8");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.mkdirSync(path.dirname(earlierMetadataPath), { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "workflow-receipt.json"), JSON.stringify({
+				version: 1,
+				workflowRunId,
+				state: "complete",
+				createdAt: Date.now(),
+				entries: {
+					review: {
+						key: "review",
+						agent: "reviewer",
+						latestRunId: childRunId,
+						continuation: { runIds: [earlierChildRunId, childRunId] },
+						resumability: { state: "resumable" },
+					},
+				},
+				workflowChildren: {
+					version: 1,
+					parentToolCallId: "tool-1",
+					workflowRunId,
+					inventoryComplete: true,
+					workflowState: "completed",
+					children: [{ childId: "review", state: "completed", runId: childRunId, agent: "reviewer" }],
+				},
+			}, null, 2), "utf-8");
+			fs.writeFileSync(earlierMetadataPath, JSON.stringify({
+				runId: earlierChildRunId,
+				agent: "reviewer",
+				usage: { input: 8, output: 3, cacheRead: 5, cacheWrite: 0, cost: 0.25, turns: 1 },
+			}, null, 2), "utf-8");
+			fs.writeFileSync(metadataPath, JSON.stringify({
+				runId: childRunId,
+				agent: "reviewer",
+				usage: { input: 20, output: 4, cacheRead: 80, cacheWrite: 0, cost: 0.5, turns: 2 },
+			}, null, 2), "utf-8");
+
+			const sent: unknown[] = [];
+			const commands = new Map<string, RegisteredSlashCommand>();
+			const pi = {
+				events: createEventBus(),
+				registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+				registerShortcut() {},
+				sendMessage(message: unknown) { sent.push(message); },
+			};
+			const branch = [
+				{ type: "message", message: { role: "assistant", usage: { input: 10, output: 2, cacheRead: 30, cacheWrite: 0, cost: { total: 0.2 } } } },
+				{ type: "compaction", usage: { input: 5, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0.05 } } },
+				{ type: "message", message: { role: "toolResult", toolName: "subagent", details: { mode: "workflow", runId: workflowRunId, results: [] } } },
+			];
+			try {
+				registerSlashCommands!(pi as never, createState(root));
+				await commands.get("subagent-cost")!.handler("", createCommandContext({
+					cwd: root,
+					sessionManager: {
+						getBranch: () => branch,
+						getSessionFile: () => sessionFile,
+						getSessionId: () => "session-parent",
+					},
+				}));
+				const report = String((sent[0] as { content?: unknown }).content ?? "");
+				assert.match(report, /Parent: ↑15 ↓3 \$0\.2500/);
+				assert.match(report, /Child 1 \(reviewer\): ↑8 ↓3 \$0\.2500 \(cache read 5, 1 turn\)/);
+				assert.match(report, /Child 2 \(reviewer\): ↑20 ↓4 \$0\.5000 \(cache read 80, 2 turns\)/);
+				assert.equal((report.match(/Child \d+ \(reviewer\):/g) ?? []).length, 2);
+				assert.match(report, /Children: ↑28 ↓7 \$0\.7500 \(cache read 85, 3 turns\)/);
+				assert.match(report, /Total: ↑43 ↓10 \$1\.0000 \(cache read 115, 4 turns\)/);
+				assert.doesNotMatch(report, /No subagent child usage/);
+			} finally {
+				fs.rmSync(asyncDir, { recursive: true, force: true });
+			}
+		});
 	});
 
 	it("registers a configured foreground detach shortcut", async () => {

--- a/test/unit/chain-root-attachment.test.ts
+++ b/test/unit/chain-root-attachment.test.ts
@@ -45,7 +45,7 @@ describe("async chain root attachment", () => {
 		writeJson(importedRoot.resultPath, {
 			state: "complete",
 			success: true,
-			results: [{ agent: "worker", output: "root output", success: true, sessionFile }],
+		results: [{ agent: "worker", output: "root output", success: true, sessionFile, usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.001, turns: 1 } }],
 		});
 
 		const result = await waitForImportedAsyncRoot(importedRoot, { pollIntervalMs: 1 });
@@ -55,11 +55,13 @@ describe("async chain root attachment", () => {
 			output: result.output,
 			exitCode: result.exitCode,
 			sessionFile: result.sessionFile,
+			usage: result.usage,
 		}, {
 			agent: "worker",
 			output: "root output",
 			exitCode: 0,
 			sessionFile,
+			usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.001, turns: 1 },
 		});
 	});
 

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -341,6 +341,7 @@ describe("subagent_wait tool", () => {
 							success: true,
 							outputState: "present",
 							output: "full output text stays out of details",
+							usage: { input: 100, output: 50, cacheRead: 25, cacheWrite: 5, cost: 0.001, turns: 1 },
 							artifactPaths: {
 								outputPath: "/tmp/a1b2c3d4_reviewer_0_output.md",
 								metadataPath: "/tmp/a1b2c3d4_reviewer_0_meta.json",
@@ -356,6 +357,7 @@ describe("subagent_wait tool", () => {
 			assert.equal(completions![0]!.runId, "run-a");
 			assert.equal(completions![0]!.mode, "workflow");
 			assert.equal(completions![0]!.success, true);
+			assert.deepEqual(result.usage, { input: 100, output: 50, cacheRead: 25, cacheWrite: 5, totalTokens: 180, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 } });
 			const child = completions![0]!.results?.[0];
 			assert.equal(child?.agent, "reviewer");
 			assert.equal(child?.runId, "a1b2c3d4");

--- a/test/unit/wait-completions.test.ts
+++ b/test/unit/wait-completions.test.ts
@@ -17,10 +17,20 @@ describe("workflow wait completion projection", () => {
 				workflowState: "completed",
 				children: [{ childId: "review", runId: "run-1", agent: "reviewer", model: "openai-codex/gpt", thinking: "high", state: "completed" }],
 			},
-			results: [{ agent: "reviewer", runId: "run-1", success: true, output: "must not be copied", task: "must not be copied" }],
+			results: [{
+				agent: "reviewer",
+				runId: "run-1",
+				success: true,
+				sessionFile: "/sessions/run-1.jsonl",
+				usage: { input: 10, output: 2, cacheRead: 30, cacheWrite: 0, cost: 0.04, turns: 1 },
+				output: "must not be copied",
+				task: "must not be copied",
+			}],
 		}, "workflow-1");
 
 		assert.equal(completion.workflowChildren?.children[0]?.childId, "review");
+		assert.deepEqual(completion.results?.[0]?.usage, { input: 10, output: 2, cacheRead: 30, cacheWrite: 0, cost: 0.04, turns: 1 });
+		assert.equal(completion.results?.[0]?.sessionFile, "/sessions/run-1.jsonl");
 		assert.doesNotMatch(JSON.stringify(completion), /must not be copied/);
 	});
 

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -180,7 +180,7 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			state,
 			workflowRunId,
 			childRunId: "child-1",
-			result: { index: 0, agent: "worker", task: `Write your findings to exactly this path: ${requestedPath}`, exitCode: 0, sessionFile, savedOutputPath: savedPath, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+			result: { index: 0, agent: "worker", task: `Write your findings to exactly this path: ${requestedPath}`, exitCode: 0, sessionFile, savedOutputPath: savedPath, usage: { input: 100, output: 50, cacheRead: 25, cacheWrite: 5, cost: 0.001, turns: 1 } },
 		}), true);
 		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; summary?: string; error?: string; sessionId?: string; workflowResolution?: string; recovery?: unknown[]; results?: Array<{ outputReference?: string; outputPathMapping?: unknown }>; workflowReceipt?: { receipt?: { state?: string; workflowResolution?: string; recovery?: unknown[]; entries?: Record<string, { resumability?: { state?: string; reason?: string } }> } } };
 		assert.equal(published.state, "failed");
@@ -192,6 +192,9 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		assert.ok(published.summary?.includes(`Output path mappings: 'detaches': requested ${requestedPath} -> saved ${savedPath}`));
 		assert.equal(published.results?.[0]?.outputReference, savedPath);
 		assert.deepEqual(published.results?.[0]?.outputPathMapping, { requestedPath, savedPath });
+		const publishedChild = published.results?.[0] as { usage?: unknown; sessionFile?: string } | undefined;
+		assert.deepEqual(publishedChild?.usage, { input: 100, output: 50, cacheRead: 25, cacheWrite: 5, cost: 0.001, turns: 1 });
+		assert.equal(publishedChild?.sessionFile, sessionFile);
 		assert.equal(published.sessionId, "session-1");
 		assert.equal(published.workflowReceipt?.receipt?.state, "failed");
 		assert.equal(published.workflowReceipt?.receipt?.workflowResolution, "settled-awaiting-resume");


### PR DESCRIPTION
Fixes #1662.

## Problem

Detached `workflowScript` launches persist an initial `subagent` tool result with `details.results = []`. Terminal children arrive through `subagent_wait.details.completions`, while `/subagent-cost` only inspected direct `subagent.details.results`. Completed async workflows therefore reported a false `Children: $0` despite complete child `_meta.json` accounting.

Parent compaction calls were also omitted because their usage lives on `type: "compaction"` entries rather than assistant messages.

## Change

- carry the bounded `Usage` and `sessionFile` projection in future wait completions;
- consume both direct `subagent` results and `subagent_wait` completions;
- discover only workflow IDs already present in the owning session branch;
- recover historical async child usage through the terminal workflow receipt and exact run/agent metadata path;
- deduplicate children by persisted run/session identity;
- report unresolved async metadata instead of silently treating it as zero;
- include parent compaction usage without counting it as an assistant turn.

The receipt/meta fallback is bounded: no recursive artifact scan is performed, run IDs are path-safe validated, and metadata must match both expected run ID and agent.

## Validation

- `npm run typecheck`
- targeted unit tests:
  - `test/unit/wait-completions.test.ts`
  - `test/unit/completion-replay.test.ts`
- targeted integration test:
  - `test/integration/slash-commands.test.ts`

The new integration regression exercises the actual async shape: empty launch results → terminal workflow receipt → persisted child metadata → non-zero `/subagent-cost`, including compaction and aggregate totals.
