### PR TITLE
test(windows): hide child process console windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Keep the Windows test harness from opening visible terminal tabs for child-process fixtures (#1664).
 - Remove the remaining `lane:` prefix from operator-facing async status rows in the TUI (#1658).
 - Avoid false preflight mismatch warnings for generated `runs.lanes(...)` stage keys (#1649).
 - Accept long host tool-call ids in workflow child summaries, matching the existing 4,096-byte session id bound. Thanks to [@SudoKillMe](https://github.com/SudoKillMe) for #1653.

--- a/test/support/isolated-temp-root.mjs
+++ b/test/support/isolated-temp-root.mjs
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import "./windows-hide-child-processes.mjs";
 
 if (!process.env.PI_SUBAGENTS_TEMP_ROOT) {
 	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-test-root-"));

--- a/test/support/windows-hide-child-processes.mjs
+++ b/test/support/windows-hide-child-processes.mjs
@@ -1,0 +1,46 @@
+import { createRequire, syncBuiltinESMExports } from "node:module";
+
+const INSTALL_MARK = Symbol.for("pi-subagents.test.windows-hide-child-processes");
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
+
+export function withWindowsHide(args, optionsIndex) {
+	const next = [...args];
+	const current = next[optionsIndex];
+	if (current === undefined || typeof current === "function") {
+		next.splice(optionsIndex, 0, { windowsHide: true });
+	} else if (current && typeof current === "object" && !Array.isArray(current)) {
+		next[optionsIndex] = { ...current, windowsHide: true };
+	} else {
+		next[optionsIndex] = { windowsHide: true };
+	}
+	return next;
+}
+
+function optionsAfterOptionalArgs(args) {
+	return Array.isArray(args[1]) ? 2 : 1;
+}
+
+export function installWindowsHiddenChildProcesses(platform = process.platform) {
+	if (platform !== "win32" || childProcess[INSTALL_MARK] === true) return false;
+	const optionIndexes = {
+		spawn: optionsAfterOptionalArgs,
+		spawnSync: optionsAfterOptionalArgs,
+		execFile: optionsAfterOptionalArgs,
+		execFileSync: optionsAfterOptionalArgs,
+		fork: optionsAfterOptionalArgs,
+		exec: () => 1,
+		execSync: () => 1,
+	};
+	for (const [name, indexFor] of Object.entries(optionIndexes)) {
+		const original = childProcess[name];
+		childProcess[name] = function (...args) {
+			return Reflect.apply(original, this, withWindowsHide(args, indexFor(args)));
+		};
+	}
+	childProcess[INSTALL_MARK] = true;
+	syncBuiltinESMExports();
+	return true;
+}
+
+installWindowsHiddenChildProcesses();

--- a/test/unit/windows-hide-test-processes.test.ts
+++ b/test/unit/windows-hide-test-processes.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+import { installWindowsHiddenChildProcesses, withWindowsHide } from "../support/windows-hide-child-processes.mjs";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+describe("Windows test child-process visibility", () => {
+	it("forces windowsHide across child-process overloads without mutating input", () => {
+		const options = { cwd: "C:/tmp", windowsHide: false };
+		const args = ["node", ["fixture.js"], options];
+		const hidden = withWindowsHide(args, 2);
+		assert.deepEqual(hidden, ["node", ["fixture.js"], { cwd: "C:/tmp", windowsHide: true }]);
+		assert.equal(args[2], options);
+		assert.equal(options.windowsHide, false);
+
+		const callback = () => {};
+		assert.deepEqual(withWindowsHide(["echo ok", callback], 1), ["echo ok", { windowsHide: true }, callback]);
+	});
+
+	it("loads the visibility guard from both unit and integration test preloads", () => {
+		const isolated = fs.readFileSync(path.join(projectRoot, "test", "support", "isolated-temp-root.mjs"), "utf-8");
+		const integration = fs.readFileSync(path.join(projectRoot, "test", "support", "register-loader.mjs"), "utf-8");
+		assert.match(isolated, /windows-hide-child-processes\.mjs/);
+		assert.match(integration, /isolated-temp-root\.mjs/);
+	});
+
+	it("installs at most once and only on Windows", () => {
+		assert.equal(installWindowsHiddenChildProcesses("linux"), false);
+		if (process.platform === "win32") assert.equal(installWindowsHiddenChildProcesses(), false);
+	});
+});


### PR DESCRIPTION
Fixes #1664.

## Problem

The full test suites repeatedly launch child processes. On Windows hosts that use Windows Terminal as the default console host, test fixtures that omit `windowsHide` can create visible blank terminal tabs every few seconds. This is especially disruptive when the suite runs from a headless Pi tool call.

Production nested Pi paths already set `windowsHide: true`; the remaining gap is the test harness and its many direct child-process fixtures.

## Change

- install a Windows-only child-process guard from the existing unit/integration preload path;
- default `windowsHide: true` for `spawn`, `spawnSync`, `exec`, `execSync`, `execFile`, `execFileSync`, and `fork`;
- preserve overloads, callback placement, existing option objects, and caller input immutability;
- sync patched Node builtin ESM exports so named imports used by tests see the same guarded functions;
- keep non-Windows behavior unchanged and install idempotently.

This avoids a broad edit across dozens of process-oriented fixtures and keeps the policy centralized in test-only code.

## Validation

- `npm run typecheck`
- `test/unit/windows-hide-test-processes.test.ts`
- `test/unit/windows-hide-spawn.test.ts`
- representative process tests:
  - `test/unit/close-grace-timer.test.ts`
  - `test/unit/session-lease.test.ts`

All focused tests passed on Windows. No production source is changed.
