### PR TITLE
fix: clarify runs.lanes retained resume error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Give `runs.lanes(...)` stage-0 retained-resume validation actionable `runs.run(...)` guidance instead of a generic error (#1657).
 - Remove the remaining `lane:` prefix from operator-facing async status rows in the TUI (#1658).
 - Allow scheduled project roots shared through a registered Git worktree's `.pi` symlink while rejecting unrelated or unproven Git-layout escapes. Thanks to [@sususu98](https://github.com/sususu98) for #1656.
 - Avoid false preflight mismatch warnings for generated `runs.lanes(...)` stage keys (#1649).

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -419,7 +419,12 @@ function validateLaneSpecs(laneSpecs) {
       if (generatedKeys.has(generatedKey)) throw new Error("runs.lanes generated child key '" + generatedKey + "' is duplicated.");
       generatedKeys.add(generatedKey);
       const resume = stage.resume;
-      if (resume !== undefined && resume !== "previous") throw new Error(stageLabel + " resume must be 'previous'.");
+      if (resume !== undefined && resume !== "previous") {
+        if (stageIndex === 0 && typeof resume === "string") {
+          throw new Error(stageLabel + " cannot resume a retained run id in runs.lanes; use runs.run(key, { resume: id }) outside lanes, or start the lane with an agent stage and use resume: \"previous\" later.");
+        }
+        throw new Error(stageLabel + " resume must be 'previous'.");
+      }
       if (stageIndex === 0 && resume === "previous") throw new Error(stageLabel + " cannot resume previous without a predecessor stage.");
       const { key: _stageKey, resume: _resume, ...params } = stage;
       const validationParams = resume === "previous" ? { ...params, resume: "retained-run-placeholder" } : params;

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -656,6 +656,23 @@ describe("scripted workflow runtime", () => {
 		]);
 	});
 
+	it("gives actionable guidance for a retained stage-0 resume", async () => {
+		let launches = 0;
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return runs.lanes([{ key: "lane", stages: [{ key: "writer", resume: "retained-run", task: "continue" }] }]);`,
+				timeoutMs: 2_000,
+				async launch(key) { launches += 1; return { key, ok: true, output: "unexpected", artifactPaths: [], results: [] }; },
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError
+				&& error.message.includes("runs.lanes lane 0 stage 0 cannot resume a retained run id in runs.lanes")
+				&& error.message.includes("use runs.run(key, { resume: id }) outside lanes")
+				&& error.message.includes('start the lane with an agent stage and use resume: "previous" later'),
+		);
+		assert.equal(launches, 0);
+	});
+
 	it("validates all lane stages before launching any child", async () => {
 		const malformedScripts = [
 			`return runs.lanes([{ key: "bad lane", stages: [{ key: "writer", agent: "worker", task: "write" }] }]);`,


### PR DESCRIPTION
Fixes #1657.

This keeps the current `runs.lanes` contract unchanged: stage resumes still only accept `"previous"`. It only makes the stage-0 retained-run-id failure explain the two supported paths: use `runs.run(key, { resume: id })` outside lanes, or start the lane with an agent stage and use `resume: "previous"` later.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/scripted-workflow.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
