### PR TITLE
fix: compact workflow preflight status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Compact workflow preflight status in default TUI/status views while keeping full details available when expanded (#1668).
 - Give `runs.lanes(...)` stage-0 retained-resume validation actionable `runs.run(...)` guidance instead of a generic error (#1657).
 - Remove the remaining `lane:` prefix from operator-facing async status rows in the TUI (#1658).
 - Allow scheduled project roots shared through a registered Git worktree's `.pi` symlink while rejecting unrelated or unproven Git-layout escapes. Thanks to [@sususu98](https://github.com/sususu98) for #1656.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -20,7 +20,7 @@ import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summar
 import { assertWorkflowGraphHostSteps, hostStepReportName, hostStepVerdictLabel, validHostStepNodes } from "../shared/host-step-status.ts";
 import { projectAsyncWorkflowRows } from "../shared/async-status-projection.ts";
 import { validateAsyncStatusLaneMetadata } from "../shared/lane-metadata.ts";
-import { formatWorkflowPreflight, formatWorkflowPreflightWarnings } from "../../workflows/workflow-preflight.ts";
+import { formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary } from "../../workflows/workflow-preflight.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -617,8 +617,9 @@ export function formatAsyncRunList(runs: AsyncRunSummary[], heading = "Active as
 	const lines = [`${heading}: ${runs.length}`, ""];
 	for (const run of runs) {
 		lines.push(`- ${formatRunHeader(run)}`);
-		if (run.preflight) lines.push(...formatWorkflowPreflight(run.preflight, { indent: "  " }).split("\n"));
-		if (run.workflow?.preflightWarnings?.length) lines.push(...formatWorkflowPreflightWarnings(run.workflow.preflightWarnings, { indent: "  " }).split("\n"));
+		if (run.preflight) lines.push(formatWorkflowPreflightPlanSummary(run.preflight, { indent: "  " }));
+		const preflightWarning = formatWorkflowPreflightWarningSummary(run.workflow?.preflightWarnings, { indent: "  " });
+		if (preflightWarning) lines.push(preflightWarning);
 		for (const step of run.steps) {
 			lines.push(`  ${formatStepLine(step)}`);
 			lines.push(...formatNestedRunStatusLines(step.children, { indent: "    ", maxLines: 12 }));

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -23,7 +23,7 @@ import { attachRootChildrenToSteps, findNestedRouteForRootId, projectNestedRegis
 import { readMissionBinding } from "../../missions/lifecycle.ts";
 import { formatWorkflowJsonPreview } from "../../workflows/scripted-workflow.ts";
 import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summary.ts";
-import { formatWorkflowPreflight, formatWorkflowPreflightWarnings } from "../../workflows/workflow-preflight.ts";
+import { formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary } from "../../workflows/workflow-preflight.ts";
 import { formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import { getExternalJobProvider } from "../../api/external-job-provider.ts";
 
@@ -512,8 +512,8 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				statusActivityText ? `Activity: ${statusActivityText}` : undefined,
 				steeringText ? `Steering: ${steeringText}` : undefined,
 				`Mode: ${status.mode}`,
-				...(status.preflight ? formatWorkflowPreflight(status.preflight).split("\n") : []),
-				...(status.workflow?.preflightWarnings ? formatWorkflowPreflightWarnings(status.workflow.preflightWarnings).split("\n") : []),
+				...(status.preflight ? [formatWorkflowPreflightPlanSummary(status.preflight)] : []),
+				...(status.workflow?.preflightWarnings?.length ? [formatWorkflowPreflightWarningSummary(status.workflow.preflightWarnings)] : []),
 				runFanoutBudget ? formatRunFanoutBudget(runFanoutBudget) : undefined,
 				status.parentWorkflowRunId ? `Workflow parent: ${status.parentWorkflowRunId}${status.workflowKey ? ` (${status.workflowKey})` : ""}` : undefined,
 				status.mode === "workflow" && workflowReturnPreview !== undefined ? `Return: ${workflowReturnPreview}` : undefined,

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -32,7 +32,7 @@ import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
 import { aggregateStepStatus, formatActivityLabel, formatAgentRunningLabel, formatParallelOutcome } from "../shared/status-format.ts";
 import { contextModeBadge, contextModePrefix } from "../runs/shared/context-mode.ts";
 import { buildWorkflowChatProgressRows, type WorkflowChatProgressRow } from "../workflows/chat-progress.ts";
-import { formatWorkflowPreflight, formatWorkflowPreflightWarnings } from "../workflows/workflow-preflight.ts";
+import { formatWorkflowPreflight, formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary, formatWorkflowPreflightWarnings } from "../workflows/workflow-preflight.ts";
 import { encodeAsyncStatusSnapshotWidget } from "../runs/background/async-status-snapshot.ts";
 import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
 import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
@@ -438,8 +438,15 @@ function widgetLaneDetailLines(job: AsyncJobState, theme: Theme): string[] {
 	return lane ? formatLaneProjectionLines(lane, theme, "  ") : [];
 }
 
-function workflowPreflightLines(job: AsyncJobState): string[] {
+function workflowPreflightLines(job: AsyncJobState, expanded = false): string[] {
 	if (job.mode !== "workflow" || !job.preflight) return [];
+	if (!expanded) {
+		const warning = formatWorkflowPreflightWarningSummary(job.workflow?.preflightWarnings, { indent: "  ", hint: "expand for debug" });
+		return [
+			formatWorkflowPreflightPlanSummary(job.preflight, { indent: "  " }),
+			...(warning ? [warning] : []),
+		];
+	}
 	return [
 		...formatWorkflowPreflight(job.preflight, { indent: "  " }).split("\n"),
 		...(job.workflow?.preflightWarnings ? formatWorkflowPreflightWarnings(job.workflow.preflightWarnings, { indent: "  " }).split("\n") : []),
@@ -835,6 +842,8 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 		chainStepCount: job.chainStepCount,
 		parallelGroups: job.parallelGroups,
 		workflowHostSteps: projectAsyncWorkflowRows([], job.hostSteps).map(hostStepRenderKey),
+		preflight: expanded ? job.preflight : job.preflight ? formatWorkflowPreflightPlanSummary(job.preflight) : undefined,
+		preflightWarnings: expanded ? job.workflow?.preflightWarnings : job.workflow?.preflightWarnings?.length || undefined,
 		steps: job.steps?.map((step, index) => widgetStepRenderKey(step, index, expanded)),
 		nestedChildren: nestedRenderKey(job.nestedChildren, expanded),
 		lane: laneRenderKey(job),
@@ -1545,7 +1554,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 	if (!job.steps?.length) {
 		const lane = projectAsyncLane(job);
 		return [
-			...workflowPreflightLines(job),
+			...workflowPreflightLines(job, expanded),
 			...(lane ? formatLaneProjectionLines(lane, theme, "  ") : []),
 			...hostStepWidgetLines(job, theme, "  "),
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
@@ -1555,7 +1564,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
 	const total = job.stepsTotal ?? job.steps.length;
 	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
-	const lines: string[] = workflowPreflightLines(job);
+	const lines: string[] = workflowPreflightLines(job, expanded);
 	for (const [index, step] of job.steps.entries()) {
 		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index + 1, total, expanded, width, frame));
 	}
@@ -2037,7 +2046,7 @@ function workflowOverallState(rows: WorkflowChatProgressRow[], hasTerminalValue:
 	return "running";
 }
 
-function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>, theme: Theme, layout: MainWindowRenderLayout, frame?: number): Component {
+function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>, theme: Theme, layout: MainWindowRenderLayout, frame?: number, expanded = false): Component {
 	const workflow = d.workflow;
 	const rows = workflow ? buildWorkflowChatProgressRows(workflow.trace, d.preflight) : d.preflight ? buildWorkflowChatProgressRows([], d.preflight) : [];
 	const state = workflowOverallState(rows, workflow?.value !== undefined, result.isError);
@@ -2050,6 +2059,7 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 	const rowIndent = mainWindowIndent(layout, 1);
 	c.addChild(new Text(truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold("workflow"))} ${runId} ${theme.fg("dim", "·")} ${d.chatProgress?.repoRelation === "same" ? "same repo" : "other repo"} ${theme.fg("dim", "·")} ${state}`, width), 0, 0));
 	c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}Repo   ${repoLabel}`), width), 0, 0));
+	if (d.preflight) c.addChild(new Text(truncLine(theme.fg("dim", formatWorkflowPreflightPlanSummary(d.preflight, { indent: rowIndent })), width), 0, 0));
 	if (phase) c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}Phase  ${phase}`), width), 0, 0));
 	if (rows.length === 0) {
 		c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}◦ waiting for workflow child launches`), width), 0, 0));
@@ -2063,7 +2073,7 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 		const duration = row.durationMs !== undefined ? ` ${theme.fg("dim", `· ${formatDuration(row.durationMs)}`)}` : "";
 		const run = row.runId ? ` ${theme.fg("dim", `[${row.runId.slice(0, 8)}]`)}` : "";
 		const error = row.error ? ` ${theme.fg(row.state === "detached" ? "warning" : "error", `· ${compactWorkflowError(row.error)}`)}` : "";
-		const hints = row.preflight ? [
+		const hints = expanded && row.preflight ? [
 			row.preflight.mode ? `mode:${row.preflight.mode}` : undefined,
 			row.preflight.decision ? `decision:${row.preflight.decision}` : undefined,
 			row.preflight.claims?.length ? `claims:${row.preflight.claims.join(",")}` : undefined,
@@ -2072,7 +2082,12 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 		].filter((value): value is string => Boolean(value)).join(" · ") : "";
 		c.addChild(new Text(truncLine(`${rowIndent}${workflowRowGlyph(row, theme, frame)} ${status} ${theme.bold(row.key)}${label}${run}${duration}${error}${hints ? ` ${theme.fg("dim", `· ${hints}`)}` : ""}`, width), 0, 0));
 	}
-	if (workflow?.preflightWarnings?.length) c.addChild(new Text(truncLine(theme.fg("warning", `${rowIndent}Warnings ${workflow.preflightWarnings.length}`), width), 0, 0));
+	if (workflow?.preflightWarnings?.length) {
+		const warningLines = expanded
+			? formatWorkflowPreflightWarnings(workflow.preflightWarnings, { indent: rowIndent }).split("\n")
+			: [formatWorkflowPreflightWarningSummary(workflow.preflightWarnings, { indent: rowIndent, hint: "expand for debug" })];
+		for (const warningLine of warningLines) c.addChild(new Text(truncLine(theme.fg("warning", warningLine), width), 0, 0));
+	}
 	if (workflow?.emits.length) c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}Emits  ${workflow.emits.length}`), width), 0, 0));
 	return c;
 }
@@ -2246,7 +2261,7 @@ export function renderSubagentResult(
 	const compact = (component: Component): Component => capCompactMainWindowResult(component, layout, theme, !options.expanded);
 	const d = result.details;
 	if (d?.mode === "workflow" && d.chatProgress?.mode === "live-card" && d.workflow?.value === undefined && (!result.isError || (d.workflow?.trace.length ?? 0) > 0)) {
-		return compact(renderWorkflowChatProgress(d, result, theme, options.expanded ? resolveMainWindowRenderLayout() : layout, frame));
+		return compact(renderWorkflowChatProgress(d, result, theme, options.expanded ? resolveMainWindowRenderLayout() : layout, frame, options.expanded));
 	}
 	if (!d || !d.results.length) {
 		const t = result.content[0];
@@ -2257,9 +2272,12 @@ export function renderSubagentResult(
 		if (d && !options.expanded && !result.isError) {
 			const lines = text.split(/\r?\n/);
 			const firstNonEmptyLine = lines.find((line) => line.trim())?.trim() || "(no output)";
+			const compactLine = d.mode === "workflow" && d.preflight
+				? formatWorkflowPreflightPlanSummary(d.preflight)
+				: firstNonEmptyLine;
 			const c = new Container();
 			const detailIndent = mainWindowIndent(layout, 1);
-			c.addChild(new Text(truncLine(`${contextPrefix}${firstNonEmptyLine} · ${lines.length} lines`, width), 0, 0));
+			c.addChild(new Text(truncLine(`${contextPrefix}${compactLine} · ${lines.length} lines`, width), 0, 0));
 			c.addChild(new Text(truncLine(theme.fg("accent", `${detailIndent}Press ${liveDetailKeyText()} for full output`), width), 0, 0));
 			return compact(c);
 		}

--- a/src/workflows/workflow-preflight.ts
+++ b/src/workflows/workflow-preflight.ts
@@ -142,13 +142,16 @@ function declaredKeys(preflight: WorkflowPreflightV1): Set<string> {
 	return new Set(preflight.lanes.map((lane) => lane.key));
 }
 
-function generatedByLane(entry: WorkflowTraceLike, laneKey: string): boolean {
-	return entry.generatedLaneKey === laneKey && entry.key.startsWith(`${laneKey}.`);
+/**
+ * Treat declared lane keys as plan roots: `lane` is the lane itself and
+ * `lane.stage` is a stage by convention, even without generated provenance.
+ */
+function declaredLaneCoversWorkflowKey(entry: WorkflowTraceLike, laneKey: string): boolean {
+	return entry.key === laneKey || entry.key.startsWith(`${laneKey}.`);
 }
 
 function keyCoveredByDeclaredLane(entry: WorkflowTraceLike, declared: ReadonlySet<string>): boolean {
-	if (declared.has(entry.key)) return true;
-	for (const laneKey of declared) if (generatedByLane(entry, laneKey)) return true;
+	for (const laneKey of declared) if (declaredLaneCoversWorkflowKey(entry, laneKey)) return true;
 	return false;
 }
 
@@ -182,7 +185,7 @@ export function workflowPreflightWarnings(
 	const launched = launchedEntries(trace);
 	const messages = launched.filter((entry) => !keyCoveredByDeclaredLane(entry, declared)).map((entry) => undeclaredWarning(entry.key));
 	if (options.settled === true) {
-		for (const lane of preflight.lanes) if (!launched.some((entry) => entry.key === lane.key || generatedByLane(entry, lane.key))) messages.push(unlaunchedWarning(lane.key));
+		for (const lane of preflight.lanes) if (!launched.some((entry) => declaredLaneCoversWorkflowKey(entry, lane.key))) messages.push(unlaunchedWarning(lane.key));
 	}
 	return warningLimit(messages);
 }
@@ -203,7 +206,15 @@ function laneCell(value: string | undefined): string {
 	return value ?? "—";
 }
 
-/** Render a bounded plain-text table suitable for tool/status/TUI output. */
+const WORKFLOW_PREFLIGHT_PLAN_LABEL_LENGTH = 96;
+
+function planLaneLabel(lane: WorkflowPreflightLaneV1): string {
+	const value = lane.decision?.trim() || lane.key;
+	if (value.length <= WORKFLOW_PREFLIGHT_PLAN_LABEL_LENGTH) return value;
+	return `${value.slice(0, WORKFLOW_PREFLIGHT_PLAN_LABEL_LENGTH - 1).trimEnd()}…`;
+}
+
+/** Render the detailed bounded table reserved for tool output and expanded/debug views. */
 export function formatWorkflowPreflight(preflight: WorkflowPreflightV1 | undefined, options: { indent?: string } = {}): string {
 	if (!preflight) return "";
 	const indent = options.indent ?? "";
@@ -230,6 +241,26 @@ export function formatWorkflowPreflightSummary(preflight: WorkflowPreflightV1 | 
 	const keys = preflight.lanes.slice(0, 4).map((lane) => lane.key).join(", ");
 	const remainder = preflight.lanes.length > 4 ? `, +${preflight.lanes.length - 4}` : "";
 	return `preflight · ${preflight.coverage} · ${preflight.lanes.length} lane${preflight.lanes.length === 1 ? "" : "s"}${keys ? `: ${keys}${remainder}` : ""}`;
+}
+
+/** Render the operator-facing one-line plan shown in routine status views. */
+export function formatWorkflowPreflightPlanSummary(preflight: WorkflowPreflightV1 | undefined, options: { indent?: string } = {}): string {
+	if (!preflight) return "";
+	const indent = options.indent ?? "";
+	const count = preflight.lanes.length;
+	const labels = count === 1
+		? planLaneLabel(preflight.lanes[0]!)
+		: preflight.lanes.slice(0, 4).map((lane) => lane.key).join(", ") + (count > 4 ? `, +${count - 4}` : "");
+	return `${indent}Plan: ${count} lane${count === 1 ? "" : "s"}${labels ? ` · ${labels}` : ""}`;
+}
+
+/** Render a bounded, non-alarming warning for routine status views. */
+export function formatWorkflowPreflightWarningSummary(warnings: readonly string[] | undefined, options: { indent?: string; hint?: string } = {}): string {
+	if (!warnings?.length) return "";
+	const indent = options.indent ?? "";
+	const hint = options.hint ?? "details available for debug";
+	const count = warnings.length;
+	return `${indent}Plan note: ${count} preflight mismatch${count === 1 ? "" : "es"} · ${hint}.`;
 }
 
 export function formatWorkflowPreflightWarnings(warnings: readonly string[] | undefined, options: { indent?: string } = {}): string {

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -206,9 +206,13 @@ describe("async status helpers", () => {
 
 			const runs = listAsyncRuns(root, { states: ["running"] });
 			const text = formatAsyncRunList(runs);
-			assert.match(text, /Preflight: v1 · complete · 1 lane/);
-			assert.match(text, /Preflight warnings:/);
-			assert.match(text, /workflow key 'review' launched without a declared lane/);
+			assert.match(text, /Plan: 1 lane · writer/);
+			assert.match(text, /Plan note: 1 preflight mismatch · details available for debug\./);
+			assert.doesNotMatch(text, /key \| mode \| decision \| claims \| expected output \| independence/);
+			assert.doesNotMatch(text, /Preflight warnings:/);
+			assert.doesNotMatch(text, /workflow key 'review' launched without a declared lane/);
+			assert.deepEqual(runs[0]?.preflight, { version: 1, coverage: "complete", lanes: [{ key: "writer", mode: "mutation" }] });
+			assert.deepEqual(runs[0]?.workflow?.preflightWarnings, ["Preflight advisory: workflow key 'review' launched without a declared lane."]);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -91,8 +91,8 @@ function resetWidgetLayout(): void {
 }
 
 describe("subagent async widget rendering", () => {
-	it("renders stored workflow preflight lanes without discovering external state", () => {
-		const text = buildWidgetLines([{
+	it("renders compact workflow plan status by default and keeps details expanded", () => {
+		const job = {
 			asyncId: "workflow-preflight",
 			asyncDir: "/tmp/workflow-preflight",
 			status: "running",
@@ -102,11 +102,26 @@ describe("subagent async widget rendering", () => {
 				coverage: "partial",
 				lanes: [{ key: "review", mode: "review", claims: ["src/tui"], expectedOutput: "review.md" }],
 			},
-			workflow: { trace: [], emits: [], console: [] },
-		}], theme, 180).join("\n");
-		assert.match(text, /Preflight: v1 · partial · 1 lane/);
-		assert.match(text, /review \| review \|/);
-		assert.match(text, /expected output \| independence/);
+			workflow: {
+				trace: [],
+				emits: [],
+				console: [],
+				preflightWarnings: ["Preflight advisory: workflow key 'review.extra' launched without a declared lane."],
+			},
+		};
+		const compact = buildWidgetLines([job], theme, 180).join("\n");
+		assert.match(compact, /Plan: 1 lane · review/);
+		assert.match(compact, /Plan note: 1 preflight mismatch · expand for debug\./);
+		assert.doesNotMatch(compact, /key \| mode \| decision \| claims \| expected output \| independence/);
+		assert.doesNotMatch(compact, /review \| review \|/);
+		assert.doesNotMatch(compact, /Preflight advisory/);
+
+		const expanded = buildWidgetLines([job], theme, 180, true).join("\n");
+		assert.match(expanded, /Preflight: v1 · partial · 1 lane/);
+		assert.match(expanded, /review \| review \|/);
+		assert.match(expanded, /expected output \| independence/);
+		assert.match(expanded, /Preflight warnings:/);
+		assert.match(expanded, /review\.extra.*without a declared lane/);
 	});
 
 	it("projects known workflow metadata into a compact lane row", () => {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1204,8 +1204,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			undefined,
 			context,
 		);
-		assert.match(statusResult.content[0]?.text ?? "", /Preflight: v1 · complete · 1 lane/);
-		assert.match(statusResult.content[0]?.text ?? "", /work \| mutation \|/);
+		assert.match(statusResult.content[0]?.text ?? "", /Plan: 1 lane · work/);
+		assert.doesNotMatch(statusResult.content[0]?.text ?? "", /key \| mode \| decision \| claims \| expected output \| independence/);
+		assert.deepEqual(statusResult.details.preflight, { version: 1, coverage: "complete", lanes: [{ key: "work", mode: "mutation", claims: ["src/work.ts"], expectedOutput: "child report" }] });
 		assert.equal(status.steps?.length, 1);
 		assert.deepEqual(status.steps?.map(({ agent, sessionName, label, phase, workflowKey }) => ({ agent, sessionName, label, phase, workflowKey })), [
 			{ agent: "echo", sessionName: "echo: Async work", label: "Run async child", phase: "Execution", workflowKey: "work" },

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -111,6 +111,16 @@ test("widget render keys keep compact payloads quiet and expanded payloads fresh
 	const nestedVisibleChange = structuredClone(job);
 	nestedVisibleChange.nestedChildren = [{ id: "nested-1", parentRunId: "workflow-1", depth: 1, path: [{ runId: "workflow-1" }], state: "failed", agent: "nested", error: "failed" }];
 	assert.notEqual(widgetRenderKey(nestedVisibleChange), widgetRenderKey(job));
+
+	const preflightJob: AsyncJobState = {
+		...job,
+		preflight: { version: 1, coverage: "complete", lanes: [{ key: "writer", decision: "Implement change" }] },
+		workflow: { trace: [], emits: [], console: [], preflightWarnings: ["first mismatch"] },
+	};
+	const warningDetailChange = structuredClone(preflightJob);
+	warningDetailChange.workflow!.preflightWarnings = ["different mismatch"];
+	assert.equal(widgetRenderKey(warningDetailChange), widgetRenderKey(preflightJob));
+	assert.notEqual(widgetRenderKey(warningDetailChange, true), widgetRenderKey(preflightJob, true));
 });
 
 test("multiline rendering omits two-column graphemes at one-column width", () => {

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -322,10 +322,85 @@ describe("workflow chat progress rendering", () => {
 			},
 		}, { expanded: false }, theme as any));
 		assert.match(text, /planned\s+writer/);
-		assert.match(text, /mode:mutation/);
 		assert.match(text, /planned\s+review/);
-		assert.match(text, /expected:review\.md/);
+		assert.doesNotMatch(text, /mode:mutation/);
+		assert.doesNotMatch(text, /expected:review\.md/);
 		assert.doesNotMatch(text, /waiting for workflow child launches/);
+
+		const expanded = componentText(renderSubagentResult({
+			content: [{ type: "text", text: "Workflow running." }],
+			details: {
+				mode: "workflow",
+				runId: "wf_planned",
+				results: [],
+				preflight,
+				chatProgress: { mode: "live-card", repoRelation: "same", repoLabel: "pi-subagents" },
+				workflow: { trace: [], emits: [], console: [] },
+			},
+		}, { expanded: true }, theme as any));
+		assert.match(expanded, /mode:mutation/);
+		assert.match(expanded, /expected:review\.md/);
+	});
+
+	it("uses the compact plan preview for collapsed workflow launch output", () => {
+		const preflight = {
+			version: 1 as const,
+			coverage: "complete" as const,
+			lanes: [{ key: "writer", mode: "mutation" as const, decision: "Implement the change" }],
+		};
+		const output = "Preflight: v1 · complete · 1 lane\n  key | mode | decision | claims | expected output | independence\n  writer | mutation | Implement the change | — | — | —\n\nAsync workflow [wf_launch] started.";
+		const result = {
+			content: [{ type: "text" as const, text: output }],
+			details: { mode: "workflow" as const, runId: "wf_launch", results: [], preflight },
+		};
+		const compact = componentText(renderSubagentResult(result, { expanded: false }, theme as any));
+		assert.match(compact, /Plan: 1 lane · Implement the change/);
+		assert.doesNotMatch(compact, /Preflight: v1/);
+		assert.doesNotMatch(compact, /key \| mode \| decision/);
+
+		const expanded = componentText(renderSubagentResult(result, { expanded: true }, theme as any));
+		assert.match(expanded, /Preflight: v1 · complete · 1 lane/);
+		assert.match(expanded, /key \| mode \| decision/);
+	});
+
+	it("keeps each expanded preflight warning visible as a bounded row", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "Workflow running." }],
+			details: {
+				mode: "workflow" as const,
+				runId: "wf_warning_rows",
+				results: [],
+				preflight: { version: 1 as const, coverage: "complete" as const, lanes: [{ key: "writer", mode: "mutation" as const }] },
+				chatProgress: { mode: "live-card" as const, repoRelation: "same" as const, repoLabel: "pi-subagents" },
+				workflow: {
+					trace: [{ operation: "run" as const, key: "writer", state: "started" as const }],
+					emits: [],
+					console: [],
+					preflightWarnings: [
+						`Preflight advisory: first warning ${"x".repeat(120)}`,
+						`Preflight advisory: second warning ${"y".repeat(120)}`,
+					],
+				},
+			},
+		};
+		const originalColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+		Object.defineProperty(process.stdout, "columns", { configurable: true, value: 56 });
+		try {
+			const expanded = renderSubagentResult(result, { expanded: true }, theme as any).render(56);
+			assert.ok(expanded.some((line) => line.includes("Preflight warnings:")));
+			const warningRows = expanded.filter((line) => line.includes("- Preflight advisory"));
+			assert.equal(warningRows.length, 2);
+			assert.match(warningRows[0]!, /first warning/);
+			assert.match(warningRows[1]!, /second warning/);
+			assert.ok(warningRows.every((line) => line.trimEnd().length <= 52));
+
+			const compact = renderSubagentResult(result, { expanded: false }, theme as any).render(56);
+			assert.equal(compact.filter((line) => line.includes("Plan note:")).length, 1);
+			assert.doesNotMatch(compact.join("\n"), /first warning|second warning/);
+		} finally {
+			if (originalColumns) Object.defineProperty(process.stdout, "columns", originalColumns);
+			else delete (process.stdout as { columns?: number }).columns;
+		}
 	});
 
 	it("keeps mixed detached and failed workflow traces failed", () => {

--- a/test/unit/workflow-preflight.test.ts
+++ b/test/unit/workflow-preflight.test.ts
@@ -8,7 +8,9 @@ import {
 	WORKFLOW_PREFLIGHT_MAX_WARNINGS,
 	annotateWorkflowPreflightTrace,
 	formatWorkflowPreflight,
+	formatWorkflowPreflightPlanSummary,
 	formatWorkflowPreflightSummary,
+	formatWorkflowPreflightWarningSummary,
 	normalizeWorkflowPreflight,
 	validateWorkflowPreflight,
 	workflowPreflightWarnings,
@@ -54,6 +56,8 @@ describe("workflow preflight metadata", () => {
 		assert.match(table, /key \| mode \| decision \| claims \| expected output \| independence/);
 		assert.match(table, /issue1624-writer \| mutation \| Implement bounded preflight/);
 		assert.match(formatWorkflowPreflightSummary(normalized), /preflight · complete · 1 lane: issue1624-writer/);
+		assert.equal(formatWorkflowPreflightPlanSummary(normalized), "Plan: 1 lane · Implement bounded preflight");
+		assert.equal(formatWorkflowPreflightWarningSummary(["one", "two"], { indent: "  ", hint: "expand for debug" }), "  Plan note: 2 preflight mismatches · expand for debug.");
 	});
 
 	it("rejects unsupported, malformed, duplicate, and over-bound metadata", () => {
@@ -117,34 +121,32 @@ describe("workflow preflight metadata", () => {
 		assert.ok(WORKFLOW_PREFLIGHT_MAX_CLAIMS > 0);
 	});
 
-	it("covers only proven generated runs.lanes stages", () => {
+	it("treats exact and direct dotted keys as declared lane stages by convention", () => {
 		const lanes = normalizeWorkflowPreflight({
 			version: 1,
 			coverage: "complete",
 			lanes: [{ key: "audit" }],
 		});
-		const generatedTrace = [
+		const generatedStageTrace = [
 			{ operation: "run", key: "audit.writer", generatedLaneKey: "audit", state: "completed" as const },
 			{ operation: "run", key: "audit.review", generatedLaneKey: "audit", state: "completed" as const },
 		];
-		assert.deepEqual(workflowPreflightWarnings(lanes, generatedTrace, { settled: true }), []);
-		assert.equal(annotateWorkflowPreflightTrace(generatedTrace, lanes).some((entry) => entry.warning), false);
+		assert.deepEqual(workflowPreflightWarnings(lanes, generatedStageTrace, { settled: true }), []);
+		assert.equal(annotateWorkflowPreflightTrace(generatedStageTrace, lanes).some((entry) => entry.warning), false);
 
-		const directTrace = [
+		// Direct runs.run keys intentionally use the same lane.stage convention without provenance.
+		const directStageTrace = [
 			{ operation: "run", key: "audit.shadow", state: "started" as const },
 			{ operation: "run", key: "audit-other.writer", state: "started" as const },
 		];
-		assert.deepEqual(workflowPreflightWarnings(lanes, directTrace), [
-			"Preflight advisory: workflow key 'audit.shadow' launched without a declared lane.",
+		assert.deepEqual(workflowPreflightWarnings(lanes, directStageTrace), [
 			"Preflight advisory: workflow key 'audit-other.writer' launched without a declared lane.",
 		]);
-		assert.deepEqual(workflowPreflightWarnings(lanes, directTrace, { settled: true }), [
-			"Preflight advisory: workflow key 'audit.shadow' launched without a declared lane.",
+		assert.deepEqual(workflowPreflightWarnings(lanes, directStageTrace, { settled: true }), [
 			"Preflight advisory: workflow key 'audit-other.writer' launched without a declared lane.",
-			"Preflight advisory: declared lane 'audit' was not launched.",
 		]);
-		const directAnnotated = annotateWorkflowPreflightTrace(directTrace, lanes);
-		assert.match(directAnnotated[0]?.warning ?? "", /without a declared lane/);
+		const directAnnotated = annotateWorkflowPreflightTrace(directStageTrace, lanes);
+		assert.equal(directAnnotated[0]?.warning, undefined);
 		assert.match(directAnnotated[1]?.warning ?? "", /without a declared lane/);
 
 		const exactTrace = [{ operation: "run", key: "audit", state: "completed" as const }];


### PR DESCRIPTION
Closes #1668.

This compacts workflow preflight plan output in default TUI and status surfaces while keeping the full table and advisory details available in expanded/detail paths. It also applies the accepted delimiter-bound `lane.stage` convention so declared lanes cover their staged workflow child keys without adding a new schema.

Validation:
- `node --experimental-strip-types --test test/unit/workflow-chat-progress.test.ts test/unit/render-helpers.test.ts test/unit/workflow-preflight.test.ts test/integration/async-status.test.ts test/integration/render-widget.test.ts test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- Fresh reviews: `No issues found` for implementation and final changelog delta.