### PR TITLE
fix: ignore stale cached UI contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Ignore stale cached UI contexts during background status refresh and session lifecycle cleanup (#1670).
 - Compact workflow preflight status in default TUI/status views while keeping full details available when expanded (#1668).
 - Give `runs.lanes(...)` stage-0 retained-resume validation actionable `runs.run(...)` guidance instead of a generic error (#1657).
 - Remove the remaining `lane:` prefix from operator-facing async status rows in the TUI (#1658).

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -26,6 +26,7 @@ import { ensureAccessibleDir } from "../shared/accessible-dir.ts";
 import { cleanupAllArtifactDirs, cleanupOldArtifacts, getArtifactsDir } from "../shared/artifacts.ts";
 import { resolveCurrentSessionId } from "../shared/session-identity.ts";
 import { getAgentDir } from "../shared/utils.ts";
+import { isStaleExtensionContextError, withCachedUiContext } from "../shared/extension-context.ts";
 import { currentCompletionOwnerId } from "../shared/completion-owner.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
 import { clearLegacyResultAnimationTimer, renderSubagentResult, renderSubagentSummary } from "../tui/render.ts";
@@ -302,12 +303,6 @@ function isSlashResultError(result: { details?: Details }): boolean {
 	return result.details?.results.some((entry) => entry.exitCode !== 0 && entry.progress?.status !== "running") || false;
 }
 
-function isStaleExtensionContextError(error: unknown): boolean {
-	return error instanceof Error
-		&& (error.message.includes("This extension ctx is stale")
-			|| error.message.includes("Extension context no longer active"));
-}
-
 function rebuildSlashResultContainer(
 	container: Container,
 	result: AgentToolResult<Details>,
@@ -476,6 +471,12 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			clear: () => {},
 		},
 	};
+	const withLastUiContext = <T>(run: (ctx: ExtensionContext) => T): T | undefined => {
+		const cached = state.lastUiContext;
+		return withCachedUiContext(cached, () => {
+			if (state.lastUiContext === cached) state.lastUiContext = null;
+		}, run);
+	};
 
 	const supervisorChannel = createNativeSupervisorChannel(pi, state);
 	const waitSubscriptionManager = createWaitSubscriptionManager(pi, state);
@@ -484,9 +485,17 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch, ownership: resultDeliveryOwnership });
 	const fleetStatus = fleetViewEnabled
 		? new SubagentFleetStatus(state, async (itemKey) => {
-			const ctx = state.lastUiContext;
-			if (!ctx?.hasUI) return;
-			await openSubagentFleet(ctx, state, { initialKey: itemKey, asyncDirRoot: DIRS.async, resultsDir: DIRS.results, fleetKeybindings: config.fleetKeybindings });
+			const ctx = withLastUiContext((current) => current);
+			if (!ctx) return;
+			try {
+				await openSubagentFleet(ctx, state, { initialKey: itemKey, asyncDirRoot: DIRS.async, resultsDir: DIRS.results, fleetKeybindings: config.fleetKeybindings });
+			} catch (error) {
+				if (isStaleExtensionContextError(error)) {
+					if (state.lastUiContext === ctx) state.lastUiContext = null;
+					return;
+				}
+				throw error;
+			}
 		}, { placement: fleetViewPlacement })
 		: undefined;
 	let executorScheduled: ((id: string, params: SubagentParamsLike, signal: AbortSignal, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
@@ -849,14 +858,13 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const suspendWidgetsForCompaction = () => {
 		if (state.widgetsSuspended) return;
 		state.widgetsSuspended = true;
-		if (state.lastUiContext?.hasUI) state.lastUiContext.ui.setWidget(WIDGET_KEY, undefined);
+		withLastUiContext((ctx) => ctx.ui.setWidget(WIDGET_KEY, undefined));
 		fleetStatus?.refresh();
 	};
 	const resumeWidgetsAfterCompaction = () => {
 		if (!state.widgetsSuspended) return;
 		state.widgetsSuspended = false;
-		const ctx = state.lastUiContext;
-		if (ctx?.hasUI) refreshWidget(ctx);
+		withLastUiContext((ctx) => refreshWidget(ctx));
 		fleetStatus?.refresh();
 	};
 
@@ -1051,7 +1059,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	pi.on("session_compact", () => {
 		const hasActiveAsyncWork = [...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running");
-		if (!hasActiveAsyncWork || state.lastUiContext?.hasUI !== true) return;
+		if (!hasActiveAsyncWork || !withLastUiContext(() => true)) return;
 		pi.sendMessage(
 			{
 				customType: "subagent-compaction-resume",

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -26,6 +26,7 @@ import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequests } fro
 import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { validHostStepNodes } from "../shared/host-step-status.ts";
+import { withCachedUiContext } from "../../shared/extension-context.ts";
 
 interface AsyncJobTrackerOptions {
 	completionRetentionMs?: number;
@@ -79,23 +80,19 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const watch = options.watch ?? fs.watch;
 	const useNativeWatcher = () => shouldUseNativeFsWatch("async-job-tracker", options.platform);
 	const terminalStatus = (status: string) => status === "complete" || status === "failed" || status === "paused" || status === "stopped";
+	const withLastUiContext = <T>(run: (ctx: ExtensionContext) => T): T | undefined => {
+		const cached = state.lastUiContext;
+		return withCachedUiContext(cached, () => {
+			if (state.lastUiContext === cached) state.lastUiContext = null;
+		}, run);
+	};
 	const rerenderWidget = (ctx: ExtensionContext, jobs = Array.from(state.asyncJobs.values())) => {
 		if (state.widgetsSuspended) return;
 		renderWidget(ctx, options.widgetEnabled === false ? [] : jobs);
 		(ctx.ui as { requestRender?: () => void }).requestRender?.();
 	};
 	const rerenderLastWidget = (jobs = Array.from(state.asyncJobs.values())) => {
-		const ctx = state.lastUiContext;
-		if (!ctx) return;
-		try {
-			if (ctx.hasUI) rerenderWidget(ctx, jobs);
-		} catch (error) {
-			if (error instanceof Error && error.message.includes("extension ctx is stale")) {
-				state.lastUiContext = null;
-				return;
-			}
-			throw error;
-		}
+		withLastUiContext((ctx) => rerenderWidget(ctx, jobs));
 	};
 	const requestLastWidgetRender = () => {
 		if (options.widgetEnabled === false) return;
@@ -345,7 +342,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	};
 
 	const refreshJob = (job: AsyncJobState): boolean => {
-		const widgetExpanded = state.lastUiContext?.hasUI ? state.lastUiContext.ui.getToolsExpanded?.() ?? false : false;
+		const widgetExpanded = withLastUiContext((ctx) => ctx.ui.getToolsExpanded?.() ?? false) ?? false;
 		const widgetStateBefore = widgetRenderKey(job, widgetExpanded);
 		let nestedRefreshFailed = false;
 		const refreshNestedProjection = () => {

--- a/src/shared/extension-context.ts
+++ b/src/shared/extension-context.ts
@@ -1,0 +1,24 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+/** Pi exposes replaced extension contexts as ordinary Errors without a stable code. */
+export function isStaleExtensionContextError(error: unknown): boolean {
+	return error instanceof Error
+		&& /extension ctx is stale|extension context no longer active|stale after session replacement or reload/i.test(error.message);
+}
+
+/** Run a synchronous operation against a cached UI context without leaking replacement errors. */
+export function withCachedUiContext<T>(
+	ctx: ExtensionContext | null | undefined,
+	onStale: () => void,
+	run: (ctx: ExtensionContext) => T,
+): T | undefined {
+	if (!ctx) return undefined;
+	try {
+		if (!ctx.hasUI) return undefined;
+		return run(ctx);
+	} catch (error) {
+		if (!isStaleExtensionContextError(error)) throw error;
+		onStale();
+		return undefined;
+	}
+}

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -6,6 +6,7 @@ import type { AsyncJobState, AsyncJobStep, FleetViewPlacement, HerdrProjectPaneS
 import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
 import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
+import { isStaleExtensionContextError } from "../shared/extension-context.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
 
@@ -239,13 +240,6 @@ function fleetTreeRows(entries: FleetStatusEntry[]): FleetTreeRow[] {
 		for (const [index, row] of nested.entries()) rows.push({ kind: "nested", ownerKey: entry.key, row, last: index === nested.length - 1 });
 	}
 	return rows;
-}
-
-function isStaleExtensionContextError(error: unknown): boolean {
-	// Pi currently exposes stale contexts as plain Errors without a stable code or subtype.
-	return error instanceof Error
-		&& (error.message.includes("This extension ctx is stale")
-			|| error.message.includes("Extension context no longer active"));
 }
 
 function foregroundDescription(control: { parentWorkflowRunId?: string; workflowKey?: string }, description: string | undefined): string | undefined {
@@ -846,7 +840,13 @@ export class SubagentFleetStatus {
 
 	private clearWidget(): void {
 		if (!this.widgetRegistered) return;
-		this.ui?.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
+		try {
+			this.ui?.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
+		} catch (error) {
+			if (!isStaleExtensionContextError(error)) throw error;
+			this.clearUiRegistration();
+			return;
+		}
 		this.widgetRegistered = false;
 		this.tui = undefined;
 	}

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -156,6 +156,40 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
+	it("clears stale cached contexts before a status refresh can leak the error", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-stale-refresh-");
+		try {
+			const runDir = path.join(asyncRoot, "run-stale-refresh");
+			fs.mkdirSync(runDir, { recursive: true });
+			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: "run-stale-refresh",
+				mode: "single",
+				state: "running",
+				startedAt: Date.now(),
+				lastUpdate: Date.now(),
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+				watch: (() => { throw new Error("watch disabled"); }) as never,
+			});
+			tracker.handleStarted({ id: "run-stale-refresh", asyncDir: runDir, agent: "worker" });
+			(state as { lastUiContext: unknown }).lastUiContext = {
+				get hasUI() {
+					throw new Error("This extension ctx is stale after session replacement or reload.");
+				},
+			};
+
+			await waitForCondition(() => state.lastUiContext === null, "stale cached context to clear during status refresh");
+			assert.equal(state.asyncJobs.get("run-stale-refresh")?.status, "running");
+		} finally {
+			removeTempDir(asyncRoot);
+		}
+	});
+
 	it("stores only parent-registered session roots from async start events", () => {
 		const asyncRoot = createTempDir("pi-async-job-tracker-session-root-");
 		try {

--- a/test/unit/compaction-resume.test.ts
+++ b/test/unit/compaction-resume.test.ts
@@ -68,4 +68,31 @@ describe("async compaction resume", () => {
 		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
 		assert.ok(true);
 	});
+
+	it("ignores stale cached UI context during compaction lifecycle callbacks", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./index.ts";
+			const handlers = new Map();
+			const events = { listeners: new Map(), on(name, handler) { this.listeners.set(name, handler); return () => this.listeners.delete(name); }, emit(name, payload) { this.listeners.get(name)?.(payload); } };
+			const pi = new Proxy({
+				events,
+				on(name, handler) { handlers.set(name, handler); },
+				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage() {}, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			let stale = false;
+			const ctx = { cwd: process.cwd(), get hasUI() { if (stale) throw new Error("This extension ctx is stale after session replacement or reload."); return true; }, ui: { setWidget() {}, requestRender() {}, onTerminalInput() { return () => {}; }, getEditorText() { return ""; }, notify() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } }, sessionManager: { getSessionId() { return "stale-context-session"; }, getSessionFile() { return null; }, getEntries() { return []; } }, modelRegistry: { getAvailable() { return []; } } };
+			registerSubagentExtension(pi);
+			handlers.get("session_start")({}, ctx);
+			events.emit("subagent:async-started", { id: "running", sessionId: "stale-context-session", mode: "single", agent: "worker", asyncDir: "/tmp/pi-stale-context-running" });
+			stale = true;
+			handlers.get("session_compact")({ reason: "threshold" });
+			handlers.get("session_before_compact")({ reason: "threshold", signal: new AbortController().signal });
+			await handlers.get("session_shutdown")();
+		`;
+		const env = { ...process.env };
+		delete env.PI_SUBAGENT_CHILD;
+		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env, stdio: "pipe" });
+		assert.ok(true);
+	});
 });

--- a/test/unit/extension-context.test.ts
+++ b/test/unit/extension-context.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { withCachedUiContext } from "../../src/shared/extension-context.ts";
+
+describe("cached extension UI context", () => {
+	it("clears a context replaced by session reload and returns no UI result", () => {
+		let cleared = false;
+		const result = withCachedUiContext({
+			get hasUI() {
+				throw new Error("This extension ctx is stale after session replacement or reload.");
+			},
+		} as never, () => {
+			cleared = true;
+		}, () => "unreachable");
+
+		assert.equal(result, undefined);
+		assert.equal(cleared, true);
+	});
+
+	it("does not hide non-stale context errors", () => {
+		assert.throws(() => withCachedUiContext({
+			get hasUI() {
+				throw new Error("UI bridge unavailable");
+			},
+		} as never, () => {}, () => "unreachable"), /UI bridge unavailable/);
+	});
+});


### PR DESCRIPTION
Closes #1670.

This fixes the pi-subagents-owned stale cached `ExtensionContext` paths that can run during background status refresh and compaction lifecycle callbacks. The host `bash` tool is outside this repository, so this does not claim to fix every host-level stale-context failure. It prevents the proven cached UI/status paths from leaking stale-context errors while preserving non-stale error signals.

Validation:
- `npm run test:unit`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/extension-context.test.ts test/unit/compaction-resume.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/fleet-status.test.ts`
- `npm run typecheck`
- `git diff --check HEAD^ HEAD`
- Fresh review: `No issues found`.