### PR TITLE
fix: harden workflow status settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Show workflow child labels and phases in async status progress while preserving stable workflow keys.
 
 ### Fixed
+- Match detached workflow completion by exact child identity, preserve host gate rows in bounded snapshots, and report missing host verdicts as inconclusive.
 - Ignore stale cached UI contexts during background status refresh and session lifecycle cleanup (#1670).
 - Compact workflow preflight status in default TUI/status views while keeping full details available when expanded (#1668).
 - Give `runs.lanes(...)` stage-0 retained-resume validation actionable `runs.run(...)` guidance instead of a generic error (#1657).

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -6564,9 +6564,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						? deriveChildSessionName({ agent: singleTask.agent, task: singleTask.task })
 						: undefined;
 				const launch = hasSingle
-					? { agent: effectiveParams.agent!, ...(singleSessionName ? { sessionName: singleSessionName } : {}), sessionFile: childSessionFileForTask(effectiveParams.agent!, 0, effectiveParams.model), async: effectiveAsync, ...(effectiveAsync ? { runId: asyncRunId } : {}) }
+					? { agent: effectiveParams.agent!, ...(singleSessionName ? { sessionName: singleSessionName } : {}), sessionFile: childSessionFileForTask(effectiveParams.agent!, 0, effectiveParams.model), async: effectiveAsync, runId: effectiveAsync ? asyncRunId : runId }
 					: singleTask
-						? { agent: singleTask.agent, ...(singleSessionName ? { sessionName: singleSessionName } : {}), sessionFile: childSessionFileForTask(singleTask.agent, 0, singleTask.model), async: effectiveAsync, ...(effectiveAsync ? { runId: asyncRunId } : {}) }
+						? { agent: singleTask.agent, ...(singleSessionName ? { sessionName: singleSessionName } : {}), sessionFile: childSessionFileForTask(singleTask.agent, 0, singleTask.model), async: effectiveAsync, runId: effectiveAsync ? asyncRunId : runId }
 						: undefined;
 				if (launch) {
 					workflowLaunchObservers.delete(params);

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -180,6 +180,16 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 	const asyncDir = job?.asyncDir ?? path.join(DIRS.async, input.workflowRunId);
 	const status = readStatus(asyncDir);
 	if (!status) return false;
+	const matchingControls = input.workflowKey === undefined ? [] : [...(input.state.foregroundControls?.values() ?? [])].filter((control) =>
+		control.parentWorkflowRunId === input.workflowRunId && control.workflowKey === input.workflowKey
+	);
+	const confirmedLiveIdentity = matchingControls.length === 1 && matchingControls[0]?.runId === input.childRunId;
+	if (confirmedLiveIdentity) {
+		const candidates = status.steps?.filter((candidate) => candidate.workflowKey === input.workflowKey) ?? [];
+		const candidate = candidates.length === 1 ? candidates[0] : undefined;
+		if (candidate && candidate.runId === undefined && candidate.sessionFile === undefined
+			&& candidate.status === "paused" && candidate.activityState === "needs_attention") candidate.runId = input.childRunId;
+	}
 	const next = applyDetachedChildToPausedWorkflow(status, {
 		childRunId: input.childRunId,
 		result: input.result,
@@ -188,7 +198,7 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 	if (!next) return false;
 	const outputReference = input.result.savedOutputPath ?? input.result.outputReference?.path;
 	const outputPathMapping = outputPathMappingFromTask(input.result.task, outputReference);
-	const settledStep = findWorkflowSettlementStep(next, input.childRunId, input.workflowKey);
+	const settledStep = findWorkflowSettlementStep(next, input.childRunId);
 	if (settledStep && outputPathMapping) settledStep.outputPathMapping = outputPathMapping;
 	const resultPath = resultFilePath(DIRS.results, input.workflowRunId);
 	let existing: Record<string, unknown> | undefined;

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -263,7 +263,7 @@ function hostStepSnapshotState(state: HostStepState, verdict: HostStepVerdict | 
 	if (state === "running") return "running";
 	if (state === "cancelled") return "stopped";
 	if (state === "error" || verdict === "fail") return "failed";
-	return verdict === "inconclusive" ? "partial" : "complete";
+	return verdict === undefined || verdict === "inconclusive" ? "partial" : "complete";
 }
 
 function projectHostStep(hostStep: HostStepNodeV1, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
@@ -312,8 +312,12 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnap
 		const stepChildren = job.steps?.map((step, index) => projectStep(step, step.index ?? index, 1, ctx)) ?? [];
 		const nestedChildren = job.nestedChildren?.map((child, index) => projectNestedRun(child, index, 1, ctx)) ?? [];
 		const hostStepChildren = validHostStepList(job.hostSteps).map((hostStep) => projectHostStep(hostStep, ctx));
+		const ordinaryChildren = [...stepChildren, ...nestedChildren];
+		const retainedHostSteps = hostStepChildren.slice(0, ctx.caps.maxChildrenPerNode);
+		const retainedOrdinaryChildren = ordinaryChildren.slice(0, ctx.caps.maxChildrenPerNode - retainedHostSteps.length);
 		const bounded: AsyncStatusSnapshotNodeV1[] = [];
-		appendBoundedChildren(bounded, [...stepChildren, ...nestedChildren, ...hostStepChildren], ctx);
+		bounded.push(...retainedOrdinaryChildren, ...retainedHostSteps);
+		ctx.omitted.children += ordinaryChildren.length - retainedOrdinaryChildren.length + hostStepChildren.length - retainedHostSteps.length;
 		if (bounded.length) node.children = bounded;
 	} else {
 		ctx.omitted.children += (job.steps?.length ?? 0) + (job.nestedChildren?.length ?? 0) + validHostStepList(job.hostSteps).length;
@@ -398,12 +402,16 @@ export function projectAsyncWorkflowRows(
 	const hostSteps = isWorkflowPreflight(hostStepsOrPreflight) ? undefined : hostStepsOrPreflight;
 	const loaded = steps ?? [];
 	const declared = new Map<string, WorkflowPreflightLaneV1>();
+	const loadedIndexByKey = new Map<string, number>();
+	for (const [index, step] of loaded.entries()) {
+		if (step.workflowKey !== undefined && !loadedIndexByKey.has(step.workflowKey)) loadedIndexByKey.set(step.workflowKey, index);
+	}
 	const consumed = new Set<number>();
 	const childRows: AsyncStatusWorkflowRow[] = [];
 	for (const lane of preflight?.lanes ?? []) {
 		declared.set(lane.key, lane);
-		const index = loaded.findIndex((step) => step.workflowKey === lane.key);
-		if (index < 0) {
+		const index = loadedIndexByKey.get(lane.key);
+		if (index === undefined) {
 			childRows.push({ name: lane.key, state: "planned", preflight: lane });
 			continue;
 		}

--- a/src/runs/shared/host-step-status.ts
+++ b/src/runs/shared/host-step-status.ts
@@ -87,7 +87,6 @@ export function assertHostStepNode(value: unknown, source = "status"): asserts v
 	if (value.verdict !== undefined && value.verdict !== "pass" && value.verdict !== "fail" && value.verdict !== "inconclusive") {
 		throw new Error(`Invalid host step '${source}': verdict is invalid.`);
 	}
-	if (value.state === "done" && value.verdict === undefined) throw new Error(`Invalid host step '${source}': done state requires a verdict.`);
 	if (value.state !== "done" && value.verdict !== undefined) throw new Error(`Invalid host step '${source}': verdict is only valid for done state.`);
 	assertBoundedString(value.reasonCode, "reasonCode", HOST_STEP_MAX_REASON_CHARS, source);
 	assertBoundedString(value.detail, "detail", HOST_STEP_MAX_DETAIL_CHARS, source);
@@ -177,6 +176,7 @@ function workflowNodeStatus(hostStep: HostStepNodeV1): WorkflowNodeStatus {
 	if (hostStep.state === "running") return "running";
 	if (hostStep.state === "cancelled") return "stopped";
 	if (hostStep.state === "error") return "failed";
+	if (hostStep.verdict === undefined || hostStep.verdict === "inconclusive") return "partial";
 	return hostStep.verdict === "fail" ? "failed" : "completed";
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -40,7 +40,7 @@ export interface ChainOutputMapEntry {
 
 export type ChainOutputMap = Record<string, ChainOutputMapEntry>;
 
-export type WorkflowNodeStatus = "pending" | "running" | "completed" | "failed" | "paused" | "stopped" | "detached" | "rejected";
+export type WorkflowNodeStatus = "pending" | "running" | "completed" | "failed" | "partial" | "paused" | "stopped" | "detached" | "rejected";
 
 export type HostStepMonitorKind = "command" | "ci" | "gate";
 export type HostStepState = "pending" | "running" | "done" | "cancelled" | "error";

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -649,7 +649,7 @@ function resultStatusLine(result: Details["results"][number], output: string): s
 
 type ResultPresentation = {
 	glyph: string;
-	label: "running" | "detached" | "stopped" | "paused" | "failed" | "completed";
+	label: "running" | "detached" | "stopped" | "paused" | "failed" | "partial" | "completed";
 	tone: "accent" | "warning" | "error" | "success";
 };
 
@@ -659,6 +659,7 @@ function semanticResultPresentation(input: {
 	stopped?: boolean;
 	interrupted?: boolean;
 	failed?: boolean;
+	partial?: boolean;
 	completedWithoutOutput?: boolean;
 	seed?: number;
 	frame?: number;
@@ -671,6 +672,7 @@ function semanticResultPresentation(input: {
 	if (input.stopped) return { glyph: "■", label: "stopped", tone: "warning" };
 	if (input.interrupted) return { glyph: "■", label: "paused", tone: "warning" };
 	if (input.failed) return { glyph: "✗", label: "failed", tone: "error" };
+	if (input.partial) return { glyph: "■", label: "partial", tone: "warning" };
 	return { glyph: "✓", label: "completed", tone: input.completedWithoutOutput ? "warning" : "success" };
 }
 
@@ -2102,6 +2104,7 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 		|| workflowGraphHasStatus(d, ["failed"]);
 	const paused = d.results.some((r) => r.interrupted)
 		|| workflowGraphHasStatus(d, ["paused"]);
+	const partial = workflowGraphHasStatus(d, ["partial"]);
 	let totalSummary = d.progressSummary;
 	if (!totalSummary) {
 		let sawProgress = false;
@@ -2125,6 +2128,7 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 		stopped,
 		interrupted: paused,
 		failed,
+		partial,
 		seed: runningSeed(progressRunningSeed(totalSummary), d.currentStepIndex),
 		frame,
 	});
@@ -2228,7 +2232,8 @@ export function renderSubagentSummary(
 	const failed = result.isError === true
 		|| results.some((entry) => !hasTerminalResultFlag(entry) && entry.exitCode !== 0 && !isResultRunning(entry))
 		|| Boolean(details && workflowGraphHasStatus(details, ["failed"]));
-	const state = running ? "running" : failed ? "failed" : stopped ? "stopped" : paused ? "paused" : "completed";
+	const partial = Boolean(details && workflowGraphHasStatus(details, ["partial"]));
+	const state = running ? "running" : failed ? "failed" : stopped ? "stopped" : paused ? "paused" : partial ? "partial" : "completed";
 	const glyph = state === "running"
 		? theme.fg("accent", STATIC_RUNNING_GLYPH)
 		: state === "completed"
@@ -2398,6 +2403,7 @@ export function renderSubagentResult(
 		|| workflowGraphHasStatus(d, ["failed"]);
 	const paused = d.results.some((r) => r.interrupted)
 		|| workflowGraphHasStatus(d, ["paused"]);
+	const partial = workflowGraphHasStatus(d, ["partial"]);
 	const completedWithoutOutput = d.results.some((r) =>
 		!hasTerminalResultFlag(r)
 		&& r.exitCode === 0
@@ -2410,6 +2416,7 @@ export function renderSubagentResult(
 		stopped,
 		interrupted: paused,
 		failed,
+		partial,
 		completedWithoutOutput,
 		frame,
 	}), theme);

--- a/src/workflows/workflow-settlement.ts
+++ b/src/workflows/workflow-settlement.ts
@@ -73,9 +73,13 @@ function withWorkflowChildren(status: AsyncStatus): AsyncStatus {
 	};
 }
 
-export function findWorkflowSettlementStep(status: AsyncStatus, childRunId: string, workflowKey?: string): WorkflowStatusStep | undefined {
-	return status.steps?.find((candidate) => candidate.runId === childRunId)
-		?? (workflowKey ? status.steps?.find((candidate) => candidate.workflowKey === workflowKey) : undefined) as WorkflowStatusStep | undefined;
+export function findWorkflowSettlementStep(status: AsyncStatus, childRunId: string, workflowKey?: string, sessionFile?: string): WorkflowStatusStep | undefined {
+	const exact = status.steps?.find((candidate) => candidate.runId === childRunId);
+	if (exact || !workflowKey || !sessionFile) return exact;
+	const candidates = status.steps?.filter((candidate) => candidate.runId === undefined
+		&& candidate.workflowKey === workflowKey
+		&& candidate.sessionFile === sessionFile) ?? [];
+	return candidates.length === 1 ? candidates[0] : undefined;
 }
 
 export function promoteSettledPausedWorkflow(status: AsyncStatus, now = Date.now()): AsyncStatus | undefined {
@@ -101,8 +105,9 @@ export function applyDetachedChildSettlement(
 ): AsyncStatus | undefined {
 	if (status.mode !== "workflow" || status.state !== "paused") return undefined;
 	const next = cloneWorkflowStatus(status);
-	const step = findWorkflowSettlementStep(next, input.childRunId, input.workflowKey);
+	const step = findWorkflowSettlementStep(next, input.childRunId, input.workflowKey, input.result.sessionFile);
 	if (!step) return undefined;
+	step.runId ??= input.childRunId;
 	const succeeded = input.result.exitCode === 0 && !input.result.error && !input.result.interrupted;
 	const failedSiblingError = next.steps?.find((candidate) => {
 		const candidateStep = candidate as WorkflowStatusStep;

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -12,9 +12,10 @@ type RenderSubagentResult = (
 		content: Array<{ type: "text"; text: string }>;
 		isError?: boolean;
 		details?: {
-			mode: "single" | "parallel" | "chain" | "management";
+			mode: "single" | "parallel" | "chain" | "workflow" | "management";
 			context?: "fresh" | "fork" | "mixed";
 			results: unknown[];
+			workflowGraph?: unknown;
 		};
 	},
 	options: { expanded: boolean },
@@ -24,7 +25,7 @@ type RenderSubagentResult = (
 type RenderSubagentSummary = (
 	result: {
 		content: Array<{ type: "text"; text: string }>;
-		details?: { mode: "single" | "parallel" | "chain" | "management"; results: unknown[]; progress?: unknown[]; asyncId?: string };
+		details?: { mode: "single" | "parallel" | "chain" | "workflow" | "management"; results: unknown[]; progress?: unknown[]; asyncId?: string; workflowGraph?: unknown };
 	},
 	options: { isPartial?: boolean },
 	theme: RenderTheme,
@@ -574,6 +575,29 @@ describe("renderSubagentResult fork indicator", () => {
 			assert.match(summary, /· completed$/, mode);
 			assert.doesNotMatch(summary, /running/, mode);
 		}
+	});
+
+	it("renders an inconclusive host graph as partial", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "inconclusive gate" }],
+			details: {
+				mode: "workflow" as const,
+				results: ["worker", "reviewer"].map((agent) => ({ agent, task: "gate", exitCode: 0, messages: [], usage: emptyUsage })),
+				workflowGraph: {
+					runId: "workflow-partial",
+					mode: "workflow" as const,
+					phases: [],
+					nodes: [{ id: "gate", kind: "host-step" as const, label: "Review gate", status: "partial" as const }],
+				},
+			},
+		};
+
+		const summary = renderSubagentSummary!(result, {}, theme).render(120).join("\n");
+		const compact = renderSubagentResult!(result, { expanded: false }, theme).render(120).join("\n");
+		const expanded = renderSubagentResult!(result, { expanded: true }, theme).render(120).join("\n");
+		assert.match(summary, /■ workflow · partial$/);
+		assert.equal(firstGrapheme(compact), "■");
+		assert.match(expanded, /■ workflow .*· partial$/m);
 	});
 
 	it("keeps all-failed async aggregate inline summaries terminal", () => {

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -116,6 +116,34 @@ describe("async status projection", () => {
 		]);
 	});
 
+	it("projects done host steps without verdicts as partial", () => {
+		const snapshot = projectAsyncStatusSnapshot([job({
+			asyncId: "inconclusive-gate",
+			status: "running",
+			hostSteps: [hostStep({ verdict: undefined })],
+		})]);
+
+		assert.equal(snapshot.runs[0]?.children?.[0]?.state, "partial");
+	});
+
+	it("reserves bounded snapshot capacity for host steps", () => {
+		const snapshot = projectAsyncStatusSnapshot([job({
+			asyncId: "bounded-gate",
+			status: "running",
+			steps: [
+				{ agent: "first", status: "running" },
+				{ agent: "second", status: "running" },
+			],
+			hostSteps: [hostStep()],
+		})], { maxChildrenPerNode: 2 });
+
+		assert.deepEqual(snapshot.runs[0]?.children?.map(({ kind, id }) => ({ kind, id })), [
+			{ kind: "step", id: "step:0" },
+			{ kind: "host-step", id: "ci-check" },
+		]);
+		assert.equal(snapshot.omitted.children, 1);
+	});
+
 	it("omits malformed host nodes instead of rendering them as agents", () => {
 		const rows = projectAsyncWorkflowRows([], {
 			runId: "workflow-1",

--- a/test/unit/host-step-status.test.ts
+++ b/test/unit/host-step-status.test.ts
@@ -32,7 +32,8 @@ describe("host step status", () => {
 		assert.equal(running.monitorKind, "ci");
 		assert.equal(hostStepWorkflowNode(running).status, "running");
 		assert.equal(hostStepWorkflowNode(hostStep({ state: "done", verdict: "pass" })).status, "completed");
-		assert.equal(hostStepWorkflowNode(hostStep({ state: "done", verdict: "inconclusive" })).status, "completed");
+		assert.equal(hostStepWorkflowNode(hostStep({ state: "done", verdict: "inconclusive" })).status, "partial");
+		assert.equal(hostStepWorkflowNode(hostStep({ state: "done" })).status, "partial");
 		assert.equal(hostStepWorkflowNode(hostStep({ state: "done", verdict: "fail" })).status, "failed");
 		assert.equal(hostStepWorkflowNode(hostStep({ state: "cancelled" })).status, "stopped");
 		assert.equal(hostStepWorkflowNode(hostStep({ state: "error" })).status, "failed");
@@ -41,7 +42,6 @@ describe("host step status", () => {
 
 	it("rejects unbounded or incomplete terminal data", () => {
 		assert.throws(() => assertHostStepNode(hostStep({ label: "x".repeat(HOST_STEP_MAX_LABEL_CHARS + 1) }), "fixture"), /label exceeds/);
-		assert.throws(() => assertHostStepNode(hostStep({ state: "done" }), "fixture"), /done state requires a verdict/);
 		assert.throws(() => assertHostStepNode(hostStep({ state: "running", verdict: "pass" }), "fixture"), /verdict is only valid/);
 		assert.throws(() => assertHostStepNode(hostStep({ state: "done", verdict: "inconclusive", freshness: {} as HostStepNodeV1["freshness"] }), "fixture"), /expected/);
 		assert.throws(() => assertHostStepNode(hostStep({ state: "done", verdict: "pass", freshness: { expectedRef: "head", stale: true } }), "fixture"), /stale freshness/);

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -349,10 +349,82 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		assert.deepEqual(published.results, [{ workflowKey: "detaches", agent: "worker", runId: "child-stopped", success: false, output: "", outputState: "absent", interrupted: true, stopped: true, error: "Subagent stopped by user." }]);
 	});
 
-	it("classifies an interrupted workflowKey-matched child as interrupted evidence", () => {
+	it("reconciles a foreground child without a persisted run id", () => {
+		const workflowRunId = "workflow-unbound-foreground-handoff";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const sessionFile = "/tmp/current-child.jsonl";
+		const status = { ...pausedWorkflow("placeholder", { runId: undefined, sessionFile }), runId: workflowRunId, sessionId: "session-1" };
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = { asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]) } as SubagentState;
+
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId: "current-child",
+			workflowKey: "detaches",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, sessionFile },
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { results?: Array<{ runId?: string; sessionFile?: string; success?: boolean }> };
+		assert.deepEqual(published.results, [{ workflowKey: "detaches", agent: "worker", runId: "current-child", sessionFile, success: true, output: "", outputState: "absent" }]);
+	});
+
+	it("reconciles a live foreground child without persisted identity fields", () => {
+		const workflowRunId = "workflow-missing-identity-handoff";
+		const childRunId = "current-child";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const status = { ...pausedWorkflow("placeholder", { runId: undefined, sessionFile: undefined }), runId: workflowRunId, sessionId: "session-1" };
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = {
+			asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]),
+			foregroundControls: new Map([[childRunId, { runId: childRunId, parentWorkflowRunId: workflowRunId, workflowKey: "detaches" }]]),
+		} as SubagentState;
+
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId,
+			workflowKey: "detaches",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, sessionFile: "/tmp/current-child.jsonl" },
+		}), true);
+		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { results?: Array<{ runId?: string; success?: boolean }> };
+		assert.equal(published.results?.[0]?.runId, childRunId);
+		assert.equal(published.results?.[0]?.success, true);
+	});
+
+	it("does not reconcile ambiguous same-key live attempts without persisted identity", () => {
+		const workflowRunId = "workflow-ambiguous-missing-identity-handoff";
+		const childRunId = "stale-child";
+		const asyncDir = path.join(DIRS.async, workflowRunId);
+		const status = { ...pausedWorkflow("placeholder", { runId: undefined, sessionFile: undefined }), runId: workflowRunId, sessionId: "session-1" };
+		fs.mkdirSync(asyncDir, { recursive: true });
+		fs.mkdirSync(DIRS.results, { recursive: true });
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
+		const state = {
+			asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]),
+			foregroundControls: new Map([
+				[childRunId, { runId: childRunId, parentWorkflowRunId: workflowRunId, workflowKey: "detaches" }],
+				["replacement-child", { runId: "replacement-child", parentWorkflowRunId: workflowRunId, workflowKey: "detaches" }],
+			]),
+		} as SubagentState;
+
+		assert.equal(reconcileDetachedWorkflowChildCompletion({
+			state,
+			workflowRunId,
+			childRunId,
+			workflowKey: "detaches",
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, sessionFile: "/tmp/current-child.jsonl" },
+		}), false);
+		assert.equal(fs.existsSync(path.join(DIRS.results, `${workflowRunId}.json`)), false);
+	});
+
+	it("ignores stale completion when only the workflow key matches", () => {
 		const workflowRunId = "workflow-key-interrupted-handoff";
 		const asyncDir = path.join(DIRS.async, workflowRunId);
-		const status = { ...pausedWorkflow("persisted-child"), runId: workflowRunId, sessionId: "session-1" };
+		const status = { ...pausedWorkflow("placeholder", { runId: undefined, sessionFile: "/tmp/replacement-child.jsonl" }), runId: workflowRunId, sessionId: "session-1" };
 		fs.mkdirSync(asyncDir, { recursive: true });
 		fs.mkdirSync(DIRS.results, { recursive: true });
 		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
@@ -362,12 +434,13 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 			workflowRunId,
 			childRunId: "latest-child-run",
 			workflowKey: "detaches",
-			result: { index: 0, agent: "worker", task: "t", exitCode: 0, interrupted: true, usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
-		}), true);
-		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { workflowResolution?: string; error?: string };
-		assert.equal(published.workflowResolution, "interrupted-child");
-		assert.notEqual(published.workflowResolution, "failed-child");
-		assert.equal(published.error, "Interrupted. Waiting for explicit next action.");
+			result: { index: 0, agent: "worker", task: "t", exitCode: 0, interrupted: true, sessionFile: "/tmp/stale-child.jsonl", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 0 } },
+		}), false);
+		const persisted = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as AsyncStatus;
+		assert.equal(persisted.steps?.[0]?.runId, undefined);
+		assert.equal(persisted.steps?.[0]?.sessionFile, "/tmp/replacement-child.jsonl");
+		assert.equal(persisted.steps?.[0]?.status, "paused");
+		assert.equal(fs.existsSync(path.join(DIRS.results, `${workflowRunId}.json`)), false);
 	});
 
 	it("classifies a stopped sibling as interrupted terminal evidence", () => {

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -85,13 +85,13 @@ describe("workflow receipts", () => {
 		assert.equal(JSON.stringify(receipt).includes("/private/report.json"), true);
 	});
 
-	it("rejects malformed host monitor receipt state", () => {
+	it("reads inconclusive host monitor receipt state without a verdict", () => {
 		const asyncRoot = tempRoot();
-		const asyncDir = path.join(asyncRoot, "workflow-host-invalid");
+		const asyncDir = path.join(asyncRoot, "workflow-host-inconclusive");
 		fs.mkdirSync(asyncDir, { recursive: true });
-		const receipt = buildWorkflowReceipt({ workflowRunId: "workflow-host-invalid", state: "complete", children: [] });
-		fs.writeFileSync(workflowReceiptPath(asyncRoot, "workflow-host-invalid"), JSON.stringify({ ...receipt, hostSteps: [{ ...hostStep(), state: "done", verdict: undefined }] }));
-		assert.throws(() => readWorkflowReceipt(asyncRoot, "workflow-host-invalid"), /done state requires a verdict/);
+		const receipt = buildWorkflowReceipt({ workflowRunId: "workflow-host-inconclusive", state: "complete", children: [] });
+		fs.writeFileSync(workflowReceiptPath(asyncRoot, "workflow-host-inconclusive"), JSON.stringify({ ...receipt, hostSteps: [{ ...hostStep(), state: "done", verdict: undefined }] }));
+		assert.equal(readWorkflowReceipt(asyncRoot, "workflow-host-inconclusive").hostSteps?.[0]?.verdict, undefined);
 	});
 
 	it("reads legacy Grok receipt metadata after the active profile is removed", () => {


### PR DESCRIPTION
## Summary

This hardens workflow status settlement and host-step projection from the unreleased deep-dive review. Detached child completion now requires exact run identity, missing or inconclusive host verdicts project as partial, host-step rows keep bounded snapshot visibility, and workflow preflight lookup avoids repeated scans.

## Validation

Focused lifecycle/status unit tests passed. Focused render integration tests passed. npm run typecheck passed. git diff --check passed. Fresh exact-head review found no issues.

## Notes

This PR touches lifecycle/status and TUI rendering surfaces, so it should merge only after exact-head CI and Greptile are clean.

No release or tag action is included.
