### PR TITLE
fix: harden workflow output boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 ### Fixed
 - Match detached workflow completion by exact child identity, preserve host gate rows in bounded snapshots, and report missing host verdicts as inconclusive.
+- Atomically replace explicit `runs.host(...)` output files inside their verified directory, retrying transient Windows destination locks instead of writing through a separately checked path.
+- Reject malformed MCP direct-tool server and metadata-cache entry fields at their JSON load boundaries.
 - Ignore stale cached UI contexts during background status refresh and session lifecycle cleanup (#1670).
 - Compact workflow preflight status in default TUI/status views while keeping full details available when expanded (#1668).
 - Give `runs.lanes(...)` stage-0 retained-resume validation actionable `runs.run(...)` guidance instead of a generic error (#1657).

--- a/src/runs/shared/mcp-config-sources.ts
+++ b/src/runs/shared/mcp-config-sources.ts
@@ -39,6 +39,44 @@ export interface McpServerDefinition {
 	literalEnv?: boolean;
 }
 
+export function isMcpServerDefinition(value: unknown): value is McpServerDefinition {
+	if (!isRecord(value)) return false;
+	for (const field of ["command", "socket", "cwd", "url", "bearerToken", "bearerTokenEnv", "protocolVersion", "httpTransport", "pluginDataDir"] as const) {
+		if (value[field] !== undefined && typeof value[field] !== "string") return false;
+	}
+	for (const field of ["args", "includeTools", "excludeTools"] as const) {
+		if (value[field] !== undefined && !isStringArray(value[field])) return false;
+	}
+	for (const field of ["env", "headers"] as const) {
+		if (value[field] !== undefined && !isStringRecord(value[field])) return false;
+	}
+	for (const field of ["exposeResources", "literalEnv"] as const) {
+		if (value[field] !== undefined && typeof value[field] !== "boolean") return false;
+	}
+	if (value.requestHeadersCommand !== undefined && !isRequestHeadersCommand(value.requestHeadersCommand)) return false;
+	if (value.auth !== undefined && value.auth !== "oauth" && value.auth !== "bearer" && value.auth !== false) return false;
+	return value.directTools === undefined || typeof value.directTools === "boolean" || isStringArray(value.directTools);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+	return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isRequestHeadersCommand(value: unknown): value is NonNullable<McpServerDefinition["requestHeadersCommand"]> {
+	if (!isRecord(value) || typeof value.command !== "string") return false;
+	if (value.args !== undefined && !isStringArray(value.args)) return false;
+	if (value.env !== undefined && !isStringRecord(value.env)) return false;
+	return value.timeoutMs === undefined || (typeof value.timeoutMs === "number" && Number.isFinite(value.timeoutMs));
+}
+
 export function loadPackageMcpServers(cwd: string): Record<string, McpServerDefinition> {
 	const servers: Record<string, McpServerDefinition> = {};
 	const seen = new Set<string>();
@@ -64,11 +102,11 @@ export function loadPackageMcpServers(cwd: string): Record<string, McpServerDefi
 			const rawServers = (config as { mcpServers?: unknown }).mcpServers;
 			if (!rawServers || typeof rawServers !== "object" || Array.isArray(rawServers)) continue;
 			for (const [serverName, definition] of Object.entries(rawServers)) {
-				if (!definition || typeof definition !== "object" || Array.isArray(definition)) continue;
+				if (!isMcpServerDefinition(definition)) continue;
 				const normalizedName = `${packagePrefix}__${formatName(serverName, "server")}`;
 				if (seen.has(normalizedName)) continue;
 				seen.add(normalizedName);
-				servers[normalizedName] = definition as McpServerDefinition;
+				servers[normalizedName] = definition;
 			}
 		}
 	}

--- a/src/runs/shared/mcp-direct-tool-allowlist.ts
+++ b/src/runs/shared/mcp-direct-tool-allowlist.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { findConfiguredProjectRoot } from "../../agents/agents.ts";
 import { getAgentDir, getProjectConfigDir } from "../../shared/utils.ts";
-import { loadAgentPluginMcpServers, loadPackageMcpServers, type McpServerDefinition } from "./mcp-config-sources.ts";
+import { isMcpServerDefinition, loadAgentPluginMcpServers, loadPackageMcpServers, type McpServerDefinition } from "./mcp-config-sources.ts";
 import {
 	normalizeMcpDirectToolSelectors,
 	parseMcpDirectToolSelectors,
@@ -154,12 +154,46 @@ function loadMetadataCache(): MetadataCache | null {
 		return null;
 	}
 
-	if (!parsed || typeof parsed !== "object") return null;
-	const raw = parsed as Record<string, unknown>;
-	if (raw.version !== CACHE_VERSION || !raw.servers || typeof raw.servers !== "object" || Array.isArray(raw.servers)) {
-		return null;
+	if (!isRecord(parsed) || parsed.version !== CACHE_VERSION || !isRecord(parsed.servers)) return null;
+	const servers: Record<string, ServerCacheEntry> = {};
+	for (const [name, value] of Object.entries(parsed.servers)) {
+		const entry = parseServerCacheEntry(value);
+		if (entry) servers[name] = entry;
 	}
-	return raw as unknown as MetadataCache;
+	return { version: CACHE_VERSION, servers };
+}
+
+function parseServerCacheEntry(value: unknown): ServerCacheEntry | undefined {
+	if (!isRecord(value)) return undefined;
+	if (value.configHash !== undefined && typeof value.configHash !== "string") return undefined;
+	if (value.cachedAt !== undefined && (typeof value.cachedAt !== "number" || !Number.isFinite(value.cachedAt))) return undefined;
+	if (value.tools !== undefined && !Array.isArray(value.tools)) return undefined;
+	if (value.resources !== undefined && !Array.isArray(value.resources)) return undefined;
+	const tools = value.tools?.map(parseCachedTool);
+	const resources = value.resources?.map(parseCachedResource);
+	if (tools && !tools.every((entry): entry is CachedTool => entry !== undefined)) return undefined;
+	if (resources && !resources.every((entry): entry is CachedResource => entry !== undefined)) return undefined;
+	return {
+		...(value.configHash !== undefined ? { configHash: value.configHash } : {}),
+		...(value.cachedAt !== undefined ? { cachedAt: value.cachedAt } : {}),
+		...(tools ? { tools } : {}),
+		...(resources ? { resources } : {}),
+	};
+}
+
+function parseCachedTool(value: unknown): CachedTool | undefined {
+	if (!isRecord(value) || (value.name !== undefined && typeof value.name !== "string")) return undefined;
+	return value.name === undefined ? {} : { name: value.name };
+}
+
+function parseCachedResource(value: unknown): CachedResource | undefined {
+	if (!isRecord(value)) return undefined;
+	if (value.uri !== undefined && typeof value.uri !== "string") return undefined;
+	if (value.name !== undefined && typeof value.name !== "string") return undefined;
+	return {
+		...(value.uri !== undefined ? { uri: value.uri } : {}),
+		...(value.name !== undefined ? { name: value.name } : {}),
+	};
 }
 
 function resolveRuntimeMcpServers(
@@ -198,9 +232,7 @@ function getRuntimeMcpServerSnapshot(
 		snapshot.name !== name ||
 		snapshot.runtime !== true ||
 		snapshot.persisted !== false ||
-		!snapshot.definition ||
-		typeof snapshot.definition !== "object" ||
-		Array.isArray(snapshot.definition)
+		!isMcpServerDefinition(snapshot.definition)
 	) {
 		throw new Error(`Invalid MCP runtime snapshot for server "${name}"`);
 	}
@@ -251,16 +283,31 @@ function readConfig(configPath: string): McpConfig | null {
 }
 
 function validateConfig(raw: unknown): McpConfig {
-	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return { mcpServers: {} };
-	const obj = raw as Record<string, unknown>;
+	if (!isRecord(raw)) return { mcpServers: {} };
+	const obj = raw;
 	const servers = obj.mcpServers ?? obj["mcp-servers"] ?? {};
 	return {
-		mcpServers: servers && typeof servers === "object" && !Array.isArray(servers) ? servers as Record<string, ServerEntry> : {},
+		mcpServers: parseServerEntries(servers),
 		imports: Array.isArray(obj.imports) ? obj.imports.filter((value): value is ImportKind => isImportKind(value)) : undefined,
-		settings: obj.settings && typeof obj.settings === "object" && !Array.isArray(obj.settings)
-			? obj.settings as McpConfig["settings"]
-			: undefined,
+		settings: parseSettings(obj.settings),
 	};
+}
+
+function parseServerEntries(value: unknown): Record<string, ServerEntry> {
+	if (!isRecord(value)) return {};
+	return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, ServerEntry] => isMcpServerDefinition(entry[1])));
+}
+
+function parseSettings(value: unknown): McpConfig["settings"] | undefined {
+	if (!isRecord(value)) return undefined;
+	const toolPrefix = value.toolPrefix === "server" || value.toolPrefix === "short" || value.toolPrefix === "none" ? value.toolPrefix : undefined;
+	const directTools = typeof value.directTools === "boolean" ? value.directTools : undefined;
+	const settings: NonNullable<McpConfig["settings"]> = {
+		...(toolPrefix ? { toolPrefix } : {}),
+		...(directTools !== undefined ? { directTools } : {}),
+		...(value.agentPluginPaths !== undefined ? { agentPluginPaths: value.agentPluginPaths } : {}),
+	};
+	return Object.keys(settings).length ? settings : undefined;
 }
 
 function mergeConfigs(base: McpConfig, next: McpConfig): McpConfig {
@@ -306,12 +353,12 @@ function resolveImportPath(importKind: ImportKind, cwd: string): string | null {
 }
 
 function extractServers(config: unknown, kind: ImportKind): Record<string, ServerEntry> {
-	if (!config || typeof config !== "object" || Array.isArray(config)) return {};
-	const obj = config as Record<string, unknown>;
+	if (!isRecord(config)) return {};
+	const obj = config;
 	const servers = kind === "cursor" || kind === "windsurf" || kind === "vscode"
 		? obj.mcpServers ?? obj["mcp-servers"]
 		: obj.mcpServers;
-	return servers && typeof servers === "object" && !Array.isArray(servers) ? servers as Record<string, ServerEntry> : {};
+	return parseServerEntries(servers);
 }
 
 export function resolveMcpDirectToolNames(mcpDirectTools: string[] | undefined, cwd = process.cwd()): string[] {
@@ -362,6 +409,10 @@ export function computeMcpServerHash(definition: ServerEntry): string {
 
 function isImportKind(value: unknown): value is ImportKind {
 	return typeof value === "string" && Object.hasOwn(IMPORT_PATHS, value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function interpolateEnvRecord(values: Record<string, string> | undefined): Record<string, string> | undefined {

--- a/src/workflows/host-command.ts
+++ b/src/workflows/host-command.ts
@@ -1,9 +1,11 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { quoteExecutableForShell } from "../runs/shared/acceptance.ts";
 import { createOwnedProcessTreeController, type OwnedProcessTreeController } from "../runs/background/owned-process-tree.ts";
 import { resolveSingleOutputClaimPath } from "../runs/shared/single-output.ts";
+import { DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS, runFileSystemOperationWithRetry } from "../shared/file-system-retry.ts";
 
 const MAX_COMMAND_BYTES = 16 * 1024;
 const MAX_OUTPUT_PATH_BYTES = 240;
@@ -88,7 +90,7 @@ export function resolveWorkflowHostOutputClaimPath(outputPath: string): string {
 	return resolveSingleOutputClaimPath(outputPath);
 }
 
-function assertSafeExplicitOutput(cwd: string, outputPath: string, key: string): void {
+function assertSafeExplicitOutput(cwd: string, outputPath: string, key: string): string {
 	const root = fs.realpathSync(cwd);
 	const outputParent = path.dirname(outputPath);
 	let existingParent = outputParent;
@@ -105,6 +107,32 @@ function assertSafeExplicitOutput(cwd: string, outputPath: string, key: string):
 		if (!stat.isFile() || stat.nlink > 1) throw new Error(`runs.host('${key}') output must be a regular, non-linked file path.`);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	return parent;
+}
+
+function writeExplicitOutput(outputParent: string, outputPath: string, capture: string, key: string): void {
+	const destination = path.join(outputParent, path.basename(outputPath));
+	const temporaryPath = path.join(outputParent, `.pi-host-output-${process.pid}-${randomUUID()}.tmp`);
+	let descriptor: number | undefined;
+	try {
+		descriptor = fs.openSync(temporaryPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+		fs.writeFileSync(descriptor, capture, { encoding: "utf8" });
+		fs.closeSync(descriptor);
+		descriptor = undefined;
+		fs.chmodSync(temporaryPath, 0o600);
+		runFileSystemOperationWithRetry(() => fs.renameSync(temporaryPath, destination), {
+			retryDelaysMs: process.platform === "win32" ? DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS : [],
+		});
+	} catch (error) {
+		throw new Error(`runs.host('${key}') could not atomically replace its output.`, { cause: error instanceof Error ? error : undefined });
+	} finally {
+		if (descriptor !== undefined) fs.closeSync(descriptor);
+		try {
+			fs.unlinkSync(temporaryPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
 	}
 }
 
@@ -128,8 +156,8 @@ export async function executeWorkflowHostCommand(input: {
 	const outputPath = input.params.output ? path.resolve(input.cwd, input.params.output) : input.defaultOutputPath;
 	const relative = path.relative(input.cwd, outputPath);
 	if (input.params.output && (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative))) throw new Error(`runs.host('${input.key}') output escapes the workflow cwd.`);
-	if (input.params.output) assertSafeExplicitOutput(input.cwd, outputPath, input.key);
-	else fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+	const explicitOutputParent = input.params.output ? assertSafeExplicitOutput(input.cwd, outputPath, input.key) : undefined;
+	if (!input.params.output) fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 	const startedAt = Date.now();
 	let stdout = "";
 	let stderr = "";
@@ -182,9 +210,14 @@ export async function executeWorkflowHostCommand(input: {
 			const state = timedOut ? "timed-out" : stopped ? "stopped" : exitCode === 0 && !spawnError && !cleanupError ? "passed" : "failed";
 			const error = spawnError instanceof Error ? spawnError.message : spawnError ? String(spawnError) : cleanupError ? `Process-tree cleanup failed: ${cleanupError}.` : state === "timed-out" ? `Command timed out after ${input.params.timeoutMs}ms.` : state === "stopped" ? "Command stopped because the workflow was aborted." : state === "failed" ? `Command exited with code ${exitCode ?? "unknown"}.` : undefined;
 			try {
-				if (input.params.output) assertSafeExplicitOutput(input.cwd, outputPath, input.key);
 				if (input.claimedOutputPath && resolveWorkflowHostOutputClaimPath(outputPath) !== input.claimedOutputPath) throw new Error(`output path changed after it was claimed.`);
-				fs.writeFileSync(outputPath, capture, { encoding: "utf8", mode: 0o600 });
+				if (explicitOutputParent) {
+					const currentParent = assertSafeExplicitOutput(input.cwd, outputPath, input.key);
+					if (currentParent !== explicitOutputParent) throw new Error(`output parent changed while the command was running.`);
+					writeExplicitOutput(explicitOutputParent, outputPath, capture, input.key);
+				} else {
+					fs.writeFileSync(outputPath, capture, { encoding: "utf8", mode: 0o600 });
+				}
 			} catch (writeError) {
 				reject(new Error(`runs.host('${input.key}') could not save command output: ${writeError instanceof Error ? writeError.message : String(writeError)}`, { cause: writeError instanceof Error ? writeError : undefined }));
 				return;

--- a/test/unit/host-command.test.ts
+++ b/test/unit/host-command.test.ts
@@ -39,6 +39,8 @@ describe("workflow host commands", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-host-command-"));
 		roots.push(root);
 		const outputPath = path.join(root, "reports", "command.log");
+		fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+		fs.writeFileSync(outputPath, "stale", "utf8");
 		const result = await executeWorkflowHostCommand({
 			key: "unit-tests",
 			params: { kind: "command", command: commandFor(root, `process.stdout.write("passed\\n"); process.stderr.write("warning\\n");`), timeoutMs: 5000, output: "reports/command.log" },
@@ -53,6 +55,8 @@ describe("workflow host commands", () => {
 		assert.match(result.stderr, /warning/);
 		assert.equal(result.outputPath, outputPath);
 		assert.match(fs.readFileSync(outputPath, "utf8"), /passed/);
+		if (process.platform !== "win32") assert.equal(fs.statSync(outputPath).mode & 0o777, 0o600);
+		assert.deepEqual(fs.readdirSync(path.dirname(outputPath)), ["command.log"]);
 	});
 
 	it("returns failed and timed-out command evidence", async () => {
@@ -97,6 +101,29 @@ describe("workflow host commands", () => {
 			/resolves outside the workflow cwd/,
 		);
 		assert.equal(fs.existsSync(path.join(outside, "sub")), false);
+	});
+
+	it("rejects an explicit output parent redirected while the command runs", { skip: process.platform === "win32" ? "symlink permissions vary on Windows" : undefined }, async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-host-command-symlink-race-"));
+		const outside = fs.mkdtempSync(path.join(os.tmpdir(), "pi-host-command-symlink-target-"));
+		roots.push(root, outside);
+		const outputParent = path.join(root, "reports");
+		const outsidePath = path.join(outside, "outside.log");
+		const command = commandFor(root, `
+			const fs = require("node:fs");
+			fs.rmdirSync(${JSON.stringify(outputParent)});
+			fs.symlinkSync(${JSON.stringify(outside)}, ${JSON.stringify(outputParent)}, "dir");
+			process.stdout.write("captured");
+		`);
+
+		await assert.rejects(executeWorkflowHostCommand({
+			key: "replaced-output",
+			params: { kind: "command", command, timeoutMs: 5000, output: "reports/command.log" },
+			cwd: root,
+			defaultOutputPath: path.join(root, "fallback.log"),
+			signal: new AbortController().signal,
+		}), /resolves outside the workflow cwd/);
+		assert.equal(fs.existsSync(outsidePath), false);
 	});
 
 	it("stops the owned process tree when the workflow aborts", async () => {

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1282,6 +1282,41 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		}), /Unresolved MCP direct-tool selectors: runtime-missing\./);
 	});
 
+	it("fails closed on malformed selected runtime MCP server fields", () => {
+		const fixture = createMcpFixture();
+		const serverName = "runtime-filtered";
+		const definition = { command: "runtime-filtered", includeTools: "safe_only" } as unknown as Parameters<typeof computeMcpServerHash>[0];
+		writeJson(path.join(fixture.agentDir, "mcp.json"), { mcpServers: {} });
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				[serverName]: {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: "safe_only" }, { name: "dangerous" }],
+				},
+			},
+		});
+		const runtimeSnapshotHost: McpRuntimeSnapshotHost = {
+			events: {
+				emit(_event, request) {
+					request.result = { ok: true, snapshot: { name: request.name, definition, runtime: true, persisted: false } };
+				},
+			},
+		};
+
+		assert.throws(() => buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: [serverName],
+			runtimeSnapshotHost,
+		}), /Unresolved MCP direct-tool selectors: runtime-filtered\./);
+	});
+
 	it("does not serialize runtime MCP servers denied by a capability ceiling", () => {
 		const fixture = createMcpFixture();
 		const definitions = {
@@ -1498,6 +1533,47 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		}), /Unresolved MCP direct-tool selectors: chrome-devtools\./);
 	});
 
+	it("rejects malformed MCP server and metadata entry fields at their load boundaries", () => {
+		const malformedConfig = createMcpFixture();
+		writeJson(path.join(malformedConfig.agentDir, "mcp.json"), {
+			mcpServers: {
+				"unsafe-server": { command: "unsafe-server", env: { TOKEN: 42 } },
+			},
+		});
+		assert.throws(() => buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["unsafe-server"],
+		}), /Unresolved MCP direct-tool selectors: unsafe-server\./);
+
+		const malformedCache = createMcpFixture();
+		const definition = { command: "cached-server" };
+		writeJson(path.join(malformedCache.agentDir, "mcp.json"), { mcpServers: { "cached-server": definition } });
+		writeJson(path.join(malformedCache.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"cached-server": {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: 42 }],
+				},
+			},
+		});
+		assert.throws(() => buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["cached-server"],
+		}), /Unresolved MCP direct-tool selectors: cached-server\./);
+	});
+
 	it("preserves MCP configuration errors during direct-tool resolution", () => {
 		const fixture = createMcpFixture();
 		writeJson(path.join(fixture.agentDir, "mcp.json"), {
@@ -1571,6 +1647,37 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		});
 
 		assert.equal(args[args.indexOf("--tools") + 1], "read,acme_tools__wiki_read_wiki_structure");
+	});
+
+	it("fails closed on malformed MCP server fields from Pi package manifests", () => {
+		const fixture = createMcpFixture();
+		const packageRoot = path.join(fixture.agentDir, "npm", "node_modules", "@acme", "tools");
+		const malformedFields: Record<string, unknown> = { includeTools: "read_wiki_structure" };
+		const definition = { command: "node", args: ["package-mcp"], ...malformedFields };
+		writeJson(path.join(fixture.agentDir, "settings.json"), { packages: ["npm:@acme/tools@1.0.0"] });
+		writeJson(path.join(packageRoot, "package.json"), { name: "@acme/tools", pi: { mcp: "./mcp.json" } });
+		writeJson(path.join(packageRoot, "mcp.json"), { mcpServers: { wiki: definition } });
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"acme_tools__wiki": {
+					configHash: computeMcpServerHash(definition),
+					cachedAt: Date.now(),
+					tools: [{ name: "read_wiki_structure" }, { name: "delete_wiki" }],
+				},
+			},
+		});
+
+		assert.throws(() => buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["acme_tools__wiki"],
+			cwd: fixture.projectDir,
+		}), /Unresolved MCP direct-tool selectors: acme_tools__wiki\./);
 	});
 
 	it("resolves direct MCP tools from the git-root package when child cwd has an incidental .pi directory", () => {


### PR DESCRIPTION
## Summary

This hardens two load and output boundaries from the unreleased deep-dive review. Explicit `runs.host` outputs now use a verified-directory temp file plus atomic rename, and MCP direct-tool cache/config/package entries are validated before grant planning.

## Validation

Focused `host-command` tests passed. Focused `pi-args` tests passed. `npm run typecheck` passed. `git diff --check` passed. Fresh exact-head follow-up review found no issues after the package-manifest MCP validation blocker was fixed.

## Notes

Windows CI should cover host-output replacement behavior on that platform. No release or tag action is included.
