### PR TITLE
fix: preserve cursor-native composite tool ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Match detached workflow completion by exact child identity, preserve host gate rows in bounded snapshots, and report missing host verdicts as inconclusive.
 - Atomically replace explicit `runs.host(...)` output files inside their verified directory, retrying transient Windows destination locks instead of writing through a separately checked path.
 - Reject malformed MCP direct-tool server and metadata-cache entry fields at their JSON load boundaries.
+- Preserve live composite child tool-call ids for `cursor-native`, so Cursor MCP results keep matching pending execs. Thanks to [@moofone](https://github.com/moofone) for #1677 and #1678.
 - Ignore stale cached UI contexts during background status refresh and session lifecycle cleanup (#1670).
 - Compact workflow preflight status in default TUI/status views while keeping full details available when expanded (#1668).
 - Give `runs.lanes(...)` stage-0 retained-resume validation actionable `runs.run(...)` guidance instead of a generic error (#1657).

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -291,6 +291,7 @@ const PORTABLE_TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_PORTABLE_TOOL_ID_LENGTH = 64;
 const COMPOSITE_TOOL_ID_APIS = new Set([
 	"azure-openai-responses",
+	"cursor-native",
 	"openai-completions",
 	"openai-responses",
 ]);

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -1468,6 +1468,26 @@ describe("subagent prompt runtime", () => {
 		assert.equal(contextHandler?.({ messages }, { model: { api: "openai-responses" } }), undefined);
 	});
 
+	it("preserves composite tool ids for cursor-native children", () => {
+		let contextHandler: ((event: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) | undefined;
+		registerSubagentPromptRuntime({
+			on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) {
+				if (event === "context") contextHandler = handler;
+			},
+		} as { on(event: string, handler: (payload: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined): void });
+
+		const toolCallId = "call_7XJjvAJfk07117JO8LgBCZjY\nfc_0e92b09b28010bac016a756e9e79cc8197b01825a5dc3d9eaa";
+		const messages = [
+			{ role: "user", content: "Task" },
+			{ role: "assistant", content: [{ type: "toolCall", id: toolCallId, name: "read", input: { path: "README.md" } }] },
+			{ role: "toolResult", toolName: "read", toolCallId, content: "file" },
+		];
+
+		assert.equal(contextHandler?.({ messages }, { model: { api: "cursor-native" } }), undefined);
+		assert.equal((messages[1] as { content: Array<{ id?: unknown }> }).content[0]?.id, toolCallId);
+		assert.equal((messages[2] as { toolCallId?: unknown }).toolCallId, toolCallId);
+	});
+
 	it("does not rewrite child context when no parent-only artifacts are present", () => {
 		let contextHandler: ((event: { messages: unknown[] }, ctx: { model?: { api: string } }) => { messages: unknown[] } | undefined) | undefined;
 		registerSubagentPromptRuntime({


### PR DESCRIPTION
## Summary

Fixes #1677.

The child context hook now preserves Cursor composite tool-call ids (`call_<id>` plus `fc_<id>` joined by a newline) when the active API is `cursor-native`. Other child contexts still sanitize inherited tool ids so forked history stays portable, including Codex.

This is the same allowlist used by #878, extended by one API. It does not skip the child runtime or change Codex sanitization.

## Validation

- Exact-baseline: `preserves composite tool ids for cursor-native children` fails on current `main` (`call_…\nfc_…` rewritten to `tool_<digest>`).
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/subagent-prompt-runtime.test.ts`: 59/59 passed.
- Focused composite-id cases: Codex still sanitized, `openai-responses` still preserved, `cursor-native` now preserved.
- `npm run typecheck`
- `git diff --check`

## Residual risks

- Live Cursor resume matching lives in pi-cursor; this PR only stops pi-subagents from mutating the ids that resume requires.
- Unbounded replay of unmatched pending execs in pi-cursor is a separate liveness gap and is not changed here.