### PR TITLE
fix: show workflow child context in fleet status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Show workflow child `[fresh]` and `[fork]` context labels in Fleet status rows alongside model and thinking badges.
+
 ## [0.59.0] - 2026-08-28
 
 ### Highlights

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -87,6 +87,7 @@ export interface AsyncStatusWorkflowRow {
 	state: AsyncJobStep["status"] | HostStepState | "planned";
 	/** Present only for typed host-owned monitor rows; legacy child rows omit it. */
 	kind?: HostStepMonitorKind;
+	context?: AsyncJobStep["context"];
 	modelThinking?: string;
 	activity?: string;
 	startedAt?: number;
@@ -431,6 +432,7 @@ function projectLoadedWorkflowRow(step: AsyncJobStep, index: number, preflight?:
 	return {
 		name: workflowStepName(step, index),
 		state: step.status,
+		...(step.context ? { context: step.context } : {}),
 		...(modelThinking ? { modelThinking } : {}),
 		...(activity ? { activity } : {}),
 		...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -4,6 +4,7 @@ import { snapshotExternalRuns } from "../api/external-runs.ts";
 import { formatModelThinking } from "../shared/formatters.ts";
 import type { AsyncJobState, AsyncJobStep, FleetViewPlacement, HerdrProjectPaneSnapshot, HostStepState, HostStepVerdict, NestedRunSummary, NestedStepSummary, SubagentState } from "../shared/types.ts";
 import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
+import { contextModeLabel } from "../runs/shared/context-mode.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
 import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
 import { isStaleExtensionContextError } from "../shared/extension-context.ts";
@@ -728,6 +729,7 @@ export class SubagentFleetStatus {
 		const marker = last ? "└─" : "├─";
 		const indent = "    ";
 		if (row.overflow !== undefined) return truncateToWidth(`${indent}${marker} ${theme.fg("dim", `+${row.overflow} hidden workflow steps`)}`, width);
+		const context = contextModeLabel(row.context);
 		const modelThinking = row.modelThinking ? ` (${row.modelThinking})` : "";
 		const activity = row.activity ? ` · ${row.activity}` : "";
 		const kind = row.kind ? `${row.kind}: ` : "";
@@ -738,7 +740,7 @@ export class SubagentFleetStatus {
 			row.preflight.expectedOutput ? `expected:${row.preflight.expectedOutput}` : undefined,
 			row.preflight.independence ? `independence:${row.preflight.independence}` : undefined,
 		].filter((value): value is string => Boolean(value)).join(" · ") : "";
-		const left = `${indent}${marker} ${this.workflowRowGlyph(row, theme)} ${theme.fg("muted", `${kind}${row.name}${modelThinking}`)} · ${this.workflowRowStateLabel(row, theme)}${activity}${hints ? ` · ${hints}` : ""}`;
+		const left = `${indent}${marker} ${this.workflowRowGlyph(row, theme)} ${theme.fg("muted", `${kind}${row.name}${context ? ` ${context}` : ""}${modelThinking}`)} · ${this.workflowRowStateLabel(row, theme)}${activity}${hints ? ` · ${hints}` : ""}`;
 		const details = [
 			row.startedAt !== undefined ? formatFleetElapsed(Date.now() - row.startedAt) : undefined,
 			row.tokens !== undefined ? formatFleetTokens(row.tokens, row.window) : undefined,
@@ -806,6 +808,7 @@ export class SubagentFleetStatus {
 						row.kind,
 						row.name,
 						row.state,
+						row.context,
 						row.modelThinking,
 						row.activity,
 						row.startedAt,

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -84,6 +84,7 @@ describe("async status projection", () => {
 			label: "Fresh review",
 			phase: "quality",
 			status: "partial",
+			context: "fresh",
 			activityState: "needs_attention",
 			startedAt: 10,
 			tokens: { input: 20, output: 5, total: 25, window: 18 },
@@ -92,6 +93,7 @@ describe("async status projection", () => {
 		assert.deepEqual(rows, [{
 			name: "quality: review · Fresh review (reviewer)",
 			state: "partial",
+			context: "fresh",
 			activity: "needs attention",
 			startedAt: 10,
 			tokens: 25,

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -977,8 +977,8 @@ describe("below-editor subagent FleetView", () => {
 			startedAt: 10,
 			updatedAt: 20,
 			steps: [
-				{ agent: "scout", workflowKey: "scan", phase: "Plan", label: "Find seams", status: "complete" as const, index: 0, tokens: { input: 10, output: 5, total: 15 } },
-				{ agent: "reviewer", workflowKey: "review", phase: "Review", status: "running" as const, index: 1, currentTool: "grep", tokens: { input: 20, output: 5, total: 25 } },
+				{ agent: "scout", workflowKey: "scan", phase: "Plan", label: "Find seams", status: "complete" as const, index: 0, context: "fresh" as const, model: "openai-codex/gpt-5.6-luna", thinking: "max", tokens: { input: 10, output: 5, total: 15 } },
+				{ agent: "reviewer", workflowKey: "review", phase: "Review", status: "running" as const, index: 1, context: "fork" as const, currentTool: "grep", tokens: { input: 20, output: 5, total: 25 } },
 				{ agent: "tester", workflowKey: "test", phase: "Verify", status: "pending" as const, index: 2 },
 			],
 		};
@@ -1007,8 +1007,8 @@ describe("below-editor subagent FleetView", () => {
 			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
 			const lines = component.render(140).join("\n");
 			assert.match(lines, /workflow · running/);
-			assert.match(lines, /Plan: scan · Find seams \(scout\) · complete/);
-			assert.match(lines, /Review: review \(reviewer\) · running · tool grep/);
+			assert.match(lines, /Plan: scan · Find seams \(scout\) \[fresh\] \(gpt-5\.6-luna · thinking max\) · complete/);
+			assert.match(lines, /Review: review \(reviewer\) \[fork\] · running · tool grep/);
 			assert.match(lines, /Verify: test \(tester\) · pending/);
 		} finally {
 			fleet.dispose();


### PR DESCRIPTION
Show workflow child context labels in Fleet status rows.

The runtime already records each workflow child step's resolved context. Plain async status output uses that field, but the compact Fleet workflow-row projection dropped it, so rows could show model/thinking without whether the child was `[fresh]` or `[fork]`.

This projects the step context into workflow rows, renders it beside the model/thinking badge, and includes it in the render cache key.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/async-status-projection.test.ts test/unit/fleet-status.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review: `reports/tui-context-badge-review.md` (`No issues found`)
