### PR TITLE
fix: preserve fork cache affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Clarify portable subagent orchestration guidance: keep the parent on the ordinary strong default model, route bounded workers/scouts to a fast worker tier, and reserve a top-reasoning model for bounded read-only critique or escalation without requiring a specific provider.
 
 ### Fixed
+- Reuse a fork-family prompt cache key for OpenAI-style forked subagent requests so sibling fork children keep cache affinity without pooling fresh children. Thanks to [@Shinkicast](https://github.com/Shinkicast) for #1682.
 - Show workflow child `[fresh]` and `[fork]` context labels in Fleet status rows alongside model and thinking badges.
 
 ## [0.59.0] - 2026-08-28

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -75,7 +75,7 @@ import {
 	DEFAULT_GLOBAL_CONCURRENCY_LIMIT,
 	Semaphore,
 } from "../shared/parallel-utils.ts";
-import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
+import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, deriveForkPromptCacheKey, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
 import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/chain-outputs.ts";
@@ -1698,6 +1698,7 @@ async function runSingleStepInner(
 			: undefined;
 		const { args, env, tempDir, toolDiagnosticPath, runtimeAcknowledgedExtensionsPath, capabilityAudit: attemptCapabilityAudit, warnings } = buildPiArgs(omitUndefinedProperties({
 			parentSessionId: step.parentSessionId,
+			forkCacheKey: step.context === "fork" ? deriveForkPromptCacheKey(step.parentSessionId) : undefined,
 			baseArgs: ["--mode", "json", "-p"],
 			task: attemptTask,
 			taskDelivery: taskDeliveryOverride,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -66,7 +66,7 @@ import { createJsonlWriter } from "../../shared/jsonl-writer.ts";
 import { createOrcaProgressTab, type OrcaProgressTab } from "../shared/orca-progress-tabs.ts";
 import { attachPostExitStdioGuard, trySignalChild } from "../../shared/post-exit-stdio-guard.ts";
 import { resolvePermissionRules } from "../shared/permissions.ts";
-import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
+import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, deriveForkPromptCacheKey, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
 import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV } from "../shared/capability-ceiling.ts";
@@ -380,6 +380,7 @@ async function runSingleAttempt(
 		parentCapabilityToken: options.nestedRoute?.capabilityToken,
 		runFanoutBudget: options.runFanoutBudget,
 		parentSessionId: options.parentSessionId,
+		forkCacheKey: options.context === "fork" ? deriveForkPromptCacheKey(options.parentSessionId) : undefined,
 		steerInboxDir: options.steerInboxDir,
 		steerCapabilityPath: options.steerCapabilityPath,
 		steerAckDir: options.steerAckDir,

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -117,6 +117,7 @@ const FAST_MODE_ALLOWED_MODELS = new Set([
 	"openai-codex/gpt-5.6-luna",
 	"openai-codex/gpt-5.6-sol",
 ]);
+const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
 export const SUBAGENT_ORCHESTRATOR_TARGET_ENV =
 	"PI_SUBAGENT_ORCHESTRATOR_TARGET";
@@ -139,6 +140,7 @@ export const SUBAGENT_PARENT_PATH_ENV = "PI_SUBAGENT_PARENT_PATH";
 export const SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV =
 	"PI_SUBAGENT_PARENT_CAPABILITY_TOKEN";
 export const SUBAGENT_PARENT_SESSION_ENV = "PI_SUBAGENT_PARENT_SESSION";
+export const SUBAGENT_FORK_CACHE_KEY_ENV = "PI_SUBAGENT_FORK_CACHE_KEY";
 export const SUBAGENT_STEER_INBOX_ENV = "PI_SUBAGENT_STEER_INBOX";
 export const SUBAGENT_STEER_CAPABILITY_ENV = "PI_SUBAGENT_STEER_CAPABILITY";
 export const SUBAGENT_STEER_ACK_DIR_ENV = "PI_SUBAGENT_STEER_ACK_DIR";
@@ -146,8 +148,16 @@ export const PI_INTERCOM_STABLE_ID_ENV = "PI_INTERCOM_STABLE_ID";
 export const PI_INTERCOM_SESSION_ID_ENV = "PI_INTERCOM_SESSION_ID";
 export const SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_GLOBAL_CONTEXT";
 
+export function deriveForkPromptCacheKey(parentSessionId: string | undefined): string | undefined {
+	const parent = parentSessionId?.trim();
+	if (!parent) return undefined;
+	const digest = createHash("sha256").update(parent).digest("hex").slice(0, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH - "pi-fork:".length);
+	return `pi-fork:${digest}`;
+}
+
 export interface BuildPiArgsInput {
 	parentSessionId?: string;
+	forkCacheKey?: string;
 	baseArgs: string[];
 	task: string;
 	sessionEnabled: boolean;
@@ -974,6 +984,7 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 
 	env[SUBAGENT_PARENT_SESSION_ENV] =
 		input.parentSessionId ?? process.env[SUBAGENT_PARENT_SESSION_ENV] ?? "";
+	env[SUBAGENT_FORK_CACHE_KEY_ENV] = input.forkCacheKey?.trim() || undefined;
 
 	return {
 		args,

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -1,12 +1,12 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { BeforeProviderRequestEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { registerNativeSupervisorClient } from "../../intercom/native-supervisor-channel.ts";
 import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 import { decodePermissionRules, permissionDecision, PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "./permissions.ts";
 import { consumeSteerRequestsFromDir, MAX_STEER_QUEUE_SIZE, steerAckPathFromDir, writeSteerAckAt, writeSteerCapabilityAt, writeSteerRequestToDir, type SteerDeliveryStatus, type SteerRequest } from "../background/control-channel.ts";
-import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV, SUBAGENT_STEER_ACK_DIR_ENV, SUBAGENT_STEER_CAPABILITY_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
+import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_FORK_CACHE_KEY_ENV, SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV, SUBAGENT_STEER_ACK_DIR_ENV, SUBAGENT_STEER_CAPABILITY_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
 import { RUNTIME_EXTENSION_ACK_EVENT, RUNTIME_EXTENSION_ACK_PATH_ENV, isRuntimeAcknowledgedExtensionId, writeRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
 import { createStructuredOutputToolParameters, STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
 import {
@@ -295,6 +295,22 @@ const COMPOSITE_TOOL_ID_APIS = new Set([
 	"openai-completions",
 	"openai-responses",
 ]);
+const PROMPT_CACHE_KEY_APIS = new Set([
+	"azure-openai-responses",
+	"openai-codex-responses",
+	"openai-completions",
+	"openai-responses",
+]);
+
+export function rewriteForkCacheProviderRequest(event: BeforeProviderRequestEvent, ctx?: Pick<ExtensionContext, "model">): unknown {
+	const forkCacheKey = process.env[SUBAGENT_FORK_CACHE_KEY_ENV]?.trim();
+	if (!forkCacheKey || !PROMPT_CACHE_KEY_APIS.has(ctx?.model?.api ?? "")) return undefined;
+	if (!event || typeof event !== "object") return undefined;
+	const payload = event.payload;
+	if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+	if (typeof (payload as { prompt_cache_key?: unknown }).prompt_cache_key !== "string") return undefined;
+	return { ...payload, prompt_cache_key: forkCacheKey };
+}
 
 function portableToolId(id: string): string {
 	if (PORTABLE_TOOL_ID_PATTERN.test(id) && id.length <= MAX_PORTABLE_TOOL_ID_LENGTH) return id;
@@ -747,6 +763,8 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 			},
 		});
 	}
+
+	onRuntimeEvent("before_provider_request", (event: unknown, ctx?: ExtensionContext) => rewriteForkCacheProviderRequest(event as BeforeProviderRequestEvent, ctx));
 
 	onRuntimeEvent("context", (event: unknown, ctx?: ExtensionContext) => {
 		if (!event || typeof event !== "object" || !("messages" in event) || !Array.isArray(event.messages)) return undefined;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -26,6 +26,7 @@ import { resolveSubagentLaunchContract } from "../../src/api/preflight.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { runSync } from "../../src/runs/foreground/execution.ts";
 import { ACTIVE_ASYNC_CAPACITY_DIR, acquireActiveAsyncCapacity, activeAsyncCapacitySessionKey } from "../../src/runs/background/active-async-capacity.ts";
+import { deriveForkPromptCacheKey, SUBAGENT_FORK_CACHE_KEY_ENV } from "../../src/runs/shared/pi-args.ts";
 
 interface LaunchResolvedExtensions {
 	version?: number;
@@ -4650,6 +4651,38 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.ok(launch.details.asyncId);
 		const payload = await readAsyncPayload(launch.details.asyncId);
 		assert.equal(payload.results[0]?.model, "gateway/parent-model");
+	});
+
+	it("background forked runs receive the derived fork cache key", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		mockPi.onCall({ echoEnv: [SUBAGENT_FORK_CACHE_KEY_ENV] });
+		const parentSessionFile = path.join(tempDir, "parent-cache.jsonl");
+		const forkedSessionFile = path.join(tempDir, "forked-cache.jsonl");
+		const sessionHeader = JSON.stringify({ type: "session", cwd: fs.realpathSync(tempDir) });
+		fs.writeFileSync(parentSessionFile, `${sessionHeader}\n`, "utf-8");
+		fs.writeFileSync(forkedSessionFile, `${sessionHeader}\n`, "utf-8");
+		const ctx = {
+			...makeMinimalCtx(tempDir),
+			sessionManager: {
+				getSessionId: () => "session-cache-parent",
+				getSessionFile: () => parentSessionFile,
+				getLeafId: () => "leaf-current",
+				openSession: () => ({ createBranchedSession: () => forkedSessionFile }),
+			},
+		};
+
+		const launch = await makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]).execute(
+			"forked-cache-key",
+			{ agent: "worker", task: "Inspect cache affinity", async: true, context: "fork" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		) as AsyncExecutionResult;
+		assert.ok(!launch.isError, launch.content[0]?.text);
+		assert.ok(launch.details.asyncId);
+
+		const payload = await readAsyncPayload(launch.details.asyncId);
+		const childEnv = JSON.parse(payload.results[0]?.output ?? "{}") as Record<string, string | null>;
+		assert.equal(childEnv[SUBAGENT_FORK_CACHE_KEY_ENV], deriveForkPromptCacheKey("session-cache-parent"));
 	});
 
 	it("revives an inherited parent model outside the current registry", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {

--- a/test/unit/fork-cache-key.test.ts
+++ b/test/unit/fork-cache-key.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { buildPiArgs, deriveForkPromptCacheKey, SUBAGENT_FORK_CACHE_KEY_ENV } from "../../src/runs/shared/pi-args.ts";
+import { rewriteForkCacheProviderRequest } from "../../src/runs/shared/subagent-prompt-runtime.ts";
+
+const originalForkCacheKey = process.env[SUBAGENT_FORK_CACHE_KEY_ENV];
+
+const baseLaunch = {
+	baseArgs: [] as string[],
+	task: "test",
+	sessionEnabled: false,
+	inheritProjectContext: false,
+	inheritGlobalContext: false,
+	inheritSkills: false,
+};
+
+afterEach(() => {
+	if (originalForkCacheKey === undefined) delete process.env[SUBAGENT_FORK_CACHE_KEY_ENV];
+	else process.env[SUBAGENT_FORK_CACHE_KEY_ENV] = originalForkCacheKey;
+});
+
+describe("fork prompt cache keys", () => {
+	it("derives a bounded sibling cache key from the parent session id", () => {
+		assert.equal(deriveForkPromptCacheKey(undefined), undefined);
+		assert.equal(deriveForkPromptCacheKey("   "), undefined);
+		const key = deriveForkPromptCacheKey("parent-session");
+		assert.ok(key);
+		assert.match(key, /^pi-fork:[0-9a-f]{56}$/);
+		assert.equal(Array.from(key).length, 64);
+		assert.equal(key.includes("parent-session"), false);
+
+		const longKey = deriveForkPromptCacheKey(`${"🙂".repeat(80)}-parent`);
+		assert.ok(longKey);
+		assert.equal(Array.from(longKey).length, 64);
+		assert.match(longKey, /^pi-fork:[0-9a-f]{56}$/);
+
+		const prefix = "/Users/example/.pi/agent/sessions/".repeat(3);
+		assert.notEqual(deriveForkPromptCacheKey(`${prefix}/one.jsonl`), deriveForkPromptCacheKey(`${prefix}/two.jsonl`));
+	});
+
+	it("passes the explicit fork cache key without inheriting ambient values", () => {
+		process.env[SUBAGENT_FORK_CACHE_KEY_ENV] = "leaked-parent-value";
+
+		assert.equal(buildPiArgs(baseLaunch).env[SUBAGENT_FORK_CACHE_KEY_ENV], undefined);
+
+		const forkCacheKey = deriveForkPromptCacheKey("parent-session");
+		assert.equal(buildPiArgs({ ...baseLaunch, forkCacheKey }).env[SUBAGENT_FORK_CACHE_KEY_ENV], forkCacheKey);
+	});
+
+	it("rewrites only existing OpenAI-style string prompt cache keys", () => {
+		process.env[SUBAGENT_FORK_CACHE_KEY_ENV] = "pi-fork:parent-session";
+		const payload = {
+			model: "test-model",
+			input: [{ role: "user", content: "hello" }],
+			prompt_cache_key: "child-session",
+		};
+
+		assert.deepEqual(
+			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload }, { model: { api: "openai-responses" } } as never),
+			{ ...payload, prompt_cache_key: "pi-fork:parent-session" },
+		);
+		assert.deepEqual(
+			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { ...payload, prompt_cache_key: "pi-fork:parent-session" } }, { model: { api: "openai-responses" } } as never),
+			{ ...payload, prompt_cache_key: "pi-fork:parent-session" },
+		);
+	});
+
+	it("does not add prompt cache keys or touch non-OpenAI payloads", () => {
+		process.env[SUBAGENT_FORK_CACHE_KEY_ENV] = "pi-fork:parent-session";
+
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: "raw" }, { model: { api: "openai-responses" } } as never), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: [] }, { model: { api: "openai-responses" } } as never), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test" } }, { model: { api: "openai-responses" } } as never), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: undefined } }, { model: { api: "openai-responses" } } as never), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, { model: { api: "anthropic-messages" } } as never), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, { model: { api: "unknown-api" } } as never), undefined);
+	});
+
+	it("is a no-op when fork cache affinity is not configured", () => {
+		delete process.env[SUBAGENT_FORK_CACHE_KEY_ENV];
+		assert.equal(
+			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, { model: { api: "openai-responses" } } as never),
+			undefined,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1682 by preserving prompt-cache affinity for fork-context subagent children on OpenAI-style providers.

This implements the narrow Part 1 path recommended by the Fable-high oracle review:

- derive a bounded fork-family cache key as `pi-fork:<sha256(parentSessionId)>`
- pass that key only for resolved `context: "fork"` children in foreground and async/background launch paths
- clear any ambient fork cache key for fresh/non-fork launches
- rewrite only existing string `prompt_cache_key` fields on recognized OpenAI-style provider payloads

This intentionally does not reorder system prompts or task preambles. That riskier Part 2 was deferred because it intersects instruction-priority behavior, output contracts, lazy skill injection, refinement overlays, and `systemPromptMode: "replace"`.

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/integration/async-execution.test.ts` — 152/152 locally after rebase; reviewer rerun saw 153/153
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/subagent-prompt-runtime.test.ts` — 59/59
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/fork-cache-key.test.ts` — 5/5
- `git diff --check origin/main..HEAD`

## Review

Fresh exact-head review for `052213918d2904907e917c9e6e6e820ce48d9b28` found no current-diff defects.
