### PR TITLE
Animate running spinner on wall clock instead of render events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Reuse a fork-family prompt cache key for OpenAI-style forked subagent requests so sibling fork children keep cache affinity without pooling fresh children. Thanks to [@Shinkicast](https://github.com/Shinkicast) for #1682.
 - Show workflow child `[fresh]` and `[fork]` context labels in Fleet status rows alongside model and thinking badges.
 - Match pi-mcp-adapter direct-tool names when configured MCP server names contain hyphens. Thanks to [@unrelentingfox](https://github.com/unrelentingfox) for #1685.
+- Animate running FleetView glyphs from the wall clock and repaint unchanged running entries. Thanks to [@Pudgey](https://github.com/Pudgey) for #1688.
 
 ## [0.59.0] - 2026-08-28
 

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -551,7 +551,12 @@ export class SubagentFleetStatus {
 			this.lastRenderKey = renderKey;
 			return;
 		}
-		if (renderKey === this.lastRenderKey) return;
+		if (renderKey === this.lastRenderKey) {
+			// Repaint anyway while anything is running so the wall-clock
+			// spinner animates between state changes (500ms tick).
+			if (this.entries.some((entry) => entry.state === "running")) this.tui?.requestRender();
+			return;
+		}
 		this.lastRenderKey = renderKey;
 		this.tui?.requestRender();
 	}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -192,7 +192,10 @@ function runningSeed(...values: Array<number | undefined>): number | undefined {
 
 function runningGlyph(seed?: number): string {
 	if (seed === undefined) return STATIC_RUNNING_GLYPH;
-	return RUNNING_FRAMES[Math.abs(seed) % RUNNING_FRAMES.length]!;
+	// Free-running wall-clock spinner: advance ~8 fps regardless of model
+	// activity; keep the seed so parallel rows stay phase-offset.
+	const clock = Math.floor(Date.now() / 125);
+	return RUNNING_FRAMES[Math.abs(seed + clock) % RUNNING_FRAMES.length]!;
 }
 
 function animatedSeed(seed: number | undefined, frame: number | undefined): number | undefined {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1411,7 +1411,8 @@ describe("subagent async widget rendering", () => {
 		);
 	});
 
-	it("keeps running widget output stable when progress seed is unchanged", async () => {
+	it("advances running widget glyphs when the wall clock moves despite unchanged progress", () => {
+		const originalNow = Date.now;
 		const job = {
 			asyncId: "run-stable",
 			asyncDir: "/tmp/run",
@@ -1423,12 +1424,19 @@ describe("subagent async widget rendering", () => {
 			currentToolStartedAt: 2_000,
 			lastActivityAt: 2_500,
 		};
-		const first = buildWidgetLines([job], theme, 120);
-		await new Promise((resolve) => setTimeout(resolve, 120));
-		const second = buildWidgetLines([job], theme, 120);
+		try {
+			Date.now = () => 1_000;
+			const first = buildWidgetLines([job], theme, 120);
+			Date.now = () => 1_125;
+			const second = buildWidgetLines([job], theme, 120);
+			const withoutRunningGlyphs = (lines: string[]) => lines.map((line) => line.replace(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/gu, ""));
 
-		assert.deepEqual(second, first);
-		assert.equal(firstGrapheme(first[1] ?? ""), firstGrapheme(second[1] ?? ""));
+			assert.notDeepEqual(second, first);
+			assert.deepEqual(withoutRunningGlyphs(second), withoutRunningGlyphs(first), "only the running glyph should change");
+			assert.notEqual(firstGrapheme(first[1] ?? ""), firstGrapheme(second[1] ?? ""));
+		} finally {
+			Date.now = originalNow;
+		}
 	});
 
 	it("advances component running glyphs with the render clock", () => {

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -258,6 +258,46 @@ describe("below-editor subagent FleetView", () => {
 		}
 	});
 
+	it("repaints unchanged running entries but keeps queued-only ticks quiet", () => {
+		const refreshCount = (status: "running" | "queued"): number => {
+			const state = stateForTest();
+			state.asyncJobs.set(`run-${status}`, {
+				asyncId: `run-${status}`,
+				asyncDir: `/tmp/run-${status}`,
+				status,
+				mode: "single",
+				startedAt: 10,
+				updatedAt: 20,
+			});
+			let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+			let renderRequests = 0;
+			const ctx = {
+				hasUI: true,
+				ui: {
+					setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+					onTerminalInput() { return () => {}; },
+					getEditorText() { return ""; },
+					requestRender() {},
+					notify() {},
+					theme,
+				},
+			} as unknown as ExtensionContext;
+			const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+			try {
+				fleet.setContext(ctx);
+				assert.ok(widgetFactory);
+				widgetFactory!({ requestRender() { renderRequests++; } }, theme);
+				fleet.refresh();
+				return renderRequests;
+			} finally {
+				fleet.dispose();
+			}
+		};
+
+		assert.equal(refreshCount("running"), 1);
+		assert.equal(refreshCount("queued"), 0);
+	});
+
 	it("counts project panes in compact status", () => {
 		const state = stateForTest();
 		const projectRoot = path.join("fixtures", "peer-project");

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { row } from "../../src/tui/render-helpers.ts";
-import { renderSubagentResult, truncLine, widgetRenderKey } from "../../src/tui/render.ts";
+import { buildWidgetLines, renderSubagentResult, truncLine, widgetRenderKey } from "../../src/tui/render.ts";
 import type { AsyncJobState } from "../../src/shared/types.ts";
 
 const theme = {
@@ -121,6 +121,42 @@ test("widget render keys keep compact payloads quiet and expanded payloads fresh
 	warningDetailChange.workflow!.preflightWarnings = ["different mismatch"];
 	assert.equal(widgetRenderKey(warningDetailChange), widgetRenderKey(preflightJob));
 	assert.notEqual(widgetRenderKey(warningDetailChange, true), widgetRenderKey(preflightJob, true));
+});
+
+test("seeded running glyphs advance at wall-clock frame boundaries while unseeded glyphs stay static", () => {
+	const originalNow = Date.now;
+	const runningGlyph = (lines: string[]): string => lines
+		.map((line) => line.match(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏●]/u)?.[0])
+		.find((glyph): glyph is string => glyph !== undefined) ?? "";
+	const seededJob: AsyncJobState = {
+		asyncId: "seeded",
+		asyncDir: "/tmp/seeded",
+		status: "running",
+		mode: "single",
+		updatedAt: 1,
+	};
+	const unseededJob: AsyncJobState = {
+		asyncId: "unseeded",
+		asyncDir: "/tmp/unseeded",
+		status: "running",
+		mode: "single",
+	};
+
+	try {
+		Date.now = () => 1_000;
+		const seededBeforeBoundary = runningGlyph(buildWidgetLines([seededJob], theme, 180));
+		const unseededBeforeBoundary = runningGlyph(buildWidgetLines([unseededJob], theme, 180));
+
+		Date.now = () => 1_125;
+		const seededAfterBoundary = runningGlyph(buildWidgetLines([seededJob], theme, 180));
+		const unseededAfterBoundary = runningGlyph(buildWidgetLines([unseededJob], theme, 180));
+
+		assert.notEqual(seededAfterBoundary, seededBeforeBoundary);
+		assert.equal(unseededAfterBoundary, unseededBeforeBoundary);
+		assert.equal(unseededBeforeBoundary, "●");
+	} finally {
+		Date.now = originalNow;
+	}
 });
 
 test("multiline rendering omits two-column graphemes at one-column width", () => {


### PR DESCRIPTION
The running spinner (braille frames in FleetView and inline status rows) only advances when a render event changes its seed/frame. During quiet stretches — a child thinking, a long tool call — the dots freeze mid-frame and read as a hang even though the run is healthy.

This PR makes the spinner free-running on wall clock:

- `runningGlyph` derives its frame from `Date.now() / 125` (~8 fps), keeping the existing `seed` term so parallel rows stay phase-offset rather than spinning in lockstep.
- FleetView's refresh gate (`renderKey === lastRenderKey` early return) now requests a repaint on its existing 500ms tick while any entry is `running`, so the clock-driven frame actually gets painted between state changes. Idle fleets keep the early return — zero extra renders when nothing runs.

No new timers, no API changes; running this locally the fleet reads as alive the whole way through a 5-lane parallel run instead of stuttering with model activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)