### PR TITLE
fix: preserve MCP server prefix hyphens

### DIFF
--- a/src/runs/shared/mcp-direct-tool-grant.ts
+++ b/src/runs/shared/mcp-direct-tool-grant.ts
@@ -125,11 +125,8 @@ export function formatUnresolvedMcpDirectToolSelectors(selectors: readonly strin
 
 function getServerPrefix(serverName: string, mode: McpToolPrefix): string {
 	if (mode === "none") return "";
-	if (mode === "short") {
-		const short = serverName.replace(/-?mcp$/i, "").replace(/-/g, "_");
-		return short || "mcp";
-	}
-	return serverName.replace(/-/g, "_");
+	if (mode === "short") return serverName.replace(/-?mcp$/i, "") || "mcp";
+	return serverName;
 }
 
 function formatToolName(toolName: string, serverName: string, prefix: McpToolPrefix): string {

--- a/test/unit/mcp-direct-tool-grant.test.ts
+++ b/test/unit/mcp-direct-tool-grant.test.ts
@@ -19,8 +19,8 @@ test("plans server grants from explicit metadata facts and preserves resource fi
 
 	assert.deepEqual(grant, {
 		selections: [
-			{ name: "browser_mcp_navigate", selector: "browser-mcp/navigate" },
-			{ name: "browser_mcp_get_console_logs", selector: "browser-mcp/get_console_logs" },
+			{ name: "browser-mcp_navigate", selector: "browser-mcp/navigate" },
+			{ name: "browser-mcp_get_console_logs", selector: "browser-mcp/get_console_logs" },
 		],
 		unresolvedSelectors: [],
 	});
@@ -95,7 +95,7 @@ test("enforces server includeTools before exclusions for tools and generated res
 
 test("matches include and exclude patterns against raw and alternate prefix names", () => {
 	for (const [toolPrefix, expectedName] of [
-		["server", "demo_mcp_search-records"],
+		["server", "demo-mcp_search-records"],
 		["short", "demo_search-records"],
 		["none", "search-records"],
 	] as const) {
@@ -114,6 +114,23 @@ test("matches include and exclude patterns against raw and alternate prefix name
 			toolPrefix,
 		});
 		assert.deepEqual(excluded.selections, []);
+	}
+});
+
+test("matches adapter names for test-mcp/example in every prefix mode", () => {
+	for (const [toolPrefix, expectedName] of [
+		["server", "test-mcp_example"],
+		["short", "test_example"],
+		["none", "example"],
+	] as const) {
+		const grant = planMcpDirectToolGrant({
+			selectors: ["test-mcp"],
+			servers: { "test-mcp": {} },
+			metadata: { "test-mcp": { tools: [{ name: "example" }] } },
+			toolPrefix,
+		});
+
+		assert.deepEqual(grant.selections, [{ name: expectedName, selector: "test-mcp/example" }]);
 	}
 });
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/nicobailon/pi-subagents/issues/1685.

Preserve provider-valid hyphens in direct MCP server prefixes so child tool names match `pi-mcp-adapter@2.31.0`. Short prefixes still remove a trailing `-mcp`, and `none` remains unchanged.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/mcp-direct-tool-grant.test.ts`: 8/8 passed.
- `npm run typecheck`
- `git diff --check`

## Residual risks

- This keeps the existing local implementation of the adapter naming contract. A future adapter naming change would still require the two packages to update together.
