### PR TITLE
fix: preserve hyphenated MCP direct tool names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Reuse a fork-family prompt cache key for OpenAI-style forked subagent requests so sibling fork children keep cache affinity without pooling fresh children. Thanks to [@Shinkicast](https://github.com/Shinkicast) for #1682.
 - Show workflow child `[fresh]` and `[fork]` context labels in Fleet status rows alongside model and thinking badges.
+- Match pi-mcp-adapter direct-tool names when configured MCP server names contain hyphens. Thanks to [@unrelentingfox](https://github.com/unrelentingfox) for #1685.
 
 ## [0.59.0] - 2026-08-28
 

--- a/src/runs/shared/mcp-direct-tool-grant.ts
+++ b/src/runs/shared/mcp-direct-tool-grant.ts
@@ -125,11 +125,8 @@ export function formatUnresolvedMcpDirectToolSelectors(selectors: readonly strin
 
 function getServerPrefix(serverName: string, mode: McpToolPrefix): string {
 	if (mode === "none") return "";
-	if (mode === "short") {
-		const short = serverName.replace(/-?mcp$/i, "").replace(/-/g, "_");
-		return short || "mcp";
-	}
-	return serverName.replace(/-/g, "_");
+	if (mode === "short") return serverName.replace(/-?mcp$/i, "") || "mcp";
+	return serverName;
 }
 
 function formatToolName(toolName: string, serverName: string, prefix: McpToolPrefix): string {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -518,11 +518,12 @@ export function resolvePiLaunchToolPlan(
 	}
 	const resolvedMcpSelections = mcpResolution.selections;
 	const resolvedMcpNames = new Set(resolvedMcpSelections.map((selection) => selection.name));
+	const legacyMcpNameCounts = countLegacyUnderscoreMcpToolNames(resolvedMcpSelections);
 	const effectiveMcpSelections = resolvedMcpSelections.filter(
 		(selection) =>
 			!allowedToolSet ||
 			allowedToolSet.has(selection.name) ||
-			isLegacyUnderscoreMcpToolAllowed(selection, allowedToolSet, resolvedMcpNames),
+			isLegacyUnderscoreMcpToolAllowed(selection, allowedToolSet, resolvedMcpNames, legacyMcpNameCounts),
 	);
 	const effectiveMcpTools = effectiveMcpSelections.map(
 		(selection) => selection.name,
@@ -678,13 +679,23 @@ export function resolvePiLaunchToolPlan(
 }
 
 // Capability ceilings persisted before #1685 may still name hyphenated MCP server prefixes with underscores.
+function countLegacyUnderscoreMcpToolNames(selections: readonly ResolvedMcpDirectToolSelection[]): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const selection of selections) {
+		const legacyName = legacyUnderscoreMcpToolName(selection);
+		if (legacyName !== selection.name) counts.set(legacyName, (counts.get(legacyName) ?? 0) + 1);
+	}
+	return counts;
+}
+
 function isLegacyUnderscoreMcpToolAllowed(
 	selection: ResolvedMcpDirectToolSelection,
 	allowedToolSet: ReadonlySet<string>,
 	resolvedMcpNames: ReadonlySet<string>,
+	legacyMcpNameCounts: ReadonlyMap<string, number>,
 ): boolean {
 	const legacyName = legacyUnderscoreMcpToolName(selection);
-	return legacyName !== selection.name && !resolvedMcpNames.has(legacyName) && allowedToolSet.has(legacyName);
+	return legacyMcpNameCounts.get(legacyName) === 1 && !resolvedMcpNames.has(legacyName) && allowedToolSet.has(legacyName);
 }
 
 function legacyUnderscoreMcpToolName(selection: ResolvedMcpDirectToolSelection): string {

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -517,11 +517,12 @@ export function resolvePiLaunchToolPlan(
 		throw new Error(formatUnresolvedMcpDirectToolSelectors(mcpResolution.unresolvedSelectors));
 	}
 	const resolvedMcpSelections = mcpResolution.selections;
+	const resolvedMcpNames = new Set(resolvedMcpSelections.map((selection) => selection.name));
 	const effectiveMcpSelections = resolvedMcpSelections.filter(
 		(selection) =>
 			!allowedToolSet ||
 			allowedToolSet.has(selection.name) ||
-			allowedToolSet.has(legacyUnderscoreMcpToolName(selection)),
+			isLegacyUnderscoreMcpToolAllowed(selection, allowedToolSet, resolvedMcpNames),
 	);
 	const effectiveMcpTools = effectiveMcpSelections.map(
 		(selection) => selection.name,
@@ -677,6 +678,15 @@ export function resolvePiLaunchToolPlan(
 }
 
 // Capability ceilings persisted before #1685 may still name hyphenated MCP server prefixes with underscores.
+function isLegacyUnderscoreMcpToolAllowed(
+	selection: ResolvedMcpDirectToolSelection,
+	allowedToolSet: ReadonlySet<string>,
+	resolvedMcpNames: ReadonlySet<string>,
+): boolean {
+	const legacyName = legacyUnderscoreMcpToolName(selection);
+	return legacyName !== selection.name && !resolvedMcpNames.has(legacyName) && allowedToolSet.has(legacyName);
+}
+
 function legacyUnderscoreMcpToolName(selection: ResolvedMcpDirectToolSelection): string {
 	const slash = selection.selector.indexOf("/");
 	if (slash < 1) return selection.name;

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -518,7 +518,10 @@ export function resolvePiLaunchToolPlan(
 	}
 	const resolvedMcpSelections = mcpResolution.selections;
 	const effectiveMcpSelections = resolvedMcpSelections.filter(
-		(selection) => !allowedToolSet || allowedToolSet.has(selection.name),
+		(selection) =>
+			!allowedToolSet ||
+			allowedToolSet.has(selection.name) ||
+			allowedToolSet.has(legacyUnderscoreMcpToolName(selection)),
 	);
 	const effectiveMcpTools = effectiveMcpSelections.map(
 		(selection) => selection.name,
@@ -671,6 +674,17 @@ export function resolvePiLaunchToolPlan(
 			: {}),
 		...(capabilityAudit ? { capabilityAudit } : {}),
 	};
+}
+
+// Capability ceilings persisted before #1685 may still name hyphenated MCP server prefixes with underscores.
+function legacyUnderscoreMcpToolName(selection: ResolvedMcpDirectToolSelection): string {
+	const slash = selection.selector.indexOf("/");
+	if (slash < 1) return selection.name;
+	const toolName = selection.selector.slice(slash + 1);
+	const suffix = `_${toolName}`;
+	if (!selection.name.endsWith(suffix)) return selection.name;
+	const prefix = selection.name.slice(0, -suffix.length);
+	return `${prefix.replace(/-/g, "_")}${suffix}`;
 }
 
 /** Escape XML-significant characters in a string for safe attribute interpolation. */

--- a/test/unit/mcp-direct-tool-grant.test.ts
+++ b/test/unit/mcp-direct-tool-grant.test.ts
@@ -19,8 +19,8 @@ test("plans server grants from explicit metadata facts and preserves resource fi
 
 	assert.deepEqual(grant, {
 		selections: [
-			{ name: "browser_mcp_navigate", selector: "browser-mcp/navigate" },
-			{ name: "browser_mcp_get_console_logs", selector: "browser-mcp/get_console_logs" },
+			{ name: "browser-mcp_navigate", selector: "browser-mcp/navigate" },
+			{ name: "browser-mcp_get_console_logs", selector: "browser-mcp/get_console_logs" },
 		],
 		unresolvedSelectors: [],
 	});
@@ -95,7 +95,7 @@ test("enforces server includeTools before exclusions for tools and generated res
 
 test("matches include and exclude patterns against raw and alternate prefix names", () => {
 	for (const [toolPrefix, expectedName] of [
-		["server", "demo_mcp_search-records"],
+		["server", "demo-mcp_search-records"],
 		["short", "demo_search-records"],
 		["none", "search-records"],
 	] as const) {
@@ -114,6 +114,23 @@ test("matches include and exclude patterns against raw and alternate prefix name
 			toolPrefix,
 		});
 		assert.deepEqual(excluded.selections, []);
+	}
+});
+
+test("matches adapter names for test-mcp/example in every prefix mode", () => {
+	for (const [toolPrefix, expectedName] of [
+		["server", "test-mcp_example"],
+		["short", "test_example"],
+		["none", "example"],
+	] as const) {
+		const grant = planMcpDirectToolGrant({
+			selectors: ["test-mcp"],
+			servers: { "test-mcp": {} },
+			metadata: { "test-mcp": { tools: [{ name: "example" }] } },
+			toolPrefix,
+		});
+
+		assert.deepEqual(grant.selections, [{ name: expectedName, selector: "test-mcp/example" }]);
 	}
 });
 

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1363,6 +1363,54 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.deepEqual(JSON.parse(launch.env[MCP_DIRECT_CHILD_TOOLS_ENV]!), ["runtime-a_search"]);
 	});
 
+	it("does not let legacy MCP ceiling aliases cross server boundaries", () => {
+		const fixture = createMcpFixture();
+		const definitions = {
+			"runtime-a": { command: "runtime-a", args: ["--stdio"] },
+			runtime_a: { command: "runtime_a", args: ["--stdio"] },
+		};
+		writeJson(path.join(fixture.agentDir, "mcp.json"), { mcpServers: {} });
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"runtime-a": { configHash: computeMcpServerHash(definitions["runtime-a"]), cachedAt: Date.now(), tools: [{ name: "search" }] },
+				runtime_a: { configHash: computeMcpServerHash(definitions.runtime_a), cachedAt: Date.now(), tools: [{ name: "search" }] },
+			},
+		});
+		const runtimeSnapshotHost: McpRuntimeSnapshotHost = {
+			events: {
+				emit(_event, request) {
+					const definition = definitions[request.name as keyof typeof definitions];
+					if (!definition) {
+						request.result = { ok: false, error: new Error(`unknown runtime server ${request.name}`) };
+						return;
+					}
+					request.result = { ok: true, snapshot: { name: request.name, definition, runtime: true, persisted: false } };
+				},
+			},
+		};
+
+		const launch = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["runtime-a", "runtime_a"],
+			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime_a_search"], denyExtensions: false, sources: ["test"] },
+			runtimeSnapshotHost,
+		});
+
+		assert.equal(launch.args[launch.args.indexOf("--tools") + 1], "read,runtime_a_search");
+		const configPath = launch.args[launch.args.indexOf("--mcp-config") + 1];
+		assert.ok(configPath);
+		assert.deepEqual(JSON.parse(fs.readFileSync(configPath, "utf-8")), {
+			mcpServers: { runtime_a: definitions.runtime_a },
+		});
+		assert.deepEqual(JSON.parse(launch.env[MCP_DIRECT_CHILD_TOOLS_ENV]!), ["runtime_a_search"]);
+	});
+
 	it("emits --no-tools for explicit empty tool allowlists", () => {
 		for (const requireReadTool of [false, true]) {
 			const { args, env } = buildPiArgs({

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1351,7 +1351,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			inheritSkills: false,
 			tools: ["read"],
 			mcpDirectTools: ["runtime-a", "runtime-b"],
-			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime-a_search"], denyExtensions: false, sources: ["test"] },
+			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime_a_search"], denyExtensions: false, sources: ["test"] },
 			runtimeSnapshotHost,
 		});
 		assert.equal(launch.args[launch.args.indexOf("--tools") + 1], "read,runtime-a_search");

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1125,7 +1125,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 		assert.equal(
 			args[args.indexOf("--tools") + 1],
-			"read,bash,chrome_devtools_take_screenshot,chrome_devtools_click",
+			"read,bash,chrome-devtools_take_screenshot,chrome-devtools_click",
 		);
 		assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
 		assert.equal(
@@ -1133,15 +1133,15 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			JSON.stringify([
 				"read",
 				"bash",
-				"chrome_devtools_take_screenshot",
-				"chrome_devtools_click",
+				"chrome-devtools_take_screenshot",
+				"chrome-devtools_click",
 			]),
 		);
 		assert.equal(
 			env[MCP_DIRECT_CHILD_TOOLS_ENV],
 			JSON.stringify([
-				"chrome_devtools_take_screenshot",
-				"chrome_devtools_click",
+				"chrome-devtools_take_screenshot",
+				"chrome-devtools_click",
 			]),
 		);
 	});
@@ -1224,8 +1224,8 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			runtimeSnapshotHost,
 		});
 		assert.deepEqual(requestedNames, [serverName, serverName]);
-		assert.equal(serverLaunch.args[serverLaunch.args.indexOf("--tools") + 1], "read,runtime_github_search_repositories,runtime_github_create_issue");
-		assert.equal(toolLaunch.args[toolLaunch.args.indexOf("--tools") + 1], "read,runtime_github_search_repositories");
+		assert.equal(serverLaunch.args[serverLaunch.args.indexOf("--tools") + 1], "read,runtime-github_search_repositories,runtime-github_create_issue");
+		assert.equal(toolLaunch.args[toolLaunch.args.indexOf("--tools") + 1], "read,runtime-github_search_repositories");
 		assert.ok(serverLaunch.args.indexOf("--mcp-config") < serverLaunch.args.indexOf("Task: hello"));
 		for (const launch of [serverLaunch, toolLaunch]) {
 			const configPath = launch.args[launch.args.indexOf("--mcp-config") + 1];
@@ -1240,11 +1240,11 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			[serverName, `${serverName}/search_repositories`],
 		);
 		assert.deepEqual(JSON.parse(serverLaunch.env[MCP_DIRECT_CHILD_TOOLS_ENV]!), [
-			"runtime_github_search_repositories",
-			"runtime_github_create_issue",
+			"runtime-github_search_repositories",
+			"runtime-github_create_issue",
 		]);
 		assert.deepEqual(JSON.parse(toolLaunch.env[MCP_DIRECT_CHILD_TOOLS_ENV]!), [
-			"runtime_github_search_repositories",
+			"runtime-github_search_repositories",
 		]);
 	});
 
@@ -1351,16 +1351,16 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			inheritSkills: false,
 			tools: ["read"],
 			mcpDirectTools: ["runtime-a", "runtime-b"],
-			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime_a_search"], denyExtensions: false, sources: ["test"] },
+			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime-a_search"], denyExtensions: false, sources: ["test"] },
 			runtimeSnapshotHost,
 		});
-		assert.equal(launch.args[launch.args.indexOf("--tools") + 1], "read,runtime_a_search");
+		assert.equal(launch.args[launch.args.indexOf("--tools") + 1], "read,runtime-a_search");
 		const configPath = launch.args[launch.args.indexOf("--mcp-config") + 1];
 		assert.ok(configPath);
 		assert.deepEqual(JSON.parse(fs.readFileSync(configPath, "utf-8")), {
 			mcpServers: { "runtime-a": definitions["runtime-a"] },
 		});
-		assert.deepEqual(JSON.parse(launch.env[MCP_DIRECT_CHILD_TOOLS_ENV]!), ["runtime_a_search"]);
+		assert.deepEqual(JSON.parse(launch.env[MCP_DIRECT_CHILD_TOOLS_ENV]!), ["runtime-a_search"]);
 	});
 
 	it("emits --no-tools for explicit empty tool allowlists", () => {
@@ -1398,7 +1398,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 			assert.equal(
 				args[args.indexOf("--tools") + 1],
-				"chrome_devtools_take_screenshot,chrome_devtools_click",
+				"chrome-devtools_take_screenshot,chrome-devtools_click",
 			);
 			assert.equal(env.MCP_DIRECT_TOOLS, "chrome-devtools");
 		}
@@ -1451,7 +1451,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 	it("matches adapter prefix modes for direct MCP names", () => {
 		for (const [prefix, expected] of [
-			["server", "read,linear_mcp_list_issues"],
+			["server", "read,linear-mcp_list_issues"],
 			["short", "read,linear_list_issues"],
 			["none", "read,list_issues"],
 		] as const) {
@@ -1497,7 +1497,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 
 		assert.equal(
 			args[args.indexOf("--tools") + 1],
-			"read,browser_mcp_navigate,browser_mcp_get_console_logs",
+			"read,browser-mcp_navigate,browser-mcp_get_console_logs",
 		);
 	});
 
@@ -1614,7 +1614,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 			cwd: fixture.projectDir,
 		});
 
-		assert.equal(args[args.indexOf("--tools") + 1], "read,project_mcp_inspect");
+		assert.equal(args[args.indexOf("--tools") + 1], "read,project-mcp_inspect");
 	});
 
 	it("resolves direct MCP tools from Pi package manifests", () => {
@@ -1861,7 +1861,7 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		);
 		assert.equal(
 			args[args.indexOf("--tools") + 1],
-			"read,chrome_devtools_take_screenshot",
+			"read,chrome-devtools_take_screenshot",
 		);
 		assert.ok(
 			extensionArgs.some((arg) =>

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1411,6 +1411,50 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.deepEqual(JSON.parse(launch.env[MCP_DIRECT_CHILD_TOOLS_ENV]!), ["runtime_a_search"]);
 	});
 
+	it("does not allow ambiguous legacy MCP ceiling aliases", () => {
+		const fixture = createMcpFixture();
+		const definitions = {
+			"runtime-a-b": { command: "runtime-a-b", args: ["--stdio"] },
+			"runtime_a-b": { command: "runtime_a-b", args: ["--stdio"] },
+		};
+		writeJson(path.join(fixture.agentDir, "mcp.json"), { mcpServers: {} });
+		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+			version: 1,
+			servers: {
+				"runtime-a-b": { configHash: computeMcpServerHash(definitions["runtime-a-b"]), cachedAt: Date.now(), tools: [{ name: "search" }] },
+				"runtime_a-b": { configHash: computeMcpServerHash(definitions["runtime_a-b"]), cachedAt: Date.now(), tools: [{ name: "search" }] },
+			},
+		});
+		const runtimeSnapshotHost: McpRuntimeSnapshotHost = {
+			events: {
+				emit(_event, request) {
+					const definition = definitions[request.name as keyof typeof definitions];
+					if (!definition) {
+						request.result = { ok: false, error: new Error(`unknown runtime server ${request.name}`) };
+						return;
+					}
+					request.result = { ok: true, snapshot: { name: request.name, definition, runtime: true, persisted: false } };
+				},
+			},
+		};
+
+		const launch = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "hello",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: ["read"],
+			mcpDirectTools: ["runtime-a-b", "runtime_a-b"],
+			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime_a_b_search"], denyExtensions: false, sources: ["test"] },
+			runtimeSnapshotHost,
+		});
+
+		assert.equal(launch.args[launch.args.indexOf("--tools") + 1], "read");
+		assert.equal(launch.args.includes("--mcp-config"), false);
+		assert.equal(launch.env[MCP_DIRECT_CHILD_TOOLS_ENV], undefined);
+	});
+
 	it("emits --no-tools for explicit empty tool allowlists", () => {
 		for (const requireReadTool of [false, true]) {
 			const { args, env } = buildPiArgs({


### PR DESCRIPTION
## Summary

Supersedes #1689 and closes #1685.

Preserve provider-valid hyphens in direct MCP server prefixes so child direct-tool names match `pi-mcp-adapter@2.31.0`. This keeps the contributor's narrow production fix from #1689, updates downstream `pi-args` expectations, and adds release-credit coverage.

Thanks to [@unrelentingfox](https://github.com/unrelentingfox) for reporting #1685 and contributing #1689.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/mcp-direct-tool-grant.test.ts test/unit/pi-args.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- . ':(exclude)package-lock.json'`\n