### PR TITLE
test: stabilize wall-clock render assertions

### DIFF
--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -81,6 +81,16 @@ function withTerminalWidth<T>(columns: number, fn: () => T): T {
 	}
 }
 
+function withMockedDateNow<T>(now: number, fn: () => T): T {
+	const original = Date.now;
+	Date.now = () => now;
+	try {
+		return fn();
+	} finally {
+		Date.now = original;
+	}
+}
+
 describe("renderSubagentResult fork indicator", () => {
 	it("renders result-owned nested children for foreground single, parallel, and chain runs", () => {
 		const cases = [
@@ -435,8 +445,10 @@ describe("renderSubagentResult fork indicator", () => {
 				content: [{ type: "text" as const, text: testCase.name }],
 				details: { mode: "single" as const, results: [child] },
 			};
-			const compact = renderSubagentResult!(result, { expanded: false }, theme).render(120).join("\n");
-			const expanded = renderSubagentResult!(result, { expanded: true }, theme).render(120).join("\n");
+			const [compact, expanded] = withMockedDateNow(0, () => [
+				renderSubagentResult!(result, { expanded: false }, theme).render(120).join("\n"),
+				renderSubagentResult!(result, { expanded: true }, theme).render(120).join("\n"),
+			]);
 
 			assert.equal(firstGrapheme(compact), testCase.glyph, `${testCase.name} compact glyph`);
 			assert.equal(firstGrapheme(expanded), testCase.glyph, `${testCase.name} expanded glyph`);
@@ -881,7 +893,7 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.doesNotMatch(text, /Agent 1\/1: reviewer · running/);
 	});
 
-	it("keeps running compact result output stable when progress is unchanged", async () => {
+	it("keeps running compact result output stable at the same render clock when progress is unchanged", () => {
 		const result = {
 			content: [{ type: "text" as const, text: "(running...)" }],
 			details: {
@@ -910,9 +922,10 @@ describe("renderSubagentResult fork indicator", () => {
 				}],
 			},
 		};
-		const first = renderSubagentResult!(result, { expanded: false }, theme).render(120);
-		await new Promise((resolve) => setTimeout(resolve, 120));
-		const second = renderSubagentResult!(result, { expanded: false }, theme).render(120);
+		const [first, second] = withMockedDateNow(0, () => [
+			renderSubagentResult!(result, { expanded: false }, theme).render(120),
+			renderSubagentResult!(result, { expanded: false }, theme).render(120),
+		]);
 
 		assert.deepEqual(second, first);
 	});

--- a/test/unit/widget-nested-render.test.ts
+++ b/test/unit/widget-nested-render.test.ts
@@ -8,6 +8,20 @@ const theme = {
 	bold(text: string): string { return text; },
 };
 
+function withMockedDateNow<T>(now: number, fn: () => T): T {
+	const original = Date.now;
+	Date.now = () => now;
+	try {
+		return fn();
+	} finally {
+		Date.now = original;
+	}
+}
+
+function withoutRunningGlyphs(lines: string[]): string[] {
+	return lines.map((line) => line.replace(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/g, "•"));
+}
+
 function nested(id: string, parentRunId: string, state: NestedRunSummary["state"] = "running", extra: Partial<NestedRunSummary> = {}): NestedRunSummary {
 	return {
 		id,
@@ -136,12 +150,12 @@ describe("nested widget rendering", () => {
 		assert.match(expanded, /\[\d{2}:\d{2}:\d{2}\] . completed-step: Finalize report · completed/);
 	});
 
-	it("keeps event-time timestamps stable instead of advancing with wall time", async () => {
+	it("keeps event-time timestamps stable while running glyphs use wall time", () => {
 		const state = job(nested("nested-reviewer", "root-run", "running", { currentTool: "read", currentToolStartedAt: 0 }));
-		const first = buildWidgetLines([state], theme as any, 120, true);
-		await new Promise((resolve) => setTimeout(resolve, 20));
-		const second = buildWidgetLines([state], theme as any, 120, true);
-		assert.deepEqual(second, first);
+		const first = withMockedDateNow(0, () => buildWidgetLines([state], theme as any, 120, true));
+		const second = withMockedDateNow(1_125, () => buildWidgetLines([state], theme as any, 120, true));
+		assert.notDeepEqual(second, first);
+		assert.deepEqual(withoutRunningGlyphs(second), withoutRunningGlyphs(first));
 	});
 
 	it("rerenders when only nested state changes", () => {


### PR DESCRIPTION
## Summary

Fix final main CI after #1688 by stabilizing older render assertions that compared running spinner glyph output across wall-clock time.

The tests now pin or normalize the render clock where they are asserting semantic status or event-time timestamp stability, while keeping the new wall-clock animation behavior covered.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/widget-nested-render.test.ts test/integration/render-fork-badge.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/fleet-status.test.ts test/unit/render-helpers.test.ts`
- `npm run test:integration`
- `npm run typecheck`
- `git diff --check`
