### PR TITLE
fix: skip watchdog untracked scans in unsafe roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Clarify workflowScript portability and runs.host working-directory limits, including the outer workflow cwd and trusted `cd ... && command` patterns (#1679).
 
 ### Fixed
+- Skip untracked-file enumeration for watchdog signatures when the Git root is the user home or has no tracked files, avoiding startup and turn hangs in accidental large home repositories. Thanks to [@AluxesLAS](https://github.com/AluxesLAS) for #1693.
 - Reuse a fork-family prompt cache key for OpenAI-style forked subagent requests so sibling fork children keep cache affinity without pooling fresh children. Thanks to [@Shinkicast](https://github.com/Shinkicast) for #1682.
 - Show workflow child `[fresh]` and `[fork]` context labels in Fleet status rows alongside model and thinking badges.
 - Match pi-mcp-adapter direct-tool names when configured MCP server names contain hyphens. Thanks to [@unrelentingfox](https://github.com/unrelentingfox) for #1685.

--- a/src/watchdog/change-signature.ts
+++ b/src/watchdog/change-signature.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { PROJECT_SUBAGENTS_RELATIVE_DIR } from "../shared/artifacts.ts";
 
@@ -11,6 +12,7 @@ const IGNORED_CHANGE_SEGMENTS = new Set([".git", "node_modules"]);
 const DEFAULT_MAX_HASH_FILE_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_HASH_TOTAL_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_HASH_ENTRIES = 2_000;
+const TRACKED_ENTRY_PROBE_MAX_BYTES = 1_024;
 
 function positiveEnvNumber(name: string, fallback: number): number {
 	const parsed = Number(process.env[name]);
@@ -41,6 +43,37 @@ function git(cwd: string, args: string[]): string | undefined {
 	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024, windowsHide: true });
 	if (result.status !== 0) return undefined;
 	return result.stdout;
+}
+
+function comparablePath(value: string): string {
+	let resolved = path.resolve(value);
+	try {
+		resolved = fs.realpathSync.native(resolved);
+	} catch {
+		// Keep the lexical path when canonicalization is unavailable.
+	}
+	return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function isHomeRepoRoot(root: string): boolean {
+	return comparablePath(root) === comparablePath(os.homedir());
+}
+
+/**
+ * Probe the index without asking Git to inspect the working tree. The output
+ * cap keeps this check bounded even for repositories with a very large index;
+ * an ENOBUFS result still proves that at least one tracked path exists.
+ */
+function hasTrackedEntries(root: string): boolean | undefined {
+	const result = spawnSync("git", ["-C", root, "ls-files", "--cached", "--error-unmatch", "--", "."], {
+		encoding: "utf-8",
+		maxBuffer: TRACKED_ENTRY_PROBE_MAX_BYTES,
+		windowsHide: true,
+	});
+	const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+	if (result.status === 0 || errorCode === "ENOBUFS") return true;
+	if (result.status === 1) return false;
+	return undefined;
 }
 
 function normalizeRelPath(value: string): string {
@@ -181,7 +214,13 @@ function buildRepoChangeSignature(root: string, statusOutput: string): WatchdogR
 export function computeWatchdogRepoChangeSignature(cwd: string): WatchdogRepoChangeSignature | undefined {
 	const root = git(cwd, ["rev-parse", "--show-toplevel"])?.trim();
 	if (!root) return undefined;
-	const statusOutput = git(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]);
+	const skipUntracked = isHomeRepoRoot(root) || hasTrackedEntries(root) === false;
+	const statusOutput = git(root, [
+		"status",
+		"--porcelain=v1",
+		"-z",
+		`--untracked-files=${skipUntracked ? "no" : "all"}`,
+	]);
 	if (statusOutput === undefined) return undefined;
 	try {
 		return buildRepoChangeSignature(root, statusOutput);

--- a/test/unit/watchdog-change-signature.test.ts
+++ b/test/unit/watchdog-change-signature.test.ts
@@ -48,11 +48,19 @@ function git(cwd: string, args: string[]): string {
 	return result.stdout.trim();
 }
 
-function createRepo(prefix: string): string {
+function createEmptyRepo(prefix: string): string {
 	const repo = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 	git(repo, ["init"]);
 	git(repo, ["config", "user.email", "watchdog@example.com"]);
 	git(repo, ["config", "user.name", "Watchdog Tests"]);
+	return repo;
+}
+
+function createRepo(prefix: string): string {
+	const repo = createEmptyRepo(prefix);
+	fs.writeFileSync(path.join(repo, ".watchdog-baseline"), "baseline\n", "utf-8");
+	git(repo, ["add", ".watchdog-baseline"]);
+	git(repo, ["commit", "-m", "initial"]);
 	return repo;
 }
 
@@ -96,6 +104,45 @@ describe("watchdog change signature", () => {
 		git(checkout, ["commit", "-m", "update tracked"]);
 		const headChange = computeWatchdogRepoChangeSignature(parent);
 		assert.notEqual(headChange?.key, first?.key, "submodule HEAD changes remain visible");
+	});
+
+	it("does not inspect untracked files in an empty repository", (t) => {
+		const repo = createEmptyRepo("watchdog-empty-");
+		t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+
+		fs.writeFileSync(path.join(repo, "untracked.txt"), "one\n", "utf-8");
+		const first = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(first, "expected a signature");
+		assert.deepEqual(first?.changedPaths, []);
+
+		fs.writeFileSync(path.join(repo, "untracked.txt"), "two\n", "utf-8");
+		const afterChange = computeWatchdogRepoChangeSignature(repo);
+		assert.equal(afterChange?.key, first?.key, "untracked-only changes must not trigger an empty-repo scan");
+	});
+
+	it("does not inspect untracked files when the repository root is the user home", (t) => {
+		const repo = createRepo("watchdog-home-");
+		t.after(() => fs.rmSync(repo, { recursive: true, force: true }));
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		process.env.HOME = repo;
+		process.env.USERPROFILE = repo;
+		t.after(() => {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+		});
+
+		fs.writeFileSync(path.join(repo, "untracked.txt"), "one\n", "utf-8");
+		const first = computeWatchdogRepoChangeSignature(repo);
+		assert.ok(first, "expected a signature");
+		assert.deepEqual(first?.changedPaths, []);
+
+		fs.writeFileSync(path.join(repo, ".watchdog-baseline"), "changed\n", "utf-8");
+		const trackedChange = computeWatchdogRepoChangeSignature(repo);
+		assert.deepEqual(trackedChange?.changedPaths, [".watchdog-baseline"]);
+		assert.notEqual(trackedChange?.key, first?.key, "tracked changes remain visible for a home-root repository");
 	});
 
 	function setThreshold(bytes: number, t: { after: (fn: () => void) => void }): void {


### PR DESCRIPTION
## Summary
- skip watchdog untracked-file enumeration when the Git root is the user home or the repo has no tracked files
- keep tracked changes visible for those fast paths and preserve ordinary repo behavior
- add focused watchdog signature regressions

Closes #1693.

Thanks to [@AluxesLAS](https://github.com/AluxesLAS) for reporting #1693.

## Validation
- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/watchdog-change-signature.test.ts
- npm run typecheck
- git diff --check