### PR TITLE
docs: clarify staged subagent workflows

### DIFF
--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -16,8 +16,10 @@ explicitly delegated fanout and their resolved `tools` allow `subagent`.
 
 | Need | Use |
 | --- | --- |
-| One disposable child | direct `{ agent, task }` |
-| Sequence, fanout, retry, gate monitor, retained resume, cross-repo wave, or aggregate result | `workflowScript` |
+| One bounded task for one child | direct `{ agent, task }` |
+| JavaScript control flow or data-dependent branching; sequence, fanout, retry, rolling fanout, or aggregation | `workflowScript` with `runs.run(...)` / `runs.all(...)` |
+| A broad plan split into visible narrow stages per lane | `workflowScript` with `runs.lanes([{ key, stages: [...] }])` |
+| Independent worktree or repository lanes | `references/multi-lane-orchestration.md` |
 | Council of advisors | `../council-mode/SKILL.md` |
 | Management, status, steering, authoring, or inspection | `action` |
 
@@ -26,6 +28,15 @@ explicitly delegated fanout and their resolved `tools` allow `subagent`.
 Keep scripts portable: use top-level `await`, plain helpers, or explicit Promise
 chains, not nested async helpers. Legacy top-level `chain` / `tasks` inputs and
 durable `.chain.md` execution are inspection or migration material only.
+
+Use `runs.lanes(...)` only inside a `workflowScript`, not as a top-level mode. It
+keeps a predeclared staged plan visible: first stages batch across lanes, later
+stages sequence per lane, and the returned board exposes lane/stage results. See
+the [canonical staged-lane example](../../docs/workflows.md#parallel-sequential-lanes).
+When staged seams are available, do not give a low-tier writer an end-to-end
+issue. Split it into narrow stages, such as a scout/red test, helper-only change,
+one render seam, validation, minimality challenge, or fresh review, and give the
+writer only its assigned implementation stage.
 
 Use async/background by default. Set `async:false` only when the parent must
 block. Final reviews, validation gates, oracle checks, and publication checks

--- a/skills/pi-subagents/references/constraints-and-recipes.md
+++ b/skills/pi-subagents/references/constraints-and-recipes.md
@@ -31,7 +31,8 @@ For durable evidence, copy only the final summary to session memory, a PR body/c
 
 ## Best Practices
 
-- Run subagents asynchronously by default; direct one-child execution is enough for a simple disposable child, and `workflowScript` is the composition surface for keyed, parallel, retained, or multi-step work. Use `async: false` only when the parent must block. See `references/execution-controls.md` → Async/background for wait semantics.
+- Run subagents asynchronously by default; direct one-child execution is enough for one bounded task, while `workflowScript` is the composition surface for JavaScript control flow and data-dependent branching. Use `async: false` only when the parent must block. See `references/execution-controls.md` → Async/background for wait semantics.
+- For a predeclared broad plan split into visible narrow stages, use `runs.lanes([...])` inside `workflowScript`; use raw `runs.run(...)`/`runs.all(...)` for conditional or rolling flows. See [`execution-controls.md`](execution-controls.md#parallel-sequential-lanes).
 - Keep one writer per cwd/worktree. Parallelize reading, review, and validation; concurrent writers need isolated worktrees. Give every child a cold-start packet with its goal, target/ref, authority, context, success criteria, validation, output, and stop rules.
 - Keep tasks narrow and standalone; do not rely on issue numbers, broad globs, or supervisor round-trips to supply missing context.
 - Keep authority with the parent. Escalate unapproved product, scope, architecture, merge, credential, or release decisions; checks, receipts, and review bots are evidence, not authority.

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -43,10 +43,11 @@ subagent({
 })
 ```
 
-Use direct single-agent execution for one disposable child when no stable key,
+Use direct single-agent execution for one bounded task when no stable key,
 branching, retained-child lookup, or aggregate workflow result is needed. Use a
-`workflowScript` even for one child when the run is part of a larger coordinated
-wave or a later step must resume it by key.
+`workflowScript` when the parent needs JavaScript control flow or data-dependent
+branching, or when the run is part of a larger coordinated wave or a later step
+must resume it by key.
 
 ### Forked context
 
@@ -67,7 +68,17 @@ its resolved launch context as `[fresh]` or `[fork]`. Aggregate headers show
 
 ### Scripted workflows
 
-`workflowScript` is the public composition surface. Use `runs.run(key, { agent, task, ... })` for keyed children, `runs.all([...])` for parallel children, and ordinary JavaScript for sequence, branching, filtering, retries, and aggregation. Scripts are ordinary JavaScript statement bodies, so use an explicit return such as `workflowScript: "return runs.run('main', { agent: 'worker', task: '...' })"` for a useful one-child result. Use top-level `await`, plain helper functions, or explicit Promise chains; nested `async function` helpers, async arrows, and async methods are rejected. Prefer a single scripted workflow whenever the parent is starting a coordinated wave, such as multiple reviews, review plus gate monitor, worker then monitor setup, cross-repo prep lanes, or a fanout that the parent will consume together.
+`workflowScript` is the public composition surface when the parent needs
+JavaScript control flow or data-dependent branching. Use
+`runs.run(key, { agent, task, ... })` for keyed children, `runs.all([...])` for
+parallel children, and ordinary JavaScript for sequence, filtering, retries,
+and aggregation. Scripts are ordinary JavaScript statement bodies, so use an
+explicit return such as `return runs.run("main", { agent: "worker", task: "..." })` for a useful one-child result. Use top-level `await`,
+plain helper functions, or explicit Promise chains; nested `async function`
+helpers, async arrows, and async methods are rejected. Prefer a single scripted
+workflow whenever the parent is starting a coordinated wave, such as multiple
+reviews, review plus gate monitor, worker then monitor setup, cross-repo prep
+lanes, or a fanout that the parent will consume together.
 
 ```js
 subagent({
@@ -104,6 +115,19 @@ return runs.run("cross-oracle", {
 ```
 
 Keyed resume reads that one exact receipt and revalidates the retained run at launch. It fails when the workflow or key is missing, the receipt is stale, `latest` is not `true`, or the recorded child is no longer resumable. The receipt is terminal-only: if `status.json` or `events.jsonl` exists without it, the workflow may still be active or terminal receipt writing may have failed. Use direct child run IDs from status/events for direct resume after the normal retained-child checks; do not reconstruct keyed entries from those files. Foreground workflow results expose the same receipt in `details.workflow.receipt`, but cross-workflow keyed lookup requires the durable receipt from an async workflow.
+
+### Parallel sequential lanes
+
+For a broad plan with a known set of narrow, visible stages per lane, use
+`runs.lanes(...)` inside a `workflowScript`; it is a nested helper, not a
+top-level `subagent` mode. Give each lane and stage a stable key. The first
+stage from every lane is launched together, then later stages sequence per lane.
+`resume: "previous"` requires the retained predecessor, and a failed or blocked
+stage blocks only that lane. The returned board exposes lane/stage results for
+the parent. See the [canonical staged-lane example](../../../docs/workflows.md#parallel-sequential-lanes).
+
+Use raw `runs.run(...)`/`runs.all(...)` instead when branching or rolling fanout
+depends on runtime data rather than a predeclared stage plan.
 
 ### Async/background
 

--- a/skills/pi-subagents/references/prompting-and-roles.md
+++ b/skills/pi-subagents/references/prompting-and-roles.md
@@ -20,7 +20,7 @@ Parent extensions may register a session-scoped, out-of-band ceiling through `pi
 
 ## Tool vs Slash Commands
 
-Agents use the `subagent(...)` tool for execution, management, status, and control. Direct `{ agent, task }` execution is enough for one simple child; use `workflowScript` when the parent needs keyed, parallel, sequential, branching, retry, retained-resume, or aggregate workflow behavior. Humans often use the slash-command layer instead:
+Agents use the `subagent(...)` tool for execution, management, status, and control. Direct `{ agent, task }` execution is enough for one bounded child task; use `workflowScript` when the parent needs JavaScript control flow or data-dependent branching, keyed, parallel, sequential, retry, retained-resume, aggregate, or explicit staged-lane behavior (`runs.lanes`). Humans often use the slash-command layer instead:
 
 - `/run` — launch a single agent
 - `workflowScript` — the sole public surface for sequence, parallelism, branching, retries, and aggregation
@@ -114,6 +114,12 @@ Use this after implementation when the user wants cleanup review or when a final
 ### Staged fix orchestration technique
 
 Use this when a broad diff has known reviewer findings across several items and the user wants the parent to “orchestrate subagents like a boss.” Keep the active worktree safe with a three-stage `workflowScript`:
+
+When staged seams are available, a low-tier writer should not receive the
+end-to-end issue. Use `runs.lanes` inside `workflowScript` to keep stages narrow:
+a scout/red test, helper-only change, one render seam, validation, minimality
+challenge, or fresh review. Give the writer only its assigned implementation
+stage; keep sequencing and synthesis with the parent.
 
 1. A parallel read-only planning fanout, one reviewer per issue cluster. Each child inspects the real diff and returns exact files, line refs, proposed fixes, and focused validation. They must not edit.
 2. One writer worker. It receives the reviewer summaries as the awaited planning results (or their durable output paths) interpolated into its task, plus the parent’s accepted scope, stop rules, and verification contract. It is the only child allowed to edit the active worktree.


### PR DESCRIPTION
## Summary
- distinguish direct one-child runs, composed workflow scripts, and explicit staged lanes
- document when to use runs.lanes for visible narrow stages
- warn against giving low-tier writers end-to-end issue-sized tasks when staged seams are available

Closes #1698.

## Validation
- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/writer-budget-guidance.test.ts test/unit/skills-fallback.test.ts test/unit/proactive-skills.test.ts
- focused public skill-doc content/link assertions
- npm run typecheck
- git diff --check
- fresh read-only review: No issues found