### PR TITLE
docs: clarify interactive async lane yielding

### DIFF
--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -42,6 +42,15 @@ Use async/background by default. Set `async:false` only when the parent must
 block. Final reviews, validation gates, oracle checks, and publication checks
 stay async.
 
+In an ordinary interactive session, yield after launching or triaging useful
+async lanes and let Pi wake the parent on completion; do not call blocking
+`subagent_wait()` merely because a child is active. Use blocking
+`subagent_wait()` only when a headless/run-to-completion contract or a required
+same-turn artifact makes the result necessary before this turn ends. For
+“continue/orchestrate/work until done,” keep the lane board moving while a safe
+immediate action remains; if only async lanes are running, record the revisit
+trigger and yield.
+
 Package agents appear in `subagent({ action: "list" })`. External CLI/job agents
 use their own runner contract. Do not pass native Pi child options to them unless
 that runner explicitly supports the option.

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -139,7 +139,20 @@ Async does not mean parallel writes. Do not edit the same active worktree while 
 
 Do not end your turn immediately after launching an async child if you promised to keep working. Continue the local inspection, synthesis, or validation prep, then check the async run when its result is needed. If no safe independent work remains, return control and let Pi wake the session; do not convert the child to foreground.
 
-In an interactive chat, normally return control when ready to yield and let Pi wake the session on completion; do not call `subagent_wait()` merely to wait. A run-to-completion user request is not by itself a reason to use foreground children. Override the normal yield-and-wake flow only when this exact turn cannot safely end without the result, such as a headless provider flow or a skill contract that must produce a same-turn artifact. Use `subagent_wait()`, not `async:false`, for that current-turn dependency. Never substitute sleep or status-polling loops.
+“Continue/orchestrate/work until done” means keep the lane board moving while a
+safe immediate action remains; it does not mean hold an interactive turn open
+until async lanes finish. If only async lanes are running, record the revisit
+trigger and yield. Do not use `subagent_wait({ all: true })` as an interactive
+lane barrier.
+
+In an ordinary interactive chat, normally return control after launching or
+triaging useful async work and let Pi wake the session on completion; do not
+call `subagent_wait()` merely to wait. A run-to-completion user request is not
+by itself a reason to use foreground children. Override the normal yield-and-
+wake flow only when this exact turn cannot safely end without the result, such
+as a headless provider flow or a skill contract that must produce a same-turn
+artifact. Use `subagent_wait()`, not `async:false`, for that current-turn
+dependency. Never substitute sleep or status-polling loops.
 
 `subagent_wait()` returns when the next initially active async run or registered provider item finishes or a subagent needs attention. Use `subagent_wait({ all: true })` for all work active at call time, `subagent_wait({ id: "..." })` for one async or remembered detached foreground run, and `subagent_wait({ timeoutMs })` to cap the block; active work keeps running if it elapses. `subagent_wait({ stopOnAttention: false })` keeps a blocking wait through idle or long-thinking attention, but supervisor/contact requests still stop it. In a long-lived interactive parent session, use `subagent_wait({ id: "...", nonBlocking: true })` to resolve the prefix to one exact run, persist an armed subscription, return immediately, and wake later on completion, failure, attention, reconciliation failure, or timeout. Ordinary status lists armed subscriptions separately from active children. This differs from disabling `waitTool`, which returns immediately without arming a future wake. If a foreground child detaches for supervisor coordination, reply first, then wait on its id; do not resume or launch a replacement while it remains detached. Headless sessions also auto-drain exact current-session work at `agent_end` as a final safeguard.
 

--- a/skills/pi-subagents/references/multi-lane-orchestration.md
+++ b/skills/pi-subagents/references/multi-lane-orchestration.md
@@ -32,6 +32,12 @@ Use one async `workflowScript` for a coordinated wave. Use `runs.all` for indepe
 
 While one lane waits, run safe independent preparation, validation, or fresh read-only review lanes. Do not block the parent just because a run is active. If no safe lane remains, record the blocker and the event that will reopen work.
 
+In an ordinary interactive session, completion wakes the parent; after useful
+async lanes are launched or triaged, yield rather than use
+`subagent_wait({ all: true })` as a barrier. “Continue/orchestrate/work until
+done” means keep the board moving while safe immediate work remains. If only
+async lanes are running, record the revisit trigger and yield.
+
 An ordinary coordinated workflow has one mission. Use its durable state, artifacts, run records, and receipts for recovery. Treat a receipt as evidence, not as authority or acceptance.
 
 After a writer produces a candidate, run the required fresh-context, read-only reviewer. The reviewer inspects the exact worktree and returns evidence-backed findings. The parent decides which findings are in scope and whether the lane is ready. Use `review-and-validation.md` for finding disposition, validation, and gate-failure triage. Send accepted fixes to that lane's sole writer, then rerun only the affected gate.


### PR DESCRIPTION
## Summary

- clarify that interactive async lane orchestration yields and lets Pi wake the parent
- document that `continue/orchestrate/work until done` means keep the lane board moving only while safe immediate work remains
- warn against using `subagent_wait({ all: true })` as an interactive lane barrier while preserving same-turn/headless exceptions

Closes #1701

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/writer-budget-guidance.test.ts`
- `npm run typecheck`
- `git diff --check`
- added public-skill private-policy grep clean
- fresh read-only review: No issues found
