### PR TITLE
fix: dedupe single-child async widget labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Remove repeated one-child async widget status labels and compact progress echoes (#1695).
 - Tighten packaged subagent and council-mode skill guidance around direct one-child launches, composed `workflowScript` runs, generic review validation, pass contracts, and private policy boundaries.
 - Clarify portable subagent orchestration guidance: keep the parent on the ordinary strong default model, route bounded workers/scouts to a fast worker tier, and reserve a top-reasoning model for bounded read-only critique or escalation without requiring a specific provider.
 - Trim duplicated orchestration recipes from the packaged skill while keeping policy in `constraints-and-recipes.md` and execution details in `execution-controls.md`.

--- a/src/tui/render-helpers.ts
+++ b/src/tui/render-helpers.ts
@@ -30,6 +30,22 @@ export function fuzzyFilter<T extends { name: string; description: string; model
 		.map((x) => x.item);
 }
 
+/** Remove a repeated job name from a child label when a safe separator follows it. */
+export function stripRepeatedAgentPrefix(label: string, jobName: string | undefined): string {
+	const value = label.trim();
+	const prefix = jobName?.trim();
+	if (!prefix || !value.startsWith(prefix)) return value;
+
+	const suffix = value.slice(prefix.length);
+	if (!suffix || !/^(?::|·|\s)/u.test(suffix)) return value;
+	return suffix.replace(/^\s*(?::|·)?\s*/u, "").trim();
+}
+
+/** Whether a status label may omit the one logical step marker. */
+export function shouldSuppressSingleStep(chainStepCount?: number, stepsTotal?: number): boolean {
+	return (chainStepCount ?? stepsTotal) === 1;
+}
+
 export function pad(s: string, len: number): string {
 	const vis = visibleWidth(s);
 	return s + " ".repeat(Math.max(0, len - vis));

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -31,6 +31,7 @@ import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
 import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
 import { aggregateStepStatus, formatActivityLabel, formatAgentRunningLabel, formatParallelOutcome } from "../shared/status-format.ts";
 import { contextModeBadge, contextModePrefix } from "../runs/shared/context-mode.ts";
+import { shouldSuppressSingleStep, stripRepeatedAgentPrefix } from "./render-helpers.ts";
 import { buildWorkflowChatProgressRows, type WorkflowChatProgressRow } from "../workflows/chat-progress.ts";
 import { formatWorkflowPreflight, formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary, formatWorkflowPreflightWarnings } from "../workflows/workflow-preflight.ts";
 import { encodeAsyncStatusSnapshotWidget } from "../runs/background/async-status-snapshot.ts";
@@ -262,6 +263,7 @@ const noisyStatusPatterns = [
 	/^(?:checking|fetching|reading|inspecting|verifying|collecting|confirming|polling)\b/i,
 	/^(?:async\s+subagent\s+)?[\w.-]+\s*·\s*(?:step|agent)\s+\d+\/\d+\s*·/i,
 	/^(?:Step|Agent)\s+\d+\/\d+:\s+[\w.-]+\s*·\s*(?:running|queued|pending|complete|completed)\b/i,
+	/^(?:async\s+subagent\s+)?[\w.-]+(?:\s+\[(?:fresh|fork|mixed)\])?\s*·\s*(?:running|queued|pending|complete|completed|done)\b/i,
 	/^Press\s+\S+\s+for\s+live\s+detail$/i,
 	/^output:\s+.+\/async-subagent-runs\//i,
 ];
@@ -782,6 +784,14 @@ function widgetStepRenderKey(step: AsyncJobStep, index: number, expanded = false
 		step.review?.status,
 		step.toolBudgetBlocked,
 		step.turnBudgetExceeded,
+		step.timedOut,
+		step.stopped,
+		step.execution?.status,
+		step.execution?.error,
+		step.execution?.timedOut,
+		step.execution?.interrupted,
+		step.execution?.stopped,
+		step.execution?.detached,
 		step.watchdog?.phase,
 		step.error,
 		expanded ? expandedStepActivityRenderKey(step) : undefined,
@@ -858,6 +868,8 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 		activeParallelGroup: job.activeParallelGroup,
 		startedAt: job.startedAt,
 		updatedAt: job.updatedAt,
+		timedOut: job.timedOut,
+		stopped: job.stopped,
 		totalTokens: job.totalTokens,
 	});
 }
@@ -875,6 +887,65 @@ function widgetJobName(job: AsyncJobState): string {
 	if (job.mode === "single" && job.agents?.length === 1) return job.agents[0]!;
 	if (job.agents?.length) return formatWidgetAgents(job.agents);
 	return job.mode ?? "subagent";
+}
+
+function isSingleChildAsyncJob(job: AsyncJobState): boolean {
+	return job.mode === "single"
+		&& job.steps?.length === 1
+		&& shouldSuppressSingleStep(job.chainStepCount, job.stepsTotal);
+}
+
+function isCompletedWidgetStepStatus(status: AsyncJobStep["status"]): boolean {
+	return status === "complete" || status === "completed";
+}
+
+function singleChildAgentName(job: AsyncJobState, step: AsyncJobStep): string {
+	return job.agents?.length === 1 ? job.agents[0]! : step.agent || widgetJobName(job);
+}
+
+function hasSingleChildDetailEvidence(job: AsyncJobState, step: AsyncJobStep): boolean {
+	return Boolean(
+		step.error?.trim()
+		|| step.execution?.error?.trim()
+		|| step.phase?.trim()
+		|| step.label?.trim()
+		|| step.workflowKey?.trim()
+		|| step.outputName?.trim()
+		|| step.lane
+		|| job.workflowKey?.trim()
+		|| job.lane
+		|| laneTraceForJob(job)?.phase?.trim()
+		|| laneTraceForJob(job)?.label?.trim()
+		|| step.timedOut
+		|| step.stopped
+		|| step.execution?.timedOut
+		|| step.execution?.interrupted
+		|| step.execution?.stopped
+		|| step.execution?.detached
+		|| job.timedOut
+		|| job.stopped
+		|| ["failed", "partial", "paused", "stopped", "detached"].includes(step.execution?.status ?? "")
+		|| step.acceptance?.status === "rejected"
+		|| step.acceptance?.reviewResult?.status === "blockers"
+		|| step.review?.status === "blockers",
+	);
+}
+
+function shouldCollapseSingleChildDetails(job: AsyncJobState, step: AsyncJobStep): boolean {
+	if (!isSingleChildAsyncJob(job) || hasSingleChildDetailEvidence(job, step)) return false;
+	if (job.status === "running") return step.status === "running";
+	if (job.status === "complete") return isCompletedWidgetStepStatus(step.status);
+	return false;
+}
+
+function singleChildTask(job: AsyncJobState, step: AsyncJobStep): string | undefined {
+	const task = compactTaskText(step.description, step.label);
+	if (task) return task;
+	const sessionName = step.sessionName?.trim();
+	if (!sessionName) return undefined;
+	const agentName = singleChildAgentName(job, step);
+	const sessionTask = stripRepeatedAgentPrefix(sessionName, agentName);
+	return sessionTask === agentName ? undefined : compactTaskText(sessionTask);
 }
 
 function widgetActivity(job: AsyncJobState): string {
@@ -1266,6 +1337,7 @@ function resultRowLabel(label: MultiProgressLabel, resultIndex: number, stepNumb
 function widgetStats(job: AsyncJobState, theme: Theme): string {
 	const parts: string[] = [];
 	const stepsTotal = job.stepsTotal ?? (job.agents?.length ?? 1);
+	const isSingleChild = isSingleChildAsyncJob(job);
 	if (job.activeParallelGroup) {
 		const running = job.runningSteps ?? (job.status === "running" ? 1 : 0);
 		const done = job.completedSteps ?? (job.status === "complete" ? stepsTotal : 0);
@@ -1283,10 +1355,10 @@ function widgetStats(job: AsyncJobState, theme: Theme): string {
 			parts.push(`step ${logicalStep + 1}/${total} · parallel group: ${groupParts.join(" · ")}`);
 		}
 	} else if (job.currentStep !== undefined) {
-		if (job.mode === "chain" && job.parallelGroups?.length) {
+		if (job.mode === "chain") {
 			const total = job.chainStepCount ?? stepsTotal;
-			parts.push(`step ${flatToLogicalStepIndex(job.currentStep, total, job.parallelGroups) + 1}/${total}`);
-		} else {
+			parts.push(`step ${flatToLogicalStepIndex(job.currentStep, total, job.parallelGroups ?? []) + 1}/${total}`);
+		} else if (!isSingleChild) {
 			parts.push(`step ${job.currentStep + 1}/${stepsTotal}`);
 		}
 	} else if (stepsTotal > 1) {
@@ -1500,16 +1572,21 @@ function foregroundStyleWidgetStepLines(
 	const status = widgetStepStatus(step.status, theme);
 	const stats = widgetStepStats(theme, step);
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
-	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${itemTitle} ${index}/${total}: ${themeBold(theme, childDisplayName(step))}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
+	const collapseDetails = shouldCollapseSingleChildDetails(job, step);
+	const displayName = collapseDetails ? singleChildAgentName(job, step) : childDisplayName(step);
+	const rowLabel = collapseDetails ? displayName : `${itemTitle} ${index}/${total}: ${displayName}`;
+	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${themeBold(theme, rowLabel)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
 	const lane = projectAsyncLane(job, step);
 	if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "    "));
-	const task = compactTaskText(step.description, step.label);
+	const task = collapseDetails ? singleChildTask(job, step) : compactTaskText(step.description, step.label);
 	if (task) lines.push(`    ${theme.fg("dim", `task: ${task}`)}`);
 	const activity = widgetStepActivityLine(step, width, expanded, job.updatedAt);
 	if (activity) lines.push(`    ${theme.fg("dim", `⎿  ${activity}`)}`);
 	for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 12 : 6)) {
 		lines.push(`    ${nestedLine}`);
 	}
+	const error = step.error?.trim() || step.execution?.error?.trim();
+	if (error) lines.push(`    ${theme.fg("error", `error: ${oneLine(error)}`)}`);
 	if (step.status === "running") {
 		if (!expanded) lines.push(`    ${theme.fg("accent", liveDetailHintText())}`);
 		const output = widgetOutputPath(job, step);
@@ -1567,7 +1644,9 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 		];
 	}
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
-	const total = job.stepsTotal ?? job.steps.length;
+	const total = job.mode === "chain"
+		? job.chainStepCount ?? job.stepsTotal ?? job.steps.length
+		: job.stepsTotal ?? job.steps.length;
 	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 	const lines: string[] = workflowPreflightLines(job, expanded);
 	for (const [index, step] of job.steps.entries()) {
@@ -1586,10 +1665,14 @@ function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number,
 	const stats = widgetStats(job, theme);
 	const count = job.mode === "chain" ? job.chainStepCount : job.stepsTotal ?? job.agents?.length ?? job.steps?.length;
 	const mode = widgetJobName(job);
-	const title = `async subagent ${mode}${count && count > 1 ? ` (${count})` : ""}`;
+	const title = isSingleChildAsyncJob(job)
+		? "async subagent"
+		: `async subagent ${mode}${count && count > 1 ? ` (${count})` : ""}`;
+	const collapseDetails = job.steps?.length === 1 && shouldCollapseSingleChildDetails(job, job.steps[0]!);
+	const summary = `${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, mode)}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`;
 	return [
 		`${theme.fg("toolTitle", themeBold(theme, title))} ${theme.fg("dim", "· background")}`,
-		`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, mode)}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+		...(collapseDetails ? [] : [summary]),
 		...foregroundStyleWidgetDetails(job, theme, expanded, width, frame),
 	].map((line) => truncLine(line, width));
 }

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1107,6 +1107,10 @@ describe("subagent async widget rendering", () => {
 						"Step 1/1: reviewer · running (gpt-5.5 · thinking xhigh) · 4 turns · 11 tool uses",
 						"reviewer · step 1/1 · 11 tool uses · 3m32s",
 						"Step 1/1: reviewer · running (gpt-5.5 · thinking xhigh) · 4 turns · 11 tool uses",
+						"reviewer [fresh] · running · 11 tool uses · 3m37s",
+						"reviewer · running · 11 tool uses · 3m39s",
+						"reviewer · running · 11 tool uses · 3m42s",
+						"reviewer · running · 11 tool uses · 3m44s",
 						"repo=nicobailon/pi-subagents",
 						"sha=d61aca... | 2m32s",
 						"output: /var/folders/x/T/pi-subagents-uid-501/async-subagent-runs/run-status-snapshots/output.log",
@@ -1116,12 +1120,16 @@ describe("subagent async widget rendering", () => {
 		};
 
 		const expandedText = buildWidgetLines([job], theme, 180, true).join("\n");
-		assert.match(expandedText, /↻ 7 progress updates/);
+		assert.match(expandedText, /↻ 11 progress updates/);
 		assert.match(expandedText, /latest: output: \/var\/folders\/x\/T\/pi-subagents-uid-501\/async-subagent-runs\/run-status-snapshots\/output.log/);
 		assert.match(expandedText, /repo=nicobailon\/pi-subagents/);
 		assert.match(expandedText, /sha=d61aca\.\.\. \| 2m32s/);
 		assert.doesNotMatch(expandedText, /3m27s/);
 		assert.doesNotMatch(expandedText, /3m29s/);
+		assert.doesNotMatch(expandedText, /3m37s/);
+		assert.doesNotMatch(expandedText, /3m39s/);
+		assert.doesNotMatch(expandedText, /3m42s/);
+		assert.doesNotMatch(expandedText, /3m44s/);
 	});
 
 	it("keeps mixed live output raw instead of hiding non-status lines", () => {
@@ -1196,41 +1204,163 @@ describe("subagent async widget rendering", () => {
 		assert.match(expandedText, /Checking final status: rejected/);
 	});
 
-	it("shows step detail and configured live detail key hint for running single async jobs with steps", () => {
+	it("dedupes one-child single async summary/title while retaining detail evidence", () => {
 		const now = Date.now();
 		const job = {
 			asyncId: "single-run",
 			asyncDir: "/tmp/single-run",
 			status: "running",
 			mode: "single",
-			agents: ["worker"],
+			agents: ["reviewer"],
+			currentStep: 0,
 			stepsTotal: 1,
 			updatedAt: now,
 			steps: [
 				{
 					index: 0,
-					agent: "worker",
-					sessionName: "  worker: Read the widget  ",
+					agent: "reviewer",
+					sessionName: "  reviewer: Review the widget  ",
 					status: "running",
+					description: "Review the widget",
 					currentTool: "read",
 					currentToolArgs: "src/tui/render.ts",
 					currentToolStartedAt: now - 2000,
-					recentOutput: ["reading render widget"],
+					toolCount: 23,
+					durationMs: 49_100,
+					recentOutput: ["error: failed to inspect the widget"],
 				},
 			],
 		};
 
 		const collapsedText = buildWidgetLines([job], theme, 180).join("\n");
-		assert.match(collapsedText, /async subagent worker · background/);
-		assert.match(collapsedText, /Step 1\/1: worker: Read the widget · running/);
+		const collapsedLines = collapsedText.split("\n");
+		const collapsedSummary = collapsedLines.slice(0, 2).join("\n");
+		assert.doesNotMatch(collapsedSummary, /step 1\/1/i);
+		assert.match(collapsedSummary, /async subagent · background/);
+		assert.match(collapsedSummary, /reviewer/);
+		assert.match(collapsedLines[1] ?? "", /reviewer · running · 23 tool uses · 49\.1s/);
+		assert.equal(collapsedLines.filter((line) => line.includes("reviewer · running · 23 tool uses · 49.1s")).length, 1);
+		assert.doesNotMatch(collapsedText, /Step 1\/1: reviewer:/);
+		assert.match(collapsedText, /reviewer · running · 23 tool uses · 49\.1s/);
+		assert.match(collapsedText, /task: Review the widget/);
 		assert.match(collapsedText, /⎿  read: src\/tui\/render\.ts \| 2\.0s/);
 		assert.match(collapsedText, /Press configured-expand-key for live detail/);
 		assert.match(collapsedText, outputPathPattern("/tmp/single-run/output-0.log"));
-		assert.doesNotMatch(collapsedText, /reading render widget/);
+		assert.doesNotMatch(collapsedText, /error: failed to inspect the widget/);
 
 		const expandedText = buildWidgetLines([job], theme, 180, true).join("\n");
+		const expandedLines = expandedText.split("\n");
+		const expandedSummary = expandedLines.slice(0, 2).join("\n");
 		assert.doesNotMatch(expandedText, /Press configured-expand-key for live detail/);
-		assert.match(expandedText, /reading render widget/);
+		assert.doesNotMatch(expandedSummary, /step 1\/1/i);
+		assert.match(expandedSummary, /async subagent · background/);
+		assert.match(expandedSummary, /reviewer/);
+		assert.match(expandedLines[1] ?? "", /reviewer · running · 23 tool uses · 49\.1s/);
+		assert.equal(expandedLines.filter((line) => line.includes("reviewer · running · 23 tool uses · 49.1s")).length, 1);
+		assert.doesNotMatch(expandedText, /Step 1\/1: reviewer:/);
+		assert.match(expandedText, /reviewer · running · 23 tool uses · 49\.1s/);
+		assert.match(expandedText, /task: Review the widget/);
+		assert.match(expandedText, /⎿  read: src\/tui\/render\.ts \| 2\.0s/);
+		assert.match(expandedText, /error: failed to inspect the widget/);
+		assert.match(expandedText, outputPathPattern("/tmp/single-run/output-0.log"));
+	});
+
+	it("collapses a completed single child but keeps a mismatched step header", () => {
+		const completed = buildWidgetLines([{
+			asyncId: "single-complete",
+			asyncDir: "/tmp/single-complete",
+			status: "complete",
+			mode: "single",
+			agents: ["reviewer"],
+			stepsTotal: 1,
+			steps: [{ index: 0, agent: "reviewer", sessionName: "reviewer: Review the widget", status: "completed" }],
+		}], theme, 180).join("\n");
+		assert.match(completed, /reviewer · complete/);
+		assert.doesNotMatch(completed, /Step 1\/1: reviewer:/);
+		assert.match(completed, /task: Review the widget/);
+
+		const mismatched = buildWidgetLines([{
+			asyncId: "single-mismatch",
+			asyncDir: "/tmp/single-mismatch",
+			status: "complete",
+			mode: "single",
+			agents: ["reviewer"],
+			currentStep: 0,
+			stepsTotal: 1,
+			steps: [{ index: 0, agent: "reviewer", sessionName: "reviewer: Review the widget", status: "running" }],
+		}], theme, 180).join("\n");
+		assert.match(mismatched, /Step 1\/1: reviewer: Review the widget · running/);
+	});
+
+	it("keeps explicit single-child error and gate evidence with a step header", () => {
+		const text = buildWidgetLines([{
+			asyncId: "single-evidence",
+			asyncDir: "/tmp/single-evidence",
+			status: "running",
+			mode: "single",
+			agents: ["reviewer"],
+			currentStep: 0,
+			stepsTotal: 1,
+			steps: [{
+				index: 0,
+				agent: "reviewer",
+				sessionName: "reviewer: Review the widget",
+				status: "running",
+				error: "failed to inspect the widget",
+				review: { status: "blockers" },
+			}],
+		}], theme, 180, true).join("\n");
+		assert.match(text, /Step 1\/1: reviewer: Review the widget · running/);
+		assert.match(text, /error: failed to inspect the widget/);
+		assert.match(text, /gate:review blockers/);
+	});
+
+	it("keeps a Step header for lane-bearing one-child single async jobs", () => {
+		const job = {
+			asyncId: "single-lane",
+			asyncDir: "/tmp/single-lane",
+			status: "running",
+			mode: "single",
+			agents: ["reviewer"],
+			currentStep: 0,
+			stepsTotal: 1,
+			steps: [{
+				index: 0,
+				agent: "reviewer",
+				sessionName: "reviewer: Review the widget",
+				status: "running",
+				phase: "fresh-review",
+				label: "Review #1695",
+				workflowKey: "review",
+				outputName: "review.md",
+			}],
+		};
+
+		for (const expanded of [false, true]) {
+			const text = buildWidgetLines([job], theme, 180, expanded).join("\n");
+			assert.match(text, /Step 1\/1: reviewer: Review the widget · running/);
+			assert.match(text, /phase:fresh-review/);
+			assert.match(text, /out:review\.md/);
+		}
+	});
+
+	it("keeps failed, paused, and stopped detail evidence in single-child summaries", () => {
+		for (const status of ["failed", "paused", "stopped"] as const) {
+			const text = buildWidgetLines([{
+				asyncId: `single-${status}`,
+				asyncDir: `/tmp/single-${status}`,
+				status,
+				mode: "single",
+				agents: ["reviewer"],
+				currentStep: 0,
+				stepsTotal: 1,
+				steps: [{ index: 0, agent: "reviewer", status }],
+			}], theme, 180).join("\n");
+			const summary = text.split("\n").slice(0, 2).join("\n");
+
+			assert.doesNotMatch(summary, /step 1\/1/i);
+			assert.match(text, new RegExp(`Step 1/1: reviewer · ${status}`));
+		}
 	});
 
 	it("keeps generic activity fallback for single async jobs without steps", () => {
@@ -1312,6 +1442,32 @@ describe("subagent async widget rendering", () => {
 			firstRunningGlyph(second.find((line) => line.includes("Step 2/2")) ?? ""),
 			"logical chain step glyph should advance with the render frame",
 		);
+	});
+
+	it("keeps chain step structure when only one logical child is materialized", () => {
+		const job = {
+			asyncId: "partial-chain",
+			asyncDir: "/tmp/partial-chain",
+			status: "running",
+			mode: "chain",
+			agents: ["planner", "reviewer"],
+			currentStep: 0,
+			chainStepCount: 2,
+			stepsTotal: 1,
+			steps: [{
+				index: 0,
+				agent: "planner",
+				sessionName: "planner: Plan the review",
+				status: "running",
+			}],
+		};
+		const text = buildWidgetLines([job], theme, 180).join("\n");
+
+		assert.match(text, /async subagent chain \(2\) · background/);
+		assert.match(text, /chain · step 1\/2/);
+		assert.match(text, /Step 1\/2: planner: Plan the review/);
+		assert.doesNotMatch(text, /Step 1\/1: planner: Plan the review/);
+		assert.doesNotMatch(text, /\s+[^\n]*planner · running/);
 	});
 
 	it("omits zero-running labels for pending active async parallel groups", () => {

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { row } from "../../src/tui/render-helpers.ts";
+import { row, shouldSuppressSingleStep, stripRepeatedAgentPrefix } from "../../src/tui/render-helpers.ts";
 import { buildWidgetLines, renderSubagentResult, truncLine, widgetRenderKey } from "../../src/tui/render.ts";
 import type { AsyncJobState } from "../../src/shared/types.ts";
 
@@ -36,6 +36,24 @@ function result(agent: string, output: string) {
 test("row clips content to the available width", () => {
 	const rendered = row("abcdef", 6, theme as any);
 	assert.equal(visibleWidth(rendered), 6);
+});
+
+test("stripRepeatedAgentPrefix removes only safe repeated job-name prefixes", () => {
+	assert.equal(stripRepeatedAgentPrefix("  reviewer: Review the diff  ", "reviewer"), "Review the diff");
+	assert.equal(stripRepeatedAgentPrefix("reviewer · Review the diff", "reviewer"), "Review the diff");
+	assert.equal(stripRepeatedAgentPrefix("reviewer Review the diff", "reviewer"), "Review the diff");
+	assert.equal(stripRepeatedAgentPrefix("reviewer-2: Review the diff", "reviewer"), "reviewer-2: Review the diff");
+	assert.equal(stripRepeatedAgentPrefix("reviewerhood: Review the diff", "reviewer"), "reviewerhood: Review the diff");
+	assert.equal(stripRepeatedAgentPrefix("worker: Review the diff", "reviewer"), "worker: Review the diff");
+	assert.equal(stripRepeatedAgentPrefix("reviewer", "reviewer"), "reviewer");
+});
+
+test("shouldSuppressSingleStep uses logical totals instead of materialized step count", () => {
+	assert.equal(shouldSuppressSingleStep(undefined, 1), true);
+	assert.equal(shouldSuppressSingleStep(1, 1), true);
+	assert.equal(shouldSuppressSingleStep(2, 1), false);
+	assert.equal(shouldSuppressSingleStep(undefined, 2), false);
+	assert.equal(shouldSuppressSingleStep(undefined, undefined), false);
 });
 
 test("row normalizes multiline content before clipping", () => {

--- a/test/unit/widget-nested-render.test.ts
+++ b/test/unit/widget-nested-render.test.ts
@@ -123,7 +123,8 @@ describe("nested widget rendering", () => {
 		state.status = "complete";
 		state.steps![0]!.status = "complete";
 		const expanded = buildWidgetLines([state], theme as any, 120, true).join("\n");
-		assert.match(expanded, /✓ Step 1\/1: owner · complete/);
+		assert.match(expanded, /✓ owner · complete/);
+		assert.doesNotMatch(expanded, /Step 1\/1: owner/);
 		assert.match(expanded, /↳ \[\d{2}:\d{2}:\d{2}\] . still-running · running/);
 	});
 


### PR DESCRIPTION
## Summary

- remove redundant `step 1/1`/agent repetition from one-child async widget labels
- keep structural step headers when detail evidence, lane metadata, or logical chain totals need them
- filter repeated status echo lines from live output

Closes #1695

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/render-helpers.test.ts test/unit/widget-nested-render.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review after follow-up fixes: No issues found
