### PR TITLE
docs: default non-trivial requests to async lanes

### DIFF
--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -72,17 +72,18 @@ review.
 
 ## Operating rules
 
-- Delegate only when a child improves evidence, independent review, or isolated execution.
+- Keep simple, low-risk one-tool-call work local; delegate asynchronously to a child or `workflowScript` for most non-trivial requests needing multiple tool calls, independent research, broad inspection, risky edits, fresh review, or progress while the parent handles another lane. Avoid duplicate scouts, overlapping writers, and vague prompts without a concrete deliverable; follow the existing `runs.lanes(...)`, worktree, and async-yield guidance.
 - Keep the parent on the ordinary strong default model. Route workers/scouts to a fast capable tier, serious reviews to a strong tier, and top reasoning to bounded read-only critique.
 - Exact model names are deployment policy. Put them in user/project settings or profiles, not package guidance.
-- Give every child a cold-start packet: goal, target/cwd/ref, authority, edit boundary, context/evidence, success criteria, validation, output, and stop rules.
-- Keep one writer per cwd/worktree. Parallel writers need isolated worktrees and a lane board.
+- Give every child a compact meta-prompt checklist: objective; repo/cwd/ref; authority/edit boundary; relevant files/contracts and constraints; success/acceptance criteria; validation; expected output/report; and stop/ask conditions. See `references/prompting-and-roles.md`.
+- For mutation work, use an isolated lane/worktree when isolation, overlap, or concurrent juggling matters; keep one writer per cwd/worktree. See `references/multi-lane-orchestration.md` for lane mechanics.
+- Keep long/high-output validation out of chat: prefer `interactive_shell` dispatch/background monitors, bounded logs, or subagent-owned reports; return a concise summary plus report path unless same-turn output is required. See `references/execution-controls.md`.
 - For cross-codebase work, record the repo, explicit `cwd`, authority boundary, and expected output before launch.
 - Make parallel prompts distinct by source seam, evidence, and decision. Do not clone prompts with only item numbers swapped.
 - Prefer fresh-context review/validation fanout, then synthesize and apply fixes in the parent.
 - For Pi extension repos under `~/.pi/agent/extensions`, put lane worktrees outside extension auto-discovery, such as `~/.pi/agent/worktrees`.
 - Preserve capability ceilings, including child tool limits and allowed-agent restrictions.
-- Escalate unresolved product, architecture, authority, release, merge, or safety decisions.
+- Keep planning, product/API/security decisions, acceptance, publication, and merge/release authority with the parent; escalate unresolved choices.
 - Treat receipts, CI, review bots, and external-run records as evidence, not authority.
 - For backlog maintenance, releases, merge queues, or other public-repo mutation policy, load the matching user/project skill. This package defines delegation primitives, not private policy.
 - As a conservative orchestration policy, do not pass a hard `toolBudget` or tight `usageBudget` to mutation-capable workers. The default tool budget blocks read/search tools rather than mutation tools. If interrupted after a tool call starts, checkpoint after the current tool returns with changed files, build/test state, and commit or PR state.


### PR DESCRIPTION
## Summary

- document async delegation as the default for most non-trivial multi-tool requests
- add a compact child meta-prompt checklist and worktree/lane guidance
- keep long/high-output validation out of chat unless same-turn output is required

Closes #1705

## Validation

- `git diff --check`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/writer-budget-guidance.test.ts`
- wording probes and referenced-doc checks from staged validation
- fresh read-only review: No issues found
