### PR TITLE
fix: hide git evidence subprocesses on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Clarify workflowScript portability and runs.host working-directory limits, including the outer workflow cwd and trusted `cd ... && command` patterns (#1679).
 
 ### Fixed
+- Hide mutation-evidence Git subprocess windows on Windows to prevent visible console flashes or terminal tabs. Thanks to [@dnnkeeper](https://github.com/dnnkeeper) for #1706.
 - Deliver immediate async workflow terminal failures on macOS without requiring a later status refresh (#1700).
 - Skip untracked-file enumeration for watchdog signatures when the Git root is the user home or has no tracked files, avoiding startup and turn hangs in accidental large home repositories. Thanks to [@AluxesLAS](https://github.com/AluxesLAS) for #1693.
 - Reuse a fork-family prompt cache key for OpenAI-style forked subagent requests so sibling fork children keep cache affinity without pooling fresh children. Thanks to [@Shinkicast](https://github.com/Shinkicast) for #1682.

--- a/src/runs/shared/mutation-evidence.ts
+++ b/src/runs/shared/mutation-evidence.ts
@@ -15,7 +15,7 @@ function gitArguments(args: string[]): string[] {
 }
 
 function gitOutput(cwd: string, args: string[], maxBuffer = MAX_HASH_BYTES): string {
-	return execFileSync("git", gitArguments(args), { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], maxBuffer });
+	return execFileSync("git", gitArguments(args), { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], maxBuffer, windowsHide: true });
 }
 
 function splitNul(output: string): string[] {
@@ -26,7 +26,7 @@ function hashLargeDiff(cwd: string, relativePath: string): string {
 	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-tracked-diff-"));
 	const diffPath = path.join(tempDir, "diff.patch");
 	try {
-		execFileSync("git", gitArguments(["diff", "--no-ext-diff", "--binary", `--output=${diffPath}`, "HEAD", "--", relativePath]), { cwd, stdio: "ignore" });
+		execFileSync("git", gitArguments(["diff", "--no-ext-diff", "--binary", `--output=${diffPath}`, "HEAD", "--", relativePath]), { cwd, stdio: "ignore", windowsHide: true });
 		const hash = createHash("sha256");
 		const buffer = Buffer.allocUnsafe(64 * 1024);
 		const fd = fs.openSync(diffPath, "r");

--- a/test/unit/windows-hide-spawn.test.ts
+++ b/test/unit/windows-hide-spawn.test.ts
@@ -23,4 +23,15 @@ describe("nested child Pi process visibility", () => {
 	it("hides background child Pi process windows on Windows", () => {
 		assertNestedPiSpawnHidesWindows("src/runs/background/subagent-runner.ts");
 	});
+
+	it("hides mutation-evidence Git process windows on Windows", () => {
+		const sourcePath = "src/runs/shared/mutation-evidence.ts";
+		const source = fs.readFileSync(path.join(projectRoot, sourcePath), "utf-8");
+		const gitExecCalls = source.match(/execFileSync\(\s*"git"[\s\S]*?\{[^}]*\}\s*\)/g) ?? [];
+
+		assert.equal(gitExecCalls.length, 2, `${sourcePath} should have exactly two Git execFileSync calls`);
+		for (const call of gitExecCalls) {
+			assert.match(call, /\bwindowsHide:\s*true\b/, `${sourcePath} Git execFileSync should set windowsHide: true`);
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- set `windowsHide: true` on both mutation-evidence Git `execFileSync` calls
- add source-contract coverage for those child-process options
- add changelog credit for @dnnkeeper

Closes #1706

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/windows-hide-spawn.test.ts test/unit/mutation-evidence.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review: No issues found
