### PR TITLE
fix: render parallel workflow groups as cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Render parallel subagent workflow groups as readable cards with nested agent rows (#1696).
 - Remove repeated one-child async widget status labels and compact progress echoes (#1695).
 - Tighten packaged subagent and council-mode skill guidance around direct one-child launches, composed `workflowScript` runs, generic review validation, pass contracts, and private policy boundaries.
 - Clarify portable subagent orchestration guidance: keep the parent on the ordinary strong default model, route bounded workers/scouts to a fast worker tier, and reserve a top-reasoning model for bounded read-only critique or escalation without requiring a specific provider.

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1056,8 +1056,7 @@ function widgetChainDetails(job: AsyncJobState, theme: Theme, expanded = false, 
 	for (const span of buildAsyncChainStepSpans(total, job.steps.length, job.parallelGroups)) {
 		const steps = job.steps.slice(span.start, span.start + span.count);
 		if (span.isParallel) {
-			const status = aggregateStepStatus(steps);
-			lines.push(`  ${widgetStepGlyph(status, theme, widgetStepsRunningSeed(steps), frame)} Step ${span.stepIndex + 1}/${total}: ${themeBold(theme, "parallel group")} ${theme.fg("dim", "·")} ${theme.fg("dim", formatParallelOutcome(steps, span.count))}`);
+			lines.push(...parallelWidgetGroupDetails(job, theme, { steps, total: span.count, stepIndex: span.stepIndex, chainTotal: total }, expanded, width, frame, false));
 			continue;
 		}
 		const step = steps[0];
@@ -1074,6 +1073,8 @@ function widgetParallelAgentDetails(job: AsyncJobState, theme: Theme, expanded =
 	if (!job.steps?.length) return [];
 	if (job.mode !== "parallel" && job.mode !== "chain") return [];
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
+	const group = activeParallelWidgetGroup(job);
+	if (group) return parallelWidgetGroupDetails(job, theme, group, expanded, width, frame, Boolean(job.activeParallelGroup));
 	const total = job.stepsTotal ?? job.steps.length;
 	const lines: string[] = [];
 	for (const [index, step] of job.steps.entries()) {
@@ -1162,6 +1163,134 @@ function buildAsyncChainStepSpans(total: number, stepCount: number, parallelGrou
 		flatIndex++;
 	}
 	return spans;
+}
+
+interface ParallelWidgetGroup {
+	steps: AsyncJobStep[];
+	total: number;
+	stepIndex?: number;
+	chainTotal?: number;
+}
+
+interface ParallelWidgetStepRow {
+	step: AsyncJobStep;
+	index: number;
+	rowLabel: string;
+}
+
+function normalizedParallelDisplayText(value: string | undefined): string | undefined {
+	if (!value?.trim()) return undefined;
+	const normalized = oneLine(value);
+	return normalized && normalized !== PROMPT_REDACTED ? normalized : undefined;
+}
+
+function parallelWidgetStepDisplayName(step: AsyncJobStep): string {
+	const agent = normalizedParallelDisplayText(step.agent);
+	const explicitLabel = normalizedParallelDisplayText(step.label);
+	if (explicitLabel) {
+		const label = compactTaskText(step.description, explicitLabel) ?? explicitLabel;
+		return agent ? `${label} (${agent})` : label;
+	}
+
+	const sessionName = normalizedParallelDisplayText(step.sessionName);
+	if (sessionName) {
+		const sessionTask = stripRepeatedAgentPrefix(sessionName, agent);
+		if (sessionTask && sessionTask !== PROMPT_REDACTED && sessionTask.toLowerCase() !== agent?.toLowerCase()) return sessionTask;
+	}
+
+	return compactTaskText(step.description) ?? agent ?? "subagent";
+}
+
+function parallelWidgetStepPriority(step: AsyncJobStep): number {
+	if (step.status === "running" || step.activityState === "needs_attention") return 0;
+	switch (step.status) {
+		case "failed":
+		case "rejected":
+		case "partial":
+		case "stopped":
+		case "paused":
+			return 1;
+		case "complete":
+		case "completed":
+			return 2;
+		default:
+			return 3;
+	}
+}
+
+function parallelWidgetStepRows(steps: AsyncJobStep[], total: number, prioritizeActive: boolean): ParallelWidgetStepRow[] {
+	const indexed = steps.map((step, index) => ({ step, index, displayName: parallelWidgetStepDisplayName(step) }));
+	if (prioritizeActive) indexed.sort((left, right) => parallelWidgetStepPriority(left.step) - parallelWidgetStepPriority(right.step) || left.index - right.index);
+	const counts = new Map<string, number>();
+	for (const row of indexed) counts.set(row.displayName, (counts.get(row.displayName) ?? 0) + 1);
+	return indexed.map(({ displayName, ...row }) => ({
+		...row,
+		rowLabel: (counts.get(displayName) ?? 0) > 1
+			? `Agent ${row.index + 1}/${total}: ${displayName}`
+			: displayName,
+	}));
+}
+
+function activeParallelWidgetGroup(job: AsyncJobState): ParallelWidgetGroup | undefined {
+	const steps = job.steps ?? [];
+	if (!steps.length) return undefined;
+	if (job.mode === "parallel") return { steps, total: job.stepsTotal ?? steps.length };
+	if (job.mode !== "chain" || !job.activeParallelGroup) return undefined;
+
+	const chainTotal = job.chainStepCount ?? job.stepsTotal ?? steps.length;
+	const spans = buildAsyncChainStepSpans(chainTotal, steps.length, job.parallelGroups);
+	const currentStep = job.currentStep;
+	const activeSpan = currentStep === undefined
+		? spans.find((span) => span.isParallel)
+		: spans.find((span) => span.isParallel
+			&& currentStep >= span.start
+			&& currentStep < span.start + span.count);
+	return {
+		steps,
+		total: activeSpan?.count ?? job.stepsTotal ?? steps.length,
+		stepIndex: activeSpan?.stepIndex,
+		chainTotal,
+	};
+}
+
+function parallelWidgetGroupHeader(
+	group: ParallelWidgetGroup,
+	theme: Theme,
+	frame?: number,
+): string {
+	const status = aggregateStepStatus(group.steps);
+	const label = group.stepIndex !== undefined && group.chainTotal !== undefined
+		? `Step ${group.stepIndex + 1}/${group.chainTotal}: parallel group`
+		: "parallel group";
+	return `  ${widgetStepGlyph(status, theme, widgetStepsRunningSeed(group.steps), frame)} ${themeBold(theme, label)} ${theme.fg("dim", "·")} ${theme.fg("dim", formatParallelOutcome(group.steps, group.total))}`;
+}
+
+function parallelWidgetGroupDetails(
+	job: AsyncJobState,
+	theme: Theme,
+	group: ParallelWidgetGroup,
+	expanded: boolean,
+	width: number,
+	frame: number | undefined,
+	prioritizeActive: boolean,
+): string[] {
+	const lines = [parallelWidgetGroupHeader(group, theme, frame)];
+	const rows = parallelWidgetStepRows(group.steps, group.total, prioritizeActive);
+	for (const [rowIndex, row] of rows.entries()) {
+		const marker = rowIndex === rows.length - 1 && rows.length >= group.total ? "└─" : "├─";
+		lines.push(...foregroundStyleWidgetStepLines(job, theme, row.step, "Agent", row.index + 1, group.total, expanded, width, frame, {
+			rowLabel: row.rowLabel,
+			rowIndent: "    ",
+			detailIndent: "      ",
+			rowMarker: marker,
+			includeCurrentPath: true,
+		}));
+	}
+	for (let index = rows.length; index < group.total; index++) {
+		const marker = index === group.total - 1 ? "└─" : "├─";
+		lines.push(`    ${marker} ${theme.fg("muted", "◦")} ${theme.fg("dim", "pending")}`);
+	}
+	return lines;
 }
 
 function isDoneResult(result: Details["results"][number]): boolean {
@@ -1568,39 +1697,47 @@ function foregroundStyleWidgetStepLines(
 	expanded: boolean,
 	width: number,
 	frame?: number,
+	options?: { rowLabel?: string; rowIndent?: string; detailIndent?: string; rowMarker?: string; includeCurrentPath?: boolean },
 ): string[] {
+	const rowIndent = options?.rowIndent ?? "  ";
+	const detailIndent = options?.detailIndent ?? "    ";
 	const status = widgetStepStatus(step.status, theme);
 	const stats = widgetStepStats(theme, step);
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
 	const collapseDetails = shouldCollapseSingleChildDetails(job, step);
 	const displayName = collapseDetails ? singleChildAgentName(job, step) : childDisplayName(step);
-	const rowLabel = collapseDetails ? displayName : `${itemTitle} ${index}/${total}: ${displayName}`;
-	const lines = [`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${themeBold(theme, rowLabel)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
+	const rowLabel = collapseDetails ? displayName : (options?.rowLabel ?? `${itemTitle} ${index}/${total}: ${displayName}`);
+	const rowMarker = options?.rowMarker ? `${options.rowMarker} ` : "";
+	const lines = [`${rowIndent}${rowMarker}${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${themeBold(theme, rowLabel)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
 	const lane = projectAsyncLane(job, step);
-	if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "    "));
+	if (lane) lines.push(...formatLaneProjectionLines(lane, theme, detailIndent));
 	const task = collapseDetails ? singleChildTask(job, step) : compactTaskText(step.description, step.label);
-	if (task) lines.push(`    ${theme.fg("dim", `task: ${task}`)}`);
+	if (task) lines.push(`${detailIndent}${theme.fg("dim", `task: ${task}`)}`);
 	const activity = widgetStepActivityLine(step, width, expanded, job.updatedAt);
-	if (activity) lines.push(`    ${theme.fg("dim", `⎿  ${activity}`)}`);
+	const currentPath = options?.includeCurrentPath && step.currentPath ? shortenPath(step.currentPath) : undefined;
+	const activityWithPath = currentPath && activity && !activity.includes(currentPath)
+		? `${activity} · ${currentPath}`
+		: activity ?? currentPath;
+	if (activityWithPath) lines.push(`${detailIndent}${theme.fg("dim", `⎿  ${activityWithPath}`)}`);
 	for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, expanded, job.updatedAt, expanded ? 12 : 6)) {
-		lines.push(`    ${nestedLine}`);
+		lines.push(`${detailIndent}${nestedLine}`);
 	}
 	const error = step.error?.trim() || step.execution?.error?.trim();
-	if (error) lines.push(`    ${theme.fg("error", `error: ${oneLine(error)}`)}`);
+	if (error) lines.push(`${detailIndent}${theme.fg("error", `error: ${oneLine(error)}`)}`);
 	if (step.status === "running") {
-		if (!expanded) lines.push(`    ${theme.fg("accent", liveDetailHintText())}`);
+		if (!expanded) lines.push(`${detailIndent}${theme.fg("accent", liveDetailHintText())}`);
 		const output = widgetOutputPath(job, step);
-		if (output) lines.push(`    ${theme.fg("dim", `output: ${shortenPath(output)}`)}`);
+		if (output) lines.push(`${detailIndent}${theme.fg("dim", `output: ${shortenPath(output)}`)}`);
 		if (expanded) {
 			const liveStatus = buildLiveStatusLine(step, job.updatedAt);
-			if (liveStatus && liveStatus !== activity) lines.push(`    ${theme.fg("accent", liveStatus)}`);
+			if (liveStatus && liveStatus !== activity) lines.push(`${detailIndent}${theme.fg("accent", liveStatus)}`);
 			for (const tool of step.recentTools?.slice(-3) ?? []) {
 				const maxArgsLen = Math.max(40, width - 30);
 				const argsPreview = renderToolArgsPreview(tool.args, maxArgsLen, expanded);
-				lines.push(`      ${theme.fg("dim", `${tool.tool}${argsPreview ? `: ${argsPreview}` : ""}`)}`);
+				lines.push(`${detailIndent}  ${theme.fg("dim", `${tool.tool}${argsPreview ? `: ${argsPreview}` : ""}`)}`);
 			}
 			for (const line of compactRecentOutputLines(step.recentOutput)) {
-				lines.push(`      ${theme.fg("dim", line)}`);
+				lines.push(`${detailIndent}  ${theme.fg("dim", line)}`);
 			}
 		}
 	}
@@ -1644,13 +1781,18 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 		];
 	}
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
-	const total = job.mode === "chain"
-		? job.chainStepCount ?? job.stepsTotal ?? job.steps.length
-		: job.stepsTotal ?? job.steps.length;
-	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
 	const lines: string[] = workflowPreflightLines(job, expanded);
-	for (const [index, step] of job.steps.entries()) {
-		lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index + 1, total, expanded, width, frame));
+	const group = activeParallelWidgetGroup(job);
+	if (group) {
+		lines.push(...parallelWidgetGroupDetails(job, theme, group, expanded, width, frame, Boolean(job.activeParallelGroup)));
+	} else {
+		const total = job.mode === "chain"
+			? job.chainStepCount ?? job.stepsTotal ?? job.steps.length
+			: job.stepsTotal ?? job.steps.length;
+		const itemTitle = "Step";
+		for (const [index, step] of job.steps.entries()) {
+			lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index + 1, total, expanded, width, frame));
+		}
 	}
 	lines.push(...hostStepWidgetLines(job, theme, "  "));
 	const attached = new Set(job.steps.flatMap((step) => step.children?.map((child) => child.id) ?? []));
@@ -1681,10 +1823,13 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 	const fullLines = buildSingleWidgetLines(job, theme, width, false, frame);
 	if (fullLines.length <= 10 || !job.steps?.length || (job.mode !== "parallel" && !job.activeParallelGroup)) return fullLines;
 
-	const total = job.stepsTotal ?? job.steps.length;
-	const itemTitle = job.mode === "parallel" || job.activeParallelGroup ? "Agent" : "Step";
+	const group = activeParallelWidgetGroup(job);
+	if (!group) return fullLines;
+	const rows = parallelWidgetStepRows(group.steps, group.total, Boolean(job.activeParallelGroup));
 	const lines = fullLines.slice(0, 2);
-	for (const [index, step] of job.steps.entries()) {
+	lines.push(parallelWidgetGroupHeader(group, theme, frame));
+	for (const [rowIndex, row] of rows.entries()) {
+		const step = row.step;
 		const status = widgetStepStatus(step.status, theme);
 		const activity = widgetStepActivityLine(step, width, false, job.updatedAt);
 		const stepStats = widgetStepStats(theme, step);
@@ -1692,10 +1837,11 @@ function compactSingleWidgetLines(job: AsyncJobState, theme: Theme, width: numbe
 		const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
 		const task = compactTaskText(step.description, step.label);
 		const taskSuffix = task ? ` ${theme.fg("dim", "·")} ${theme.fg("dim", `task: ${task}`)}` : "";
-		lines.push(`  ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index), frame)} ${itemTitle} ${index + 1}/${total}: ${themeBold(theme, childDisplayName(step))}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${taskSuffix}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
+		const marker = rowIndex === rows.length - 1 && rowIndex >= group.total - 1 ? "└─" : "├─";
+		lines.push(`    ${marker} ${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, row.index), frame)} ${themeBold(theme, row.rowLabel)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${taskSuffix}${activitySuffix}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}`);
 		const lane = projectAsyncLane(job, step);
-		if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "  "));
-		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, 6)) lines.push(`    ${nestedLine}`);
+		if (lane) lines.push(...formatLaneProjectionLines(lane, theme, "      "));
+		for (const nestedLine of formatNestedWidgetLines(step.children, theme, width, false, job.updatedAt, 6)) lines.push(`      ${nestedLine}`);
 	}
 	lines.push(...hostStepWidgetLines(job, theme, "  "));
 	if (job.steps.some((step) => step.status === "running")) lines.push(theme.fg("accent", `  ${liveDetailHintText()}`));

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -549,9 +549,144 @@ describe("subagent async widget rendering", () => {
 		}], theme, 120);
 
 		const text = lines.join("\n");
-		assert.match(text, /Agent 1\/2: Review auth — private auth task \(reviewer\) · running/);
-		assert.match(text, /Agent 2\/2: Review billing — private billing task \(reviewer\) · running/);
+		assert.match(text, /Review auth — private auth task \(reviewer\) · running/);
+		assert.match(text, /Review billing — private billing task \(reviewer\) · running/);
+		assert.doesNotMatch(text, /Agent \d+\/2:/);
 		assert.equal(compactTaskText("  [prompt redacted]  ", "Review auth"), "Review auth");
+	});
+
+	it("renders a named top-level parallel group card with nested readable agent rows", () => {
+		const now = Date.now();
+		const text = buildWidgetLines([{
+			asyncId: "named-parallel-group",
+			asyncDir: "/tmp/named-parallel-group",
+			status: "running",
+			mode: "parallel",
+			agents: ["scout", "reviewer", "worker"],
+			activeParallelGroup: true,
+			runningSteps: 2,
+			completedSteps: 0,
+			stepsTotal: 3,
+			updatedAt: now,
+			steps: [
+				{
+					index: 0,
+					agent: "scout",
+					label: "Gather context",
+					description: "Read source files",
+					status: "running",
+					currentTool: "read",
+					currentToolStartedAt: now - 2_000,
+					currentPath: "src/tui/render.ts",
+				},
+				{
+					index: 1,
+					agent: "reviewer",
+					sessionName: "reviewer: Review diff",
+					status: "running",
+					currentTool: "grep",
+					currentToolStartedAt: now - 1_000,
+					currentPath: "test/integration/render-widget.test.ts",
+					phase: "review",
+					workflowKey: "review",
+					outputName: "review.md",
+					children: [{
+						id: "nested-reviewer",
+						parentRunId: "named-parallel-group",
+						parentStepIndex: 1,
+						depth: 1,
+						path: [{ runId: "named-parallel-group", stepIndex: 1 }],
+						state: "running",
+						agent: "nested-reviewer",
+						lastUpdate: now,
+					}],
+				},
+				{
+					index: 2,
+					agent: "worker",
+					label: "Apply fixes",
+					status: "pending",
+					phase: "implementation",
+					workflowKey: "worker",
+					outputName: "fix.md",
+				},
+			],
+		}], theme, 220, true).join("\n");
+
+		assert.equal((text.match(/parallel group/g) ?? []).length, 1);
+		assert.match(text, /parallel · (?:2 agents running|2 running) · 0\/3 done/);
+		assert.match(text, /Gather context/);
+		assert.match(text, /Review diff/);
+		assert.doesNotMatch(text, /reviewer: Review diff/);
+		assert.match(text, /Apply fixes/);
+		assert.doesNotMatch(text, /Agent \d+\/3:/);
+		assert.match(text, /nested-reviewer/);
+		assert.match(text, /src\/tui\/render\.ts/);
+		assert.match(text, /out:review\.md/);
+		assert.match(text, /pending/);
+	});
+
+	it("groups active parallel-card rows before completed and pending rows", () => {
+		const text = buildWidgetLines([{
+			asyncId: "active-first-group",
+			asyncDir: "/tmp/active-first-group",
+			status: "running",
+			mode: "parallel",
+			agents: ["scout", "worker", "reviewer", "auditor"],
+			activeParallelGroup: true,
+			runningSteps: 2,
+			completedSteps: 1,
+			stepsTotal: 4,
+			steps: [
+				{ index: 0, agent: "scout", label: "done-scout", status: "complete" },
+				{ index: 1, agent: "worker", label: "pending-worker", status: "pending" },
+				{ index: 2, agent: "reviewer", label: "active-reviewer", status: "running" },
+				{ index: 3, agent: "auditor", label: "active-auditor", status: "running" },
+			],
+		}], theme, 220, true).join("\n");
+		const rowIndex = (label: string): number => text.split("\n").findIndex((line) => line.includes(label) && !line.includes("task:"));
+		const done = rowIndex("done-scout");
+		const pending = rowIndex("pending-worker");
+		const reviewer = rowIndex("active-reviewer");
+		const auditor = rowIndex("active-auditor");
+
+		assert.ok(reviewer >= 0 && auditor >= 0 && done >= 0 && pending >= 0);
+		assert.ok(reviewer < auditor, "active rows should retain stable input order");
+		assert.ok(auditor < done, "active rows should precede completed rows");
+		assert.ok(done < pending, "completed rows should precede pending rows");
+		assert.match(text, /done-scout.*complete/);
+		assert.match(text, /pending-worker.*pending/);
+	});
+
+	it("preserves completed, pending, and hidden overflow evidence in a parallel group card", () => {
+		const group = {
+			asyncId: "evidence-group",
+			asyncDir: "/tmp/evidence-group",
+			status: "running",
+			mode: "parallel",
+			agents: ["scout", "worker"],
+			activeParallelGroup: true,
+			runningSteps: 0,
+			completedSteps: 1,
+			stepsTotal: 2,
+			steps: [
+				{ index: 0, agent: "scout", label: "done-scout", status: "complete" },
+				{ index: 1, agent: "worker", label: "pending-worker", status: "pending" },
+			],
+		};
+		const text = buildWidgetLines([
+			group,
+			{ asyncId: "overflow-1", asyncDir: "/tmp/overflow-1", status: "running", agents: ["one"] },
+			{ asyncId: "overflow-2", asyncDir: "/tmp/overflow-2", status: "running", agents: ["two"] },
+			{ asyncId: "overflow-3", asyncDir: "/tmp/overflow-3", status: "running", agents: ["three"] },
+			{ asyncId: "overflow-4", asyncDir: "/tmp/overflow-4", status: "running", agents: ["four"] },
+		], theme, 220).join("\n");
+
+		assert.equal((text.match(/parallel group/g) ?? []).length, 1);
+		assert.match(text, /1\/2 done/);
+		assert.match(text, /done-scout.*complete/);
+		assert.match(text, /pending-worker.*pending/);
+		assert.match(text, /\+1 more \(1 running\)/);
 	});
 
 	it("shows peak context usage and falls back to token usage without a limit", () => {
@@ -608,6 +743,7 @@ describe("subagent async widget rendering", () => {
 		const lines = (widget as (_tui: unknown, widgetTheme: typeof theme) => { render(width: number): string[] })(undefined, theme).render(180).map((line) => line.trimEnd());
 		const text = lines.join("\n");
 		assert.match(text, /async subagent parallel \(3\) · background/);
+		assert.match(text, /parallel group · 3 agents running · 0\/3 done/);
 		assert.match(text, /Agent 1\/3: reviewer · running · active now · 5 turns · 18 tool uses · 44k token/);
 		assert.match(text, /Agent 2\/3: reviewer · running · active 2s ago · 4 turns · 13 tool uses · 22k token/);
 		assert.match(text, /Agent 3\/3: reviewer · running · grep \| 1\.0s · 3 turns · 11 tool uses · 19k token/);
@@ -856,7 +992,8 @@ describe("subagent async widget rendering", () => {
 
 			const text = renderWidgetLines(ui.widgets.at(-1)).join("\n");
 			assert.match(text, /async subagent parallel · background/);
-			assert.match(text, /Agent 1\/1: reviewer · running/);
+			assert.match(text, /parallel group · 1 agent running · 0\/1 done/);
+			assert.match(text, /reviewer · running/);
 			assert.doesNotMatch(text, /subagents \(1\/1 running\)/);
 		});
 		resetWidgetLayout();
@@ -887,7 +1024,8 @@ describe("subagent async widget rendering", () => {
 		const text = lines.join("\n");
 		assert.match(text, /async subagent parallel \(3\) · background/);
 		assert.match(text, /parallel · 2 agents running · 1\/3 done/);
-		assert.match(text, /Agent 1\/3: reviewer: Inspect the first row · running · 2 tool uses/);
+		assert.match(text, /Inspect the first row · running · 2 tool uses/);
+		assert.doesNotMatch(text, /Agent 1\/3: reviewer/);
 		assert.match(text, /⎿  active now/);
 		assert.match(text, /Agent 2\/3: reviewer · running\n\s+⎿  read \| 2\.0s/);
 		assert.match(text, /Press configured-expand-key for live detail/);
@@ -918,8 +1056,8 @@ describe("subagent async widget rendering", () => {
 			},
 		], theme, 180).join("\n");
 
-		assert.match(text, /Agent 1\/1: reviewer: Inspect the multi-job row · running/);
-		assert.doesNotMatch(text, /Agent 1\/1: reviewer · running/);
+		assert.match(text, /Inspect the multi-job row · running/);
+		assert.doesNotMatch(text, /reviewer: Inspect the multi-job row/);
 	});
 
 	it("shows async job and step context badges", () => {
@@ -945,8 +1083,8 @@ describe("subagent async widget rendering", () => {
 		], theme, 160).join("\n");
 
 		assert.match(text, /parallel \[mixed\]/);
-		assert.match(text, /Agent 1\/2: scout \[fresh\] · running/);
-		assert.match(text, /Agent 2\/2: worker \[fork\] · running/);
+		assert.match(text, /scout \[fresh\] · running/);
+		assert.match(text, /worker \[fork\] · running/);
 	});
 
 	it("shows model and thinking for active async widget rows", () => {
@@ -969,8 +1107,8 @@ describe("subagent async widget rendering", () => {
 		], theme, 180);
 
 		const text = lines.join("\n");
-		assert.match(text, /Agent 1\/2: reviewer · running \(gpt-5\.5 · thinking high\)/);
-		assert.match(text, /Agent 2\/2: scout · running \(claude-haiku-4-5 · thinking low\)/);
+		assert.match(text, /reviewer · running \(gpt-5\.5 · thinking high\)/);
+		assert.match(text, /scout · running \(claude-haiku-4-5 · thinking low\)/);
 		assert.doesNotMatch(text, /openai-codex\/gpt-5\.5/);
 		assert.doesNotMatch(text, /gpt-5\.5:high/);
 	});
@@ -993,9 +1131,9 @@ describe("subagent async widget rendering", () => {
 			},
 		], theme, 68);
 
-		const row = lines.find((line) => line.includes("Agent 1/1")) ?? "";
-		assert.match(row, /Agent 1\/1: reviewer · running/);
-		assert.doesNotMatch(row, /Agent 1\/1: reviewer \(/);
+		const row = lines.find((line) => line.includes("reviewer · running")) ?? "";
+		assert.match(row, /reviewer · running/);
+		assert.doesNotMatch(row, /reviewer \(/);
 	});
 
 	it("shows inline live detail for expanded async parallel widget rows", () => {
@@ -1405,6 +1543,91 @@ describe("subagent async widget rendering", () => {
 		assert.match(text, /step 2\/3 · parallel group: 1 agent running · 1\/2 done/);
 	});
 
+	it("keeps the chain step number while nesting readable rows in an active parallel group card", () => {
+		const text = buildWidgetLines([{
+			asyncId: "active-chain-group",
+			asyncDir: "/tmp/active-chain-group",
+			status: "running",
+			mode: "chain",
+			agents: ["producer", "scout", "reviewer"],
+			activeParallelGroup: true,
+			currentStep: 2,
+			chainStepCount: 3,
+			parallelGroups: [{ start: 1, count: 2, stepIndex: 1 }],
+			runningSteps: 1,
+			completedSteps: 1,
+			stepsTotal: 2,
+			steps: [
+				{ index: 1, agent: "scout", label: "Inspect source", status: "complete" },
+				{ index: 2, agent: "reviewer", label: "Review diff", status: "running" },
+			],
+		}], theme, 220, true).join("\n");
+
+		assert.match(text, /chain · step 2\/3/);
+		assert.match(text, /Step 2\/3: parallel group/);
+		assert.match(text, /Inspect source/);
+		assert.match(text, /Review diff/);
+		assert.doesNotMatch(text, /Agent \d+\/3:/);
+	});
+
+	it("renders child rows beneath an inactive chain parallel-group header", () => {
+		const text = buildWidgetLines([{
+			asyncId: "completed-chain-group",
+			asyncDir: "/tmp/completed-chain-group",
+			status: "running",
+			mode: "chain",
+			agents: ["scout", "reviewer", "writer"],
+			activeParallelGroup: false,
+			currentStep: 3,
+			chainStepCount: 2,
+			parallelGroups: [{ start: 0, count: 2, stepIndex: 0 }],
+			stepsTotal: 3,
+			steps: [
+				{ index: 0, agent: "scout", label: "Gather context", status: "complete" },
+				{ index: 1, agent: "reviewer", label: "Review diff", status: "complete" },
+				{ index: 2, agent: "writer", label: "Apply fixes", status: "running" },
+			],
+		}], theme, 220, true).join("\n");
+		const headerIndex = text.indexOf("Step 1/2: parallel group");
+
+		assert.ok(headerIndex >= 0);
+		assert.ok(text.indexOf("Gather context", headerIndex) > headerIndex);
+		assert.ok(text.indexOf("Review diff", headerIndex) > headerIndex);
+		assert.match(text, /Step 2\/2: writer/);
+	});
+
+	it("renders a pending dynamic fanout placeholder instead of an empty parallel group", () => {
+		const text = buildWidgetLines([{
+			asyncId: "dynamic-placeholder",
+			asyncDir: "/tmp/dynamic-placeholder",
+			status: "running",
+			mode: "chain",
+			agents: ["expand:reviewer"],
+			activeParallelGroup: true,
+			currentStep: 0,
+			chainStepCount: 1,
+			parallelGroups: [{ start: 0, count: 1, stepIndex: 0 }],
+			runningSteps: 0,
+			completedSteps: 0,
+			stepsTotal: 1,
+			steps: [{
+				index: 0,
+				agent: "expand:reviewer",
+				label: "Dynamic fanout (reviews)",
+				description: "Await review targets",
+				status: "pending",
+				workflowKey: "dynamic-review",
+				outputName: "reviews.md",
+			}],
+		}], theme, 220, true).join("\n");
+
+		assert.match(text, /parallel group/);
+		assert.match(text, /Step 1\/1: parallel group/);
+		assert.match(text, /Dynamic fanout \(reviews\)/);
+		assert.match(text, /pending/);
+		assert.match(text, /next:await launch/);
+	});
+
 	it("uses logical chain steps after an async chain parallel group finishes", () => {
 		const job = {
 			asyncId: "run-chain",
@@ -1637,8 +1860,8 @@ describe("subagent async widget rendering", () => {
 			assert.notEqual(firstRunningGlyph(first[0] ?? ""), firstRunningGlyph(second[0] ?? ""), "header glyph should advance");
 			assert.notEqual(firstRunningGlyph(first[1] ?? ""), firstRunningGlyph(second[1] ?? ""), "job glyph should advance");
 			assert.notEqual(
-				firstRunningGlyph(first.find((line) => line.includes("Agent 1/1")) ?? ""),
-				firstRunningGlyph(second.find((line) => line.includes("Agent 1/1")) ?? ""),
+				firstRunningGlyph(first.find((line) => line.includes("reviewer · running")) ?? ""),
+				firstRunningGlyph(second.find((line) => line.includes("reviewer · running")) ?? ""),
 				"step glyph should advance",
 			);
 		} finally {


### PR DESCRIPTION
## Summary

- render top-level and active chain parallel workflow groups as a single readable group card
- keep duplicate unlabeled agents distinguishable while preferring labels, session names, and task excerpts
- reconcile render-widget coverage for the accepted group-card contract
- add changelog entry

Closes #1696

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/render-helpers.test.ts test/unit/widget-nested-render.test.ts test/unit/status-format.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review: No issues found
