### PR TITLE
fix: hide Windows resume runner consoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Clarify workflowScript portability and runs.host working-directory limits, including the outer workflow cwd and trusted `cd ... && command` patterns (#1679).
 
 ### Fixed
+- Keep retained-session resume runners from flashing console windows on Windows while preserving Unix background detachment.
 - Hide mutation-evidence Git subprocess windows on Windows to prevent visible console flashes or terminal tabs. Thanks to [@dnnkeeper](https://github.com/dnnkeeper) for #1706.
 - Deliver immediate async workflow terminal failures on macOS without requiring a later status refresh (#1700).
 - Skip untracked-file enumeration for watchdog signatures when the Git root is the user home or has no tracked files, avoiding startup and turn hangs in accidental large home repositories. Thanks to [@AluxesLAS](https://github.com/AluxesLAS) for #1693.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Clarify workflowScript portability and runs.host working-directory limits, including the outer workflow cwd and trusted `cd ... && command` patterns (#1679).
 
 ### Fixed
-- Keep retained-session resume runners from flashing console windows on Windows while preserving Unix background detachment.
+- Keep retained-session resume runners from flashing console windows on Windows while preserving Unix background detachment. Thanks to [@Zethu5](https://github.com/Zethu5) for #1711.
 - Hide mutation-evidence Git subprocess windows on Windows to prevent visible console flashes or terminal tabs. Thanks to [@dnnkeeper](https://github.com/dnnkeeper) for #1706.
 - Deliver immediate async workflow terminal failures on macOS without requiring a later status refresh (#1700).
 - Skip untracked-file enumeration for watchdog signatures when the Git root is the user home or has no tracked files, avoiding startup and turn hangs in accidental large home repositories. Thanks to [@AluxesLAS](https://github.com/AluxesLAS) for #1693.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -22,6 +22,7 @@ import type { ContextMode } from "../shared/context-mode.ts";
 import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
 import { preflightLaunchCwd } from "../shared/launch-cwd.ts";
 import { resolveNodeExecutable } from "../../shared/node-executable.ts";
+import { backgroundProcessOptions } from "../shared/background-process-options.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV, PROMPT_REDACTED, resolveChildCwd } from "../../shared/utils.ts";
@@ -562,9 +563,8 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Om
 		}
 		const proc = spawn(nodeCommand, [jitiCliPath, runner, cfgPath], {
 			cwd,
-			detached: true,
+			...backgroundProcessOptions(),
 			stdio: ["ignore", stdoutFd ?? "ignore", stderrFd ?? "ignore"],
-			windowsHide: true,
 			env: {
 				...omitExtensionBindingsEnv(process.env),
 				...(piPackageRoot ? { [PI_CODING_AGENT_PACKAGE_ROOT_ENV]: piPackageRoot } : {}),

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -1,8 +1,9 @@
 /**
  * Cross-OS control channel for async subagent runs.
  *
- * Background runs are detached OS processes. The original control path delivered
- * an interrupt with `process.kill(pid, SIGUSR2|SIGBREAK)`, but Windows cannot
+ * Background runs use child processes. Unix detaches them from the parent process.
+ * The original control path delivered an interrupt with
+ * `process.kill(pid, SIGUSR2|SIGBREAK)`, but Windows cannot
  * deliver those signals cross-process via `process.kill` and throws `ENOSYS`,
  * which left async runs uninterruptible (no stop, no live steer) on Windows.
  *

--- a/src/runs/shared/background-process-options.ts
+++ b/src/runs/shared/background-process-options.ts
@@ -1,0 +1,9 @@
+export function backgroundProcessOptions(platform: NodeJS.Platform = process.platform): {
+	detached: boolean;
+	windowsHide: true;
+} {
+	return {
+		detached: platform !== "win32",
+		windowsHide: true,
+	};
+}

--- a/test/unit/background-process-options.test.ts
+++ b/test/unit/background-process-options.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { backgroundProcessOptions } from "../../src/runs/shared/background-process-options.ts";
+
+test("Windows background runners stay hidden without requesting a new console", () => {
+	assert.deepEqual(backgroundProcessOptions("win32"), {
+		detached: false,
+		windowsHide: true,
+	});
+});
+
+test("background runners remain detached on Unix", () => {
+	assert.deepEqual(backgroundProcessOptions("linux"), {
+		detached: true,
+		windowsHide: true,
+	});
+});


### PR DESCRIPTION
## Problem

Retained-session resume runners flash short console windows on Windows.

Fresh workflow children do not show this behavior. The problem occurs when resume starts an outer async runner.

I reproduced the problem with five retained `worker` resumes. Each resume caused a visible console flash.

The outer runner used `detached: true` with `windowsHide: true`. Windows can create a new console before it applies the hidden state.

## Fix

Use `detached: false` for the outer async runner on Windows.

Keep these existing behaviors:

- Keep `windowsHide: true` on Windows.
- Keep `detached: true` on Unix.
- Keep `proc.unref()` for background execution.
- Keep the startup handshake and file control channel.
- Keep stop and resume behavior unchanged.

A small helper makes the platform rule easy to test.

## Verification

- Repeated the retained-resume test after the local patch.
- Confirmed that no console window appeared.
- Ran the focused platform tests: 2 passed.
- Ran the retained-resume workflow test separately: passed.
- Ran TypeScript type checking: passed.
- Ran `git diff --check`: passed.
- Ran the full unit suite: 2,672 passed, 20 failed, and 34 skipped.

The observed full-suite failures do not cover the changed helper or launch site. This Windows environment cannot create test symlinks, and the concurrent suite reports unrelated package fixture failures.

## Risk

The focused test verifies process options. It does not inspect Windows window visibility.

Manual Windows verification covers the visible behavior.
