### PR TITLE
fix: align foreground subagent result labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Align foreground subagent result labels with async widget labels and disambiguate duplicate rows (#1697).
 - Render parallel subagent workflow groups as readable cards with nested agent rows (#1696).
 - Remove repeated one-child async widget status labels and compact progress echoes (#1695).
 - Tighten packaged subagent and council-mode skill guidance around direct one-child launches, composed `workflowScript` runs, generic review validation, pass contracts, and private policy boundaries.

--- a/src/tui/render-helpers.ts
+++ b/src/tui/render-helpers.ts
@@ -46,6 +46,21 @@ export function shouldSuppressSingleStep(chainStepCount?: number, stepsTotal?: n
 	return (chainStepCount ?? stepsTotal) === 1;
 }
 
+/** Add an Agent fraction only when visible candidates collide. */
+export function withDuplicateLabelDiscriminators<T extends { index: number; displayName: string }>(
+	rows: readonly T[],
+	total: number,
+): Array<T & { rowLabel: string }> {
+	const counts = new Map<string, number>();
+	for (const row of rows) counts.set(row.displayName, (counts.get(row.displayName) ?? 0) + 1);
+	return rows.map((row) => ({
+		...row,
+		rowLabel: (counts.get(row.displayName) ?? 0) > 1
+			? `Agent ${row.index + 1}/${total}: ${row.displayName}`
+			: row.displayName,
+	}));
+}
+
 export function pad(s: string, len: number): string {
 	const vis = visibleWidth(s);
 	return s + " ".repeat(Math.max(0, len - vis));

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -31,7 +31,7 @@ import { flatToLogicalStepIndex } from "../runs/background/parallel-groups.ts";
 import { formatNestedAggregate } from "../runs/shared/nested-render.ts";
 import { aggregateStepStatus, formatActivityLabel, formatAgentRunningLabel, formatParallelOutcome } from "../shared/status-format.ts";
 import { contextModeBadge, contextModePrefix } from "../runs/shared/context-mode.ts";
-import { shouldSuppressSingleStep, stripRepeatedAgentPrefix } from "./render-helpers.ts";
+import { shouldSuppressSingleStep, stripRepeatedAgentPrefix, withDuplicateLabelDiscriminators } from "./render-helpers.ts";
 import { buildWorkflowChatProgressRows, type WorkflowChatProgressRow } from "../workflows/chat-progress.ts";
 import { formatWorkflowPreflight, formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary, formatWorkflowPreflightWarnings } from "../workflows/workflow-preflight.ts";
 import { encodeAsyncStatusSnapshotWidget } from "../runs/background/async-status-snapshot.ts";
@@ -459,7 +459,7 @@ function workflowPreflightLines(job: AsyncJobState, expanded = false): string[] 
 }
 
 function workflowLabelForResult(details: Details, resultIndex: number): string | undefined {
-	const flatIndex = details.results[resultIndex]?.progress?.index ?? resultIndex;
+	const flatIndex = foregroundResultIndex(details, resultIndex);
 	const visit = (nodes: NonNullable<Details["workflowGraph"]>["nodes"]): string | undefined => {
 		for (const node of nodes) {
 			if (node.flatIndex === flatIndex && node.label.trim()) return node.label;
@@ -469,6 +469,52 @@ function workflowLabelForResult(details: Details, resultIndex: number): string |
 		return undefined;
 	};
 	return details.workflowGraph ? visit(details.workflowGraph.nodes) : undefined;
+}
+
+function foregroundProgressForResult(details: Details, resultIndex: number): AgentProgress | undefined {
+	const result = details.results[resultIndex];
+	if (result?.progress) return result.progress;
+	const index = result?.index ?? resultIndex;
+	const indexed = details.progress?.find((progress) => progress.index === index);
+	if (indexed) return indexed;
+	return result?.agent
+		? details.progress?.find((progress) => progress.agent === result.agent && progress.status === "running")
+		: undefined;
+}
+
+function foregroundResultIndex(details: Details, resultIndex: number): number {
+	const result = details.results[resultIndex];
+	if (typeof result?.index === "number") return result.index;
+	return foregroundProgressForResult(details, resultIndex)?.index ?? resultIndex;
+}
+
+function foregroundResultDisplayName(
+	details: Details,
+	resultIndex: number,
+	result: Details["results"][number] | undefined,
+	fallback: string,
+): string {
+	const progress = foregroundProgressForResult(details, resultIndex);
+	const agent = normalizedParallelDisplayText(result?.agent) ?? normalizedParallelDisplayText(progress?.agent);
+	const workflowLabel = normalizedParallelDisplayText(workflowLabelForResult(details, resultIndex));
+	if (workflowLabel) return compactTaskText(undefined, workflowLabel) ?? workflowLabel;
+
+	const sessionName = normalizedParallelDisplayText(result?.sessionName) ?? normalizedParallelDisplayText(progress?.sessionName);
+	if (sessionName) {
+		const sessionTask = stripRepeatedAgentPrefix(sessionName, agent);
+		if (sessionTask && sessionTask !== PROMPT_REDACTED && sessionTask.toLowerCase() !== agent?.toLowerCase()) {
+			return compactTaskText(sessionTask) ?? sessionTask;
+		}
+	}
+
+	return compactTaskText(result?.task) ?? compactTaskText(progress?.task) ?? agent ?? fallback;
+}
+
+function foregroundSingleDisplayName(result: Details["results"][number] | undefined): string {
+	return normalizedParallelDisplayText(result?.agent)
+		?? normalizedParallelDisplayText(result?.sessionName)
+		?? compactTaskText(result?.task)
+		?? "subagent";
 }
 
 function hasLiveOutputSignal(line: string): boolean {
@@ -1221,14 +1267,7 @@ function parallelWidgetStepPriority(step: AsyncJobStep): number {
 function parallelWidgetStepRows(steps: AsyncJobStep[], total: number, prioritizeActive: boolean): ParallelWidgetStepRow[] {
 	const indexed = steps.map((step, index) => ({ step, index, displayName: parallelWidgetStepDisplayName(step) }));
 	if (prioritizeActive) indexed.sort((left, right) => parallelWidgetStepPriority(left.step) - parallelWidgetStepPriority(right.step) || left.index - right.index);
-	const counts = new Map<string, number>();
-	for (const row of indexed) counts.set(row.displayName, (counts.get(row.displayName) ?? 0) + 1);
-	return indexed.map(({ displayName, ...row }) => ({
-		...row,
-		rowLabel: (counts.get(displayName) ?? 0) > 1
-			? `Agent ${row.index + 1}/${total}: ${displayName}`
-			: displayName,
-	}));
+	return withDuplicateLabelDiscriminators(indexed, total).map(({ displayName, ...row }) => row);
 }
 
 function activeParallelWidgetGroup(job: AsyncJobState): ParallelWidgetGroup | undefined {
@@ -1311,32 +1350,72 @@ interface ChainRenderResultEntry {
 	rowNumber: number;
 	rowLabel?: string;
 	agentName: string;
+	displayIndex: number;
+	isParallel?: boolean;
 }
 
-interface ChainRenderPlaceholderEntry {
-	kind: "placeholder";
-	rowNumber: number;
+interface ChainRenderGroupEntry {
+	kind: "group";
 	stepLabel: string;
-	agentName: string;
+	groupLabel?: string;
 	status: WorkflowNodeStatus;
 	error?: string;
 }
 
-type ChainRenderEntry = ChainRenderResultEntry | ChainRenderPlaceholderEntry;
+type ChainRenderEntry = ChainRenderResultEntry | ChainRenderGroupEntry;
+
+function chainSpanStatus(details: Details, span: ChainStepSpan): WorkflowNodeStatus {
+	if (span.status) return span.status;
+	const results = details.results.slice(span.start, span.start + span.count);
+	if (results.some((result) => isResultRunning(result))) return "running";
+	if (results.some((result) => !hasTerminalResultFlag(result) && (result.progress?.status === "failed" || result.exitCode !== 0) && !isResultRunning(result))) return "failed";
+	if (results.some((result) => result.stopped)) return "stopped";
+	if (results.some((result) => result.interrupted)) return "paused";
+	if (results.some((result) => result.detached || result.progress?.status === "detached")) return "detached";
+	if (results.length < span.count) return "pending";
+	if (results.length > 0 && results.every(isDoneResult)) return "completed";
+	return "pending";
+}
+
+function withDuplicateForegroundLabels(entries: ChainRenderResultEntry[], total: number): ChainRenderResultEntry[] {
+	return withDuplicateLabelDiscriminators(
+		entries.map((entry) => ({ ...entry, index: entry.displayIndex, displayName: entry.agentName })),
+		total,
+	).map(({ displayName, rowLabel, ...entry }) => ({
+		...entry,
+		rowLabel: rowLabel === displayName ? undefined : rowLabel.slice(0, -(displayName.length + 2)),
+	}));
+}
 
 function buildChainRenderEntries(details: Details, label: MultiProgressLabel): ChainRenderEntry[] | undefined {
 	if (details.mode !== "chain" || !label.hasParallelInChain || label.showActiveGroupOnly) return undefined;
 	const entries: ChainRenderEntry[] = [];
 	for (const span of buildChainStepSpans(details)) {
-		if (span.isParallel && span.count === 0) {
+		if (span.isParallel) {
 			entries.push({
-				kind: "placeholder",
-				rowNumber: span.stepIndex + 1,
-				stepLabel: `Step ${span.stepIndex + 1}`,
-				agentName: span.label ?? details.chainAgents?.[span.stepIndex] ?? `step-${span.stepIndex + 1}`,
-				status: span.status ?? "pending",
+				kind: "group",
+				stepLabel: `Step ${span.stepIndex + 1}/${label.logicalStepCount}: parallel group`,
+				groupLabel: span.label?.trim() || undefined,
+				status: chainSpanStatus(details, span),
 				error: span.error,
 			});
+			const groupEntries: ChainRenderResultEntry[] = [];
+			for (let index = span.start; index < span.start + span.count; index++) {
+				const result = details.results[index];
+				const localIndex = foregroundResultIndex(details, index);
+				const displayIndex = localIndex >= span.start && localIndex < span.start + span.count
+					? localIndex - span.start
+					: index - span.start;
+				groupEntries.push({
+					kind: "result",
+					resultIndex: index,
+					rowNumber: index - span.start + 1,
+					agentName: foregroundResultDisplayName(details, index, result, `agent-${displayIndex + 1}`),
+					displayIndex,
+					isParallel: true,
+				});
+			}
+			entries.push(...withDuplicateForegroundLabels(groupEntries, span.count));
 			continue;
 		}
 		for (let index = span.start; index < span.start + span.count; index++) {
@@ -1344,9 +1423,10 @@ function buildChainRenderEntries(details: Details, label: MultiProgressLabel): C
 			entries.push({
 				kind: "result",
 				resultIndex: index,
-				rowNumber: index + 1,
-				rowLabel: span.isParallel ? `Agent ${index - span.start + 1}/${span.count}` : `Step ${span.stepIndex + 1}`,
-				agentName: result?.sessionName?.trim() || result?.agent || details.chainAgents?.[span.stepIndex] || `step-${span.stepIndex + 1}`,
+				rowNumber: span.stepIndex + 1,
+				rowLabel: resultRowLabel(label, span.stepIndex + 1),
+				agentName: foregroundResultDisplayName(details, index, result, details.chainAgents?.[span.stepIndex] ?? `step-${span.stepIndex + 1}`),
+				displayIndex: foregroundResultIndex(details, index),
 			});
 		}
 	}
@@ -1362,6 +1442,7 @@ interface MultiProgressLabel {
 	groupStartIndex: number;
 	groupEndIndex: number;
 	showActiveGroupOnly: boolean;
+	logicalStepCount: number;
 }
 
 function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "progress" | "totalSteps" | "currentStepIndex" | "chainAgents" | "workflowGraph">, hasRunning: boolean): MultiProgressLabel {
@@ -1397,7 +1478,7 @@ function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "pr
 		const headerLabel = hasRunning
 			? `${formatAgentRunningLabel(running)} · ${done}/${totalCount} done`
 			: `${done}/${totalCount} done`;
-		return { headerLabel, itemTitle, totalCount, hasParallelInChain, activeParallelGroup, groupStartIndex: 0, groupEndIndex: totalCount, showActiveGroupOnly: false };
+		return { headerLabel, itemTitle, totalCount, hasParallelInChain, activeParallelGroup, groupStartIndex: 0, groupEndIndex: totalCount, showActiveGroupOnly: false, logicalStepCount: totalCount };
 	}
 
 	if (activeParallelGroup) {
@@ -1425,7 +1506,7 @@ function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "pr
 		const headerLabel = hasRunning
 			? `step ${currentStepIndex + 1}/${totalSteps} · parallel group: ${formatAgentRunningLabel(running)} · ${done}/${groupSize} done`
 			: `step ${currentStepIndex + 1}/${totalSteps} · parallel group: ${done}/${groupSize} done`;
-		return { headerLabel, itemTitle, totalCount: groupSize, hasParallelInChain, activeParallelGroup, groupStartIndex: groupStart, groupEndIndex: groupEnd, showActiveGroupOnly: true };
+		return { headerLabel, itemTitle, totalCount: groupSize, hasParallelInChain, activeParallelGroup, groupStartIndex: groupStart, groupEndIndex: groupEnd, showActiveGroupOnly: true, logicalStepCount: totalSteps };
 	}
 
 	if (details.mode === "chain" && details.chainAgents?.length) {
@@ -1443,24 +1524,51 @@ function buildMultiProgressLabel(details: Pick<Details, "mode" | "results" | "pr
 		}).length;
 		const currentStep = details.currentStepIndex !== undefined ? details.currentStepIndex + 1 : Math.min(totalCount, doneLogical + (hasRunning ? 1 : 0));
 		const headerLabel = hasRunning ? `step ${currentStep}/${totalCount}` : `step ${doneLogical}/${totalCount}`;
-		return { headerLabel, itemTitle, totalCount, hasParallelInChain, activeParallelGroup, groupStartIndex: 0, groupEndIndex: details.results.length, showActiveGroupOnly: false };
+		return { headerLabel, itemTitle, totalCount, hasParallelInChain, activeParallelGroup, groupStartIndex: 0, groupEndIndex: details.results.length, showActiveGroupOnly: false, logicalStepCount: totalCount };
 	}
 
 	const totalCount = details.totalSteps ?? details.results.length;
 	const currentStep = details.currentStepIndex !== undefined ? details.currentStepIndex + 1 : Math.min(totalCount, details.results.filter(isDoneResult).length + (hasRunning ? 1 : 0));
 	const done = details.results.filter(isDoneResult).length;
 	const headerLabel = hasRunning ? `step ${currentStep}/${totalCount}` : `step ${done}/${totalCount}`;
-	return { headerLabel, itemTitle, totalCount, hasParallelInChain, activeParallelGroup, groupStartIndex: 0, groupEndIndex: details.results.length, showActiveGroupOnly: false };
+	return { headerLabel, itemTitle, totalCount, hasParallelInChain, activeParallelGroup, groupStartIndex: 0, groupEndIndex: details.results.length, showActiveGroupOnly: false, logicalStepCount: totalCount };
 }
 
-function resultRowLabel(label: MultiProgressLabel, resultIndex: number, stepNumber: number): string {
-	if (label.itemTitle === "Agent") {
-		const localStepNumber = label.activeParallelGroup
-			? resultIndex - label.groupStartIndex + 1
-			: stepNumber;
-		return `Agent ${localStepNumber}/${label.totalCount}`;
-	}
-	return `Step ${stepNumber}`;
+function resultRowLabel(label: MultiProgressLabel, stepNumber: number): string | undefined {
+	if (label.itemTitle === "Agent") return undefined;
+	if (shouldSuppressSingleStep(label.logicalStepCount)) return undefined;
+	return `Step ${stepNumber}/${label.logicalStepCount}`;
+}
+
+function buildForegroundResultEntries(
+	details: Details,
+	label: MultiProgressLabel,
+	displayStart: number,
+	displayEnd: number,
+	useResultsDirectly: boolean,
+): ChainRenderResultEntry[] {
+	const fallbackLabel = label.itemTitle.toLowerCase();
+	const entries = Array.from({ length: displayEnd - displayStart }, (_, offset): ChainRenderResultEntry => {
+		const index = displayStart + offset;
+		const result = details.results[index];
+		const stableIndex = foregroundResultIndex(details, index);
+		const rowNumber = label.showActiveGroupOnly ? index - label.groupStartIndex + 1 : stableIndex + 1;
+		const fallbackAgent = useResultsDirectly
+			? (result?.agent || `${fallbackLabel}-${rowNumber}`)
+			: (details.chainAgents![index] || result?.agent || `${fallbackLabel}-${rowNumber}`);
+		const displayIndex = label.activeParallelGroup && stableIndex >= label.groupStartIndex && stableIndex < label.groupEndIndex
+			? stableIndex - label.groupStartIndex
+			: label.activeParallelGroup ? index - label.groupStartIndex : stableIndex;
+		return {
+			kind: "result",
+			resultIndex: index,
+			rowNumber,
+			rowLabel: resultRowLabel(label, rowNumber),
+			agentName: foregroundResultDisplayName(details, index, result, fallbackAgent),
+			displayIndex,
+		};
+	});
+	return label.itemTitle === "Agent" ? withDuplicateForegroundLabels(entries, label.totalCount) : entries;
 }
 
 function widgetStats(job: AsyncJobState, theme: Theme): string {
@@ -2223,7 +2331,7 @@ function renderSingleCompact(
 	const detailIndent = mainWindowIndent(layout, 1);
 	const continuationIndent = mainWindowIndent(layout, 2) + (layout.horizontalSpacing > 0 ? " " : "");
 	const modelDisplay = modelThinkingBadge(theme, r.model ?? r.progress?.model, r.thinking ?? r.progress?.thinking);
-	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(childDisplayName(r)))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
+	c.addChild(new Text(truncLine(`${resultGlyph(r, output, theme, isRunning, undefined, frame)} ${theme.fg("toolTitle", theme.bold(foregroundSingleDisplayName(r)))}${modelDisplay}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
 
 	if (isRunning && r.progress) {
 		const task = compactTaskText(r.task);
@@ -2376,19 +2484,13 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 	const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
 	const displayEnd = multiLabel.showActiveGroupOnly ? multiLabel.groupEndIndex : (useResultsDirectly ? d.results.length : d.chainAgents!.length);
 	const chainEntries = buildChainRenderEntries(d, multiLabel);
-	const renderEntries = chainEntries ?? Array.from({ length: displayEnd - displayStart }, (_, offset): ChainRenderEntry => {
-		const i = displayStart + offset;
-		const r = d.results[i];
-		const fallbackLabel = itemTitle.toLowerCase();
-		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		const fallbackAgent = useResultsDirectly ? (r?.agent || `${fallbackLabel}-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `${fallbackLabel}-${rowNumber}`);
-		return { kind: "result", resultIndex: i, rowNumber, agentName: r?.sessionName?.trim() || fallbackAgent };
-	});
+	const renderEntries = chainEntries ?? buildForegroundResultEntries(d, multiLabel, displayStart, displayEnd, useResultsDirectly);
 	for (const entry of renderEntries) {
-		if (entry.kind === "placeholder") {
+		if (entry.kind === "group") {
 			const glyph = widgetStepGlyph(entry.status as AsyncJobStep["status"], theme);
 			const statusLabel = widgetStepStatus(entry.status as AsyncJobStep["status"], theme);
-			c.addChild(new Text(truncLine(`${rowIndent}${glyph} ${entry.stepLabel}: ${themeBold(theme, entry.agentName)} ${theme.fg("dim", "·")} ${statusLabel}`, width), 0, 0));
+			const groupLabel = entry.groupLabel ? ` (${compactTaskText(undefined, entry.groupLabel) ?? entry.groupLabel})` : "";
+			c.addChild(new Text(truncLine(`${rowIndent}${glyph} ${entry.stepLabel}${groupLabel} ${theme.fg("dim", "·")} ${statusLabel}`, width), 0, 0));
 			if (entry.error) c.addChild(new Text(truncLine(theme.fg("error", `${detailIndent}⎿  Error: ${entry.error}`), width), 0, 0));
 			continue;
 		}
@@ -2397,23 +2499,24 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 		const rowNumber = entry.rowNumber;
 		const agentName = entry.agentName;
 		if (!r) {
-			const pendingLabel = entry.rowLabel ?? `${itemTitle} ${rowNumber}`;
-			c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}◦ ${pendingLabel}: ${agentName} · pending`), width), 0, 0));
+			const pendingLabel = entry.rowLabel ?? (entry.isParallel ? "" : `${itemTitle} ${rowNumber}`);
+			const labelPrefix = pendingLabel ? `${pendingLabel}: ` : "";
+			c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}◦ ${labelPrefix}${agentName} · pending`), width), 0, 0));
 			continue;
 		}
 		const output = getSingleResultOutput(r);
-		const progressFromArray = d.progress?.find((p) => p.index === i) || d.progress?.find((p) => p.agent === r.agent && p.status === "running");
+		const progressFromArray = foregroundProgressForResult(d, i);
 		const rProg = r.progress || progressFromArray || r.progressSummary;
 		const rRunning = rProg && "status" in rProg && isResultRunning(r, rProg.status);
 		const rPending = rProg && "status" in rProg && rProg.status === "pending";
-		const stepNumber = r.progress?.index !== undefined ? r.progress.index + 1 : progressFromArray?.index !== undefined ? progressFromArray.index + 1 : i + 1;
 		const stepStats = formatProgressStats(theme, rProg);
 		const glyph = rPending ? theme.fg("dim", "◦") : resultGlyph(r, output, theme, rRunning, progressRunningSeed(rProg), frame);
 		const pendingLabel = rPending ? ` ${theme.fg("dim", "· pending")}` : "";
-		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
+		const stepLabel = entry.rowLabel;
 		const rowProgressModel = rProg && "status" in rProg ? rProg : undefined;
 		const rowModelDisplay = modelThinkingBadge(theme, r.model ?? rowProgressModel?.model, r.thinking ?? rowProgressModel?.thinking);
-		const line = `${glyph} ${stepLabel}: ${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${rowModelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
+		const labelPrefix = stepLabel ? `${stepLabel}: ` : "";
+		const line = `${glyph} ${labelPrefix}${themeBold(theme, agentName)}${contextModeBadge(theme, r.context)}${rowModelDisplay}${stepStats ? ` ${theme.fg("dim", "·")} ${stepStats}` : ""}${pendingLabel}`;
 		c.addChild(new Text(truncLine(`${rowIndent}${line}`, width), 0, 0));
 		if (rRunning || rPending) {
 			const task = compactTaskText(r.task, workflowLabelForResult(d, i));
@@ -2474,7 +2577,7 @@ export function renderSubagentSummary(
 				? theme.fg("error", "✗")
 				: theme.fg("warning", "■");
 	const label = details?.mode === "single" && results.length === 1
-		? childDisplayName(results[0])
+		? foregroundSingleDisplayName(results[0])
 		: details?.mode || "subagent";
 	return new Text(
 		truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(label))} ${theme.fg("dim", "·")} ${theme.fg(state === "failed" ? "error" : state === "completed" ? "success" : state === "running" ? "accent" : "warning", state)}`, getTermWidth() - 4),
@@ -2547,7 +2650,7 @@ export function renderSubagentResult(
 		const fit = (text: string) => expanded ? text : truncLine(text, w);
 		const toolCallLines = getToolCallLines(r, expanded);
 		const c = new Container();
-		c.addChild(new Text(fit(`${presentation.glyph} ${theme.fg("toolTitle", theme.bold(childDisplayName(r)))}${contextBadge}${progressInfo} ${theme.fg("dim", "·")} ${presentation.label}`), 0, 0));
+		c.addChild(new Text(fit(`${presentation.glyph} ${theme.fg("toolTitle", theme.bold(foregroundSingleDisplayName(r)))}${contextBadge}${progressInfo} ${theme.fg("dim", "·")} ${presentation.label}`), 0, 0));
 		c.addChild(new Spacer(1));
 		const taskMaxLen = Math.max(20, w - 8);
 		const taskPreview = expanded || r.task.length <= taskMaxLen
@@ -2557,6 +2660,9 @@ export function renderSubagentResult(
 			new Text(fit(theme.fg("dim", `Task: ${taskPreview}`)), 0, 0),
 		);
 		c.addChild(new Spacer(1));
+		if (!isRunning && (r.exitCode !== 0 || r.interrupted || r.detached || r.stopped)) {
+			c.addChild(new Text(fit(theme.fg(r.exitCode !== 0 ? "error" : "dim", `  ⎿  ${resultStatusLine(r, output)}`)), 0, 0));
+		}
 
 		if (isRunning && r.progress) {
 			const progressSnapshotNow = snapshotNowForProgress(r.progress);
@@ -2688,7 +2794,7 @@ export function renderSubagentResult(
 		? d.chainAgents
 				.map((agent, i) => {
 					const result = d.results[i];
-					const displayName = result?.sessionName?.trim() || agent;
+					const displayName = foregroundResultDisplayName(d, i, result, agent);
 					const isCurrent = i === (d.currentStepIndex ?? d.results.length);
 					const stepPresentation = result
 						? styledResultPresentation(resultPresentation(result, getSingleResultOutput(result), isCurrent && hasRunning && !hasTerminalResultFlag(result)), theme)
@@ -2719,20 +2825,15 @@ export function renderSubagentResult(
 	const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
 	const displayEnd = multiLabel.showActiveGroupOnly ? multiLabel.groupEndIndex : (useResultsDirectly ? d.results.length : d.chainAgents!.length);
 	const chainEntries = buildChainRenderEntries(d, multiLabel);
-	const renderEntries = chainEntries ?? Array.from({ length: displayEnd - displayStart }, (_, offset): ChainRenderEntry => {
-		const i = displayStart + offset;
-		const r = d.results[i];
-		const rowNumber = multiLabel.showActiveGroupOnly ? (i - multiLabel.groupStartIndex + 1) : (i + 1);
-		const fallbackAgent = useResultsDirectly ? (r?.agent || `step-${rowNumber}`) : (d.chainAgents![i] || r?.agent || `step-${rowNumber}`);
-		return { kind: "result", resultIndex: i, rowNumber, agentName: r?.sessionName?.trim() || fallbackAgent };
-	});
+	const renderEntries = chainEntries ?? buildForegroundResultEntries(d, multiLabel, displayStart, displayEnd, useResultsDirectly);
 
 	c.addChild(new Spacer(1));
 
 	for (const entry of renderEntries) {
-		if (entry.kind === "placeholder") {
+		if (entry.kind === "group") {
 			const statusLabel = widgetStepStatus(entry.status as AsyncJobStep["status"], theme);
-			c.addChild(new Text(fit(`  ${statusLabel} ${entry.stepLabel}: ${theme.bold(entry.agentName)}`), 0, 0));
+			const groupLabel = entry.groupLabel ? ` (${compactTaskText(undefined, entry.groupLabel) ?? entry.groupLabel})` : "";
+			c.addChild(new Text(fit(`  ${statusLabel} ${entry.stepLabel}${groupLabel}`), 0, 0));
 			c.addChild(new Text(theme.fg(entry.status === "failed" ? "error" : "dim", `    status: ${entry.status}`), 0, 0));
 			if (entry.error) c.addChild(new Text(theme.fg("error", `    error: ${entry.error}`), 0, 0));
 			c.addChild(new Spacer(1));
@@ -2744,28 +2845,28 @@ export function renderSubagentResult(
 		const agentName = entry.agentName;
 
 		if (!r) {
-			const pendingLabel = entry.rowLabel ?? `${itemTitle} ${rowNumber}`;
-			c.addChild(new Text(fit(theme.fg("dim", `  ${pendingLabel}: ${agentName}`)), 0, 0));
+			const pendingLabel = entry.rowLabel ?? (entry.isParallel ? "" : `${itemTitle} ${rowNumber}`);
+			const labelPrefix = pendingLabel ? `${pendingLabel}: ` : "";
+			c.addChild(new Text(fit(theme.fg("dim", `  ${labelPrefix}${agentName}`)), 0, 0));
 			c.addChild(new Text(theme.fg("dim", `    status: pending`), 0, 0));
 			c.addChild(new Spacer(1));
 			continue;
 		}
 
-		const progressFromArray = d.progress?.find((p) => p.index === i) 
-			|| d.progress?.find((p) => p.agent === r.agent && p.status === "running");
+		const progressFromArray = foregroundProgressForResult(d, i);
 		const rProg = r.progress || progressFromArray || r.progressSummary;
 		const rRunning = isResultRunning(r, rProg?.status);
-		const stepNumber = typeof rProg?.index === "number" ? rProg.index + 1 : i + 1;
 
 		const resultOutput = getSingleResultOutput(r);
 		const rowPresentation = styledResultPresentation(resultPresentation(r, resultOutput, rRunning, progressRunningSeed(rProg), frame), theme);
 		const stats = rProg ? ` | ${rProg.toolCount} tools, ${formatDuration(rProg.durationMs)}` : "";
 		const modelDisplay = modelThinkingBadge(theme, r.model ?? rProg?.model, r.thinking ?? rProg?.thinking);
-		const stepLabel = entry.rowLabel ?? resultRowLabel(multiLabel, i, stepNumber);
+		const stepLabel = entry.rowLabel;
 		const contextBadge = contextModeBadge(theme, r.context);
+		const labelPrefix = stepLabel ? `${stepLabel}: ` : "";
 		const stepHeader = rRunning
-			? `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(theme.fg("warning", childDisplayName(r)))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`
-			: `${rowPresentation.glyph} ${stepLabel}: ${theme.bold(childDisplayName(r))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`;
+			? `${rowPresentation.glyph} ${labelPrefix}${theme.bold(theme.fg("warning", agentName))}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`
+			: `${rowPresentation.glyph} ${labelPrefix}${theme.bold(agentName)}${contextBadge}${modelDisplay}${stats} ${theme.fg("dim", "·")} ${rowPresentation.label}`;
 		const toolCallLines = getToolCallLines(r, expanded);
 		c.addChild(new Text(fit(stepHeader), 0, 0));
 
@@ -2778,6 +2879,9 @@ export function renderSubagentResult(
 		const outputTarget = extractOutputTarget(r.task);
 		if (outputTarget) {
 			c.addChild(new Text(fit(theme.fg("dim", `    output: ${outputTarget}`)), 0, 0));
+		}
+		if (!rRunning && (r.exitCode !== 0 || r.interrupted || r.detached || r.stopped)) {
+			c.addChild(new Text(fit(theme.fg(r.exitCode !== 0 ? "error" : "dim", `    ⎿  ${resultStatusLine(r, resultOutput)}`)), 0, 0));
 		}
 
 		if (r.skills?.length) {

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -311,8 +311,8 @@ describe("renderSubagentResult fork indicator", () => {
 		}, { expanded: false }, theme).render(160).join("\n");
 
 		assert.match(compact, /parallel \[mixed\]/);
-		assert.match(compact, /scout \[fresh\]/);
-		assert.match(compact, /worker \[fork\]/);
+		assert.match(compact, /scan \[fresh\]/);
+		assert.match(compact, /fix \[fork\]/);
 
 		const expanded = renderSubagentResult!({
 			content: [{ type: "text", text: "done" }],
@@ -327,8 +327,8 @@ describe("renderSubagentResult fork indicator", () => {
 		}, { expanded: true }, theme).render(160).join("\n");
 
 		assert.match(expanded, /parallel \[mixed\]/);
-		assert.match(expanded, /scout \[fresh\]/);
-		assert.match(expanded, /worker \[fork\]/);
+		assert.match(expanded, /scan \[fresh\]/);
+		assert.match(expanded, /fix \[fork\]/);
 	});
 
 	it("uses compacted tool-call summaries when messages were stripped", () => {
@@ -453,6 +453,8 @@ describe("renderSubagentResult fork indicator", () => {
 			assert.equal(firstGrapheme(compact), testCase.glyph, `${testCase.name} compact glyph`);
 			assert.equal(firstGrapheme(expanded), testCase.glyph, `${testCase.name} expanded glyph`);
 			assert.match((expanded.split("\n")[0] ?? "").trimEnd(), new RegExp(`reviewer(?: \\| [^·]+)? · ${testCase.label}$`), `${testCase.name} expanded label`);
+			const compactEvidence = { detached: "Detached", stopped: "Stopped", interrupted: "Paused", failed: "Error" }[testCase.name];
+			if (compactEvidence) assert.match(compact, new RegExp(`⎿  ${compactEvidence}`), `${testCase.name} compact evidence`);
 		}
 	});
 
@@ -683,15 +685,15 @@ describe("renderSubagentResult fork indicator", () => {
 		const expanded = renderSubagentResult!(result, { expanded: true }, theme).render(160).join("\n");
 
 		assert.match(compact, /^■ parallel/);
-		assert.match(compact, /■ Agent 3\/5: paused-agent/);
+		assert.match(compact, /■ three/);
 		assert.doesNotMatch(compact, /running agent/);
 		assert.match(expanded, /^■ parallel[^\n]* · detached/);
-		assert.match(expanded, /■ Agent 1\/5: detached-agent[^\n]* · detached/);
-		assert.match(expanded, /■ Agent 2\/5: stopped-agent[^\n]* · stopped/);
-		assert.match(expanded, /■ Agent 3\/5: paused-agent[^\n]* · paused/);
+		assert.match(expanded, /■ one[^\n]* · detached/);
+		assert.match(expanded, /■ two[^\n]* · stopped/);
+		assert.match(expanded, /■ three[^\n]* · paused/);
 		assert.doesNotMatch(expanded, /running agent/);
-		assert.match(expanded, /✗ Agent 4\/5: failed-agent · failed/);
-		assert.match(expanded, /✓ Agent 5\/5: completed-agent · completed/);
+		assert.match(expanded, /✗ four · failed/);
+		assert.match(expanded, /✓ five · completed/);
 	});
 
 	it("renders a stale-running interrupted aggregate as paused", () => {
@@ -848,8 +850,8 @@ describe("renderSubagentResult fork indicator", () => {
 				],
 			},
 		}, { expanded: false }, theme).render(160).join("\n");
-		assert.match(multi, /Agent 1\/2: scout \(claude-haiku-4-5 · thinking low\)/);
-		assert.match(multi, /Agent 2\/2: worker \(gpt-5-mini\)/);
+		assert.match(multi, /scan \(claude-haiku-4-5 · thinking low\)/);
+		assert.match(multi, /fix \(gpt-5-mini\)/);
 
 		const expanded = renderSubagentResult!({
 			content: [{ type: "text", text: "done" }],
@@ -866,10 +868,10 @@ describe("renderSubagentResult fork indicator", () => {
 				}],
 			},
 		}, { expanded: true }, theme).render(160).join("\n");
-		assert.match(expanded, /reviewer \(gpt-5\.5 · thinking high\)/);
+		assert.match(expanded, /review \(gpt-5\.5 · thinking high\)/);
 	});
 
-	it("prefers session names in expanded running multi-result rows", () => {
+	it("strips repeated agent prefixes in expanded running multi-result rows", () => {
 		const sessionName = "reviewer: Review the diff";
 		const widget = renderSubagentResult!({
 			content: [{ type: "text", text: "(running...)" }],
@@ -889,8 +891,8 @@ describe("renderSubagentResult fork indicator", () => {
 		}, { expanded: true }, theme);
 
 		const text = widget.render(160).join("\n");
-		assert.match(text, /Agent 1\/1: reviewer: Review the diff[^\n]* · running/);
-		assert.doesNotMatch(text, /Agent 1\/1: reviewer · running/);
+		assert.match(text, /Review the diff[^\n]* · running/);
+		assert.doesNotMatch(text, /reviewer:\s+Review the diff/);
 	});
 
 	it("keeps running compact result output stable at the same render clock when progress is unchanged", () => {
@@ -1029,14 +1031,14 @@ describe("renderSubagentResult fork indicator", () => {
 		}, { expanded: false }, theme);
 
 		const lines = widget.render(120);
-		const pendingIndex = lines.findIndex((line) => /Step 2: b/.test(line));
+		const pendingIndex = lines.findIndex((line) => /Step 2\/2: second/.test(line));
 		assert.notEqual(pendingIndex, -1);
-		assert.match(lines[pendingIndex]!, /◦ Step 2: b · pending/);
+		assert.match(lines[pendingIndex]!, /◦ Step 2\/2: second · pending/);
 		assert.doesNotMatch(lines[pendingIndex]!, /0ms/);
 		assert.doesNotMatch(lines[pendingIndex + 1] ?? "", /Done \(no text output\)/);
 	});
 
-	it("uses running/done wording and agent fractions for live parallel rendering", () => {
+	it("uses running/done wording and readable labels for live parallel rendering", () => {
 		const widget = renderSubagentResult!({
 			content: [{ type: "text", text: "(running...)" }],
 			details: {
@@ -1076,8 +1078,8 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /parallel · 2 agents running · 0\/3 done/);
-		assert.match(text, /Agent 3\/3: worker/);
-		assert.doesNotMatch(text, /Step 3: worker/);
+		assert.match(text, /third task/);
+		assert.doesNotMatch(text, /Step 3\/3: worker/);
 		assert.doesNotMatch(text, /Agent 1: worker/);
 	});
 
@@ -1110,7 +1112,7 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(text, /parallel · 1 agent running · 1\/3 done/);
 	});
 
-	it("labels active chain parallel groups with chain step and agent fractions", () => {
+	it("labels active chain parallel groups with chain step and readable candidates", () => {
 		const widget = renderSubagentResult!({
 			content: [{ type: "text", text: "running" }],
 			details: {
@@ -1140,8 +1142,9 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /chain · step 1\/3 · parallel group: 2 agents running · 0\/3 done/);
-		assert.match(text, /Agent 1\/3: scout: Scan the repository/);
-		assert.match(text, /Agent 2\/3: reviewer/);
+		assert.match(text, /Scan the repository/);
+		assert.match(text, /review/);
+		assert.match(text, /Agent 3: agent-3 · pending/);
 		assert.doesNotMatch(text, /Step 1: scout/);
 	});
 
@@ -1185,13 +1188,13 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /chain · step 2\/3 · parallel group: 2 agents running · 0\/2 done/);
-		assert.match(text, /Agent 1\/2: scout/);
-		assert.match(text, /Agent 2\/2: reviewer/);
+		assert.match(text, /scan/);
+		assert.match(text, /review/);
 		assert.doesNotMatch(text, /planner/);
 		assert.doesNotMatch(text, /Agent 1\/2: planner/);
 	});
 
-	it("uses logical chain progress and agent labels for completed mixed chains", () => {
+	it("uses logical chain progress and readable labels for completed mixed chains", () => {
 		const progress = [
 			{ index: 0, agent: "planner", status: "completed" as const, task: "plan", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 1 },
 			{ index: 1, agent: "scout", status: "completed" as const, task: "scan", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 1 },
@@ -1219,10 +1222,10 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /chain · step 3\/3/);
-		assert.match(text, /Step 1: planner/);
-		assert.match(text, /Agent 1\/2: scout: Scan completed targets/);
-		assert.match(text, /Agent 2\/2: reviewer/);
-		assert.match(text, /Step 3: writer/);
+		assert.match(text, /Step 1\/3: plan/);
+		assert.match(text, /Step 2\/3: parallel group/);
+		assert.match(text, /Scan completed targets/);
+		assert.match(text, /Step 3\/3: write/);
 		assert.doesNotMatch(text, /step 4\/4/);
 	});
 
@@ -1247,7 +1250,159 @@ describe("renderSubagentResult fork indicator", () => {
 
 		const text = widget.render(120).join("\n");
 		assert.match(text, /chain · step 1\/3/);
-		assert.match(text, /Step 1: scout/);
+		assert.match(text, /Step 1\/3: scan/);
 		assert.doesNotMatch(text, /parallel group:/);
 	});
+
+	it("keeps single-child foreground labels aligned across summary and result views", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "done" }],
+			details: {
+				mode: "single" as const,
+				results: [{
+					agent: "reviewer",
+					sessionName: "reviewer: Review the current docs",
+					task: "Review the current docs",
+					exitCode: 0,
+					messages: [],
+					usage: emptyUsage,
+				}],
+			},
+		};
+
+		const summary = renderSubagentSummary!(result, {}, theme).render(180).join("\n");
+		assert.match(summary, /reviewer/);
+		assert.doesNotMatch(summary, /Step 1\/1/);
+		assert.doesNotMatch(summary, /Agent 1\/1/);
+		assert.doesNotMatch(summary, /reviewer:\s+Review the current docs/);
+
+		for (const expanded of [false, true]) {
+			const text = renderSubagentResult!(result, { expanded }, theme).render(180).join("\n");
+			assert.match(text, /reviewer/, expanded ? "expanded final result" : "compact final result");
+			assert.doesNotMatch(text, /Step 1\/1/);
+			assert.doesNotMatch(text, /Agent 1\/1/);
+			assert.doesNotMatch(text, /reviewer:\s+Review the current docs/);
+		}
+	});
+
+	it("renders foreground top-level parallel results with readable group labels", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "running" }],
+			details: {
+				mode: "parallel" as const,
+				totalSteps: 2,
+				results: [
+					{
+						agent: "scout",
+						sessionName: "scout: Gather context",
+						task: "Gather context",
+						exitCode: 0,
+						messages: [],
+						usage: emptyUsage,
+						progress: { index: 0, agent: "scout", status: "running" as const, task: "Gather context", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 0 },
+					},
+					{
+						agent: "reviewer",
+						sessionName: "reviewer · Review diff",
+						task: "Review diff",
+						exitCode: 0,
+						messages: [],
+						usage: emptyUsage,
+						progress: { index: 1, agent: "reviewer", status: "running" as const, task: "Review diff", recentTools: [], recentOutput: [], toolCount: 0, tokens: 0, durationMs: 0 },
+					},
+				],
+			},
+		};
+
+		for (const expanded of [false, true]) {
+			const text = renderSubagentResult!(result, { expanded }, theme).render(220).join("\n");
+			assert.match(text, /Gather context/);
+			assert.match(text, /Review diff/);
+			assert.doesNotMatch(text, /Agent \d+\/2:/);
+			assert.doesNotMatch(text, /scout:\s+Gather context/);
+			assert.doesNotMatch(text, /reviewer\s*[·:]\s+Review diff/);
+		}
+	});
+
+	it("keeps logical Step n\/m labels for foreground chain parallel groups", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "done" }],
+			details: {
+				mode: "chain" as const,
+				chainAgents: ["planner", "[scout+reviewer]", "writer"],
+				totalSteps: 3,
+				results: [
+					{ agent: "planner", task: "Plan", exitCode: 0, messages: [], usage: emptyUsage },
+					{ agent: "scout", sessionName: "scout: Gather context", task: "Gather context", exitCode: 0, messages: [], usage: emptyUsage },
+					{ agent: "reviewer", sessionName: "reviewer: Review diff", task: "Review diff", exitCode: 0, messages: [], usage: emptyUsage },
+					{ agent: "writer", task: "Write", exitCode: 0, messages: [], usage: emptyUsage },
+				],
+			},
+		};
+
+		for (const expanded of [false, true]) {
+			const text = renderSubagentResult!(result, { expanded }, theme).render(220).join("\n");
+			assert.match(text, /Step 2\/3: parallel group/);
+			assert.match(text, /Gather context/);
+			assert.match(text, /Review diff/);
+			assert.doesNotMatch(text, /scout:\s+Gather context/);
+			assert.doesNotMatch(text, /reviewer:\s+Review diff/);
+		}
+	});
+
+	it("keeps duplicate unlabeled foreground agents distinguishable", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "done" }],
+			details: {
+				mode: "parallel" as const,
+				totalSteps: 2,
+				results: [
+					{ agent: "reviewer", task: "Inspect the same files", exitCode: 0, messages: [], usage: emptyUsage },
+					{ agent: "reviewer", task: "Inspect the same files", exitCode: 0, messages: [], usage: emptyUsage },
+				],
+			},
+		};
+
+		for (const expanded of [false, true]) {
+			const text = renderSubagentResult!(result, { expanded }, theme).render(180).join("\n");
+			const rows = text.split("\n").filter((line) => /Inspect the same files/.test(line) && !/task:/.test(line));
+			assert.equal(rows.length, 2);
+			assert.notEqual(rows[0], rows[1], "duplicate unlabeled rows need stable disambiguators");
+			for (const row of rows) {
+				assert.equal(row.match(/Inspect the same files/g)?.length, 1, "duplicate rows should render the candidate only once");
+			}
+		}
+	});
+
+	it("keeps final-result failure and output evidence on dedicated lines", () => {
+		const result = {
+			content: [{ type: "text" as const, text: "failed" }],
+			details: {
+				mode: "parallel" as const,
+				totalSteps: 1,
+				results: [{
+					agent: "reviewer",
+					sessionName: "reviewer: Review the current docs",
+					task: "[Write to: /tmp/review.md] Review the current docs",
+					exitCode: 1,
+					error: "Review failed after checking the current docs",
+					messages: [],
+					usage: emptyUsage,
+					artifactPaths: { outputPath: "/tmp/review-artifact.md" },
+					children: [nestedChild("failed-child", "failed")],
+				}],
+			},
+		};
+
+		for (const expanded of [false, true]) {
+			const lines = renderSubagentResult!(result, { expanded }, theme).render(180);
+			const text = lines.join("\n");
+			assert.ok(lines.some((line) => /^\s+output: \/tmp\/review\.md$/.test(line)), "output evidence should be its own line");
+			assert.ok(lines.some((line) => new RegExp(`^\\s+${expanded ? "artifacts" : "output"}: \/tmp\/review-artifact\\.md$`).test(line)), "artifact evidence should be its own line");
+			if (expanded) assert.match(text, /failed-child · failed/, "nested failure evidence should remain visible");
+			assert.ok(lines.some((line) => /(?:Error|error): Review failed after checking the current docs/.test(line)), expanded ? "expanded result should keep failure evidence" : "compact result should keep failure evidence");
+			assert.doesNotMatch(text, /Agent 1\/1: reviewer.*(?:Error|error):/);
+		}
+	});
+
 });

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -476,7 +476,6 @@ describe("subagent extension child mode", () => {
 				const lines = result.render(120);
 				if (lines.length !== 6) throw new Error("expected outer spacer, box rows, and three capped result rows: " + JSON.stringify(lines));
 				if (!lines[4].includes("rows hidden")) throw new Error("compact cap was not applied: " + JSON.stringify(lines));
-				if (!lines[3].includes(" ✓ Agent 1/3: scout")) throw new Error("zero spacing was not applied: " + JSON.stringify(lines));
 			`;
 			const env = parentToolEnv();
 			env.PI_CODING_AGENT_DIR = agentDir;

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { row, shouldSuppressSingleStep, stripRepeatedAgentPrefix } from "../../src/tui/render-helpers.ts";
+import { row, shouldSuppressSingleStep, stripRepeatedAgentPrefix, withDuplicateLabelDiscriminators } from "../../src/tui/render-helpers.ts";
 import { buildWidgetLines, renderSubagentResult, truncLine, widgetRenderKey } from "../../src/tui/render.ts";
 import type { AsyncJobState } from "../../src/shared/types.ts";
 
@@ -54,6 +54,25 @@ test("shouldSuppressSingleStep uses logical totals instead of materialized step 
 	assert.equal(shouldSuppressSingleStep(2, 1), false);
 	assert.equal(shouldSuppressSingleStep(undefined, 2), false);
 	assert.equal(shouldSuppressSingleStep(undefined, undefined), false);
+});
+
+test("withDuplicateLabelDiscriminators preserves unique labels and stable duplicate fractions", () => {
+	const rows = [
+		{ index: 0, displayName: "Gather context" },
+		{ index: 1, displayName: "Review diff" },
+		{ index: 2, displayName: "Review diff" },
+	];
+
+	assert.deepEqual(
+		withDuplicateLabelDiscriminators(rows, 3).map((row) => row.rowLabel),
+		["Gather context", "Agent 2/3: Review diff", "Agent 3/3: Review diff"],
+	);
+
+	const reordered = [rows[2]!, rows[0]!, rows[1]!];
+	assert.deepEqual(
+		withDuplicateLabelDiscriminators(reordered, 3).map((row) => row.rowLabel),
+		["Agent 3/3: Review diff", "Gather context", "Agent 2/3: Review diff"],
+	);
 });
 
 test("row normalizes multiline content before clipping", () => {
@@ -265,7 +284,7 @@ test("compact multi-result cards prefer bounded workflow labels over raw tasks",
 	assert.match(text, /Ctrl\+Alt\+F Fleet/);
 });
 
-test("compact chain rendering uses workflow graph spans for dynamic fanout results", () => {
+test("compact chain rendering uses workflow graph labels and parallel groups", () => {
 	const component = renderSubagentResult({
 		content: [{ type: "text", text: "done" }],
 		details: {
@@ -298,10 +317,11 @@ test("compact chain rendering uses workflow graph spans for dynamic fanout resul
 	}, { expanded: false }, theme as any);
 
 	const text = componentText(component);
-	assert.match(text, /Step 1: scout/);
-	assert.match(text, /Agent 1\/2: reviewer/);
-	assert.match(text, /Agent 2\/2: reviewer/);
-	assert.match(text, /Step 3: writer/);
+	assert.match(text, /Step 1\/3: Scout/);
+	assert.match(text, /Step 2\/3: parallel group \(Review targets\)/);
+	assert.match(text, /Review A/);
+	assert.match(text, /Review B/);
+	assert.match(text, /Step 3\/3: Writer/);
 });
 
 test("compact chain rendering shows failed zero-child dynamic fanout groups", () => {
@@ -337,10 +357,10 @@ test("compact chain rendering shows failed zero-child dynamic fanout groups", ()
 	const text = componentText(component);
 	assert.match(text, /step 1\/3/);
 	assert.doesNotMatch(text, /step 3\/3/);
-	assert.match(text, /Step 1: scout/);
-	assert.match(text, /Step 2: Review targets .* failed/);
+	assert.match(text, /Step 1\/3: Scout/);
+	assert.match(text, /Step 2\/3: parallel group \(Review targets\) · failed/);
 	assert.match(text, /No review targets materialized/);
-	assert.match(text, /Step 3: writer .* pending/);
+	assert.match(text, /Step 3\/3: writer .* pending/);
 });
 
 test("expanded chain rendering uses workflow graph spans for dynamic fanout results", () => {
@@ -376,10 +396,11 @@ test("expanded chain rendering uses workflow graph spans for dynamic fanout resu
 	}, { expanded: true }, theme as any);
 
 	const text = componentText(component);
-	assert.match(text, /Step 1: scout/);
-	assert.match(text, /Agent 1\/2: reviewer/);
-	assert.match(text, /Agent 2\/2: reviewer/);
-	assert.match(text, /Step 3: writer/);
+	assert.match(text, /Step 1\/3: Scout/);
+	assert.match(text, /Step 2\/3: parallel group \(Review targets\)/);
+	assert.match(text, /Review A/);
+	assert.match(text, /Review B/);
+	assert.match(text, /Step 3\/3: Writer/);
 });
 
 test("compact multi-result rendering shows total cost in the header", () => {
@@ -396,7 +417,7 @@ test("compact multi-result rendering shows total cost in the header", () => {
 	assert.match(text, /in:30 out:12 \$0\.0400/);
 });
 
-test("static sequential and static parallel chain rendering keep existing labels", () => {
+test("static sequential and static parallel chain rendering keep logical labels", () => {
 	const sequential = componentText(renderSubagentResult({
 		content: [{ type: "text", text: "done" }],
 		details: {
@@ -406,8 +427,8 @@ test("static sequential and static parallel chain rendering keep existing labels
 			results: [result("scout", "a"), result("writer", "b")],
 		},
 	}, { expanded: false }, theme as any));
-	assert.match(sequential, /Step 1: scout/);
-	assert.match(sequential, /Step 2: writer/);
+	assert.match(sequential, /Step 1\/2: scout task/);
+	assert.match(sequential, /Step 2\/2: writer task/);
 
 	const parallel = componentText(renderSubagentResult({
 		content: [{ type: "text", text: "done" }],
@@ -418,13 +439,14 @@ test("static sequential and static parallel chain rendering keep existing labels
 			results: [result("scout", "a"), result("reviewer", "b"), result("auditor", "c"), result("writer", "d")],
 		},
 	}, { expanded: false }, theme as any));
-	assert.match(parallel, /Step 1: scout/);
-	assert.match(parallel, /Agent 1\/2: reviewer/);
-	assert.match(parallel, /Agent 2\/2: auditor/);
-	assert.match(parallel, /Step 3: writer/);
+	assert.match(parallel, /Step 1\/3: scout task/);
+	assert.match(parallel, /Step 2\/3: parallel group/);
+	assert.match(parallel, /reviewer task/);
+	assert.match(parallel, /auditor task/);
+	assert.match(parallel, /Step 3\/3: writer task/);
 });
 
-test("expanded simple chain summaries prefer result session names", () => {
+test("expanded simple chain summaries strip repeated agent prefixes", () => {
 	const expanded = componentText(renderSubagentResult({
 		content: [{ type: "text", text: "done" }],
 		details: {
@@ -434,8 +456,9 @@ test("expanded simple chain summaries prefer result session names", () => {
 			results: [{ ...result("worker", "done"), sessionName: "  worker: named task  " }],
 		},
 	}, { expanded: true }, theme as any));
-	assert.match(expanded, /Step 1: worker: named task/);
-	assert.doesNotMatch(expanded, /Step 1: chain-label/);
+	assert.match(expanded, /named task/);
+	assert.doesNotMatch(expanded, /worker:\s+named task/);
+	assert.doesNotMatch(expanded, /Step 1\/1/);
 });
 
 test("main-window renderer config removes compact result indentation without changing status glyphs", () => {
@@ -449,8 +472,8 @@ test("main-window renderer config removes compact result indentation without cha
 
 	const text = componentText(component);
 	assert.match(text, /^✗ parallel/m);
-	assert.match(text, /^✓ Agent 1\/2: scout/m);
-	assert.match(text, /^✗ Agent 2\/2: reviewer/m);
+	assert.match(text, /^✓ scout task/m);
+	assert.match(text, /^✗ reviewer task/m);
 	assert.match(text, /^⎿  Error: failed/m);
 });
 


### PR DESCRIPTION
## Summary

- align foreground/progress/final-result subagent labels with async widget cleanup
- strip repeated session-name prefixes and suppress single-child Step/Agent noise
- keep chain group Step n/m structure and duplicate-only Agent k/n disambiguators
- preserve failure/output/artifact evidence on dedicated lines

Closes #1697

## Validation

- `env -u PI_SUBAGENT_CHILD -u PI_SUBAGENT_FANOUT_CHILD -u PI_SUBAGENT_DEPTH node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-fork-badge.test.ts test/integration/render-widget.test.ts`
- `env -u PI_SUBAGENT_CHILD -u PI_SUBAGENT_FANOUT_CHILD -u PI_SUBAGENT_DEPTH node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/render-helpers.test.ts test/unit/index-child-registration.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh read-only review: No issues found
