### PR TITLE
fix: focus staged workflow status on active work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Show `runs.lanes(...)` workflows with active-stage focus and planned-stage progress in async status widgets (#1699).
 - Align foreground subagent result labels with async widget labels and disambiguate duplicate rows (#1697).
 - Render parallel subagent workflow groups as readable cards with nested agent rows (#1696).
 - Remove repeated one-child async widget status labels and compact progress echoes (#1695).

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -146,6 +146,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			chainStepCount: run.chainStepCount,
 			parallelGroups: groups,
 			hostSteps: run.hostSteps,
+			...(run.mode === "workflow" && run.workflowGraph ? { workflowGraph: run.workflowGraph } : {}),
 			preflight: run.preflight,
 			steps: visibleSteps,
 			stepsTotal: visibleSteps.length,
@@ -401,6 +402,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				job.workflowKey = status.workflowKey ?? job.workflowKey;
 				job.lane = status.lane ?? job.lane;
 				job.workflow = status.workflow ?? job.workflow;
+				if (status.mode === "workflow") job.workflowGraph = status.workflowGraph ?? job.workflowGraph;
 				job.hostSteps = validHostStepNodes(status.workflowGraph);
 				const workflowChildren = parseWorkflowChildSummary(status.workflowChildren);
 				if (workflowChildren && workflowChildren.workflowRunId !== status.runId) throw new Error("workflowChildren.workflowRunId does not match async status runId.");
@@ -627,6 +629,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			turnBudget: info.turnBudget,
 			parentWorkflowRunId: info.parentWorkflowRunId,
 			workflowKey: info.workflowKey,
+			...(info.mode === "workflow" && info.workflowGraph ? { workflowGraph: info.workflowGraph } : {}),
 			controlEventCursor: 0,
 		});
 		const job = state.asyncJobs.get(info.id)!;

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../../shared/formatters.ts";
 import { formatActivityLabel, formatParallelOutcome } from "../../shared/status-format.ts";
-import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type HostStepNodeV1, type HostStepState, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TokenUsage, type TurnBudgetState, type UsageBudgetState, type WorkflowPreflightV1 } from "../../shared/types.ts";
+import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type HostStepNodeV1, type HostStepState, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TokenUsage, type TurnBudgetState, type UsageBudgetState, type WorkflowPreflightV1, type WorkflowGraphSnapshot } from "../../shared/types.ts";
 import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../shared/capability-ceiling.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { attachRootChildrenToSteps, buildNestedRouteIndex, findNestedRouteForRootId, type NestedRoute, projectNestedEvents } from "../shared/nested-events.ts";
@@ -21,6 +21,7 @@ import { assertWorkflowGraphHostSteps, hostStepReportName, hostStepVerdictLabel,
 import { projectAsyncWorkflowRows } from "../shared/async-status-projection.ts";
 import { validateAsyncStatusLaneMetadata } from "../shared/lane-metadata.ts";
 import { formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary } from "../../workflows/workflow-preflight.ts";
+import { workflowGraphStageNodes } from "../shared/workflow-graph.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -116,6 +117,7 @@ export interface AsyncRunSummary {
 	pendingAppends?: number;
 	parallelGroups?: AsyncParallelGroupStatus[];
 	hostSteps?: HostStepNodeV1[];
+	workflowGraph?: AsyncStatus["workflowGraph"];
 	steps: AsyncRunStepSummary[];
 	sessionDir?: string;
 	outputFile?: string;
@@ -381,6 +383,7 @@ function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string 
 		...(status.pendingAppends !== undefined ? { pendingAppends: status.pendingAppends } : {}),
 		...(parallelGroups.length ? { parallelGroups } : {}),
 		...(hostSteps.length ? { hostSteps } : {}),
+		...(status.mode === "workflow" && status.workflowGraph ? { workflowGraph: status.workflowGraph } : {}),
 		steps: summarizedSteps,
 		...(nestedChildren.length ? { nestedChildren } : {}),
 		...(nestedWarnings.length ? { nestedWarnings } : {}),
@@ -575,12 +578,39 @@ function formatHostStepLine(row: ReturnType<typeof projectAsyncWorkflowRows>[num
 	return `host ${row.kind}: ${row.name} | ${state}${details.length ? ` | ${details.join(" | ")}` : ""}`;
 }
 
+function workflowStageStateLabel(status: WorkflowGraphSnapshot["nodes"][number]["status"]): string {
+	switch (status) {
+		case "completed":
+			return "complete";
+		case "detached":
+			return "paused";
+		default:
+			return status;
+	}
+}
+
+export function formatWorkflowStageLine(node: WorkflowGraphSnapshot["nodes"][number], index: number, total: number): string {
+	const state = workflowStageStateLabel(node.status);
+	const display = node.label && node.label !== node.id ? ` | ${node.label}` : "";
+	const agent = node.agent ? ` | ${node.agent}` : "";
+	const error = node.error ? ` | ${node.error.replace(/\s+/g, " ").trim()}` : "";
+	return `stage ${index + 1}/${total}: ${node.id}${display}${agent} | ${state}${error}`;
+}
+
 export function formatAsyncRunOutputPath(run: Pick<AsyncRunSummary, "asyncDir" | "outputFile">): string | undefined {
 	if (!run.outputFile) return undefined;
 	return path.isAbsolute(run.outputFile) ? run.outputFile : path.join(run.asyncDir, run.outputFile);
 }
 
-export function formatAsyncRunProgressLabel(run: Pick<AsyncRunSummary, "mode" | "state" | "currentStep" | "chainStepCount" | "parallelGroups" | "steps">): string {
+export function formatAsyncRunProgressLabel(run: Pick<AsyncRunSummary, "mode" | "state" | "currentStep" | "chainStepCount" | "parallelGroups" | "steps"> & { workflowGraph?: WorkflowGraphSnapshot }): string {
+	const graphStages = run.mode === "workflow" ? workflowGraphStageNodes(run.workflowGraph) : [];
+	if (graphStages.length > 0) {
+		const currentNode = graphStages.find((node) => node.id === run.workflowGraph?.currentNodeId);
+		if (currentNode && currentNode.status !== "completed") return `stage ${graphStages.indexOf(currentNode) + 1}/${graphStages.length}`;
+		const activeNode = graphStages.find((node) => node.status === "running") ?? graphStages.find((node) => node.status !== "completed");
+		if (activeNode) return `stage ${graphStages.indexOf(activeNode) + 1}/${graphStages.length}`;
+		return `stage ${graphStages.length}/${graphStages.length}`;
+	}
 	const stepCount = run.steps.length || 1;
 	const chainStepCount = run.chainStepCount ?? stepCount;
 	const groups = normalizeParallelGroups(run.parallelGroups, run.steps.length, chainStepCount);
@@ -623,6 +653,11 @@ export function formatAsyncRunList(runs: AsyncRunSummary[], heading = "Active as
 		for (const step of run.steps) {
 			lines.push(`  ${formatStepLine(step)}`);
 			lines.push(...formatNestedRunStatusLines(step.children, { indent: "    ", maxLines: 12 }));
+		}
+		const loadedWorkflowKeys = new Set(run.steps.flatMap((step) => step.workflowKey ? [step.workflowKey] : []));
+		const graphStages = run.mode === "workflow" ? workflowGraphStageNodes(run.workflowGraph) : [];
+		for (const [index, node] of graphStages.entries()) {
+			if (!loadedWorkflowKeys.has(node.id)) lines.push(`  ${formatWorkflowStageLine(node, index, graphStages.length)}`);
 		}
 		for (const row of projectAsyncWorkflowRows([], run.hostSteps)) {
 			const line = formatHostStepLine(row);

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { safeTerminalText } from "../../shared/display-text.ts";
-import { formatAsyncRunList, formatAsyncRunOutputPath, formatAsyncRunProgressLabel, listAsyncRuns } from "./async-status.ts";
+import { formatAsyncRunList, formatAsyncRunOutputPath, formatAsyncRunProgressLabel, formatWorkflowStageLine, listAsyncRuns } from "./async-status.ts";
 import { formatAsyncResultTranscript, formatAsyncRunTranscript, formatNestedRunTranscript, inspectSubagentFleet } from "./fleet-view.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
@@ -25,6 +25,7 @@ import { formatWorkflowJsonPreview } from "../../workflows/scripted-workflow.ts"
 import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary } from "../../workflows/workflow-preflight.ts";
 import { formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
+import { workflowGraphStageNodes } from "../shared/workflow-graph.ts";
 import { getExternalJobProvider } from "../../api/external-job-provider.ts";
 
 interface RunStatusParams {
@@ -481,6 +482,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				currentStep: status.currentStep,
 				chainStepCount: status.chainStepCount,
 				parallelGroups: status.parallelGroups,
+				workflowGraph: status.workflowGraph,
 				steps: (status.steps ?? []).map((step, index) => ({ index, agent: step.agent, status: step.status })),
 			});
 			const started = new Date(status.startedAt).toISOString();
@@ -592,6 +594,11 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				} else if (step.status === "running" && (step.runner?.type === "external-cli" || step.runner?.type === "external-job")) {
 					lines.push("  Steer: unavailable; external runners do not accept live messages.");
 				}
+			}
+			const loadedWorkflowKeys = new Set((status.steps ?? []).flatMap((step) => step.workflowKey ? [step.workflowKey] : []));
+			const graphStages = status.mode === "workflow" ? workflowGraphStageNodes(status.workflowGraph) : [];
+			for (const [index, node] of graphStages.entries()) {
+				if (!loadedWorkflowKeys.has(node.id)) lines.push(`  ${formatWorkflowStageLine(node, index, graphStages.length)}`);
 			}
 			const attached = new Set((status.steps ?? []).flatMap((step) => step.children?.map((child) => child.id) ?? []));
 			const unattached = nestedChildren.filter((child) => !attached.has(child.id));

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -112,7 +112,7 @@ import { createMissionWorkflowState } from "../../missions/workflow-state.ts";
 import { resolveAuthorityDecision } from "../../policy/authority.ts";
 import { handleHerdrInspectorAction, HERDR_INSPECTOR_ACTIONS } from "../../inspectors/herdr/actions.ts";
 import { handleHerdrProjectPaneAction, HERDR_PROJECT_PANE_ACTIONS } from "../../inspectors/herdr/project-panes.ts";
-import { previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError, type WorkflowReceiptResumeReference, type WorkflowScriptChildResult, type WorkflowSteerOptions, type WorkflowSteerResult } from "../../workflows/scripted-workflow.ts";
+import { previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError, type WorkflowLanePlan, type WorkflowReceiptResumeReference, type WorkflowScriptChildResult, type WorkflowScriptTraceEntry, type WorkflowSteerOptions, type WorkflowSteerResult } from "../../workflows/scripted-workflow.ts";
 import { executeWorkflowHostCommand, resolveWorkflowHostOutputClaimPath, type WorkflowHostCommandParams, type WorkflowHostCommandResult } from "../../workflows/host-command.ts";
 import { buildWorkflowReceipt, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
 import { upsertHostStep, validHostStepNodes } from "../shared/host-step-status.ts";
@@ -160,6 +160,9 @@ import {
 	type ToolBudgetConfig,
 	type Usage,
 	type UsageBudgetConfig,
+	type WorkflowGraphNode,
+	type WorkflowGraphSnapshot,
+	type WorkflowNodeStatus,
 	type WorkflowTerminalOutcome,
 	type SubagentRunMode,
 	type SubagentState,
@@ -4411,6 +4414,90 @@ function formatWorkflowValue(value: unknown): string {
 	}
 }
 
+function buildWorkflowLaneGraph(runId: string, lanes: WorkflowLanePlan[], existing?: WorkflowGraphSnapshot): WorkflowGraphSnapshot {
+	const plannedIds = new Set(lanes.flatMap((lane) => lane.stages.map((stage) => stage.generatedKey)));
+	const previousById = new Map((existing?.nodes ?? []).map((node) => [node.id, node]));
+	const nodes: WorkflowGraphNode[] = [];
+	const phases: WorkflowGraphSnapshot["phases"] = [];
+	let flatIndex = 0;
+	for (const lane of lanes) {
+		const nodeIds: string[] = [];
+		for (const [stageIndex, stage] of lane.stages.entries()) {
+			const previous = previousById.get(stage.generatedKey);
+			const outputName = stage.outputName || previous?.outputName;
+			const structured = stage.structured ?? previous?.structured;
+			const node: WorkflowGraphNode = {
+				id: stage.generatedKey,
+				kind: "step",
+				agent: stage.agent ?? previous?.agent,
+				phase: stage.phase ?? previous?.phase,
+				label: stage.label ?? stage.key,
+				status: previous?.status ?? (stageIndex === 0 ? "running" : "pending"),
+				flatIndex,
+				stepIndex: flatIndex,
+				...(outputName ? { outputName } : {}),
+				...(structured !== undefined ? { structured } : {}),
+				...(previous?.acceptanceStatus ? { acceptanceStatus: previous.acceptanceStatus } : {}),
+				...(previous?.error ? { error: previous.error } : {}),
+			};
+			nodes.push(node);
+			nodeIds.push(node.id);
+			flatIndex++;
+		}
+		if (nodeIds.length > 0) phases.push({ title: lane.key, nodeIds });
+	}
+	for (const node of existing?.nodes ?? []) {
+		if (!plannedIds.has(node.id)) nodes.push(node);
+	}
+	for (const phase of existing?.phases ?? []) {
+		const retainedNodeIds = phase.nodeIds.filter((nodeId) => !plannedIds.has(nodeId));
+		if (retainedNodeIds.length === 0) continue;
+		const currentPhase = phases.find((candidate) => candidate.title === phase.title);
+		if (currentPhase) currentPhase.nodeIds.push(...retainedNodeIds);
+		else phases.push({ title: phase.title, nodeIds: retainedNodeIds });
+	}
+	const currentNodeId = nodes.find((node) => node.status === "running")?.id ?? existing?.currentNodeId;
+	return { runId, mode: "workflow", phases, nodes, ...(currentNodeId ? { currentNodeId } : {}) };
+}
+
+function workflowLaneTraceStatus(state: WorkflowScriptTraceEntry["state"]): WorkflowNodeStatus | undefined {
+	switch (state) {
+		case "started":
+			return "running";
+		case "reused":
+			return undefined;
+		case "completed":
+			return "completed";
+		case "failed":
+			return "failed";
+		case "detached":
+			return "detached";
+		case "stopped":
+			return "stopped";
+		default:
+			return undefined;
+	}
+}
+
+function applyWorkflowLaneTrace(graph: WorkflowGraphSnapshot, trace: WorkflowScriptTraceEntry[]): void {
+	const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
+	for (const entry of trace) {
+		if (entry.operation !== "run") continue;
+		const node = nodesById.get(entry.key);
+		if (!node) continue;
+		const status = workflowLaneTraceStatus(entry.state);
+		if (status) node.status = status;
+		if (entry.agent) node.agent = entry.agent;
+		if (entry.phase && (entry.phase !== "auto-resume" || node.phase === undefined)) node.phase = entry.phase;
+		if (entry.label) node.label = entry.label;
+		if (entry.error) node.error = entry.error;
+		else if (status === "completed" || status === "running") delete node.error;
+	}
+	const currentNodeId = graph.nodes.find((node) => node.status === "running")?.id;
+	if (currentNodeId) graph.currentNodeId = currentNodeId;
+	else delete graph.currentNodeId;
+}
+
 function workflowChatProgressUpdate(
 	runId: string,
 	chatProgress: WorkflowChatProgressProjection,
@@ -4800,6 +4887,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						liveJob.toolCount = status.toolCount;
 						liveJob.currentStep = status.currentStep;
 						liveJob.preflight = status.preflight;
+						liveJob.workflowGraph = status.workflowGraph;
 						if (status.steps) {
 							liveJob.steps = status.steps.map((step, index) => ({ ...step, index }));
 							liveJob.agents = status.steps.map((step) => step.agent);
@@ -4883,6 +4971,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							trace: projectedTrace,
 							...(preflightWarnings.length ? { preflightWarnings } : {}),
 						};
+						if (status.workflowGraph) applyWorkflowLaneTrace(status.workflowGraph, trace);
 						const rebuild = trace.length < projectedTraceLength
 							|| (projectedTraceLength > 0 && trace[projectedTraceLength - 1] !== projectedTraceTail);
 						if (rebuild) {
@@ -4986,6 +5075,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							},
 							...(workflowState ? { state: workflowState } : {}),
 							onTrace: updateTrace,
+							onLanePlan: (lanes) => {
+								status.workflowGraph = buildWorkflowLaneGraph(workflowRunId, lanes, status.workflowGraph);
+								applyWorkflowLaneTrace(status.workflowGraph, status.workflow?.trace ?? []);
+								persist({ tolerateStatusWriteFailure: true });
+							},
 							host: runHostCommand,
 							onHostStep: (hostStep) => {
 								status = upsertHostStep({ status, hostStep, persist: (nextStatus) => {

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -2,6 +2,7 @@ import { sanitizeDisplayText, truncateDisplayText } from "../../shared/display-t
 import { formatModelThinking } from "../../shared/formatters.ts";
 import type { AsyncJobState, AsyncJobStep, HostStepFreshnessV1, HostStepMonitorKind, HostStepNodeV1, HostStepState, HostStepVerdict, NestedRunSummary, NestedStepSummary, SubagentRunMode, WorkflowGraphSnapshot, WorkflowPreflightLaneV1, WorkflowPreflightV1 } from "../../shared/types.ts";
 import { HOST_STEP_MAX_COUNT, HOST_STEP_MAX_DETAIL_CHARS, HOST_STEP_MAX_LABEL_CHARS, HOST_STEP_MAX_PROVIDER_CHARS, HOST_STEP_MAX_REASON_CHARS, HOST_STEP_MAX_REF_CHARS, HOST_STEP_MAX_ROLE_CHARS, HOST_STEP_MAX_TARGET_CHARS, hostStepReportName, parseHostStepNode, validHostStepNodes } from "./host-step-status.ts";
+import { workflowGraphStageNodes } from "./workflow-graph.ts";
 
 export const ASYNC_STATUS_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
 export const ASYNC_STATUS_SNAPSHOT_VERSION = 1;
@@ -231,6 +232,16 @@ function projectStep(step: AsyncJobStep | NestedStepSummary, index: number, dept
 	return node;
 }
 
+function projectWorkflowGraphNode(node: WorkflowGraphSnapshot["nodes"][number], index: number, depth: number, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
+	const step: AsyncJobStep = {
+		agent: node.agent ?? node.label,
+		status: workflowGraphStepStatus(node.status),
+		workflowKey: node.id,
+		label: node.label,
+	};
+	return projectStep(step, node.flatIndex ?? index, depth, ctx);
+}
+
 function projectNestedRun(child: NestedRunSummary, index: number, depth: number, ctx: ProjectionContext): AsyncStatusSnapshotNodeV1 {
 	const state = normalizeState(child.state);
 	const startedAt = publicTime(child.startedAt);
@@ -311,9 +322,14 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnap
 	};
 	if (ctx.caps.maxDepth > 0) {
 		const stepChildren = job.steps?.map((step, index) => projectStep(step, step.index ?? index, 1, ctx)) ?? [];
+		const loadedKeys = new Set(job.steps?.flatMap((step) => step.workflowKey ? [step.workflowKey] : []) ?? []);
+		const graphStages = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph) : [];
+		const graphChildren = graphStages
+			.filter((graphNode) => !loadedKeys.has(graphNode.id))
+			.map((graphNode, index) => projectWorkflowGraphNode(graphNode, index, 1, ctx));
 		const nestedChildren = job.nestedChildren?.map((child, index) => projectNestedRun(child, index, 1, ctx)) ?? [];
 		const hostStepChildren = validHostStepList(job.hostSteps).map((hostStep) => projectHostStep(hostStep, ctx));
-		const ordinaryChildren = [...stepChildren, ...nestedChildren];
+		const ordinaryChildren = [...stepChildren, ...graphChildren, ...nestedChildren];
 		const retainedHostSteps = hostStepChildren.slice(0, ctx.caps.maxChildrenPerNode);
 		const retainedOrdinaryChildren = ordinaryChildren.slice(0, ctx.caps.maxChildrenPerNode - retainedHostSteps.length);
 		const bounded: AsyncStatusSnapshotNodeV1[] = [];
@@ -321,7 +337,10 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnap
 		ctx.omitted.children += ordinaryChildren.length - retainedOrdinaryChildren.length + hostStepChildren.length - retainedHostSteps.length;
 		if (bounded.length) node.children = bounded;
 	} else {
-		ctx.omitted.children += (job.steps?.length ?? 0) + (job.nestedChildren?.length ?? 0) + validHostStepList(job.hostSteps).length;
+		const loadedKeys = new Set(job.steps?.flatMap((step) => step.workflowKey ? [step.workflowKey] : []) ?? []);
+		const graphStages = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph) : [];
+		const graphCount = graphStages.filter((graphNode) => !loadedKeys.has(graphNode.id)).length;
+		ctx.omitted.children += (job.steps?.length ?? 0) + graphCount + (job.nestedChildren?.length ?? 0) + validHostStepList(job.hostSteps).length;
 	}
 	return node;
 }
@@ -393,6 +412,50 @@ function isWorkflowPreflight(value: readonly HostStepNodeV1[] | WorkflowGraphSna
 	return value !== undefined && !Array.isArray(value) && "lanes" in value;
 }
 
+function isWorkflowGraph(value: readonly HostStepNodeV1[] | WorkflowGraphSnapshot | WorkflowPreflightV1 | undefined): value is WorkflowGraphSnapshot {
+	return value !== undefined && !Array.isArray(value) && "nodes" in value;
+}
+
+function workflowGraphRowState(status: WorkflowGraphSnapshot["nodes"][number]["status"]): AsyncStatusWorkflowRow["state"] {
+	switch (status) {
+		case "pending":
+			return "planned";
+		case "completed":
+			return "complete";
+		case "detached":
+			return "paused";
+		default:
+			return status;
+	}
+}
+
+function workflowGraphStepStatus(status: WorkflowGraphSnapshot["nodes"][number]["status"]): AsyncJobStep["status"] {
+	switch (status) {
+		case "completed":
+			return "complete";
+		case "detached":
+			return "paused";
+		default:
+			return status;
+	}
+}
+
+function workflowGraphRowName(node: WorkflowGraphSnapshot["nodes"][number]): string {
+	const key = publicText(node.id, "stage", HOST_STEP_MAX_LABEL_CHARS);
+	const label = publicOptionalText(node.label, HOST_STEP_MAX_LABEL_CHARS);
+	const phase = publicOptionalText(node.phase, HOST_STEP_MAX_LABEL_CHARS);
+	const agent = publicOptionalText(node.agent, HOST_STEP_MAX_LABEL_CHARS);
+	return `${phase ? `${phase}: ` : ""}${key}${label && label !== node.id ? ` · ${label}` : ""}${agent ? ` (${agent})` : ""}`;
+}
+
+function projectWorkflowGraphRow(node: WorkflowGraphSnapshot["nodes"][number], preflight?: WorkflowPreflightLaneV1): AsyncStatusWorkflowRow {
+	return {
+		name: workflowGraphRowName(node),
+		state: workflowGraphRowState(node.status),
+		...(preflight ? { preflight } : {}),
+	};
+}
+
 /** Project loaded workflow child facts plus stored preflight hints into compact rows. */
 export function projectAsyncWorkflowRows(
 	steps: readonly AsyncJobStep[] | undefined,
@@ -400,9 +463,62 @@ export function projectAsyncWorkflowRows(
 	preflightOverride?: WorkflowPreflightV1,
 ): AsyncStatusWorkflowRow[] {
 	const preflight = preflightOverride ?? (isWorkflowPreflight(hostStepsOrPreflight) ? hostStepsOrPreflight : undefined);
-	const hostSteps = isWorkflowPreflight(hostStepsOrPreflight) ? undefined : hostStepsOrPreflight;
+	const graph = isWorkflowGraph(hostStepsOrPreflight) ? hostStepsOrPreflight : undefined;
+	const hostSteps = isWorkflowPreflight(hostStepsOrPreflight) || graph ? undefined : hostStepsOrPreflight;
 	const loaded = steps ?? [];
 	const declared = new Map<string, WorkflowPreflightLaneV1>();
+	if (graph) {
+		const loadedIndexesByKey = new Map<string, number[]>();
+		for (const [index, step] of loaded.entries()) {
+			if (!step.workflowKey) continue;
+			const indexes = loadedIndexesByKey.get(step.workflowKey) ?? [];
+			indexes.push(index);
+			loadedIndexesByKey.set(step.workflowKey, indexes);
+		}
+		const consumed = new Set<number>();
+		const childRows: AsyncStatusWorkflowRow[] = [];
+		for (const lane of preflight?.lanes ?? []) declared.set(lane.key, lane);
+		const graphStages = workflowGraphStageNodes(graph);
+		const graphKeys = new Set(graphStages.map((node) => node.id));
+		const graphPhaseByNodeId = new Map<string, string>();
+		for (const phase of graph.phases) {
+			for (const nodeId of phase.nodeIds) {
+				if (graphKeys.has(nodeId) && !graphPhaseByNodeId.has(nodeId)) graphPhaseByNodeId.set(nodeId, phase.title);
+			}
+		}
+		const graphLaneKeys = new Set(graphPhaseByNodeId.values());
+		const preflightForNode = (node: WorkflowGraphSnapshot["nodes"][number]): WorkflowPreflightLaneV1 | undefined => {
+			const phaseTitle = graphPhaseByNodeId.get(node.id);
+			return declared.get(node.id) ?? (node.phase ? declared.get(node.phase) : undefined) ?? (phaseTitle ? declared.get(phaseTitle) : undefined);
+		};
+		for (const node of graphStages) {
+			const indexes = (loadedIndexesByKey.get(node.id) ?? []).filter((index) => !consumed.has(index));
+			if (indexes.length > 0) {
+				for (const index of indexes) {
+					consumed.add(index);
+					childRows.push(projectLoadedWorkflowRow(loaded[index]!, index, preflightForNode(node)));
+				}
+			} else {
+				childRows.push(projectWorkflowGraphRow(node, preflightForNode(node)));
+			}
+		}
+		for (const lane of preflight?.lanes ?? []) {
+			if (graphKeys.has(lane.key) || graphLaneKeys.has(lane.key)) continue;
+			const indexes = (loadedIndexesByKey.get(lane.key) ?? []).filter((index) => !consumed.has(index));
+			if (indexes.length > 0) {
+				for (const index of indexes) {
+					consumed.add(index);
+					childRows.push(projectLoadedWorkflowRow(loaded[index]!, index, lane));
+				}
+			} else {
+				childRows.push({ name: lane.key, state: "planned", preflight: lane });
+			}
+		}
+		for (const [index, step] of loaded.entries()) {
+			if (!consumed.has(index)) childRows.push(projectLoadedWorkflowRow(step, index, step.workflowKey ? declared.get(step.workflowKey) : undefined));
+		}
+		return [...childRows, ...validHostStepList(graph).map(hostStepRow)];
+	}
 	const loadedIndexByKey = new Map<string, number>();
 	for (const [index, step] of loaded.entries()) {
 		if (step.workflowKey !== undefined && !loadedIndexByKey.has(step.workflowKey)) loadedIndexByKey.set(step.workflowKey, index);

--- a/src/runs/shared/workflow-graph.ts
+++ b/src/runs/shared/workflow-graph.ts
@@ -13,6 +13,21 @@ export interface WorkflowGraphBuildInput {
 	dynamicGroupStatuses?: Record<number, { status: WorkflowNodeStatus; error?: string; acceptance?: SingleResult["acceptance"] }>;
 }
 
+/** Return displayable workflow stages while hiding structural parallel groups and host monitors. */
+export function workflowGraphStageNodes(graph: WorkflowGraphSnapshot | undefined): WorkflowGraphNode[] {
+	if (!graph?.nodes?.length) return [];
+	const stages: WorkflowGraphNode[] = [];
+	const visit = (node: WorkflowGraphNode): void => {
+		if (node.kind === "parallel-group" || node.kind === "dynamic-parallel-group") {
+			for (const child of node.children ?? []) visit(child);
+			return;
+		}
+		if (node.kind !== "host-step") stages.push(node);
+	};
+	for (const node of graph.nodes) visit(node);
+	return stages;
+}
+
 function normalizeStatus(status: string | undefined): WorkflowNodeStatus | undefined {
 	switch (status) {
 		case "complete":

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1889,6 +1889,8 @@ export interface AsyncJobState {
 	parallelGroups?: AsyncParallelGroupStatus[];
 	/** Bounded host-owned CI/gate nodes loaded from the workflow status graph. */
 	hostSteps?: HostStepNodeV1[];
+	/** Full bounded workflow plan, including not-yet-materialized stages. */
+	workflowGraph?: WorkflowGraphSnapshot;
 	steps?: AsyncJobStep[];
 	preflight?: WorkflowPreflightV1;
 	stepsTotal?: number;

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -363,7 +363,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 		if (job.mode === "workflow") {
 			const latestEmit = job.workflow?.emits?.length ? formatWorkflowJsonPreview(job.workflow.emits.at(-1), 120) : undefined;
 			const workflowSteps = workflowStepsWithoutMaterializedChildren(job.steps, materializedChildrenByWorkflow.get(`async:${job.asyncId}`));
-			const workflowRows = projectAsyncWorkflowRows(workflowSteps, job.hostSteps, job.preflight);
+			const workflowRows = projectAsyncWorkflowRows(workflowSteps, job.workflowGraph ?? job.hostSteps, job.preflight);
 			entries.push({
 				key: `async:${job.asyncId}`,
 				...(linkedParentKey ? { parentKey: linkedParentKey } : {}),

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -37,6 +37,7 @@ import { formatWorkflowPreflight, formatWorkflowPreflightPlanSummary, formatWork
 import { encodeAsyncStatusSnapshotWidget } from "../runs/background/async-status-snapshot.ts";
 import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
 import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
+import { workflowGraphStageNodes } from "../runs/shared/workflow-graph.ts";
 
 type Theme = ExtensionContext["ui"]["theme"];
 
@@ -314,9 +315,129 @@ function boundedLaneValue(value: string | undefined, maxChars = LANE_VALUE_MAX_C
 	return previewDisplayText(oneLine(value), maxChars);
 }
 
+function workflowNodeStepStatus(status: WorkflowNodeStatus): AsyncJobStep["status"] {
+	switch (status) {
+		case "completed":
+			return "completed";
+		case "detached":
+			return "paused";
+		default:
+			return status;
+	}
+}
+
+function workflowNodeStatusLabel(status: WorkflowNodeStatus): string {
+	switch (status) {
+		case "completed":
+			return "complete";
+		case "detached":
+			return "paused";
+		default:
+			return status;
+	}
+}
+
+function workflowStepPriority(step: AsyncJobStep, currentNodeId?: string): number {
+	const isCurrent = step.workflowKey === currentNodeId;
+	if (step.status === "running" || (isCurrent && step.status !== "complete" && step.status !== "completed")) return 0;
+	const gate = laneGate(step);
+	if (
+		step.status === "failed"
+		|| step.status === "partial"
+		|| step.status === "paused"
+		|| step.status === "stopped"
+		|| step.status === "rejected"
+		|| step.toolBudgetBlocked === true
+		|| step.turnBudgetExceeded === true
+		|| step.activityState === "needs_attention"
+		|| step.watchdog?.phase === "stale"
+		|| gate !== undefined
+	) return 1;
+	if (step.status === "pending") return 2;
+	return 3;
+}
+
+/** Merge materialized child rows with the planned workflow stages for rendering. */
+function workflowWidgetSteps(job: AsyncJobState): AsyncJobStep[] {
+	const planned = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph) : [];
+	const loaded = job.steps ?? [];
+	if (planned.length === 0) return loaded;
+
+	const loadedIndexesByKey = new Map<string, number[]>();
+	for (const [index, step] of loaded.entries()) {
+		if (!step.workflowKey) continue;
+		const indexes = loadedIndexesByKey.get(step.workflowKey) ?? [];
+		indexes.push(index);
+		loadedIndexesByKey.set(step.workflowKey, indexes);
+	}
+	const consumed = new Set<number>();
+	const entries: Array<{ step: AsyncJobStep; order: number }> = [];
+	for (const [order, node] of planned.entries()) {
+		const loadedIndex = loadedIndexesByKey.get(node.id)?.find((index) => !consumed.has(index));
+		if (loadedIndex !== undefined) {
+			consumed.add(loadedIndex);
+			const loadedStep = loaded[loadedIndex]!;
+			entries.push({
+				step: {
+					...loadedStep,
+					index: node.flatIndex ?? loadedStep.index ?? order,
+					agent: loadedStep.agent || node.agent || job.agents?.[0] || "workflow",
+					phase: loadedStep.phase ?? node.phase,
+					label: loadedStep.label ?? node.label,
+					workflowKey: loadedStep.workflowKey ?? node.id,
+					...(loadedStep.outputName === undefined && node.outputName !== undefined ? { outputName: node.outputName } : {}),
+					...(loadedStep.structured === undefined && node.structured !== undefined ? { structured: node.structured } : {}),
+					...(loadedStep.error === undefined && node.error !== undefined ? { error: node.error } : {}),
+				},
+				order,
+			});
+			continue;
+		}
+		entries.push({
+			step: {
+				index: node.flatIndex ?? order,
+				agent: node.agent ?? job.agents?.[0] ?? "workflow",
+				status: workflowNodeStepStatus(node.status),
+				workflowKey: node.id,
+				label: node.label,
+				...(node.phase ? { phase: node.phase } : {}),
+				...(node.outputName ? { outputName: node.outputName } : {}),
+				...(node.structured !== undefined ? { structured: node.structured } : {}),
+				...(node.error ? { error: node.error } : {}),
+			},
+			order,
+		});
+	}
+	for (const [index, step] of loaded.entries()) {
+		if (!consumed.has(index)) entries.push({ step, order: planned.length + index });
+	}
+	entries.sort((left, right) => workflowStepPriority(left.step, job.workflowGraph?.currentNodeId) - workflowStepPriority(right.step, job.workflowGraph?.currentNodeId) || left.order - right.order);
+	return entries.map(({ step }) => step);
+}
+
+function workflowStageProgress(job: AsyncJobState): { total: number; current?: number } | undefined {
+	if (job.mode !== "workflow") return undefined;
+	const stages = workflowGraphStageNodes(job.workflowGraph);
+	if (stages.length === 0) return undefined;
+	const currentId = job.workflowGraph?.currentNodeId;
+	const currentIndex = currentId ? stages.findIndex((stage) => stage.id === currentId) : -1;
+	if (currentIndex >= 0 && stages[currentIndex]?.status !== "completed") return { total: stages.length, current: currentIndex };
+	const runningIndex = stages.findIndex((stage) => stage.status === "running");
+	if (runningIndex >= 0) return { total: stages.length, current: runningIndex };
+	const indexedStage = job.currentStep !== undefined && job.currentStep >= 0 ? stages[job.currentStep] : undefined;
+	if (indexedStage && indexedStage.status !== "completed") return { total: stages.length, current: job.currentStep };
+	if (stages.every((stage) => stage.status === "completed")) return { total: stages.length, current: stages.length - 1 };
+	return { total: stages.length };
+}
+
 function laneStepForJob(job: AsyncJobState): AsyncJobStep | undefined {
-	const steps = job.steps ?? [];
+	const steps = workflowWidgetSteps(job);
 	if (steps.length === 0) return undefined;
+	const graphCurrent = job.workflowGraph?.currentNodeId;
+	if (graphCurrent) {
+		const current = steps.find((step) => step.workflowKey === graphCurrent);
+		if (current) return current;
+	}
 	if (job.currentStep !== undefined) {
 		const current = steps[job.currentStep];
 		if (current && (current.index === undefined || current.index === job.currentStep)) return current;
@@ -903,6 +1024,10 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 		chainStepCount: job.chainStepCount,
 		parallelGroups: job.parallelGroups,
 		workflowHostSteps: projectAsyncWorkflowRows([], job.hostSteps).map(hostStepRenderKey),
+		workflowGraph: job.mode === "workflow" && job.workflowGraph ? {
+			currentNodeId: job.workflowGraph.currentNodeId,
+			stages: workflowGraphStageNodes(job.workflowGraph).map((node) => [node.id, node.status, node.agent, node.phase, node.label, node.flatIndex, node.outputName, node.structured, node.error]),
+		} : undefined,
 		preflight: expanded ? job.preflight : job.preflight ? formatWorkflowPreflightPlanSummary(job.preflight) : undefined,
 		preflightWarnings: expanded ? job.workflow?.preflightWarnings : job.workflow?.preflightWarnings?.length || undefined,
 		steps: job.steps?.map((step, index) => widgetStepRenderKey(step, index, expanded)),
@@ -1573,9 +1698,17 @@ function buildForegroundResultEntries(
 
 function widgetStats(job: AsyncJobState, theme: Theme): string {
 	const parts: string[] = [];
-	const stepsTotal = job.stepsTotal ?? (job.agents?.length ?? 1);
+	const stageProgress = workflowStageProgress(job);
+	const stepsTotal = stageProgress?.total ?? job.stepsTotal ?? (job.agents?.length ?? 1);
 	const isSingleChild = isSingleChildAsyncJob(job);
-	if (job.activeParallelGroup) {
+	if (stageProgress) {
+		const stages = workflowGraphStageNodes(job.workflowGraph);
+		const currentStage = stageProgress.current !== undefined ? stages[stageProgress.current] : undefined;
+		const focus = currentStage
+			? [compactTaskText(undefined, currentStage.label) ?? boundedLaneValue(currentStage.id), currentStage.agent ? boundedLaneValue(currentStage.agent) : "", workflowNodeStatusLabel(currentStage.status)].filter(Boolean)
+			: [];
+		parts.push(["staged lane", stageProgress.current !== undefined ? `stage ${stageProgress.current + 1}/${stageProgress.total}` : `${stageProgress.total} stages`, ...focus].join(" · "));
+	} else if (job.activeParallelGroup) {
 		const running = job.runningSteps ?? (job.status === "running" ? 1 : 0);
 		const done = job.completedSteps ?? (job.status === "complete" ? stepsTotal : 0);
 		if (job.mode === "parallel") {
@@ -1799,7 +1932,7 @@ function foregroundStyleWidgetStepLines(
 	job: AsyncJobState,
 	theme: Theme,
 	step: NonNullable<AsyncJobState["steps"]>[number],
-	itemTitle: "Agent" | "Step",
+	itemTitle: "Agent" | "Stage" | "Step",
 	index: number,
 	total: number,
 	expanded: boolean,
@@ -1814,7 +1947,11 @@ function foregroundStyleWidgetStepLines(
 	const modelDisplay = modelThinkingBadge(theme, step.model, step.thinking);
 	const collapseDetails = shouldCollapseSingleChildDetails(job, step);
 	const displayName = collapseDetails ? singleChildAgentName(job, step) : childDisplayName(step);
-	const rowLabel = collapseDetails ? displayName : (options?.rowLabel ?? `${itemTitle} ${index}/${total}: ${displayName}`);
+	const stageName = itemTitle === "Stage"
+		? compactTaskText(undefined, step.label) ?? boundedLaneValue(step.workflowKey) ?? displayName
+		: undefined;
+	const stageIdentity = stageName && stageName !== displayName ? `${stageName} (${displayName})` : stageName ?? displayName;
+	const rowLabel = collapseDetails ? displayName : (options?.rowLabel ?? `${itemTitle} ${index}/${total}: ${itemTitle === "Stage" ? stageIdentity : displayName}`);
 	const rowMarker = options?.rowMarker ? `${options.rowMarker} ` : "";
 	const lines = [`${rowIndent}${rowMarker}${widgetStepGlyph(step.status, theme, widgetStepRunningSeed(step, index - 1), frame)} ${themeBold(theme, rowLabel)}${contextModeBadge(theme, step.context)} ${theme.fg("dim", "·")} ${status}${modelDisplay}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`];
 	const lane = projectAsyncLane(job, step);
@@ -1878,7 +2015,8 @@ function hostStepWidgetLines(job: AsyncJobState, theme: Theme, indent: string): 
 }
 
 function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, frame?: number): string[] {
-	if (!job.steps?.length) {
+	const steps = workflowWidgetSteps(job);
+	if (!steps.length) {
 		const lane = projectAsyncLane(job);
 		return [
 			...workflowPreflightLines(job, expanded),
@@ -1894,16 +2032,26 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 	if (group) {
 		lines.push(...parallelWidgetGroupDetails(job, theme, group, expanded, width, frame, Boolean(job.activeParallelGroup)));
 	} else {
+		const stageProgress = workflowStageProgress(job);
 		const total = job.mode === "chain"
-			? job.chainStepCount ?? job.stepsTotal ?? job.steps.length
-			: job.stepsTotal ?? job.steps.length;
-		const itemTitle = "Step";
-		for (const [index, step] of job.steps.entries()) {
-			lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, index + 1, total, expanded, width, frame));
+			? job.chainStepCount ?? job.stepsTotal ?? steps.length
+			: stageProgress?.total ?? job.stepsTotal ?? steps.length;
+		const stageTotal = stageProgress?.total ?? total;
+		const plannedKeys = stageProgress ? new Set(workflowGraphStageNodes(job.workflowGraph).map((node) => node.id)) : undefined;
+		const extraStepCount = plannedKeys
+			? steps.filter((step) => step.workflowKey === undefined || !plannedKeys.has(step.workflowKey)).length
+			: total;
+		let extraStepIndex = 0;
+		for (const [index, step] of steps.entries()) {
+			const isPlannedStage = plannedKeys !== undefined && step.workflowKey !== undefined && plannedKeys.has(step.workflowKey);
+			const itemTitle = isPlannedStage ? "Stage" : "Step";
+			const displayIndex = isPlannedStage ? (step.index ?? index) + 1 : plannedKeys ? ++extraStepIndex : index + 1;
+			const displayTotal = isPlannedStage ? stageTotal : extraStepCount;
+			lines.push(...foregroundStyleWidgetStepLines(job, theme, step, itemTitle, displayIndex, displayTotal, expanded, width, frame));
 		}
 	}
 	lines.push(...hostStepWidgetLines(job, theme, "  "));
-	const attached = new Set(job.steps.flatMap((step) => step.children?.map((child) => child.id) ?? []));
+	const attached = new Set(steps.flatMap((step) => step.children?.map((child) => child.id) ?? []));
 	const unattached = job.nestedChildren?.filter((child) => !attached.has(child.id)) ?? [];
 	for (const nestedLine of formatNestedWidgetLines(unattached, theme, width, expanded, job.updatedAt, expanded ? 12 : 6)) {
 		lines.push(`  ${nestedLine}`);
@@ -1913,7 +2061,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 
 function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, frame?: number): string[] {
 	const stats = widgetStats(job, theme);
-	const count = job.mode === "chain" ? job.chainStepCount : job.stepsTotal ?? job.agents?.length ?? job.steps?.length;
+	const count = job.mode === "chain" ? job.chainStepCount : workflowStageProgress(job)?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length;
 	const mode = widgetJobName(job);
 	const title = isSingleChildAsyncJob(job)
 		? "async subagent"
@@ -2189,6 +2337,10 @@ function fitAdaptiveWidgetLines(jobs: AsyncJobState[], buildLines: () => string[
 
 	const lines = buildLines();
 	if (lines.length <= availableRows) {
+		widgetLayoutSession = { expanded, rows, columns, tier: "full", visibleJobKeys: [] };
+		return fitWidgetLineBudget(lines, theme, width, false);
+	}
+	if (availableRows > 2 && jobs.length === 1 && workflowStageProgress(jobs[0]!)) {
 		widgetLayoutSession = { expanded, rows, columns, tier: "full", visibleJobKeys: [] };
 		return fitWidgetLineBudget(lines, theme, width, false);
 	}

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -500,8 +500,26 @@ function runLane(lane, firstResult, observe) {
   return visit(0, firstResult);
 }
 
+function workflowPlanStringMetadata(params) {
+  return {
+    ...(typeof params.phase === "string" && params.phase.trim() ? { phase: params.phase.trim() } : {}),
+    ...(typeof params.label === "string" && params.label.trim() ? { label: params.label.trim() } : {}),
+    ...(typeof params.agent === "string" && params.agent.trim() ? { agent: params.agent.trim() } : {}),
+  };
+}
+
 function runLanes(laneSpecs) {
   const lanes = validateLaneSpecs(laneSpecs);
+  parentPort.postMessage({ type: "lanePlan", lanes: lanes.map((lane) => ({
+    key: lane.key,
+    stages: lane.stages.map((stage) => ({
+      key: stage.key,
+      generatedKey: stage.generatedKey,
+      ...workflowPlanStringMetadata(stage.params),
+      ...(typeof stage.params.as === "string" && stage.params.as.trim() ? { outputName: stage.params.as.trim() } : {}),
+      ...(stage.params.outputSchema !== undefined ? { structured: true } : {}),
+    })),
+  })) });
   const firstItems = lanes.map((lane) => {
     const first = lane.stages[0];
     return { key: first.generatedKey, ...first.params };
@@ -982,6 +1000,22 @@ export interface WorkflowScriptTraceEntry {
 	warning?: string;
 }
 
+/** Bounded plan metadata emitted when a workflow materializes a runs.lanes graph. */
+export interface WorkflowLanePlanStage {
+	key: string;
+	generatedKey: string;
+	agent?: string;
+	phase?: string;
+	label?: string;
+	outputName?: string;
+	structured?: boolean;
+}
+
+export interface WorkflowLanePlan {
+	key: string;
+	stages: WorkflowLanePlanStage[];
+}
+
 export interface WorkflowSteerOptions {
 	mode?: "steer" | "follow_up" | "auto";
 	index?: number;
@@ -1049,6 +1083,7 @@ export interface RunWorkflowScriptOptions {
 	};
 	registerStopChild?: (stop: ((key: string, message?: string) => boolean) | undefined) => void;
 	onTrace?: (trace: WorkflowScriptTraceEntry[]) => void;
+	onLanePlan?: (lanes: WorkflowLanePlan[]) => void;
 	onEmit?: (emits: unknown[]) => void;
 }
 
@@ -1529,6 +1564,13 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			console.error("Workflow onTrace callback failed:", error);
 		}
 	};
+	const lanePlanChanged = (lanes: WorkflowLanePlan[]) => {
+		try {
+			options.onLanePlan?.(lanes);
+		} catch (error) {
+			console.error("Workflow onLanePlan callback failed:", error);
+		}
+	};
 	const hostStepChanged = (hostStep: HostStepNodeV1) => {
 		try {
 			options.onHostStep?.(hostStep);
@@ -1631,6 +1673,10 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 		});
 		worker.on("message", (message: Record<string, unknown>) => {
 			if (settled) return;
+			if (message.type === "lanePlan" && Array.isArray(message.lanes)) {
+				lanePlanChanged(message.lanes as WorkflowLanePlan[]);
+				return;
+			}
 			if (message.type === "emit") {
 				try {
 					assertWorkflowJsonValue(message.value, "emit");

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -19,6 +19,27 @@ function createAsyncDir(root: string, id: string, status: Record<string, unknown
 	return dir;
 }
 
+const stagedLaneKeys = ["scope-scout", "red-tests", "label-helpers", "summary-title", "detail-row", "tiers-noise", "validation", "minimality-challenge", "fresh-review"];
+
+function stagedLaneStatusGraph(runId: string): Record<string, unknown> {
+	const nodeIds = stagedLaneKeys.map((key) => `${runId}.${key}`);
+	return {
+		runId,
+		mode: "workflow",
+		phases: [{ title: `${runId} staged lane`, nodeIds }],
+		nodes: stagedLaneKeys.map((key, index) => ({
+			id: nodeIds[index],
+			kind: "step",
+			agent: index === 0 ? "scout" : index === 7 ? "simplifier" : "worker",
+			label: key,
+			status: index === 0 ? "running" : "pending",
+			flatIndex: index,
+			stepIndex: index,
+		})),
+		currentNodeId: nodeIds[0],
+	};
+}
+
 describe("async status helpers", () => {
 	it("lists only requested states and includes flattened step summaries", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-"));
@@ -73,6 +94,33 @@ describe("async status helpers", () => {
 			if (budgetDirectory) fs.rmSync(budgetDirectory, { recursive: true, force: true });
 		}
 	});
+
+	it("reports the planned runs.lanes stage count while the first child is running", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-staged-lane-"));
+		try {
+			const runId = "run-staged-lane";
+			createAsyncDir(root, runId, {
+				runId,
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				currentStep: 0,
+				steps: [{ agent: "scout", workflowKey: `${runId}.scope-scout`, label: "scope-scout", status: "running" }],
+				workflowGraph: stagedLaneStatusGraph(runId),
+			});
+
+			const runs = listAsyncRuns(root, { states: ["running"], reconcile: false });
+			const text = formatAsyncRunList(runs);
+			assert.match(text, /stage\s+1\/9/i);
+			assert.doesNotMatch(text, /step\s+1\/1/i);
+			assert.match(text, /scope-scout/);
+			assert.match(text, /stage\s+9\/9:.*fresh-review.*pending/i);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("loads typed host monitor nodes from workflow status without child identity", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-host-step-"));
 		try {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -926,6 +926,110 @@ describe("subagent async widget rendering", () => {
 		resetWidgetLayout();
 	});
 
+	it("keeps the active runs.lanes stage in focus before collapsed history", () => {
+		resetWidgetLayout();
+		withStdoutSize(60, 120, () => {
+			const stageKeys = ["scope-scout", "red-tests", "label-helpers", "summary-title", "detail-row", "tiers-noise", "validation", "minimality-challenge", "fresh-review"];
+			const nodeIds = stageKeys.map((key) => `issue-1695.${key}`);
+			const statuses = stageKeys.map((_, index) => index < 3 ? "completed" : index === 3 ? "running" : "pending");
+			const workflowGraph = {
+				runId: "workflow-1695",
+				mode: "workflow",
+				phases: [{ title: "issue-1695 staged lane", nodeIds }],
+				nodes: stageKeys.map((key, index) => ({
+					id: nodeIds[index],
+					kind: "step",
+					agent: index === 0 ? "scout" : "worker",
+					label: key,
+					status: statuses[index],
+					flatIndex: index,
+					stepIndex: index,
+				})),
+				currentNodeId: nodeIds[3],
+			};
+			const job = {
+				asyncId: "workflow-1695",
+				asyncDir: "/tmp/workflow-1695",
+				status: "running",
+				mode: "workflow",
+				agents: ["scout", "worker"],
+				currentStep: 3,
+				stepsTotal: 4,
+				updatedAt: 200,
+				workflowGraph,
+				steps: stageKeys.slice(0, 4).map((key, index) => ({
+					index,
+					agent: index === 0 ? "scout" : "worker",
+					status: statuses[index],
+					label: key,
+					workflowKey: nodeIds[index],
+					phase: "issue-1695",
+					description: `${key} task`,
+					outputName: `${key}.md`,
+					...(index < 3 ? { lastActivityAt: 100 } : { currentTool: "read", currentToolStartedAt: 190, lastActivityAt: 195 }),
+				})),
+			};
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, [job]);
+			const lines = renderWidgetLines(ui.widgets.at(-1));
+			const text = lines.join("\n");
+			const activeIndex = lines.findIndex((line) => line.includes("summary-title"));
+			const hiddenIndex = lines.findIndex((line) => /lines hidden/.test(line));
+			assert.ok(hiddenIndex >= 0, `collapsed history should expose a hidden-lines marker:\n${text}`);
+			assert.ok(activeIndex >= 0, `active stage should remain visible:\n${text}`);
+			assert.ok(activeIndex < hiddenIndex, `active stage must precede the hidden-lines marker:\n${text}`);
+			assert.match(text, /stage\s+4\/9/i);
+			assert.match(text, /summary-title task/);
+			assert.match(lines[activeIndex]!, /worker/);
+		});
+		resetWidgetLayout();
+	});
+
+	it("prioritizes failed, blocked, and gate stages over completed history", () => {
+		const stages = [
+			{ index: 0, agent: "scout", label: "completed-history", workflowKey: "issue-1695.completed-history", status: "complete" },
+			{ index: 1, agent: "worker", label: "failed-stage", workflowKey: "issue-1695.failed-stage", status: "failed", error: "stage failed" },
+			{ index: 2, agent: "worker", label: "blocked-stage", workflowKey: "issue-1695.blocked-stage", status: "pending", toolBudgetBlocked: true },
+			{ index: 3, agent: "reviewer", label: "gate-stage", workflowKey: "issue-1695.gate-stage", status: "complete", review: { status: "blockers" } },
+			{ index: 4, agent: "worker", label: "completed-tail", workflowKey: "issue-1695.completed-tail", status: "complete" },
+		];
+		const workflowGraph = {
+			runId: "workflow-priority",
+			mode: "workflow",
+			phases: [{ title: "issue-1695 staged lane", nodeIds: stages.map((stage) => stage.workflowKey) }],
+			nodes: stages.map((stage) => ({
+				id: stage.workflowKey,
+				kind: "step",
+				agent: stage.agent,
+				label: stage.label,
+				status: stage.status === "complete" ? "completed" : stage.status === "failed" ? "failed" : "pending",
+				flatIndex: stage.index,
+				stepIndex: stage.index,
+			})),
+			currentNodeId: "issue-1695.failed-stage",
+		};
+		const text = buildWidgetLines([{
+			asyncId: "workflow-priority",
+			asyncDir: "/tmp/workflow-priority",
+			status: "running",
+			mode: "workflow",
+			agents: ["scout", "worker", "reviewer"],
+			currentStep: 1,
+			stepsTotal: stages.length,
+			workflowGraph,
+			steps: stages,
+		}], theme, 220, false).join("\n");
+		const rowIndex = (label: string): number => text.split("\n").findIndex((line) => line.includes(label));
+		const completed = rowIndex("completed-history");
+		const failed = rowIndex("failed-stage");
+		const blocked = rowIndex("blocked-stage");
+		const gate = rowIndex("gate-stage");
+		assert.ok(completed >= 0 && failed >= 0 && blocked >= 0 && gate >= 0, text);
+		assert.ok(failed < completed, `failed stage should precede completed history:\n${text}`);
+		assert.ok(blocked < completed, `blocked stage should precede completed history:\n${text}`);
+		assert.ok(gate < completed, `gate stage should precede completed history:\n${text}`);
+	});
+
 	it("keeps constrained progressive slots focused on active jobs", () => {
 		resetWidgetLayout();
 		withStdoutSize(22, 120, () => {

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { AsyncJobState, HostStepNodeV1 } from "../../src/shared/types.ts";
+import type { AsyncJobState, HostStepNodeV1, WorkflowGraphSnapshot, WorkflowNodeStatus } from "../../src/shared/types.ts";
 import {
 	ASYNC_STATUS_SNAPSHOT_KIND,
 	ASYNC_STATUS_SNAPSHOT_VERSION,
@@ -27,6 +27,27 @@ function hostStep(overrides: Partial<HostStepNodeV1> = {}): HostStepNodeV1 {
 		verdict: "pass",
 		updatedAt: 20,
 		...overrides,
+	};
+}
+
+const stagedLaneKeys = ["scope-scout", "red-tests", "label-helpers", "summary-title", "detail-row", "tiers-noise", "validation", "minimality-challenge", "fresh-review"];
+
+function stagedLaneGraph(statuses: WorkflowNodeStatus[] = stagedLaneKeys.map((_, index) => index === 0 ? "running" : "pending")): WorkflowGraphSnapshot {
+	const nodeIds = stagedLaneKeys.map((key) => `issue-1695.${key}`);
+	return {
+		runId: "workflow-1695",
+		mode: "workflow",
+		phases: [{ title: "issue-1695", nodeIds }],
+		nodes: stagedLaneKeys.map((key, index) => ({
+			id: nodeIds[index]!,
+			kind: "step",
+			agent: index === 0 ? "scout" : index === 7 ? "simplifier" : "worker",
+			label: key,
+			status: statuses[index] ?? "pending",
+			flatIndex: index,
+			stepIndex: index,
+		})),
+		currentNodeId: nodeIds[statuses.findIndex((status) => status === "running")],
 	};
 }
 
@@ -172,6 +193,27 @@ describe("async status projection", () => {
 			{ name: "writer · Writer (worker)", state: "running", mode: "mutation" },
 			{ name: "review", state: "planned", mode: "review" },
 		]);
+	});
+
+	it("projects known runs.lanes stages from the workflow graph, including pending stages", () => {
+		const rows = projectAsyncWorkflowRows([{
+			agent: "scout",
+			workflowKey: "issue-1695.scope-scout",
+			label: "scope-scout",
+			status: "running",
+		}], stagedLaneGraph(), {
+			version: 1,
+			coverage: "complete",
+			lanes: [{ key: "issue-1695", mode: "scout" }],
+		});
+
+		for (const [index, key] of stagedLaneKeys.entries()) {
+			const row = rows.find((candidate) => candidate.name.includes(key));
+			assert.ok(row, `stage ${key} should remain discoverable`);
+			assert.equal(row?.state, index === 0 ? "running" : "planned", `stage ${key} state`);
+		}
+		assert.equal(rows.filter((row) => row.state === "planned").length, stagedLaneKeys.length - 1);
+		assert.equal(rows.every((row) => row.preflight?.mode === "scout"), true);
 	});
 
 	it("preserves duplicate loaded rows when a declared lane key is reused", () => {


### PR DESCRIPTION
## Summary
- project generated `runs.lanes(...)` stage plans into workflow graph status
- show planned/pending stages in async status and Fleet projections
- keep collapsed async widgets focused on active or attention stages before completed history

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/async-status-projection.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-status.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `npm run typecheck`
- `git diff --check`

Closes #1699.
