### PR TITLE
test: relax Windows external runner deadline

### DIFF
--- a/test/unit/external-cli-runner.test.ts
+++ b/test/unit/external-cli-runner.test.ts
@@ -150,7 +150,7 @@ describe("external CLI runner", () => {
 					limits: { parserLineBytes: 64 },
 					parser: { parseLine() { return undefined; }, finish() { return { state: "completed" }; } },
 				}),
-				new Promise<never>((_, reject) => { settleTimer = setTimeout(() => reject(new Error("unterminated oversized line did not fail promptly")), 1_000); }),
+				new Promise<never>((_, reject) => { settleTimer = setTimeout(() => reject(new Error("unterminated oversized line did not fail promptly")), 10_000); }),
 			]);
 			assert.equal(unterminated.exitCode, 1);
 			assert.match(unterminated.error ?? "", /line exceeded/);


### PR DESCRIPTION
## Summary

- Increase the external CLI runner test safety deadline from 1 second to 10 seconds.
- Keep the parser failure assertions unchanged.

## Why

Windows CI can spend more than one second on child process startup and cleanup. The old deadline measured runner load instead of parser behavior.

This change addresses the failure in [job 99117259669](https://github.com/nicobailon/pi-subagents/actions/runs/33258874125/job/99117259669).

## Validation

- Repeated the focused test 10 times on Windows: all passed.
- Ran `npm run typecheck`: passed.
- Ran `git diff --check`: passed.
- Ran the full unit suite locally: 2,675 passed and 19 failed. All failures require Windows symbolic-link privileges that this host does not have. CI provides the full-suite result.