### PR TITLE
chore: deslop unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add compact prompt-free agent capability discovery with `action: "list", capabilities: true`. Thanks to [@peedrr](https://github.com/peedrr) for #1717.
 
 ### Fixed
+- Treat malformed persisted async status states as partial, bound persisted workflow stage text, and fail closed when an explicit child-output path cannot be inspected before a run.
 - Surface recovery-needed diagnostics for dirty timed-out children that miss requested reports, while keeping them fail-closed (#1713).
 - Keep retained-session resume runners from flashing console windows on Windows while preserving Unix background detachment. Thanks to [@Zethu5](https://github.com/Zethu5) for #1711.
 - Hide mutation-evidence Git subprocess windows on Windows to prevent visible console flashes or terminal tabs. Thanks to [@dnnkeeper](https://github.com/dnnkeeper) for #1706.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -35,7 +35,7 @@ Add `autofix` to `/parallel-review` or `/parallel-cleanup` to apply only the syn
 
 ## Scripted workflows (workflowScript)
 
-All model-facing subagent execution is expressed through `workflowScript` in the `subagent` tool. Use stable keys and ordinary JavaScript for one child, sequence, and parallelism. For ordinary parallel fanout, use `await runs.all([{ key, agent, task }, ...])`. It resolves to an ordered array, not a key map, so use indexes, destructuring, or `.map(...)`, not `results.<key>`. Do not read `.output` from unawaited `runs.run` launches. Store a `runs.run` promise only when the script later observes it with `await`, `Promise.race`, or `Promise.all`, such as steering a live child before awaiting its result. Scripts are ordinary JavaScript statement bodies. Use an explicit `return` for a useful result:
+Use direct `{ agent, task }` for one bounded child. Use `workflowScript` when the parent needs a stable keyed child, sequence, fanout, steering, retry, or aggregation. For ordinary parallel fanout, use `await runs.all([{ key, agent, task }, ...])`. It resolves to an ordered array, not a key map, so use indexes, destructuring, or `.map(...)`, not `results.<key>`. Do not read `.output` from unawaited `runs.run` launches. Store a `runs.run` promise only when the script later observes it with `await`, `Promise.race`, or `Promise.all`, such as steering a live child before awaiting its result. Scripts are ordinary JavaScript statement bodies. Use an explicit `return` for a useful result:
 
 Child results cross into the script as plain JSON data. Non-JSON host metadata is omitted, so use returned fields such as `runId`, `ok`, `output`, and `structuredOutput` for workflow control.
 

--- a/skills/council-mode/references/pass-contracts.md
+++ b/skills/council-mode/references/pass-contracts.md
@@ -137,7 +137,7 @@ Create model-based advisors in the user or project agent directory, not in this 
 name: council-sol
 description: Read-only fresh-context advisor for bounded council decisions
 tools: read, grep, find, ls
-model: openai-codex/gpt-5.6-sol
+model: provider/top-reasoning-model
 thinking: high
 systemPromptMode: replace
 inheritProjectContext: true

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -139,12 +139,6 @@ Async does not mean parallel writes. Do not edit the same active worktree while 
 
 Do not end your turn immediately after launching an async child if you promised to keep working. Continue the local inspection, synthesis, or validation prep, then check the async run when its result is needed. If no safe independent work remains, return control and let Pi wake the session; do not convert the child to foreground.
 
-“Continue/orchestrate/work until done” means keep the lane board moving while a
-safe immediate action remains; it does not mean hold an interactive turn open
-until async lanes finish. If only async lanes are running, record the revisit
-trigger and yield. Do not use `subagent_wait({ all: true })` as an interactive
-lane barrier.
-
 In an ordinary interactive chat, normally return control after launching or
 triaging useful async work and let Pi wake the session on completion; do not
 call `subagent_wait()` merely to wait. A run-to-completion user request is not

--- a/skills/pi-subagents/references/prompting-and-roles.md
+++ b/skills/pi-subagents/references/prompting-and-roles.md
@@ -281,7 +281,7 @@ agent with the same name only when you want a substantially different agent.
 
 Keep the parent/orchestrator on the ordinary strong default model because omission failures are cheaper than unnecessary commissions. Route workers and scouts to a fast, capable worker tier, and keep serious reviews on the strong tier at high thinking. Use a top-reasoning model only for bounded, read-only critic/oracle/root-cause audits; critic-tier high thinking is escalation-only and never an autonomous root. Explicit parent/user model policy wins over these recommendations.
 
-Examples are illustrative, not requirements. One maintainer setup maps these tiers to GPT-5.5 for the parent and serious reviews, GPT-5.6 Luna for workers/scouts, and GPT-5.6 Sol for critic/oracle escalation. A non-OpenAI setup should choose comparable available models by capability and record that mapping in user/project settings or a profile.
+Examples are illustrative, not requirements. Map these tiers to concrete models in user/project settings or a profile. A non-OpenAI setup should choose comparable available models by capability.
 
 Use `fallbackModels` when a tier has provider quota or availability risk. Prefer fresh context for cross-provider children when inherited provider-specific reasoning blocks would force thinking off.
 

--- a/src/extension/tool-description.ts
+++ b/src/extension/tool-description.ts
@@ -28,13 +28,13 @@ export const SUBAGENT_TOOL_PROMPT_GUIDELINES = [
 	WORKFLOW_OUTPUT_BINDING_GUIDANCE,
 	"For ordinary parallel work, use await runs.all([{key,agent,task}, ...]); it resolves to an ordered array, not a key map, so use results[0], destructuring, or results.map(...), not results.<key>. Do not read .output from unawaited runs.run launches. Stored runs.run promises are only for advanced rolling fanout and each must later be observed with direct await, Promise.race, or Promise.all.",
 	"Keep one writer per cwd/worktree unless writers run in isolated worktrees.",
-	"To pass an explicit model to a child, first call { action: \"models\" } and copy an exact provider/id (e.g. openai-codex/gpt-5.6-sol); bare ids resolve only when unique in the registry, and agent names (gpt-pro, advisor) are not model ids. Set per-run thinking with a suffix on the model string (e.g. openai-codex/gpt-5.6-sol:high; off/minimal/low/medium/high/xhigh/max); the suffix wins over the agent's thinking default. The thinking field only applies to action='watchdog.configure' and is ignored on dispatch.",
+	"To pass an explicit model to a child, first call { action: \"models\" } and copy an exact provider/id (e.g. provider/model-id); bare ids resolve only when unique in the registry, and agent names (gpt-pro, advisor) are not model ids. Set per-run thinking with a suffix on the model string (e.g. provider/model-id:high; off/minimal/low/medium/high/xhigh/max); the suffix wins over the agent's thinking default. The thinking field only applies to action='watchdog.configure' and is ignored on dispatch.",
 	EXTERNAL_CLI_RUNNER_GUIDANCE,
 	"Use guide or the pi-subagents skill for advanced scheduling, missions, steering, and retention.",
 ];
 
 export const SUBAGENT_SAFETY_GUIDANCE = `SAFETY-CRITICAL SUBAGENT GUIDANCE:
-• Use { action: "list" } before execution and only run executable/non-disabled agents. ${AGENT_CAPABILITY_GUIDANCE}
+• Use { action: "list" } before execution and only run executable/non-disabled agents.
 • Keep execution and management separate: omit action for structured single-child or workflowScript execution; use action only for management/control.
 • Async/background runs are the normal default unless config sets asyncByDefault:false; set async:true explicitly when async behavior matters. Use async:false only when the parent must block until completion. Async mode still shows progress. Final reviews and gate checks stay async; needing a result is not a blocking reason. After an async launch, continue independent work only until its next dependency barrier; consume the result before work that depends on it. Do not sleep or poll status just to wait; use subagent_wait only when the current request must finish in this turn.
 • ${WORKFLOW_RESUME_KEY_GUIDANCE}

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../../shared/formatters.ts";
+import { previewDisplayText } from "../../shared/display-text.ts";
 import { formatActivityLabel, formatParallelOutcome } from "../../shared/status-format.ts";
 import { type ActivityState, type AsyncJobStep, type AsyncParallelGroupStatus, type AsyncStatus, type CostSummary, type Details, type HostStepNodeV1, type HostStepState, type LaunchResolvedChildExtensionsV1, type RuntimeAcknowledgedChildExtensionsV1, type NestedRunSummary, type SteeringStatus, type SubagentRunMode, type TimeoutRecoveryProjection, type TokenUsage, type TurnBudgetState, type UsageBudgetState, type WorkflowPreflightV1, type WorkflowGraphSnapshot } from "../../shared/types.ts";
 import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../shared/capability-ceiling.ts";
@@ -595,10 +596,12 @@ function workflowStageStateLabel(status: WorkflowGraphSnapshot["nodes"][number][
 
 export function formatWorkflowStageLine(node: WorkflowGraphSnapshot["nodes"][number], index: number, total: number): string {
 	const state = workflowStageStateLabel(node.status);
-	const display = node.label && node.label !== node.id ? ` | ${node.label}` : "";
-	const agent = node.agent ? ` | ${node.agent}` : "";
-	const error = node.error ? ` | ${node.error.replace(/\s+/g, " ").trim()}` : "";
-	return `stage ${index + 1}/${total}: ${node.id}${display}${agent} | ${state}${error}`;
+	const id = previewDisplayText(node.id, 160);
+	const label = node.label ? previewDisplayText(node.label, 160) : "";
+	const display = label && label !== id ? ` | ${label}` : "";
+	const agent = node.agent ? ` | ${previewDisplayText(node.agent, 80)}` : "";
+	const error = node.error ? ` | ${previewDisplayText(node.error, 240)}` : "";
+	return `stage ${index + 1}/${total}: ${id}${display}${agent} | ${state}${error}`;
 }
 
 export function formatAsyncRunOutputPath(run: Pick<AsyncRunSummary, "asyncDir" | "outputFile">): string | undefined {

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -16,6 +16,21 @@ const DEFAULT_MAX_SERIALIZED_BYTES = 32 * 1024;
 export type AsyncStatusSnapshotState = "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
 export type AsyncStatusSnapshotKind = "subagent" | "workflow" | "step";
 
+const ASYNC_STATUS_SNAPSHOT_STATES: Record<AsyncStatusSnapshotState, true> = {
+	queued: true,
+	running: true,
+	complete: true,
+	failed: true,
+	partial: true,
+	paused: true,
+	stopped: true,
+	rejected: true,
+};
+
+function isAsyncStatusSnapshotState(value: string): value is AsyncStatusSnapshotState {
+	return Object.hasOwn(ASYNC_STATUS_SNAPSHOT_STATES, value);
+}
+
 export interface AsyncStatusSnapshotActivityV1 {
 	state?: string;
 	currentTool?: string;
@@ -157,7 +172,8 @@ function publicCount(value: unknown): number | undefined {
 function normalizeState(value: string): AsyncStatusSnapshotState {
 	if (value === "completed") return "complete";
 	if (value === "pending") return "queued";
-	return value as AsyncStatusSnapshotState;
+	if (isAsyncStatusSnapshotState(value)) return value;
+	return "partial";
 }
 
 function terminalState(state: AsyncStatusSnapshotState): boolean {

--- a/src/runs/shared/single-output.ts
+++ b/src/runs/shared/single-output.ts
@@ -8,6 +8,17 @@ export interface SingleOutputSnapshot {
 	exists: boolean;
 	mtimeMs?: number;
 	size?: number;
+	error?: string;
+}
+
+function missingFileStatError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code;
+	return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function snapshotFromStatError(error: unknown): SingleOutputSnapshot {
+	if (missingFileStatError(error)) return { exists: false };
+	return { exists: false, error: error instanceof Error ? error.message : String(error) };
 }
 
 /**
@@ -183,9 +194,8 @@ export function captureSingleOutputSnapshot(outputPath: string | undefined): Sin
 	try {
 		const stat = fs.statSync(outputPath);
 		return { exists: true, mtimeMs: stat.mtimeMs, size: stat.size };
-	} catch {
-		// The snapshot is advisory; resolveSingleOutput reports concrete read/write failures.
-		return { exists: false };
+	} catch (error) {
+		return snapshotFromStatError(error);
 	}
 }
 
@@ -193,14 +203,14 @@ function inspectSingleOutputChange(
 	outputPath: string,
 	beforeRun: SingleOutputSnapshot | undefined,
 ): { changed: boolean; error?: string } {
+	if (beforeRun?.error) return { changed: false, error: beforeRun.error };
 	try {
 		const stat = fs.statSync(outputPath);
 		return {
 			changed: !beforeRun?.exists || stat.mtimeMs !== beforeRun.mtimeMs || stat.size !== beforeRun.size,
 		};
 	} catch (error) {
-		const code = error && typeof error === "object" && "code" in error ? (error as { code?: unknown }).code : undefined;
-		if (code === "ENOENT" || code === "ENOTDIR") return { changed: false };
+		if (missingFileStatError(error)) return { changed: false };
 		return { changed: false, error: error instanceof Error ? error.message : String(error) };
 	}
 }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -2390,9 +2390,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 	let hiddenFinished = 0;
 	let queuedSummaryShown = false;
 	let slots = MAX_WIDGET_JOBS;
-
-	for (const job of running) {
-		if (slots <= 0) { hiddenRunning++; continue; }
+	const appendJob = (job: AsyncJobState): void => {
 		const stats = widgetStats(job, theme);
 		items.push([
 			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
@@ -2400,6 +2398,11 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 			...widgetLaneDetailLines(job, theme),
 			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 		]);
+	};
+
+	for (const job of running) {
+		if (slots <= 0) { hiddenRunning++; continue; }
+		appendJob(job);
 		slots--;
 	}
 
@@ -2411,13 +2414,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 
 	for (const job of finished) {
 		if (slots <= 0) { hiddenFinished++; continue; }
-		const stats = widgetStats(job, theme);
-		items.push([
-			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
-			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-			...widgetLaneDetailLines(job, theme),
-			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
-		]);
+		appendJob(job);
 		slots--;
 	}
 

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -4,7 +4,7 @@ import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { formatAsyncRunList, listAsyncRuns } from "../../src/runs/background/async-status.ts";
+import { formatAsyncRunList, formatWorkflowStageLine, listAsyncRuns } from "../../src/runs/background/async-status.ts";
 import { ACTIVE_RUN_INDEX_DIR, DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { encodeIndexSegment } from "../../src/runs/background/index-segment.ts";
 import { TERMINAL_RUN_INDEX_DIR } from "../../src/runs/background/terminal-run-index.ts";
@@ -41,6 +41,21 @@ function stagedLaneStatusGraph(runId: string): Record<string, unknown> {
 }
 
 describe("async status helpers", () => {
+	it("bounds workflow stage text from persisted status", () => {
+		const line = formatWorkflowStageLine({
+			id: `${"stage".repeat(80)}\u001b[31m`,
+			kind: "step",
+			label: `${"label".repeat(80)}\nsecond line`,
+			agent: "worker".repeat(40),
+			status: "failed",
+			error: `${"boom".repeat(100)}\nwith details`,
+		}, 0, 1);
+
+		assert.equal(line.includes("\u001b"), false);
+		assert.equal(line.includes("\n"), false);
+		assert.ok(line.length < 700, line);
+	});
+
 	it("lists only requested states and includes flattened step summaries", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-"));
 		let budgetDirectory: string | undefined;

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -98,6 +98,18 @@ describe("async status projection", () => {
 		assert.doesNotMatch(serialized, /private\/report|fileMutation|Required file-only output/);
 	});
 
+	it("maps malformed persisted states to partial instead of widening the public state union", () => {
+		const snapshot = projectAsyncStatusSnapshot([{
+			asyncId: "bad-state",
+			asyncDir: "/tmp/bad-state",
+			status: "mystery",
+			steps: [{ agent: "worker", status: "also-mystery" }],
+		} as unknown as AsyncJobState]);
+
+		assert.equal(snapshot.runs[0]?.state, "partial");
+		assert.equal(snapshot.runs[0]?.children?.[0]?.state, "partial");
+	});
+
 	it("projects compact Fleet workflow rows without applying UI bounds", () => {
 		const rows = projectAsyncWorkflowRows([{
 			agent: "reviewer",

--- a/test/unit/fork-cache-key.test.ts
+++ b/test/unit/fork-cache-key.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { buildPiArgs, deriveForkPromptCacheKey, SUBAGENT_FORK_CACHE_KEY_ENV } from "../../src/runs/shared/pi-args.ts";
 import { rewriteForkCacheProviderRequest } from "../../src/runs/shared/subagent-prompt-runtime.ts";
 
@@ -13,6 +14,10 @@ const baseLaunch = {
 	inheritGlobalContext: false,
 	inheritSkills: false,
 };
+
+function providerContext(api: string): Pick<ExtensionContext, "model"> {
+	return { model: { api } };
+}
 
 afterEach(() => {
 	if (originalForkCacheKey === undefined) delete process.env[SUBAGENT_FORK_CACHE_KEY_ENV];
@@ -56,11 +61,11 @@ describe("fork prompt cache keys", () => {
 		};
 
 		assert.deepEqual(
-			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload }, { model: { api: "openai-responses" } } as never),
+			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload }, providerContext("openai-responses")),
 			{ ...payload, prompt_cache_key: "pi-fork:parent-session" },
 		);
 		assert.deepEqual(
-			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { ...payload, prompt_cache_key: "pi-fork:parent-session" } }, { model: { api: "openai-responses" } } as never),
+			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { ...payload, prompt_cache_key: "pi-fork:parent-session" } }, providerContext("openai-responses")),
 			{ ...payload, prompt_cache_key: "pi-fork:parent-session" },
 		);
 	});
@@ -68,18 +73,18 @@ describe("fork prompt cache keys", () => {
 	it("does not add prompt cache keys or touch non-OpenAI payloads", () => {
 		process.env[SUBAGENT_FORK_CACHE_KEY_ENV] = "pi-fork:parent-session";
 
-		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: "raw" }, { model: { api: "openai-responses" } } as never), undefined);
-		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: [] }, { model: { api: "openai-responses" } } as never), undefined);
-		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test" } }, { model: { api: "openai-responses" } } as never), undefined);
-		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: undefined } }, { model: { api: "openai-responses" } } as never), undefined);
-		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, { model: { api: "anthropic-messages" } } as never), undefined);
-		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, { model: { api: "unknown-api" } } as never), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: "raw" }, providerContext("openai-responses")), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: [] }, providerContext("openai-responses")), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test" } }, providerContext("openai-responses")), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: undefined } }, providerContext("openai-responses")), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, providerContext("anthropic-messages")), undefined);
+		assert.equal(rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, providerContext("unknown-api")), undefined);
 	});
 
 	it("is a no-op when fork cache affinity is not configured", () => {
 		delete process.env[SUBAGENT_FORK_CACHE_KEY_ENV];
 		assert.equal(
-			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, { model: { api: "openai-responses" } } as never),
+			rewriteForkCacheProviderRequest({ type: "before_provider_request", payload: { model: "test", prompt_cache_key: "child" } }, providerContext("openai-responses")),
 			undefined,
 		);
 	});

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -145,6 +145,47 @@ function writeMcpFixture(
 	});
 }
 
+type RuntimeMcpDefinition = { command: string; args: string[] };
+
+function buildLegacyAliasLaunch(params: {
+	definitions: Record<string, RuntimeMcpDefinition>;
+	mcpDirectTools: string[];
+	allowedTools: string[];
+}) {
+	const fixture = createMcpFixture();
+	writeJson(path.join(fixture.agentDir, "mcp.json"), { mcpServers: {} });
+	writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
+		version: 1,
+		servers: Object.fromEntries(Object.entries(params.definitions).map(([name, definition]) => [
+			name,
+			{ configHash: computeMcpServerHash(definition), cachedAt: Date.now(), tools: [{ name: "search" }] },
+		])),
+	});
+	const runtimeSnapshotHost: McpRuntimeSnapshotHost = {
+		events: {
+			emit(_event, request) {
+				const definition = params.definitions[request.name];
+				if (!definition) {
+					request.result = { ok: false, error: new Error(`unknown runtime server ${request.name}`) };
+					return;
+				}
+				request.result = { ok: true, snapshot: { name: request.name, definition, runtime: true, persisted: false } };
+			},
+		},
+	};
+	return buildPiArgs({
+		baseArgs: ["-p"],
+		task: "hello",
+		sessionEnabled: false,
+		inheritProjectContext: false,
+		inheritSkills: false,
+		tools: ["read"],
+		mcpDirectTools: params.mcpDirectTools,
+		capabilityCeiling: { version: 1, allowedTools: params.allowedTools, denyExtensions: false, sources: ["test"] },
+		runtimeSnapshotHost,
+	});
+}
+
 afterEach(() => {
 	process.chdir(originalCwd);
 	for (const [key, value] of Object.entries(originalEnv)) {
@@ -1364,42 +1405,14 @@ describe("buildPiArgs system prompt mode wiring", () => {
 	});
 
 	it("does not let legacy MCP ceiling aliases cross server boundaries", () => {
-		const fixture = createMcpFixture();
 		const definitions = {
 			"runtime-a": { command: "runtime-a", args: ["--stdio"] },
 			runtime_a: { command: "runtime_a", args: ["--stdio"] },
 		};
-		writeJson(path.join(fixture.agentDir, "mcp.json"), { mcpServers: {} });
-		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
-			version: 1,
-			servers: {
-				"runtime-a": { configHash: computeMcpServerHash(definitions["runtime-a"]), cachedAt: Date.now(), tools: [{ name: "search" }] },
-				runtime_a: { configHash: computeMcpServerHash(definitions.runtime_a), cachedAt: Date.now(), tools: [{ name: "search" }] },
-			},
-		});
-		const runtimeSnapshotHost: McpRuntimeSnapshotHost = {
-			events: {
-				emit(_event, request) {
-					const definition = definitions[request.name as keyof typeof definitions];
-					if (!definition) {
-						request.result = { ok: false, error: new Error(`unknown runtime server ${request.name}`) };
-						return;
-					}
-					request.result = { ok: true, snapshot: { name: request.name, definition, runtime: true, persisted: false } };
-				},
-			},
-		};
-
-		const launch = buildPiArgs({
-			baseArgs: ["-p"],
-			task: "hello",
-			sessionEnabled: false,
-			inheritProjectContext: false,
-			inheritSkills: false,
-			tools: ["read"],
+		const launch = buildLegacyAliasLaunch({
+			definitions,
 			mcpDirectTools: ["runtime-a", "runtime_a"],
-			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime_a_search"], denyExtensions: false, sources: ["test"] },
-			runtimeSnapshotHost,
+			allowedTools: ["read", "runtime_a_search"],
 		});
 
 		assert.equal(launch.args[launch.args.indexOf("--tools") + 1], "read,runtime_a_search");
@@ -1412,42 +1425,13 @@ describe("buildPiArgs system prompt mode wiring", () => {
 	});
 
 	it("does not allow ambiguous legacy MCP ceiling aliases", () => {
-		const fixture = createMcpFixture();
-		const definitions = {
+		const launch = buildLegacyAliasLaunch({
+			definitions: {
 			"runtime-a-b": { command: "runtime-a-b", args: ["--stdio"] },
 			"runtime_a-b": { command: "runtime_a-b", args: ["--stdio"] },
-		};
-		writeJson(path.join(fixture.agentDir, "mcp.json"), { mcpServers: {} });
-		writeJson(path.join(fixture.agentDir, "mcp-cache.json"), {
-			version: 1,
-			servers: {
-				"runtime-a-b": { configHash: computeMcpServerHash(definitions["runtime-a-b"]), cachedAt: Date.now(), tools: [{ name: "search" }] },
-				"runtime_a-b": { configHash: computeMcpServerHash(definitions["runtime_a-b"]), cachedAt: Date.now(), tools: [{ name: "search" }] },
 			},
-		});
-		const runtimeSnapshotHost: McpRuntimeSnapshotHost = {
-			events: {
-				emit(_event, request) {
-					const definition = definitions[request.name as keyof typeof definitions];
-					if (!definition) {
-						request.result = { ok: false, error: new Error(`unknown runtime server ${request.name}`) };
-						return;
-					}
-					request.result = { ok: true, snapshot: { name: request.name, definition, runtime: true, persisted: false } };
-				},
-			},
-		};
-
-		const launch = buildPiArgs({
-			baseArgs: ["-p"],
-			task: "hello",
-			sessionEnabled: false,
-			inheritProjectContext: false,
-			inheritSkills: false,
-			tools: ["read"],
 			mcpDirectTools: ["runtime-a-b", "runtime_a-b"],
-			capabilityCeiling: { version: 1, allowedTools: ["read", "runtime_a_b_search"], denyExtensions: false, sources: ["test"] },
-			runtimeSnapshotHost,
+			allowedTools: ["read", "runtime_a_b_search"],
 		});
 
 		assert.equal(launch.args[launch.args.indexOf("--tools") + 1], "read");

--- a/test/unit/single-output.test.ts
+++ b/test/unit/single-output.test.ts
@@ -169,6 +169,19 @@ describe("resolveSingleOutput", () => {
 		assert.equal(result.savedPath, undefined);
 		assert.match(result.saveError ?? "", /Failed to read changed output file/);
 	});
+
+	it("fails closed when the pre-run output snapshot could not be inspected", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-output-test-"));
+		tempDirs.push(dir);
+		const outputPath = path.join(dir, "review.md");
+
+		const result = resolveSingleOutput(outputPath, "fallback output", { exists: false, error: "permission denied" });
+
+		assert.equal(result.fullOutput, "fallback output");
+		assert.equal(result.savedPath, undefined);
+		assert.match(result.saveError ?? "", /Failed to inspect output file: permission denied/);
+		assert.equal(fs.existsSync(outputPath), false);
+	});
 });
 
 describe("extractChildWrittenOutput", () => {

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -46,7 +46,7 @@ describe("registered subagent tool description", () => {
 		assert.match(description, /no per-step cwd.*workflow cwd.*outer subagent request.*cd \/path\/to\/worktree/i);
 		assert.equal(metadata.promptSnippet, SUBAGENT_TOOL_PROMPT_SNIPPET);
 		assert.equal(Buffer.byteLength(metadata.promptSnippet!), 62);
-		assert.equal(Buffer.byteLength(metadata.promptGuidelines!.join("\n")), 3497);
+		assert.equal(Buffer.byteLength(metadata.promptGuidelines!.join("\n")), 3483);
 		assert.deepEqual(metadata.promptGuidelines, SUBAGENT_TOOL_PROMPT_GUIDELINES);
 		assert.match(metadata.promptGuidelines!.join("\n"), /Use subagent only when delegation is needed/i);
 		assert.match(metadata.promptGuidelines!.join("\n"), /action: \"list\".*executable, non-disabled/i);


### PR DESCRIPTION
## Summary
- Bound malformed persisted async status state/stage text before rendering or snapshotting.
- Preserve explicit output-path stat failures so single-output fallback fails closed instead of overwriting an inaccessible path.
- Trim duplicated workflow/model guidance and repeated test/render fixtures from unreleased changes.

## Validation
- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/single-output.test.ts test/unit/async-status-projection.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-status.test.ts test/integration/single-execution.test.ts`
- `npm run test:integration`
- `npm run test:e2e` (runtime package suite skipped by environment)
- `npm run test:unit` (only known pre-existing `anti-slop-oxlint.test.ts` missing `no-chained-type-assertions` fixture failed)
- `fallow audit --format json --quiet` (`introduced` findings: 0)
- `slop-scan delta --base /tmp/pi-subagents-v059-base --head . --json`
- `git diff --check`
