### PR TITLE
Clarify subagent orchestrator mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Tighten packaged subagent and council-mode skill guidance around direct one-child launches, composed `workflowScript` runs, generic review validation, pass contracts, and private policy boundaries.
 - Clarify portable subagent orchestration guidance: keep the parent on the ordinary strong default model, route bounded workers/scouts to a fast worker tier, and reserve a top-reasoning model for bounded read-only critique or escalation without requiring a specific provider.
 - Trim duplicated orchestration recipes from the packaged skill while keeping policy in `constraints-and-recipes.md` and execution details in `execution-controls.md`.
+- Clarify direct versus orchestrator mode in packaged subagent guidance, including parent authority and a lightweight writer/challenge/review loop (#1722).
 - Clarify workflowScript portability and runs.host working-directory limits, including the outer workflow cwd and trusted `cd ... && command` patterns (#1679).
 - Add compact prompt-free agent capability discovery with `action: "list", capabilities: true`. Thanks to [@peedrr](https://github.com/peedrr) for #1717.
 - Add structured `details.agentCapabilities` records for capability discovery so callers can select agents without parsing prose rows (#1720).

--- a/skills/pi-subagents/SKILL.md
+++ b/skills/pi-subagents/SKILL.md
@@ -9,8 +9,23 @@ description: |
 
 # Pi Subagents
 
-Parent owns orchestration. Children do not spawn subagents unless the parent
-explicitly delegated fanout and their resolved `tools` allow `subagent`.
+Choose a mode:
+
+- **Direct mode:** For tiny or focused work, the parent handles the task
+  directly; a single bounded child handoff is fine. Skip workflow ceremony.
+- **Orchestrator mode:** For substantial or delegated work, the parent is the
+  supervisor, arbiter, and authority holder—not the routine primary doer.
+  Subagents may own planning/design, scouting, implementation,
+  simplification/challenge, validation, and review as useful. The parent keeps
+  user intent, constraints, authority, routing, arbitration, final acceptance,
+  and publication.
+- A useful loop for substantial work is **writer → challenge/simplify → review**;
+  the parent arbitrates between steps, and tiny tasks can skip it.
+- Direct parent edits during orchestrator mode should be intentional, small
+  interventions with a brief reason.
+
+Children do not spawn subagents unless the parent explicitly delegated fanout
+and their resolved `tools` allow `subagent`.
 
 ## Launch shape
 
@@ -29,14 +44,11 @@ Keep scripts portable: use top-level `await`, plain helpers, or explicit Promise
 chains, not nested async helpers. Legacy top-level `chain` / `tasks` inputs and
 durable `.chain.md` execution are inspection or migration material only.
 
-Use `runs.lanes(...)` only inside a `workflowScript`, not as a top-level mode. It
-keeps a predeclared staged plan visible: first stages batch across lanes, later
-stages sequence per lane, and the returned board exposes lane/stage results. See
-the [canonical staged-lane example](../../docs/workflows.md#parallel-sequential-lanes).
-When staged seams are available, do not give a low-tier writer an end-to-end
-issue. Split it into narrow stages, such as a scout/red test, helper-only change,
-one render seam, validation, minimality challenge, or fresh review, and give the
-writer only its assigned implementation stage.
+Use `runs.lanes(...)` only inside a `workflowScript`, not as a top-level mode,
+when a broad, predeclared plan benefits from visible per-lane stages; otherwise
+use ordinary `runs.run(...)` / `runs.all(...)`. See the [canonical staged-lane
+example](../../docs/workflows.md#parallel-sequential-lanes). Keep assignments
+bounded, but do not add stages or ceremony just to satisfy this skill.
 
 Use async/background by default. Set `async:false` only when the parent must
 block. Final reviews, validation gates, oracle checks, and publication checks
@@ -72,7 +84,7 @@ review.
 
 ## Operating rules
 
-- Keep simple, low-risk one-tool-call work local; delegate asynchronously to a child or `workflowScript` for most non-trivial requests needing multiple tool calls, independent research, broad inspection, risky edits, fresh review, or progress while the parent handles another lane. Avoid duplicate scouts, overlapping writers, and vague prompts without a concrete deliverable; follow the existing `runs.lanes(...)`, worktree, and async-yield guidance.
+- Avoid duplicate scouts, overlapping writers, and vague prompts without a concrete deliverable.
 - Keep the parent on the ordinary strong default model. Route workers/scouts to a fast capable tier, serious reviews to a strong tier, and top reasoning to bounded read-only critique.
 - Exact model names are deployment policy. Put them in user/project settings or profiles, not package guidance.
 - Give every child a compact meta-prompt checklist: objective; repo/cwd/ref; authority/edit boundary; relevant files/contracts and constraints; success/acceptance criteria; validation; expected output/report; and stop/ask conditions. See `references/prompting-and-roles.md`.
@@ -83,7 +95,7 @@ review.
 - Prefer fresh-context review/validation fanout, then synthesize and apply fixes in the parent.
 - For Pi extension repos under `~/.pi/agent/extensions`, put lane worktrees outside extension auto-discovery, such as `~/.pi/agent/worktrees`.
 - Preserve capability ceilings, including child tool limits and allowed-agent restrictions.
-- Keep planning, product/API/security decisions, acceptance, publication, and merge/release authority with the parent; escalate unresolved choices.
+- Preserve parent authority and escalate unresolved choices.
 - Treat receipts, CI, review bots, and external-run records as evidence, not authority.
 - For backlog maintenance, releases, merge queues, or other public-repo mutation policy, load the matching user/project skill. This package defines delegation primitives, not private policy.
 - As a conservative orchestration policy, do not pass a hard `toolBudget` or tight `usageBudget` to mutation-capable workers. The default tool budget blocks read/search tools rather than mutation tools. If interrupted after a tool call starts, checkpoint after the current tool returns with changed files, build/test state, and commit or PR state.


### PR DESCRIPTION
## Summary
- distinguish direct mode from orchestrator mode in the packaged subagents skill
- clarify that subagents can own planning/design, implementation, challenge/simplification, validation, and review
- keep the parent role focused on intent, authority, arbitration, final acceptance, and publication
- soften staged-lane wording so it stays useful without becoming ceremony

Closes #1722.

## Validation
- `npm run typecheck`
- `npm pack --dry-run --json` plus package-content assertion
- `git diff --check`
- anchored conflict-marker scan
- fresh read-only review: `lane-reports/issue-1722-orchestrator-mode-review.md`