### PR TITLE
fix: preserve durable acceptance recovery evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Changed
 - Clarify that `oracle` and top-reasoning models are escalation tools, not routine fresh-review defaults.
 
+### Fixed
+- Preserve durable file-only child reports and continue read-only workflow review after malformed acceptance metadata (#1724).
+
 ## [0.60.0] - 2026-08-30
 
 ### Highlights

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -2149,7 +2149,7 @@ async function runSingleStepInner(
 			report: structuredAcceptanceReport as import("../../shared/types.ts").AcceptanceReport | undefined,
 			reportError: structuredAcceptanceReportError,
 			fileOutput: childWrittenOutput !== undefined && step.outputPath
-				? { content: childWrittenOutput, path: step.outputPath, authoritative: step.outputMode === "file-only" }
+				? { content: childWrittenOutput, path: step.outputPath, authoritative: step.outputMode === "file-only", durable: resolvedOutput.savedPath !== undefined }
 				: undefined,
 			cwd: step.cwd ?? ctx.cwd,
 			signal: combinedAbortSignal([ctx.timeoutSignal, ctx.stopSignal]),

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -2159,7 +2159,7 @@ async function runSyncCompletionInner(
 				report: (result as SingleResult & { structuredAcceptanceReport?: import("../../shared/types.ts").AcceptanceReport; structuredAcceptanceReportError?: string }).structuredAcceptanceReport,
 				reportError: (result as SingleResult & { structuredAcceptanceReport?: import("../../shared/types.ts").AcceptanceReport; structuredAcceptanceReportError?: string }).structuredAcceptanceReportError,
 				fileOutput: childWrittenOutput !== undefined && options.outputPath
-					? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only" }
+					? { content: childWrittenOutput, path: options.outputPath, authoritative: options.outputMode === "file-only", durable: result.savedOutputPath !== undefined }
 					: undefined,
 				cwd: options.cwd ?? runtimeCwd,
 				reportOptional: isAgentContractV1(options.agentContract),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4022,7 +4022,8 @@ function workflowChildResult(
 			: result.details.usageBudget?.exhausted || result.details.results.some((child) => child.turnBudgetExceeded || child.toolBudgetBlocked)
 				? { state: "partial" as const, reason: "budget_exhausted" as const }
 				: undefined);
-	const ok = result.isError !== true && !detached && !interrupted && !stopped;
+	const acceptanceRecovery = result.details.results.find((child) => child.acceptance?.recovery)?.acceptance?.recovery;
+	const ok = result.isError !== true && !detached && !interrupted && !stopped && acceptanceRecovery === undefined;
 	const artifactPaths = new Set<string>();
 	if (result.details.asyncDir) artifactPaths.add(result.details.asyncDir);
 	if (result.details.parallelHandoff?.path) artifactPaths.add(result.details.parallelHandoff.path);
@@ -4080,6 +4081,7 @@ function workflowChildResult(
 		...(requestedContext ? { requestedContext } : {}),
 		...(resolvedContext ? { resolvedContext } : {}),
 		...(outputReference ? { outputReference } : {}),
+		...(acceptanceRecovery ? { recovery: acceptanceRecovery } : {}),
 		...(outputPathMapping ? { outputPathMapping } : {}),
 		...(externalAdapter ? { externalAdapter } : {}),
 		resumability,
@@ -4089,13 +4091,14 @@ function workflowChildResult(
 	};
 }
 
-function workflowChildAccountingFields(child: WorkflowScriptChildResult): { usage?: Usage; sessionFile?: string } {
+function workflowChildAccountingFields(child: WorkflowScriptChildResult): { usage?: Usage; sessionFile?: string; recovery?: import("../../shared/types.ts").AcceptanceRecoveryMetadata } {
 	if (!child.results?.length) return {};
 	const usage = sumResultsUsage(child.results);
 	const sessionFile = child.results.find((result) => result.sessionFile)?.sessionFile;
 	return {
 		...(usage.input !== 0 || usage.output !== 0 || usage.cacheRead !== 0 || usage.cacheWrite !== 0 || usage.cost !== 0 || usage.turns !== 0 ? { usage } : {}),
 		...(sessionFile ? { sessionFile } : {}),
+		...(child.recovery ? { recovery: child.recovery } : {}),
 	};
 }
 

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -678,7 +678,15 @@ function parseAcceptanceReportBody(body: string): { report?: AcceptanceReport; e
 	return validateAcceptanceReport(parseReportJson(body));
 }
 
-function parseUnterminatedAcceptanceReportFence(output: string): { report?: AcceptanceReport; error?: string } {
+interface AcceptanceReportParseResult {
+	report?: AcceptanceReport;
+	error?: string;
+	/** True when an acceptance-report signal was found but its envelope was invalid. */
+	malformed?: boolean;
+	sourcePath?: string;
+}
+
+function parseUnterminatedAcceptanceReportFence(output: string): AcceptanceReportParseResult {
 	const opener = /```acceptance[-_]report\b[^\n]*\n/gi.exec(output);
 	if (!opener) return {};
 	const bodyStart = opener.index + opener[0].length;
@@ -687,13 +695,13 @@ function parseUnterminatedAcceptanceReportFence(output: string): { report?: Acce
 		const validation = validateAcceptanceReport(JSON.parse(output.slice(bodyStart).trim()) as unknown);
 		return validation.report
 			? { report: validation.report }
-			: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
+			: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
 	} catch (error) {
-		return { error: `Failed to parse acceptance-report: ${error instanceof Error ? error.message : String(error)}` };
+		return { error: `Failed to parse acceptance-report: ${error instanceof Error ? error.message : String(error)}`, malformed: true };
 	}
 }
 
-function parseGenericJsonAcceptanceReportBody(body: string): { report?: AcceptanceReport; error?: string } {
+function parseGenericJsonAcceptanceReportBody(body: string): AcceptanceReportParseResult {
 	const parsed = parseReportJson(body);
 	const normalized = normalizeAcceptanceReportValue(parsed);
 	const hasCriteriaMarker = normalized.value !== null
@@ -704,12 +712,12 @@ function parseGenericJsonAcceptanceReportBody(body: string): { report?: Acceptan
 	const validation = validateAcceptanceReport(parsed);
 	return validation.report
 		? { report: validation.report }
-		: { error: `Invalid acceptance-report: ${validation.errors.join("; ")}` };
+		: { error: `Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
 }
 
 export const ACCEPTANCE_REPORT_NOT_FOUND = "Structured acceptance report not found.";
 
-export function parseAcceptanceReport(output: string): { report?: AcceptanceReport; error?: string } {
+export function parseAcceptanceReport(output: string): AcceptanceReportParseResult {
 	const explicitFencePresent = /```acceptance[-_]report\b/i.test(output);
 	const fenced = fencedBlocks(output, "acceptance[-_]report");
 	const parseErrors: string[] = [];
@@ -722,17 +730,17 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 			parseErrors.push(error instanceof Error ? error.message : String(error));
 		}
 	}
-	if (parseErrors.length > 0) return { error: `Failed to parse acceptance-report: ${parseErrors.join("; ")}` };
+	if (parseErrors.length > 0) return { error: `Failed to parse acceptance-report: ${parseErrors.join("; ")}`, malformed: true };
 	if (explicitFencePresent) {
 		const recovered = parseUnterminatedAcceptanceReportFence(output);
 		if (recovered.report || recovered.error) return recovered;
-		return { error: "Failed to parse acceptance-report: Empty or unterminated acceptance-report fence." };
+		return { error: "Failed to parse acceptance-report: Empty or unterminated acceptance-report fence.", malformed: true };
 	}
 	for (const body of fencedBlocks(output, "(?:json|jsonc|json5)")) {
 		try {
 			const parsed = parseGenericJsonAcceptanceReportBody(body);
 			if (parsed.report) return { report: parsed.report };
-			if (parsed.error) return { error: `Failed to parse acceptance-report: ${parsed.error}` };
+			if (parsed.error) return { error: `Failed to parse acceptance-report: ${parsed.error}`, malformed: parsed.malformed };
 		} catch {
 			// Ignore unrelated malformed generic JSON. A recognizable report shape
 			// returns exact validation errors above instead of being mistaken for prose.
@@ -742,20 +750,20 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 	if (markerIndex !== -1) {
 		const jsonStart = output.indexOf("{", markerIndex);
 		if (jsonStart === -1) {
-			return { error: "Failed to parse acceptance-report: Expected a JSON object after ACCEPTANCE_REPORT:." };
+			return { error: "Failed to parse acceptance-report: Expected a JSON object after ACCEPTANCE_REPORT:.", malformed: true };
 		}
 		const json = extractBalancedJson(output, jsonStart);
 		if (!json) {
-			return { error: "Failed to parse acceptance-report: Unterminated JSON object after ACCEPTANCE_REPORT:." };
+			return { error: "Failed to parse acceptance-report: Unterminated JSON object after ACCEPTANCE_REPORT:.", malformed: true };
 		}
 		try {
 			const parsed = JSON.parse(json) as unknown;
 			const validation = validateAcceptanceReport(parsed);
 			if (validation.report) return { report: validation.report };
-			return { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
+			return { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			return { error: `Failed to parse acceptance-report: ${message}` };
+			return { error: `Failed to parse acceptance-report: ${message}`, malformed: true };
 		}
 	}
 	return { error: ACCEPTANCE_REPORT_NOT_FOUND };
@@ -764,14 +772,18 @@ export function parseAcceptanceReport(output: string): { report?: AcceptanceRepo
 function parseAcceptanceReportSources(
 	output: string,
 	fileOutput: { content: string; path: string; authoritative?: boolean } | undefined,
-): { report?: AcceptanceReport; error?: string } {
+): AcceptanceReportParseResult {
 	const fromText = () => parseAcceptanceReport(output);
 	const fromFile = () => {
 		if (!fileOutput) return { error: ACCEPTANCE_REPORT_NOT_FOUND };
 		const parsed = parseAcceptanceReport(fileOutput.content);
 		return parsed.report || parsed.error === ACCEPTANCE_REPORT_NOT_FOUND
 			? parsed
-			: { error: `${parsed.error} (in configured output ${fileOutput.path})` };
+			: {
+				...parsed,
+				error: `${parsed.error} (in configured output ${fileOutput.path})`,
+				sourcePath: fileOutput.path,
+			};
 	};
 	const [primary, secondary] = fileOutput?.authoritative ? [fromFile, fromText] : [fromText, fromFile];
 	const first = primary();
@@ -1272,7 +1284,7 @@ export async function evaluateAcceptance(input: {
 	 * be misattributed). Searched for the acceptance report; searched before
 	 * the assistant output when `authoritative` (outputMode "file-only").
 	 */
-	fileOutput?: { content: string; path: string; authoritative?: boolean };
+	fileOutput?: { content: string; path: string; authoritative?: boolean; durable?: boolean };
 	report?: AcceptanceReport;
 	reportError?: string;
 	reviewResult?: AcceptanceReviewResult;
@@ -1296,16 +1308,25 @@ export async function evaluateAcceptance(input: {
 	};
 	if (acceptance.level === "none") return ledger;
 
-	const parsed = input.reportError
+	const parsed: AcceptanceReportParseResult = input.reportError
 		? { error: input.reportError }
 		: input.report
 		? (() => {
 			const validation = validateAcceptanceReport(input.report);
 			return validation.report
 				? { report: validation.report }
-				: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}` };
+				: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
 		})()
 		: parseAcceptanceReportSources(input.output, input.fileOutput);
+	const durableFileOutput = input.fileOutput?.authoritative && input.fileOutput.durable ? input.fileOutput : undefined;
+	if (parsed.malformed && parsed.sourcePath && durableFileOutput) {
+		ledger.recovery = {
+			status: "available-for-review",
+			reason: "acceptance-metadata-rejected",
+			reportPath: parsed.sourcePath,
+			reportHash: hash(durableFileOutput.content),
+		};
+	}
 	const needsReport = acceptanceRequiresChildReport(acceptance);
 	if (parsed.report) {
 		ledger.childReport = parsed.report;
@@ -1314,6 +1335,10 @@ export async function evaluateAcceptance(input: {
 	} else if (!input.reportOptional || needsReport || parsed.error !== ACCEPTANCE_REPORT_NOT_FOUND) {
 		ledger.childReportParseError = parsed.error;
 		ledger.runtimeChecks.push({ id: "attestation", status: "failed", message: parsed.error ?? "Structured acceptance report missing." });
+		if (ledger.recovery) {
+			ledger.status = "rejected";
+			ledger.evidenceStatus = "rejected";
+		}
 		if (!input.reportOptional) {
 			ledger.status = "rejected";
 			ledger.evidenceStatus = "rejected";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -189,6 +189,7 @@ export type WorkflowReceiptEntry = WorkflowReceiptEntryResumability & {
 	requestedContext?: "fresh" | "fork";
 	resolvedContext?: "fresh" | "fork" | "mixed";
 	outputReference?: string;
+	acceptanceRecovery?: AcceptanceRecoveryMetadata;
 	externalAdapter?: ExternalCliReceiptMetadata;
 	continuation: { runIds: string[] };
 };
@@ -1086,6 +1087,18 @@ export type AcceptanceLedgerStatus =
 	| "reviewed"
 	| "accepted";
 
+/**
+ * Durable child evidence that can be handed to a read-only review after the
+ * acceptance envelope itself was rejected. This never upgrades acceptance;
+ * the enclosing ledger remains rejected and the child remains unsuccessful.
+ */
+export interface AcceptanceRecoveryMetadata {
+	status: "available-for-review";
+	reason: "acceptance-metadata-rejected";
+	reportPath: string;
+	reportHash: string;
+}
+
 export interface AcceptanceLedger {
 	status: AcceptanceLedgerStatus;
 	evidenceStatus: AcceptanceEvidenceStatus;
@@ -1095,6 +1108,7 @@ export interface AcceptanceLedger {
 	criteria: ResolvedAcceptanceGate[];
 	childReport?: AcceptanceReport;
 	childReportParseError?: string;
+	recovery?: AcceptanceRecoveryMetadata;
 	runtimeChecks: AcceptanceRuntimeCheck[];
 	verifyRuns: AcceptanceVerifyResult[];
 	reviewResult?: AcceptanceReviewResult;

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -4,7 +4,8 @@ import { dirname, resolve as resolvePath } from "node:path";
 import { Worker } from "node:worker_threads";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../runs/shared/parallel-utils.ts";
 import { HOST_STEP_MAX_COUNT } from "../runs/shared/host-step-status.ts";
-import type { HostStepNodeV1, SingleResult } from "../shared/types.ts";
+import { classifyTaskMutationIntent } from "../runs/shared/task-intent.ts";
+import type { AcceptanceRecoveryMetadata, HostStepNodeV1, SingleResult } from "../shared/types.ts";
 import { normalizeWorkflowHostCommandParams, type WorkflowHostCommandParams, type WorkflowHostCommandResult } from "./host-command.ts";
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -975,6 +976,7 @@ export interface WorkflowScriptChildResult {
 	requestedContext?: "fresh" | "fork";
 	resolvedContext?: "fresh" | "fork" | "mixed";
 	outputReference?: string;
+	recovery?: AcceptanceRecoveryMetadata;
 	outputPathMapping?: { requestedPath: string; savedPath: string };
 	externalAdapter?: import("../shared/types.ts").ExternalCliReceiptMetadata;
 	resumability?: { state: "resumable" } | { state: "not-resumable"; reason: string };
@@ -1105,6 +1107,138 @@ function combinedAbortSignal(signals: AbortSignal[]): AbortSignal {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isAcceptanceMetadataRecovery(result: WorkflowScriptChildResult): boolean {
+	return !result.ok
+		&& result.recovery?.status === "available-for-review"
+		&& result.recovery.reason === "acceptance-metadata-rejected";
+}
+
+const RECOVERY_REVIEW_MUTATION_VERB_PATTERN = /\b(?:add(?:ing)?|append(?:ing)?|apply(?:ing)?|cherry[ -]pick(?:ing)?|change|changing|clean(?:ing)?|commit(?:ting)?|cop(?:y|ying)|create|creating|delete|deleting|edit(?:ing)?|fix(?:ing)?|implement(?:ing)?|insert(?:ing)?|make|making|merge|merging|mov(?:e|ing)|modify(?:ing)?|mutate|mutating|open(?:ing)?|patch(?:ing)?|prepend(?:ing)?|push(?:ing)?|rebase|rebasing|refactor(?:ing)?|remove|removing|rename|renaming|replace|replacing|revert(?:ing)?|revise|revising|rewrite|rewriting|sav(?:e|ing)|stag(?:e|ing)|stash(?:ing)?|tag(?:ging)?|touch(?:ing)?|update|updating|write|writing)\b/i;
+const RECOVERY_REVIEW_READ_ONLY_PATTERN = /\b(?:read[- ]only|review only|only return findings|return findings only|suggest fixes only|without\s+(?:editing|modifying|changing|writing|touching)|do not\s+(?:edit|modify|change|write|touch)|don't\s+(?:edit|modify|change|write|touch)|must not\s+(?:edit|modify|change|write|touch))\b/i;
+const RECOVERY_REVIEW_NO_MUTATION_CLAUSE_PATTERN = /\b(?:do not|don't|must not)\s+(?:edit|modify|change|write|touch)(?:\s+files?)?(?:\s*,\s*(?:commit|push|comment|merge|launch(?:\s+subagents?)?)(?=\s*(?:,|\bor\b|[.;!?\n)]|$)))*(?:\s*,?\s*or\s+(?:commit|push|comment|merge|launch(?:\s+subagents?)?)(?=\s*(?:[.;!?\n)]|$)))?/gi;
+const RECOVERY_REVIEW_DELIVERABLE_PATTERN = /\b(?:compose|create|draft|prepare|produce|write)\s+(?:(?:a|an|the|your)\s+)?(?:findings?|review|report|summary|analysis|recommendations?)(?:\s+(?:to|at|in)\s+\S+)?/gi;
+const RECOVERY_REVIEW_CONTEXT_OBJECT_PATTERN = /\breview\s+(?:(?:the|this|that|saved)\s+)?(?:patch|diff|changes?|implementation|report)\b/gi;
+const RECOVERY_REVIEW_MUTATION_NOUN_CONTEXT_PATTERN = /\b(?:later\s+real\s+)?update\s+imperatives?\b/gi;
+const RECOVERY_REVIEW_PRIOR_FIX_CONTEXT_PATTERN = /\bthe\s+prior\s+fix\s+keeps\b/gi;
+const RECOVERY_REVIEW_DETECTION_CONTEXT_PATTERN = /\b(?:mutation\s+detection\s+now\s+includes\s+move\/rename\/copy\s+file\s+mutation\s+imperatives|delegation\s+detection\s+now\s+blocks\s+get\/let\/have\/tell\/ask\s+follow-up\s+forms)(?=[,.;!?\n]|\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b|$)/gi;
+const RECOVERY_REVIEW_PATTERN_CHANGE_CONTEXT_PATTERN = /\bRECOVERY_REVIEW_MUTATION_VERB_PATTERN\s+now\s+includes\s+append,\s+prepend,\s+and\s+sav(?:e|ing)\b(?=\s*(?:[,.;!?\n)]|$))/gi;
+const RECOVERY_REVIEW_GIT_PATTERN_CHANGE_CONTEXT_PATTERN = /\bfixed\s+mutating\s+git\s+follow-up\s+bypasses\b|\b(?:added|adding)\s+[a-z][a-z-]*(?:\/[a-z][a-z-]*)*(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)[a-z][a-z-]*(?:\/[a-z][a-z-]*)*)*\s+to\s+the\s+(?:mutation\s+imperative|mutating\s+git\s+command)\s+pattern\b|\band\s+[a-z][a-z-]*(?:\/[a-z][a-z-]*)*(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)[a-z][a-z-]*(?:\/[a-z][a-z-]*)*)*\s+to\s+the\s+mutating\s+git\s+command\s+pattern\b/gi;
+const RECOVERY_REVIEW_VALIDATION_EVIDENCE_PATTERN = /\bvalidation(?:\s+after\s+fix)?\s*:/gi;
+const RECOVERY_REVIEW_CONTRACT_PROHIBITION_PATTERN = /\b(?:do not|don't|must not)\s+(?:mutate\s+durable\s+state|launch\s+(?:mutating|destructive|mutating\/destructive)\s+work)(?:\s+or\s+(?:mutate\s+durable\s+state|launch\s+(?:mutating|destructive|mutating\/destructive)\s+work))*/gi;
+const RECOVERY_REVIEW_ONLY_REVIEW_CONTRACT_PATTERN = /\bmay\s+only\s+launch\s+explicit\s+read-only\s+review\s+children\s+with\s+acceptance:false\b/gi;
+const RECOVERY_REVIEW_BLOCKED_CONTEXT_FRAGMENT_PATTERN = /\bstate\.set, runs\.host, runs\.steer, ordinary\/mutating children, and destructive command wording are blocked(?=[,.;!?\n)\]}]|$)/gi;
+const RECOVERY_REVIEW_REGRESSION_EVIDENCE_PATTERN = /\b(?:existing regressions cover plain rm and git clean\/reset\/restore|prior regressions covering rm\/git clean as evidence only)(?=[,.;!?\n)\]}]|$)/gi;
+const RECOVERY_REVIEW_BLOCKED_QUOTED_EXAMPLE_PATTERN = /(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+")(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+"))*\s+(?:is|are|remains?)\s+(?:blocked|(?:an?\s+)?blocked\s+examples?)(?=[,.;!?\n)\]}]|$)/gi;
+const RECOVERY_REVIEW_CONTEXT_QUOTED_EXAMPLE_PATTERN = /\b(?:examples?|phrasing|forms|variants):\s*(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+")(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+"))*/gi;
+const RECOVERY_REVIEW_LISTED_BLOCKED_EXAMPLE_PATTERN = /(?:^|[.;!?\n]\s*)blocked\s+examples:\s*(?:\r?\n[ \t]*(?:[-*]|\d+[.)])\s+[^\r\n]+)+/gim;
+const RECOVERY_REVIEW_BLOCKS_QUOTED_EXAMPLE_PATTERN = /\b(?:this\s+)?blocks?\s+examples?\s+like\s+(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+")(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+"))*/gi;
+const RECOVERY_REVIEW_EXAMPLES_LIKE_BLOCKED_PATTERN = /\bexamples?\s+like\s+(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+")(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+"))*\s+(?:is|are|remains?)\s+blocked\b/gi;
+const RECOVERY_REVIEW_QUOTED_VISIBLE_BLOCKED_PATTERN = /(?:\b(?:(?:the\s+)?examples?|commands?\s+hidden\s+in)\s+|(?:^|[\s([{]))(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+")(?:(?:\s*,\s*(?:and\s+|or\s+)?|\s+(?:and|or)\s+)(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+"))*\s+(?:(?:is|are|remains?)\s+)?visible\s+and\s+blocked\b/gi;
+const RECOVERY_REVIEW_PROMPTS_LIKE_BLOCKED_PATTERN = /\bdescribed\s+prompts?\s+like\s+Run\s+git\s+rebase\s+main,\s+git\s+rebase\s+main,\s+Run\s+git\s+cherry-pick\s+abc123,\s+cherry-pick\s+abc123,\s+and\s+Stage\s+the\s+changed\s+files\s+as\s+blocked\b/gi;
+const RECOVERY_REVIEW_GIT_MUTATIONS_BROADER_CONTEXT_PATTERN = /\bpositive\s+git\s+mutations\s+are\s+broader:\s*git\s+branch\s+-D\s+old,\s+git\s+tag\s+-d\s+v1\.0,\s+git\s+stash,\s+git\s+revert\s+abc123,\s+and\s+natural\s+cherry\s+pick\s+abc123\s+now\s+trips?\s+the\s+recovery\s+barrier\b/gi;
+const RECOVERY_REVIEW_GIT_COVERAGE_CONTEXT_PATTERN = /\bbroadened\s+positive\s+git\s+mutation\s+coverage\s+for\s+natural\s+`cherry\s+pick`,\s+`revert`,\s+`stash`,\s+`tag`,\s+plus\s+git\s+`branch\|revert\|stash\|tag`/gi;
+const RECOVERY_REVIEW_REGRESSION_QUOTED_EXAMPLE_PATTERN = /\b(?:added\s+)?exact\s+regressions?\s+for\s+(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+")(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)(?:`[^`\n]+`|'[^'\n]+'|"[^"\n]+"))*/gi;
+const RECOVERY_REVIEW_REGRESSION_ANAPHORIC_EXAMPLE_PATTERN = /\b(?:added\s+)?exact\s+regressions?\s+for\s+(?:do|run|execute|perform|apply)\s+(?:it|that|this|(?:the\s+)?(?:(?:previous(?:ly)?|prior|above|quoted|blocked)\s+){0,4}(?:command|example|operation|action|phrase|instruction|request))(?:[\s,]+(?:now|still|again|really|actually|immediately)){0,3}[\s,]+anyway(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)(?:do|run|execute|perform|apply)\s+(?:it|that|this|(?:the\s+)?(?:(?:previous(?:ly)?|prior|above|quoted|blocked)\s+){0,4}(?:command|example|operation|action|phrase|instruction|request))(?:[\s,]+(?:now|still|again|really|actually|immediately)){0,3}[\s,]+anyway)*/gi;
+const RECOVERY_REVIEW_REGRESSION_FOLLOWED_BY_ANAPHORIC_PATTERN = /\badded\s+(?:exact\s+)?regressions?\s+for\s+quoted\s+rm\s+remaining\s+blocked\s+followed\s+by\s+execute\s+the\s+previous\s+command\b(?=\s*(?:[,.;!?\n)]|\bwhile\b|$))/gi;
+const RECOVERY_REVIEW_REGRESSION_FOLLOWED_BY_NAMED_RM_PATTERN = /\b(?:added\s+)?(?:exact\s+)?regressions?\s+for\s+quoted\s+rm\s+remaining\s+blocked\s+followed\s+by\s+(?:do|run|execute|perform|apply)\s+(?:it|that|this|(?:the\s+)?(?:(?:previous(?:ly)?|prior|above|quoted|blocked)\s+){0,4}(?:command|example|operation|action|phrase|instruction|request))(?:[\s,]+(?:now|still|again|really|actually|immediately)){0,3}(?:[\s,]+anyway)?(?=\s*(?:[,.;!?\n)]|\bwhile\b|$))/gi;
+const RECOVERY_REVIEW_BLOCKED_LIVE_VARIANT_CONTEXT_PATTERN = /\b(?:while\s+)?keeping\s+live-command\s+variants\s+such\s+as\s+followed\s+by\s+execute\s+the\s+previous\s+command\s+then\s+update\s+tests\s+blocked\b(?=\s*(?:[,.;!?\n)]|$))/gi;
+const RECOVERY_REVIEW_ANAPHORIC_REFERENCES_CONTEXT_PATTERN = /\bdirect\s+anaphoric\s+references\s+now\s+include\s+numeric\s+and\s+word\s+ordinals\s+through\s+tenth\s+plus\s+one,\s+so\s+(?:do|run|execute|perform|apply)\s+(?:it|that|this|(?:the\s+)?(?:(?:\d+(?:st|nd|rd|th)|first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|last|next|previous(?:ly)?|prior|above|quoted|blocked)\s+){0,4}(?:command|example|operation|action|phrase|instruction|request|one))(?:[\s,]+(?:right|now|still|again|really|actually|immediately)){0,4}[\s,]+anyway(?:(?:\s*,\s*(?:and\s+)?|\s+and\s+)(?:do|run|execute|perform|apply)\s+(?:it|that|this|(?:the\s+)?(?:(?:\d+(?:st|nd|rd|th)|first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|last|next|previous(?:ly)?|prior|above|quoted|blocked)\s+){0,4}(?:command|example|operation|action|phrase|instruction|request|one))(?:[\s,]+(?:right|now|still|again|really|actually|immediately)){0,4}[\s,]+anyway)*\s+(?:is|are|remains?)\s+blocked\b(?:\s+after\s+quoted\s+destructive\s+examples\s+are\s+scrubbed)?/gi;
+const RECOVERY_REVIEW_NO_ANAPHORIC_MUTATION_CLAUSE_PATTERN = /\b(?:do not|don't|must not)\s+(?:do|run|execute|perform|apply)\s+(?:it|that|this|(?:the\s+)?(?:(?:\d+(?:st|nd|rd|th)|first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|last|next|previous(?:ly)?|prior|above|quoted|blocked)\s+){0,4}(?:command|example|operation|action|phrase|instruction|request|one))(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n—–-]){0,80}/gi;
+const RECOVERY_REVIEW_NO_DELEGATION_CLAUSE_PATTERN = /\b(?:do not|don't|must not)\s+(?:(?:launch|start|spawn|run)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*(?:workers?|reviewers?|agents?|subagents?|children|child|runs?)|(?:get|let|request|hand\s+off|assign|use|have|tell)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*(?:workers?|reviewers?|agents?|subagents?|children|child)|(?:get|let|have|tell|request)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*(?:review|implementation|fix(?:es)?|changes?|follow-up)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*\b(?:from|with|via|by)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*(?:workers?|reviewers?|agents?|subagents?|children|child)|ask\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*(?:(?:workers?|reviewers?|agents?|subagents?|children|child)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*\b(?:continue|implement|review|fix|edit|write|modify|change|patch|update|delete|remove|create|follow-up)|(?:review|implementation|fix(?:es)?|changes?|follow-up)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*\b(?:from|via)\b(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n])*(?:workers?|reviewers?|agents?|subagents?|children|child)))\b/gi;
+const RECOVERY_REVIEW_DELEGATION_PATTERN = /\b(?:launch|start|spawn|run)\b[^,.;!?\n]*(?:workers?|reviewers?|agents?|subagents?|children|child|runs?)\b|\b(?:delegate|hand\s+off|assign)\s+(?:remediation|implementation(?:\s+follow-up)?|changes?|fix(?:es)?|follow-up)\s+to\s+(?:(?:a|an|the)\s+)?(?:workers?|reviewers?|agents?|subagents?|children|child)\b|\b(?:get|let|have|tell|request)\b[^,.;!?\n]*(?:workers?|reviewers?|agents?|subagents?|children|child)\b[^,.;!?\n]*\b(?:continue|implement|review|fix|edit|write|modify|change|patch|update|delete|remove|create|follow-up)\b|\b(?:get|let|have|tell|request)\b[^,.;!?\n]*(?:review|implementation|fix(?:es)?|changes?|follow-up)\b[^,.;!?\n]*\b(?:from|with|via|by)\b[^,.;!?\n]*(?:workers?|reviewers?|agents?|subagents?|children|child)\b|\bask\b[^,.;!?\n]*(?:(?:workers?|reviewers?|agents?|subagents?|children|child)\b[^,.;!?\n]*\b(?:continue|implement|review|fix|edit|write|modify|change|patch|update|delete|remove|create|follow-up)|(?:review|implementation|fix(?:es)?|changes?|follow-up)\b[^,.;!?\n]*\b(?:from|via)\b[^,.;!?\n]*(?:workers?|reviewers?|agents?|subagents?|children|child))\b|\buse\b[^,.;!?\n]*(?:workers?|reviewers?|agents?|subagents?|children|child|runs?)\s+(?:for|to)\s+(?:implementation|follow-up|remediation|fix|edit|write|modify|change|patch|update|delete|remove|create)\b/i;
+const RECOVERY_REVIEW_ANAPHORIC_MUTATION_PATTERN = /\b(?:do|run|execute|perform|apply)\s+(?:it|that|this|(?:the\s+)?(?:(?:\d+(?:st|nd|rd|th)|first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|last|next|previous(?:ly)?|prior|above|quoted|blocked)\s+){0,4}(?:command|example|operation|action|phrase|instruction|request|one))(?!(?:\s+(?:(?:now|still|also|already)\s+)*(?:is|are|remains?)\s+blocked\b))(?:(?:[\s,]+\w+){0,4}[\s,]+anyway|(?:(?!\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b)[^,.;!?\n]){0,80})(?=\s*(?:[,.;!?\n)]|\b(?:and|but|then|however|nevertheless|nonetheless|yet)\b|$))/i;
+const RECOVERY_REVIEW_DESTRUCTIVE_COMMAND_PATTERN = /(?:^|[\s;,.`'"([{])(?:\S*\/)?(?:rm|rmdir|unlink|truncate|mv|cp|chmod|chown)\b|\bgit\b(?:\s+(?:-[A-Za-z](?:\s+(?:"[^"\n]*"|'[^'\n]*'|\S+))?|--(?:git-dir|work-tree|namespace|exec-path|config-env)(?:=(?:"[^"\n]*"|'[^'\n]*'|\S+)|\s+(?:"[^"\n]*"|'[^'\n]*'|\S+))|--[A-Za-z0-9-]+(?:=(?:"[^"\n]*"|'[^'\n]*'|\S+))?))*\s+(?:add|branch|cherry-pick|clean|commit|merge|rebase|reset|restore|revert|stash|tag|checkout|switch)\b/i;
+const RECOVERY_REVIEW_DASH_LIVE_ACTION_PATTERN = /(?:[—–]|--|\s-\s|:|\s\/\s)\s*(?:then\s+)?(?:(?:add|append|apply|change|cherry[ -]pick|clean|commit|copy|create|delete|edit|fix|implement|insert|make|merge|move|modify|mutate|open|patch|prepend|push|rebase|refactor|remove|rename|replace|revert|revise|rewrite|save|stage|stash|tag|touch|update|write)\b|(?:launch|start|spawn|run)\b[^,.;!?\n]*(?:workers?|reviewers?|agents?|subagents?|children|child|runs?)\b|(?:\S*\/)?(?:rm|rmdir|unlink|truncate|mv|cp|chmod|chown)\b|git\b[^,.;!?\n]*\b(?:add|branch|cherry-pick|clean|commit|merge|rebase|reset|restore|revert|stash|tag|checkout|switch)\b)/i;
+
+function isExplicitReadOnlyRecoveryReview(params: Record<string, unknown>): boolean {
+	const agent = typeof params.agent === "string" ? params.agent.trim() : "";
+	const task = typeof params.task === "string" ? params.task.trim() : "";
+	const taskDestructiveCommandText = task
+		.replace(RECOVERY_REVIEW_BLOCKED_CONTEXT_FRAGMENT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_EVIDENCE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKED_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_CONTEXT_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_LISTED_BLOCKED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKS_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_EXAMPLES_LIKE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_QUOTED_VISIBLE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_PROMPTS_LIKE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_MUTATIONS_BROADER_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_COVERAGE_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_FOLLOWED_BY_NAMED_RM_PATTERN, " ");
+	const taskDashLiveActionText = task
+		.replace(RECOVERY_REVIEW_DELIVERABLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_CONTEXT_OBJECT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_MUTATION_NOUN_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_PRIOR_FIX_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_DETECTION_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_PATTERN_CHANGE_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_PATTERN_CHANGE_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_VALIDATION_EVIDENCE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_CONTRACT_PROHIBITION_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_ONLY_REVIEW_CONTRACT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKED_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_CONTEXT_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_LISTED_BLOCKED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKS_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_EXAMPLES_LIKE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_QUOTED_VISIBLE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_PROMPTS_LIKE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_MUTATIONS_BROADER_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_COVERAGE_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_ANAPHORIC_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_FOLLOWED_BY_ANAPHORIC_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKED_LIVE_VARIANT_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_ANAPHORIC_REFERENCES_CONTEXT_PATTERN, " ");
+	const taskMutationText = task
+		.replace(RECOVERY_REVIEW_DELIVERABLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_CONTEXT_OBJECT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_MUTATION_NOUN_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_PRIOR_FIX_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_DETECTION_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_PATTERN_CHANGE_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_PATTERN_CHANGE_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_VALIDATION_EVIDENCE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_CONTRACT_PROHIBITION_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_ONLY_REVIEW_CONTRACT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKED_CONTEXT_FRAGMENT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_EVIDENCE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKED_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_CONTEXT_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_LISTED_BLOCKED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKS_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_EXAMPLES_LIKE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_QUOTED_VISIBLE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_PROMPTS_LIKE_BLOCKED_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_MUTATIONS_BROADER_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_GIT_COVERAGE_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_QUOTED_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_ANAPHORIC_EXAMPLE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_REGRESSION_FOLLOWED_BY_ANAPHORIC_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_BLOCKED_LIVE_VARIANT_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_ANAPHORIC_REFERENCES_CONTEXT_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_NO_ANAPHORIC_MUTATION_CLAUSE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_NO_DELEGATION_CLAUSE_PATTERN, " ")
+		.replace(RECOVERY_REVIEW_NO_MUTATION_CLAUSE_PATTERN, " ")
+		.replace(new RegExp(RECOVERY_REVIEW_READ_ONLY_PATTERN.source, "gi"), " ");
+	return params.acceptance === false
+		&& agent !== ""
+		&& /\b(?:advisor|oracle|review|reviewer)\b/i.test(agent)
+		&& RECOVERY_REVIEW_READ_ONLY_PATTERN.test(task)
+		&& !RECOVERY_REVIEW_DESTRUCTIVE_COMMAND_PATTERN.test(taskDestructiveCommandText)
+		&& !RECOVERY_REVIEW_MUTATION_VERB_PATTERN.test(taskMutationText)
+		&& !RECOVERY_REVIEW_DELEGATION_PATTERN.test(taskMutationText)
+		&& !RECOVERY_REVIEW_ANAPHORIC_MUTATION_PATTERN.test(taskMutationText)
+		&& !RECOVERY_REVIEW_DESTRUCTIVE_COMMAND_PATTERN.test(taskMutationText)
+		&& !RECOVERY_REVIEW_DASH_LIVE_ACTION_PATTERN.test(taskDashLiveActionText)
+		&& classifyTaskMutationIntent(agent, task).kind === "read-only";
+}
+
+function recoveryBarrierMessage(sourceKey: string, target: string): string {
+	return `Run '${target}' cannot launch after run '${sourceKey}' returned rejected acceptance recovery; only explicit read-only review children with acceptance:false may follow.`;
 }
 
 function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
@@ -1545,6 +1679,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	const observedSteerCalls = new Set<number>();
 	const observedHostCalls = new Set<number>();
 	const childController = new AbortController();
+	let acceptanceRecoveryBarrier: { key: string } | undefined;
 	let settled = false;
 	let finishing = false;
 
@@ -1582,6 +1717,13 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	const responseBoundaryFailure = (key: string, error: unknown): WorkflowScriptChildResult => {
 		const text = error instanceof Error ? error.message : String(error);
 		return { key, ok: false, output: text, error: text, artifactPaths: [] };
+	};
+	const assertRecoveryBarrierAllowsRun = (key: string, params: Record<string, unknown>): void => {
+		if (!acceptanceRecoveryBarrier || isExplicitReadOnlyRecoveryReview(params)) return;
+		throw new Error(recoveryBarrierMessage(acceptanceRecoveryBarrier.key, key));
+	};
+	const recordAcceptanceRecoveryBarrier = (key: string, result: WorkflowScriptChildResult): void => {
+		if (isAcceptanceMetadataRecovery(result)) acceptanceRecoveryBarrier = { key };
 	};
 	const stopChild = (key: string, message = `Workflow child '${key}' stopped by user.`): boolean => {
 		if (!launches.has(key) || children.has(key)) return false;
@@ -1763,6 +1905,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 					return respond(Promise.reject(error));
 				}
 				if (message.method === "state.get") return respond(Promise.resolve().then(() => options.state!.get(key)));
+				if (acceptanceRecoveryBarrier) return respond(Promise.reject(new Error(recoveryBarrierMessage(acceptanceRecoveryBarrier.key, `state.set('${key}')`))));
 				const value = message.args.value;
 				try {
 					assertWorkflowJsonValue(value, `state.set('${key}') value`);
@@ -1799,6 +1942,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				const steerMessage = message.args.message;
 				if (typeof steerMessage !== "string" || !steerMessage.trim()) return respond(Promise.reject(new Error(`runs.steer('${key}') requires a non-empty message.`)));
 				const steerOptions = isRecord(message.args.options) ? message.args.options as WorkflowSteerOptions : {};
+				if (acceptanceRecoveryBarrier) return respond(Promise.reject(new Error(recoveryBarrierMessage(acceptanceRecoveryBarrier.key, `runs.steer('${key}')`))));
 				const startedAt = Date.now();
 				trace.push({ operation: "steer", key, state: "started" });
 				traceChanged();
@@ -1829,6 +1973,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				} catch (error) {
 					return respond(Promise.reject(error));
 				}
+				if (acceptanceRecoveryBarrier) return respond(Promise.reject(new Error(recoveryBarrierMessage(acceptanceRecoveryBarrier.key, `runs.host('${key}')`))));
 				if (!options.host) return respond(Promise.reject(new Error("runs.host is unavailable in this host context.")));
 				if (hostCalls.size >= HOST_STEP_MAX_COUNT) return respond(Promise.reject(new Error(`workflowScript supports at most ${HOST_STEP_MAX_COUNT} runs.host calls.`)));
 				const startedAt = Date.now();
@@ -1884,7 +2029,9 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			const deliver = (promise: Promise<WorkflowScriptChildResult>) => collectFailure
 				? promise
 				: promise.then((result) => {
-					if (!result.ok && !result.stopped) {
+					const recoverableAcceptanceMetadata = result.recovery?.status === "available-for-review"
+						&& result.recovery.reason === "acceptance-metadata-rejected";
+					if (!result.ok && !result.stopped && !recoverableAcceptanceMetadata) {
 						const childError = new Error(result.detached ? `Run '${key}' detached: ${result.error ?? result.output}` : `Run '${key}' failed: ${result.error ?? result.output}`) as Error & { workflowErrorKind?: "detached-child" };
 						if (result.detached) childError.workflowErrorKind = "detached-child";
 						throw childError;
@@ -1948,6 +2095,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				});
 				admission = Promise.resolve().then(() => {
 					if (settled || finishing) return;
+					for (const call of calls) assertRecoveryBarrierAllowsRun(call.key, call.params);
 					return options.admit?.(calls);
 				});
 				if (batch) batchAdmissions.set(batch.id, admission);
@@ -2008,6 +2156,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				childStopControllers.delete(key);
 				if (stoppedLaunches.has(key)) return children.get(key) ?? normalized;
 				children.set(key, normalized);
+				recordAcceptanceRecoveryBarrier(key, normalized);
 				const state = normalized.ok ? "completed" : normalized.stopped ? "stopped" : normalized.detached ? "detached" : "failed";
 				trace.push({ operation: "run", key, state, durationMs: Date.now() - startedAt, ...workflowStringMetadata(params), ...(generatedLaneKey ? { generatedLaneKey } : {}), ...(normalized.agent ? { agent: normalized.agent } : {}), ...(normalized.runId ? { runId: normalized.runId } : {}), ...(!normalized.ok ? { error: normalized.error ?? normalized.output } : {}) });
 				traceChanged();

--- a/src/workflows/workflow-receipt.ts
+++ b/src/workflows/workflow-receipt.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { writePrivateAtomicJson } from "../shared/atomic-json.ts";
-import type { ExternalCliReceiptMetadata, WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState, WorkflowRecoveryAction, WorkflowTerminalOutcome, WorkflowTerminalResolution } from "../shared/types.ts";
+import type { AcceptanceRecoveryMetadata, ExternalCliReceiptMetadata, WorkflowReceipt, WorkflowReceiptEntry, WorkflowReceiptState, WorkflowRecoveryAction, WorkflowTerminalOutcome, WorkflowTerminalResolution } from "../shared/types.ts";
 import type { WorkflowReceiptResumeReference, WorkflowScriptChildResult } from "./scripted-workflow.ts";
 import { parseWorkflowChildSummary } from "./workflow-child-summary.ts";
 import { HOST_STEP_MAX_COUNT, assertUniqueHostStepIds, parseHostStepNode } from "../runs/shared/host-step-status.ts";
@@ -61,6 +61,7 @@ export function buildWorkflowReceipt(input: {
 			...(child.requestedContext ? { requestedContext: child.requestedContext } : {}),
 			...(child.resolvedContext ? { resolvedContext: child.resolvedContext } : {}),
 			...(child.outputReference ? { outputReference: child.outputReference } : {}),
+			...(child.recovery ? { acceptanceRecovery: child.recovery } : {}),
 			...(child.externalAdapter ? { externalAdapter: child.externalAdapter } : {}),
 			continuation: { runIds },
 		};
@@ -210,6 +211,20 @@ function parseTerminalOutcome(value: unknown, label: string): WorkflowTerminalOu
 	return { state: "partial", reason: outcome.reason };
 }
 
+function parseAcceptanceRecoveryMetadata(value: unknown, label: string): AcceptanceRecoveryMetadata | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object.`);
+	const recovery = value as Record<string, unknown>;
+	if (recovery.status !== "available-for-review" || recovery.reason !== "acceptance-metadata-rejected") throw new Error(`${label} is invalid.`);
+	if (typeof recovery.reportPath !== "string" || !recovery.reportPath.trim() || typeof recovery.reportHash !== "string" || !/^[a-f0-9]{64}$/u.test(recovery.reportHash)) throw new Error(`${label} is invalid.`);
+	return {
+		status: "available-for-review",
+		reason: "acceptance-metadata-rejected",
+		reportPath: recovery.reportPath,
+		reportHash: recovery.reportHash,
+	};
+}
+
 function parseEntry(value: unknown, key: string, source: string): WorkflowReceiptEntry {
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' must be an object.`);
 	const entry = value as Record<string, unknown>;
@@ -231,10 +246,11 @@ function parseEntry(value: unknown, key: string, source: string): WorkflowReceip
 	if (state === "resumable" && latestRunId === undefined) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' resumable entry has no retained run id.`);
 	if (state === "not-resumable" && (typeof reason !== "string" || !reason.trim())) throw new Error(`Invalid workflow receipt '${source}': entry '${key}' non-resumable reason is missing.`);
 	const terminalOutcome = parseTerminalOutcome(entry.terminalOutcome, `Invalid workflow receipt '${source}': entry '${key}' terminalOutcome`);
+	const acceptanceRecovery = parseAcceptanceRecoveryMetadata(entry.acceptanceRecovery, `Invalid workflow receipt '${source}': entry '${key}' acceptanceRecovery`);
 	parseExternalCliReceiptMetadata(entry.externalAdapter, key, source);
 	const lane = normalizeWorkflowLaneMetadata(entry.lane, `Invalid workflow receipt '${source}': entry '${key}'.lane`);
 	assertWorkflowLaneKey(lane, key, `Invalid workflow receipt '${source}': entry '${key}'.lane`);
-	return { ...(value as WorkflowReceiptEntry), ...(lane ? { lane } : {}), ...(terminalOutcome ? { terminalOutcome } : {}) };
+	return { ...(value as WorkflowReceiptEntry), ...(lane ? { lane } : {}), ...(terminalOutcome ? { terminalOutcome } : {}), ...(acceptanceRecovery ? { acceptanceRecovery } : {}) };
 }
 
 function parseWorkflowResolution(value: unknown, source: string): WorkflowTerminalResolution | undefined {

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2983,6 +2983,61 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(fs.readFileSync(sharedOutput), Buffer.from(usefulReport));
 	});
 
+	it("continues to a read-only review after malformed file-only acceptance metadata", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const sharedOutput = path.join(tempDir, "implementation-report.md");
+		const malformed = `ACCEPTANCE_REPORT: ${JSON.stringify({ criteriaSatisfied: true, commandsRun: ["npm test"] })}`;
+		mockPi.onCall({
+			output: "Implementation report persisted.",
+			matchArgIncludes: "Write implementation report",
+			jsonl: [...events.completedWrite(sharedOutput, malformed), events.assistantMessage("Implementation report persisted.")],
+			writeFiles: [{ path: sharedOutput, content: malformed }],
+		});
+		mockPi.onCall({ output: "Read-only review completed.", matchArgIncludes: "Review the persisted implementation report without editing it" });
+		const executor = makeExecutor([
+			makeAgent("worker", { tools: ["read", "write"], completionGuard: false }),
+			makeAgent("reviewer", { tools: ["read"], completionGuard: false }),
+		]);
+
+		const result = await executor.execute(
+			"scripted-workflow-malformed-acceptance-recovery",
+			{
+				async: false,
+				workflowScript: `
+					const writer = await runs.run("writer", {
+						agent: "worker",
+						task: "Write implementation report",
+						output: ${JSON.stringify(sharedOutput)},
+						outputMode: "file-only",
+						acceptance: { level: "checked", criteria: ["Return the implementation report"] }
+					});
+					const review = await runs.run("review", {
+						agent: "reviewer",
+						task: "Review the persisted implementation report without editing it",
+						acceptance: false
+					});
+					return { writerOk: writer.ok, writerRecovery: writer.recovery, reviewOk: review.ok };
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		const value = result.details.workflow?.value as { writerOk?: boolean; writerRecovery?: { status?: string; reason?: string; reportPath?: string; reportHash?: string }; reviewOk?: boolean };
+		assert.equal(value.writerOk, false);
+		assert.equal(value.writerRecovery?.status, "available-for-review");
+		assert.equal(value.writerRecovery?.reason, "acceptance-metadata-rejected");
+		assert.equal(value.writerRecovery?.reportPath, sharedOutput);
+		assert.match(value.writerRecovery?.reportHash ?? "", /^[0-9a-f]{64}$/);
+		assert.equal(value.reviewOk, true);
+		assert.equal(result.details.results[0]?.acceptance?.status, "rejected");
+		assert.equal(result.details.results[0]?.outputReference?.path, sharedOutput);
+		assert.equal(result.details.results[0]?.savedOutputPath, sharedOutput);
+		assert.equal(result.details.workflowChildren?.children.find((child) => child.childId === "writer")?.state, "rejected");
+		assert.deepEqual(fs.readFileSync(sharedOutput, "utf-8"), malformed);
+	});
+
 	it("identifies validation failures before any workflow child launches", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const executor = makeExecutor([makeAgent("worker")]);
 		const workflowId = "scripted-workflow-invalid-nested-async";

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -1070,6 +1071,70 @@ describe("acceptance gates", () => {
 			});
 			assert.equal(inline.status, "rejected");
 			assert.match(inline.childReportParseError ?? "", /Failed to parse acceptance-report/);
+		} finally {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("records durable malformed report evidence without relaxing rejection", async () => {
+		const cwd = tempRepo();
+		try {
+			const acceptance = resolveEffectiveAcceptance({
+				agentName: "worker",
+				task: "Implement a fix",
+				explicit: { level: "checked" },
+			});
+			const reportPath = path.join(cwd, "child-report.md");
+			const malformed = JSON.stringify({ criteriaSatisfied: true, commandsRun: ["npm test"] });
+			const ledger = await evaluateAcceptance({
+				acceptance,
+				output: "file-only child output",
+				fileOutput: { content: `ACCEPTANCE_REPORT: ${malformed}`, path: reportPath, authoritative: true, durable: true },
+				cwd,
+			});
+
+			assert.equal(ledger.status, "rejected");
+			assert.deepEqual(ledger.recovery, {
+				status: "available-for-review",
+				reason: "acceptance-metadata-rejected",
+				reportPath,
+				reportHash: createHash("sha256").update(`ACCEPTANCE_REPORT: ${malformed}`).digest("hex"),
+			});
+			const optional = await evaluateAcceptance({
+				acceptance,
+				output: "file-only child output",
+				fileOutput: { content: `ACCEPTANCE_REPORT: ${malformed}`, path: reportPath, authoritative: true, durable: true },
+				cwd,
+				reportOptional: true,
+			});
+			assert.equal(optional.status, "rejected");
+			assert.deepEqual(optional.recovery, ledger.recovery);
+
+			const missing = await evaluateAcceptance({
+				acceptance,
+				output: "file-only child output",
+				fileOutput: { content: "artifact without acceptance metadata", path: reportPath, authoritative: true, durable: true },
+				cwd,
+			});
+			assert.equal(missing.status, "rejected");
+			assert.equal(missing.recovery, undefined);
+			const textOnlyMalformed = await evaluateAcceptance({
+				acceptance,
+				output: `ACCEPTANCE_REPORT: ${malformed}`,
+				fileOutput: { content: "artifact without acceptance metadata", path: reportPath, authoritative: true, durable: true },
+				cwd,
+			});
+			assert.equal(textOnlyMalformed.status, "rejected");
+			assert.equal(textOnlyMalformed.recovery, undefined);
+
+			const unmet = await evaluateAcceptance({
+				acceptance,
+				output: report({ criteriaSatisfied: [{ id: "criterion-1", status: "not-satisfied", evidence: "not proved" }] }),
+				fileOutput: { content: report({ criteriaSatisfied: [{ id: "criterion-1", status: "not-satisfied", evidence: "not proved" }] }), path: reportPath, authoritative: true, durable: true },
+				cwd,
+			});
+			assert.equal(unmet.status, "rejected");
+			assert.equal(unmet.recovery, undefined);
 		} finally {
 			fs.rmSync(cwd, { recursive: true, force: true });
 		}

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -794,11 +794,433 @@ describe("scripted workflow runtime", () => {
 			runWorkflowScript({
 				script: `return await runs.run("fails", { agent: "worker", task: "fail" });`,
 				timeoutMs: 2_000,
-				async launch(key) { return { key, ok: false, output: "failed", artifactPaths: [], results: [] }; },
+				async launch(key) { return { key, ok: false, output: "failed", artifactPaths: [], results: [{ acceptance: { status: "rejected" } }] }; },
 				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
 			}),
 			(error: unknown) => error instanceof WorkflowScriptError && /Run 'fails' failed: failed/.test(error.message),
 		);
+	});
+
+	it("continues with a later review after a durable acceptance metadata rejection", async () => {
+		const launches: string[] = [];
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "a".repeat(64),
+		};
+		const result = await runWorkflowScript({
+			script: `
+				const writer = await runs.run("writer", { agent: "worker", task: "write" });
+				const review = await runs.run("review", { agent: "reviewer", task: "Read-only review. Do not edit files, commit, push, comment, merge, or launch subagents. Review the patch and return findings only. Do not run workers. Do not launch worker subagents. Do not hand off remediation to workers. Do not use worker subagents. Do not have a worker continue follow-up. Do not tell a worker to continue follow-up. Do not get a worker to continue follow-up. Do not let a worker continue follow-up. Do not request implementation follow-up from a worker. Do not ask a reviewer to implement changes. Do not ask for a review from another reviewer. Delta since prior review: fixed quoted git option handling and added exact regressions; mutation detection now includes move/rename/copy file mutation imperatives; Delegation now catches target-after-preposition forms using from/with/via/by and request phrasing: 'Get implementation follow-up via a worker.', 'Get a review via another reviewer.', 'Have implementation follow-up done by a worker.', and 'Request implementation follow-up from a worker.'; 'Launch two workers for implementation follow-up.' and 'Launch review subagents for follow-up.' are blocked; 'Launch two reviewers for follow-up.' is blocked; \`rm -rf .\` is blocked. RECOVERY_REVIEW_MUTATION_VERB_PATTERN now includes append, prepend, and save, with gerund forms. Added exact regressions for 'Append a regression test.', 'Prepend a guard clause.', and 'Save the updated report.' This keeps a later object phrase visible, so a prompt ending with \`save the updated report\` remains blocked. Accepted contract: after rejected durable acceptance-metadata recovery, sequential workflow continuation may only launch explicit read-only review children with acceptance:false, must not mutate durable state, and must not launch mutating/destructive work. state.get remains allowed; state.set, runs.host, runs.steer, ordinary/mutating children, and destructive command wording are blocked. Existing regressions cover plain rm and git clean/reset/restore. Prior regressions covering rm/git clean as evidence only. Validation after fix: npm exec -- tsx --test test/unit/scripted-workflow.test.ts --test-name-pattern \\\"acceptance metadata rejection|mission state writes\\\" (101 pass), npm run typecheck, git diff --check HEAD^..HEAD. (Validation after fix: npm run typecheck) Write findings to reports/review.md.", acceptance: false });
+				return { writerOk: writer.ok, writerStatus: writer.results?.[0]?.acceptance?.status, writerRecovery: writer.recovery, reviewOk: review.ok };
+			`,
+			launch(key) {
+				launches.push(key);
+				if (key === "writer") {
+					return Promise.resolve({
+						key,
+						ok: false,
+						output: "saved writer report",
+						error: "Acceptance rejected: malformed acceptance-report",
+						runId: "writer-run",
+						outputReference: recovery.reportPath,
+						recovery,
+						artifactPaths: [recovery.reportPath],
+						results: [{ acceptance: { status: "rejected", recovery } }],
+					});
+				}
+				return Promise.resolve({ key, ok: true, output: "review complete", runId: "review-run", artifactPaths: [] });
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.deepEqual(launches, ["writer", "review"]);
+		assert.deepEqual(result.value, { writerOk: false, writerStatus: "rejected", writerRecovery: recovery, reviewOk: true });
+		assert.deepEqual(result.trace.filter((entry) => entry.operation === "run" && entry.state !== "started").map(({ key, state }) => ({ key, state })), [
+			{ key: "writer", state: "failed" },
+			{ key: "review", state: "completed" },
+		]);
+	});
+
+	it("allows review prompts to describe mutation nouns after durable acceptance metadata recovery", async () => {
+		const launches: string[] = [];
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "a".repeat(64),
+		};
+		const result = await runWorkflowScript({
+			script: `
+				const writer = await runs.run("writer", { agent: "worker", task: "write" });
+				const review = await runs.run("review", { agent: "reviewer", task: "Read-only review. Do not edit files. The later real update imperative regression passed. Return findings only.", acceptance: false });
+				return review.ok;
+			`,
+			launch(key) {
+				launches.push(key);
+				if (key === "writer") {
+					return Promise.resolve({
+						key,
+						ok: false,
+						output: "saved writer report",
+						error: "Acceptance rejected: malformed acceptance-report",
+						runId: "writer-run",
+						outputReference: recovery.reportPath,
+						recovery,
+						artifactPaths: [recovery.reportPath],
+						results: [{ acceptance: { status: "rejected", recovery } }],
+					});
+				}
+				return Promise.resolve({ key, ok: true, output: "review complete", runId: "review-run", artifactPaths: [] });
+			},
+		});
+
+		assert.deepEqual(launches, ["writer", "review"]);
+		assert.equal(result.value, true);
+	});
+
+	it("allows review prompts to describe anaphoric regression examples after durable acceptance metadata recovery", async () => {
+		const launches: string[] = [];
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "a".repeat(64),
+		};
+		const result = await runWorkflowScript({
+			script: `
+				const writer = await runs.run("writer", { agent: "worker", task: "write" });
+				const review = await runs.run("review", { agent: "reviewer", task: "Read-only review. Do not edit files. Added exact regressions for Execute the command now anyway, Run that now anyway, and Perform the operation now anyway after stripped quoted blocked examples. This blocks examples like \`Execute the previous command right now anyway\` and \`Execute the blocked phrase right now anyway\`. Examples like \`Execute the previous command and keep reviewing\`, \`Execute the previous command but only for review\`, and \`Execute the previous command then return findings\` are blocked after quoted destructive context is stripped. Added regression for quoted rm remaining blocked followed by Execute the previous command while keeping live-command variants such as followed by Execute the previous command then update tests blocked. Delta since prior review: fixed mutating Git follow-up bypasses. Added cherry-pick/rebase/stage to the mutation imperative pattern and add/cherry-pick/commit/merge/rebase to the mutating Git command pattern, described prompts like Run git rebase main, git rebase main, Run git cherry-pick abc123, cherry-pick abc123, and Stage the changed files as blocked. Positive Git mutations are broader: git branch -D old, git tag -d v1.0, git stash, git revert abc123, and natural cherry pick abc123 now trip the recovery barrier. Broadened positive Git mutation coverage for natural \`cherry pick\`, \`revert\`, \`stash\`, \`tag\`, plus git \`branch|revert|stash|tag\`. The prior fix keeps commands hidden in \`Broadened positive Git mutation coverage for natural cherry pick, then update tests, plus git branch\` or \`then run git reset --hard\` visible and blocked. The examples \`rm -rf .\` and \`git reset --hard\` are visible and blocked. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one anyway, Run the 1st command anyway, and Run the fourth command anyway are blocked after quoted destructive examples are scrubbed. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one anyway is blocked. Exact regressions for \`Do not launch worker subagents -- launch a worker subagent\` remain blocked. Return findings only.", acceptance: false });
+				return review.ok;
+			`,
+			launch(key) {
+				launches.push(key);
+				if (key === "writer") {
+					return Promise.resolve({
+						key,
+						ok: false,
+						output: "saved writer report",
+						error: "Acceptance rejected: malformed acceptance-report",
+						runId: "writer-run",
+						outputReference: recovery.reportPath,
+						recovery,
+						artifactPaths: [recovery.reportPath],
+						results: [{ acceptance: { status: "rejected", recovery } }],
+					});
+				}
+				return Promise.resolve({ key, ok: true, output: "review complete", runId: "review-run", artifactPaths: [] });
+			},
+		});
+
+		assert.deepEqual(launches, ["writer", "review"]);
+		assert.equal(result.value, true);
+	});
+
+	it("allows listed blocked examples after durable acceptance metadata recovery", async () => {
+		const launches: string[] = [];
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "a".repeat(64),
+		};
+		const task = "Read-only review. Do not edit files. Review the saved report and return findings only. Blocked examples:\n- update tests\n- launch a worker subagent";
+		const result = await runWorkflowScript({
+			script: `
+				const writer = await runs.run("writer", { agent: "worker", task: "write" });
+				const review = await runs.run("review", { agent: "reviewer", task: ${JSON.stringify(task)}, acceptance: false });
+				return review.ok;
+			`,
+			launch(key) {
+				launches.push(key);
+				if (key === "writer") {
+					return Promise.resolve({ key, ok: false, output: "saved writer report", recovery, artifactPaths: [recovery.reportPath], results: [{ acceptance: { status: "rejected", recovery } }] });
+				}
+				return Promise.resolve({ key, ok: true, output: "review complete", artifactPaths: [] });
+			},
+		});
+
+		assert.deepEqual(launches, ["writer", "review"]);
+		assert.equal(result.value, true);
+	});
+
+	it("allows quoted blocked examples phrased as blocked examples after durable acceptance metadata recovery", async () => {
+		const launches: string[] = [];
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "a".repeat(64),
+		};
+		const task = "Read-only review. Do not edit files. Review the saved report and return findings only. `update tests` is a blocked example.";
+		const result = await runWorkflowScript({
+			script: `
+				const writer = await runs.run("writer", { agent: "worker", task: "write" });
+				const review = await runs.run("review", { agent: "reviewer", task: ${JSON.stringify(task)}, acceptance: false });
+				return review.ok;
+			`,
+			launch(key) {
+				launches.push(key);
+				if (key === "writer") {
+					return Promise.resolve({ key, ok: false, output: "saved writer report", recovery, artifactPaths: [recovery.reportPath], results: [{ acceptance: { status: "rejected", recovery } }] });
+				}
+				return Promise.resolve({ key, ok: true, output: "review complete", artifactPaths: [] });
+			},
+		});
+
+		assert.deepEqual(launches, ["writer", "review"]);
+		assert.equal(result.value, true);
+	});
+
+	it("blocks mutating workflow work after a durable acceptance metadata rejection", async () => {
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "a".repeat(64),
+		};
+		for (const [agent, task] of [
+			["worker", "Implement a follow-up change"],
+			["worker", "Read-only review. Do not edit files. Return findings only."],
+			["reviewer", "Review the saved report and delete files"],
+			["custom-reviewer", "Review the saved report and add tests"],
+			["oracle", "Review the saved report and create files"],
+			["reviewer", "Review the saved report, then add a regression case"],
+			["custom-reviewer", "Review the saved report and create a regression test"],
+			["oracle", "Review the saved report and replace the brittle assertion"],
+			["reviewer", "Review the saved report and patch src/parser.ts"],
+			["reviewer", "Change src/parser.ts after reviewing the saved report"],
+			["reviewer", "Read-only review. Do not edit files. Append a regression test."],
+			["reviewer", "Read-only review. Do not edit files. Prepend a guard clause."],
+			["reviewer", "Read-only review. Do not edit files. Save the updated report."],
+			["reviewer", "Read-only review. Do not edit files. Move src/a.ts to src/b.ts."],
+			["reviewer", "Read-only review. Do not edit files. Rename src/a.ts to src/b.ts."],
+			["reviewer", "Read-only review. Do not edit files. Copy src/a.ts to src/b.ts."],
+			["advisor", "Review only, then apply the fix"],
+			["reviewer", "Read-only review. Do not edit files. Launch a worker subagent to continue."],
+			["reviewer", "Read-only review. Do not edit files. Launch worker subagents for implementation follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Launch workers for implementation follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Launch two workers for implementation follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Launch review subagents for follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Launch two reviewers for follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Delegate remediation to a worker."],
+			["reviewer", "Read-only review. Do not edit files. Hand off remediation to a worker."],
+			["reviewer", "Read-only review. Do not edit files. Assign implementation follow-up to a worker."],
+			["reviewer", "Read-only review. Do not edit files. Assign implementation follow-up to workers."],
+			["reviewer", "Read-only review. Do not edit files. Ask a worker to implement the fix."],
+			["reviewer", "Read-only review. Do not edit files. Ask a reviewer to review the saved report."],
+			["reviewer", "Read-only review. Do not edit files. Ask another reviewer to review the saved report."],
+			["reviewer", "Read-only review. Do not edit files. Ask for a review from another reviewer."],
+			["reviewer", "Read-only review. Do not edit files. Do not ask for a review from another reviewer and ask for a review from a worker."],
+			["reviewer", "Read-only review. Do not edit files. Do not ask for a review from another reviewer however ask for a review from a worker."],
+			["reviewer", "Read-only review. Do not edit files. Use a worker subagent for follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Get a worker to continue follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Let a worker continue follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Ask a worker for follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Get implementation follow-up from a worker."],
+			["reviewer", "Read-only review. Do not edit files. Get a review from another reviewer."],
+			["reviewer", "Read-only review. Do not edit files. Let follow-up continue with a worker."],
+			["reviewer", "Read-only review. Do not edit files. Get implementation follow-up via a worker."],
+			["reviewer", "Read-only review. Do not edit files. Get a review via another reviewer."],
+			["reviewer", "Read-only review. Do not edit files. Have implementation follow-up done by a worker."],
+			["reviewer", "Read-only review. Do not edit files. Request implementation follow-up from a worker."],
+			["reviewer", "Read-only review. Do not edit files. Have a worker continue follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Tell a worker to continue follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Do not launch worker subagents and launch a worker subagent to continue."],
+			["reviewer", "Read-only review. Do not edit files. Do not launch worker subagents however launch a worker subagent to continue."],
+			["reviewer", "Read-only review. Do not edit files. Do not launch worker subagents — launch a worker subagent. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Do not execute the previous command — delete src/a. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Do not launch worker subagents -- launch a worker subagent. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Do not execute the previous command -- delete src/a. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Do not launch worker subagents: launch a worker subagent. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Do not run workers: run a worker. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Do not execute the previous command: delete src/a. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Do not launch worker subagents / launch a worker subagent. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. `update tests` is a blocked example, then update tests."],
+			["reviewer", "Read-only review. Do not edit files. Blocked examples:\n- update tests\n- launch a worker subagent\nThen update tests."],
+			["reviewer", "Read-only review. Do not edit files. Not blocked examples:\n- launch a worker subagent"],
+			["reviewer", "Read-only review. Do not edit files. Destructive command wording is blocked, then run rm -rf ."],
+			["reviewer", "Read-only review. Do not edit files. state.set is forbidden. Run rm -rf . This is blocked."],
+			["reviewer", "Read-only review. Do not edit files. state.set: Run rm -rf /tmp/worktree because it is blocked."],
+			["reviewer", "Read-only review. Do not edit files. Prior validation after the fix: npm run typecheck."],
+			["reviewer", "Read-only review. Do not edit files. Validation after fix: npm run typecheck, then update tests."],
+			["reviewer", "Read-only review. Do not edit files. Validation after fix: npm run typecheck and update tests."],
+			["reviewer", "Read-only review. Do not edit files. Validation after fix: npm run typecheck and launch a worker subagent."],
+			["reviewer", "Read-only review. Do not edit files. Validation after fix: npm run typecheck and run a worker subagent."],
+			["reviewer", "Read-only review. Do not edit files. Mutation detection now includes move/rename/copy file mutation imperatives, then update tests."],
+			["reviewer", "Read-only review. Do not edit files. Mutation detection now includes delete src/a.ts. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Delegation detection now blocks get/let/have/tell/ask follow-up forms, then launch a worker subagent."],
+			["reviewer", "Read-only review. Do not edit files. Delegation detection now blocks get/let/have/tell/ask follow-up forms and then launch a worker subagent."],
+			["reviewer", "Read-only review. Do not edit files. Mutation detection now includes move/rename/copy file mutation imperatives and update tests."],
+			["reviewer", "Read-only review. Do not edit files. Delegation detection now blocks get/let/have/tell/ask follow-up forms and launch a worker subagent."],
+			["reviewer", "Read-only review. Do not edit files. RECOVERY_REVIEW_MUTATION_VERB_PATTERN now includes append, prepend, and save, then update tests."],
+			["reviewer", "Read-only review. Do not edit files. RECOVERY_REVIEW_MUTATION_VERB_PATTERN now includes append, prepend, and save the updated report."],
+			["reviewer", "Read-only review. Do not edit files. A prompt ending with `save the updated report` remains blocked, then update tests."],
+			["reviewer", "Read-only review. Do not edit files. Prompts like update tests are blocked, then update tests. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Examples like `update tests` are blocked because they are dangerous, then update tests. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Examples like `rm -rf .` are blocked because they are destructive, then run rm -rf . Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Examples like `launch a worker` are blocked because delegation is unsafe, then launch a worker subagent. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Positive Git mutations are broader: run rm -rf . now trips the recovery barrier. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Positive Git mutations are broader: then launch a worker subagent now trips the recovery barrier. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. `update tests` remains blocked. Do it anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Run it anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the command anyway."],
+			["reviewer", "Read-only review. Do not edit files. `update tests` remains blocked. Run that anyway."],
+			["reviewer", "Read-only review. Do not edit files. `update tests` remains blocked. Apply the quoted example anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the command now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the command right now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command right now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command please."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command while reviewing."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command while you review."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command for review."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command while you review because the example is blocked."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command for review because this is blocked."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command and keep reviewing."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command but only for review."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previous command then return findings."],
+			["reviewer", "Read-only review. Do not edit files. commands hidden in `rm -rf .` are visible and blocked. Run the first command anyway."],
+			["reviewer", "Read-only review. Do not edit files. commands hidden in `rm -rf .` are visible and blocked. Run the first one anyway."],
+			["reviewer", "Read-only review. Do not edit files. commands hidden in `rm -rf .` are visible and blocked. Run the 1st command anyway."],
+			["reviewer", "Read-only review. Do not edit files. The examples `rm -rf .`, `git reset --hard`, `rm -rf /tmp/a`, and `git clean -fd` are visible and blocked. Run the fourth command anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the previously quoted command anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the blocked phrase right now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the above quoted blocked command anyway."],
+			["reviewer", "Read-only review. Do not edit files. `update tests` remains blocked. Run that now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Perform the operation now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Execute the command, now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `update tests` remains blocked. Run that, now anyway."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .` remains blocked. Perform the operation, now anyway."],
+			["reviewer", "Read-only review. Do not edit files. Added exact regressions for Execute the command then update tests anyway. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Added exact regressions for Run that then launch workers anyway. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Added regression for delete src/a followed by Execute the previous command. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Added regression for rm -rf /tmp followed by Execute the previous command. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Added regression for quoted rm remaining blocked followed by Execute the previous command then update tests."],
+			["reviewer", "Read-only review. Do not edit files. Keeping live-command variants such as delete src/a blocked. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Keeping live-command variants such as launch a worker subagent blocked. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Broadened positive Git mutation coverage for delete src/a, plus git `branch`. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Broadened positive Git mutation coverage for launch a worker subagent, plus git `branch`. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Broadened positive Git mutation coverage for natural `cherry pick`, then update tests, plus git `branch|revert|stash|tag`."],
+			["reviewer", "Read-only review. Do not edit files. Broadened positive Git mutation coverage for natural `cherry pick`, then run git reset --hard, plus git `branch|revert|stash|tag`."],
+			["reviewer", "Read-only review. Do not edit files. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one anyway, Run the 1st command anyway, and Run the fourth command anyway are blocked, then update tests. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one anyway and launch a worker subagent are blocked. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one anyway plus launch a worker subagent are blocked. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one anyway or launch a worker subagent are blocked. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one and update tests anyway are blocked. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Direct anaphoric references now include numeric and word ordinals through tenth plus one, so Run the first one and launch workers anyway are blocked. Return findings only."],
+			["reviewer", "Read-only review. Do not edit files. Run a worker."],
+			["reviewer", "Read-only review. Do not edit files. Open a PR."],
+			["reviewer", "Read-only review. Do not edit files. Merge the branch."],
+			["reviewer", "Read-only review. Do not edit files, merge the branch."],
+			["reviewer", "Read-only review. Do not edit files, commit the changes."],
+			["reviewer", "Read-only review. Do not edit files. Do not use a worker subagent, use a worker subagent for follow-up."],
+			["reviewer", "Read-only review. Do not edit files. Do not hand off to a worker, hand off remediation to a worker."],
+			["reviewer", "Read-only review. Do not edit files. Do not assign this to a worker, assign implementation follow-up to a worker."],
+			["reviewer", "Read-only review. Do not edit files; update tests."],
+			["reviewer", "Read-only review. Do not edit files; updating tests is required."],
+			["reviewer", "Do not edit files, run git clean -fd"],
+			["reviewer", "Review only; do not edit files. Run git clean -fd"],
+			["reviewer", "Read-only review. Do not edit files. Validation after fix: rm -rf ."],
+			["reviewer", "Read-only review. Do not edit files. Existing regressions cover plain rm, then run rm -rf ."],
+			["reviewer", "Read-only review. Do not edit files. git clean -fd; existing regressions cover git clean."],
+			["reviewer", "Read-only review. Do not edit files. Existing regressions cover rm/git clean. Write findings."],
+			["reviewer", "Read-only review. Do not edit files. Existing regressions cover rm. Write findings."],
+			["reviewer", "Read-only review. Do not edit files. Existing regressions cover git clean and run git clean -fd."],
+			["reviewer", "Read-only review. Do not edit files. Existing regressions cover git clean and launch a worker subagent."],
+			["reviewer", "Read-only review. Do not edit files. rm -rf ."],
+			["reviewer", "Read-only review. Do not edit files. `rm -rf .`"],
+			["reviewer", "Read-only review. Do not edit files. 'rm -rf .'"],
+			["reviewer", "Read-only review. Do not edit files. /bin/rm -rf ."],
+			["reviewer", "Read-only review. Do not edit files. /usr/bin/rm -rf ."],
+			["reviewer", "Read-only review. Do not edit files. /usr/local/bin/rm -rf ."],
+			["reviewer", "Read-only review. Do not edit files. Validation after fix: git -C . reset --hard."],
+			["reviewer", "Read-only review. Do not edit files. git --work-tree . reset --hard."],
+			["reviewer", "Read-only review. Do not edit files. git --work-tree \"/tmp/my repo\" reset --hard."],
+			["reviewer", "Read-only review. Do not edit files. git --work-tree '/tmp/my repo' reset --hard."],
+			["reviewer", "Read-only review. Do not edit files. Run git rebase main."],
+			["reviewer", "Read-only review. Do not edit files. git rebase main."],
+			["reviewer", "Read-only review. Do not edit files. Run git cherry-pick abc123."],
+			["reviewer", "Read-only review. Do not edit files. cherry-pick abc123."],
+			["reviewer", "Read-only review. Do not edit files. cherry pick abc123."],
+			["reviewer", "Read-only review. Do not edit files. git branch -D old."],
+			["reviewer", "Read-only review. Do not edit files. git tag -d v1.0."],
+			["reviewer", "Read-only review. Do not edit files. git stash."],
+			["reviewer", "Read-only review. Do not edit files. git revert abc123."],
+			["reviewer", "Read-only review. Do not edit files. Stage the changed files."],
+			["reviewer", "Read-only review. Do not edit files. git reset --hard"],
+			["reviewer", "Read-only review. Do not edit files. git restore src/workflows/scripted-workflow.ts"],
+		]) {
+			const launches: string[] = [];
+			await assert.rejects(
+				runWorkflowScript({
+					script: `
+						await runs.run("writer", { agent: "worker", task: "write" });
+						await runs.run("mutate", { agent: ${JSON.stringify(agent)}, task: ${JSON.stringify(task)}, acceptance: false });
+					`,
+					launch(key) {
+						launches.push(key);
+						if (key === "mutate") return Promise.resolve({ key, ok: true, output: "mutated", artifactPaths: [] });
+						return Promise.resolve({
+							key,
+							ok: false,
+							output: "saved writer report",
+							error: "Acceptance rejected: malformed acceptance-report",
+							runId: "writer-run",
+							outputReference: recovery.reportPath,
+							recovery,
+							artifactPaths: [recovery.reportPath],
+							results: [{ acceptance: { status: "rejected", recovery } }],
+						});
+					},
+					async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+				}),
+				(error: unknown) => error instanceof WorkflowScriptError && /only explicit read-only review children with acceptance:false may follow/.test(error.message),
+			);
+			assert.deepEqual(launches, ["writer"]);
+		}
+	});
+
+	it("blocks mission state writes after a durable acceptance metadata rejection", async () => {
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "a".repeat(64),
+		};
+		const values = new Map<string, unknown>();
+		const launches: string[] = [];
+		await assert.rejects(
+			runWorkflowScript({
+				script: `
+					const writer = await runs.run("writer", { agent: "worker", task: "write" });
+					await state.set("recovered.output", writer.output);
+				`,
+				state: {
+					get: (key) => values.get(key),
+					set: (key, value) => { values.set(key, value); },
+				},
+				launch(key) {
+					launches.push(key);
+					return Promise.resolve({
+						key,
+						ok: false,
+						output: "saved writer report",
+						error: "Acceptance rejected: malformed acceptance-report",
+						runId: "writer-run",
+						outputReference: recovery.reportPath,
+						recovery,
+						artifactPaths: [recovery.reportPath],
+						results: [{ acceptance: { status: "rejected", recovery } }],
+					});
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /Run 'state\.set\('recovered\.output'\)' cannot launch after run 'writer' returned rejected acceptance recovery/.test(error.message),
+		);
+		assert.deepEqual(launches, ["writer"]);
+		assert.deepEqual([...values.entries()], []);
 	});
 
 	it("tags only fail-fast detached child errors as detached-child", async () => {

--- a/test/unit/workflow-receipt.test.ts
+++ b/test/unit/workflow-receipt.test.ts
@@ -142,6 +142,26 @@ describe("workflow receipts", () => {
 		assert.ok(serialized.length < 400_000, `receipt metadata unexpectedly large: ${serialized.length}`);
 	});
 
+	it("round-trips durable acceptance recovery metadata in terminal receipts", () => {
+		const recovery = {
+			status: "available-for-review" as const,
+			reason: "acceptance-metadata-rejected" as const,
+			reportPath: "/tmp/writer-report.md",
+			reportHash: "b".repeat(64),
+		};
+		const receipt = buildWorkflowReceipt({
+			workflowRunId: "workflow-recovery",
+			state: "complete",
+			children: [child("writer", { ok: false, recovery })],
+			createdAt: 10,
+		});
+		const asyncRoot = tempRoot();
+		const asyncDir = path.join(asyncRoot, "workflow-recovery");
+		fs.mkdirSync(asyncDir, { recursive: true });
+		writeWorkflowReceipt(asyncDir, receipt);
+		assert.deepEqual(readWorkflowReceipt(asyncRoot, "workflow-recovery").entries.writer?.acceptanceRecovery, recovery);
+	});
+
 	it("persists structured partial outcomes for workflows and children", () => {
 		const asyncRoot = tempRoot();
 		const asyncDir = path.join(asyncRoot, "workflow-budget");


### PR DESCRIPTION
## Summary
- preserve durable acceptance metadata across workflow result recovery paths
- block sequential workflow continuation after rejected durable acceptance recovery unless the next child is an explicit read-only review with acceptance:false
- carry recovery evidence through workflow receipts and result delivery so failed acceptance remains visible

Fixes #1724.

## Validation
- npm exec -- tsx --test test/unit/scripted-workflow.test.ts --test-name-pattern "acceptance metadata rejection|blocked examples|mission state writes" (105 pass)
- npm run typecheck
- git diff --check HEAD^..HEAD
- Fresh high-risk read-only reviewer: No issues found on e0961d1128e4ccc015a492998b41682b1701fdf4
