### PR TITLE
perf: add session-aware background-work listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Pass the requested session and timestamp as optional context to background-work providers so they can avoid listing unrelated sessions while preserving strict snapshot validation (#1737).
 - Clarify that `oracle` and top-reasoning models are escalation tools, not routine fresh-review defaults.
 
 ## [0.60.0] - 2026-08-30

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -287,8 +287,8 @@ import { registerBackgroundWorkProvider } from "pi-subagents/background-work";
 const dispose = registerBackgroundWorkProvider({
   name: "my-background-extension",
   wakeChannels: ["my-extension:job-finished"],
-  listActiveWork: () => jobs
-    .filter((job) => job.status === "running")
+  listActiveWork: (context) => jobs
+    .filter((job) => job.status === "running" && (!context || job.ownerSessionId === context.sessionId))
     .map((job) => ({ id: job.id, sessionId: job.ownerSessionId })),
   reconcile: ({ sessionId, nowMs }) => reconcileJobs(sessionId, nowMs),
 });
@@ -297,6 +297,7 @@ const dispose = registerBackgroundWorkProvider({
 Semantics:
 
 - Each item needs a stable provider-local ID and the exact Pi session ID that owns it. `subagent_wait` captures those identities rather than a count, so one job finishing while another starts still satisfies first-completion waits without losing the replacement.
+- `listActiveWork` receives an optional `{ sessionId, nowMs }` context during snapshots. Providers can use `sessionId` to avoid scanning unrelated work; existing zero-argument `() => items` providers continue to work, and returned items are still validated and filtered to the exact requested session.
 - It filters snapshots to the active session, fails closed if a provider disappears while its work is tracked, and surfaces malformed snapshots or provider errors with provider context.
 - Wake channels only shorten polling; validated snapshots remain authoritative.
 - Providers share a registry through `Symbol.for("pi-subagents.background-work.v1")`, allowing independently loaded extension modules to meet in one Pi process.

--- a/src/api/background-work.ts
+++ b/src/api/background-work.ts
@@ -22,9 +22,14 @@ export interface BackgroundWorkReconcileContext {
 	nowMs: number;
 }
 
+export interface BackgroundWorkListContext {
+	sessionId: string;
+	nowMs: number;
+}
+
 export interface BackgroundWorkProvider {
 	name: string;
-	listActiveWork(): readonly BackgroundWorkItem[];
+	listActiveWork(context?: BackgroundWorkListContext): readonly BackgroundWorkItem[];
 	wakeChannels?: readonly string[];
 	reconcile?(context: BackgroundWorkReconcileContext): void;
 }
@@ -171,7 +176,7 @@ export function snapshotBackgroundWork(sessionId: string, nowMs = Date.now()): B
 		}
 		let active: readonly BackgroundWorkItem[];
 		try {
-			active = provider.listActiveWork();
+			active = provider.listActiveWork({ sessionId, nowMs });
 		} catch (error) {
 			throw new Error(
 				`Background-work provider '${provider.name}' listActiveWork failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/test/unit/background-work.test.ts
+++ b/test/unit/background-work.test.ts
@@ -9,6 +9,7 @@ import {
 	listBackgroundWorkWakeChannels,
 	registerBackgroundWorkProvider,
 	snapshotBackgroundWork,
+	type BackgroundWorkListContext,
 	type BackgroundWorkSnapshot,
 } from "../../src/api/background-work.ts";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
@@ -106,6 +107,39 @@ describe("background-work provider protocol", () => {
 		assert.deepEqual(listBackgroundWorkProviders(), []);
 	});
 
+	it("passes an optional session context while preserving legacy providers and exact filtering", () => {
+		let listContext: BackgroundWorkListContext | undefined;
+		let legacyCalled = false;
+		registerBackgroundWorkProvider({
+			name: "legacy",
+			listActiveWork: () => {
+				legacyCalled = true;
+				return [{ id: "legacy-job", sessionId: "session-a" }];
+			},
+		});
+		registerBackgroundWorkProvider({
+			name: "scoped",
+			listActiveWork: (context) => {
+				if (!context) throw new Error("expected background-work list context");
+				listContext = context;
+				return [
+					{ id: "mine", sessionId: context.sessionId },
+					{ id: "theirs", sessionId: "session-b" },
+				];
+			},
+		});
+
+		assert.deepEqual(snapshotBackgroundWork("session-a", 42), {
+			providers: ["legacy", "scoped"],
+			items: [
+				{ provider: "legacy", id: "legacy-job", sessionId: "session-a" },
+				{ provider: "scoped", id: "mine", sessionId: "session-a" },
+			],
+		});
+		assert.equal(legacyCalled, true);
+		assert.deepEqual(listContext, { sessionId: "session-a", nowMs: 42 });
+	});
+
 	it("validates provider metadata and work items strictly", () => {
 		assert.throws(() => registerBackgroundWorkProvider({ name: " patty", listActiveWork: () => [] }), /leading or trailing/);
 		assert.throws(() => registerBackgroundWorkProvider({ name: "patty", listActiveWork: () => [], wakeChannels: ["done", "done"] }), /duplicates/);
@@ -123,6 +157,27 @@ describe("background-work provider protocol", () => {
 				{ id: "job", sessionId: "session-a" },
 				{ id: "job", sessionId: "session-a" },
 			],
+		});
+		assert.throws(() => snapshotBackgroundWork("session-a"), /duplicate item 'job'/);
+	});
+
+	it("validates scoped provider results before filtering them", () => {
+		registerBackgroundWorkProvider({
+			name: "scoped",
+			listActiveWork: () => [{ id: "job", sessionId: "session-a", extra: true } as never],
+		});
+		assert.throws(() => snapshotBackgroundWork("session-a"), /unknown fields: extra/);
+
+		clearRegistry();
+		registerBackgroundWorkProvider({
+			name: "scoped",
+			listActiveWork: (context) => {
+				if (!context) throw new Error("expected background-work list context");
+				return [
+					{ id: "job", sessionId: context.sessionId },
+					{ id: "job", sessionId: context.sessionId },
+				];
+			},
 		});
 		assert.throws(() => snapshotBackgroundWork("session-a"), /duplicate item 'job'/);
 	});


### PR DESCRIPTION
## Summary
- add an optional `{ sessionId, nowMs }` context to background-work provider listing
- keep legacy zero-argument providers compatible
- preserve provider/item validation, duplicate detection, caps, exact-session filtering, wait, and auto-drain behavior

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/background-work.test.ts test/unit/auto-drain.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Closes #1737.
