### PR TITLE
perf: serve untargeted RPC status from memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Pass the requested session and timestamp as optional context to background-work providers so they can avoid listing unrelated sessions while preserving strict snapshot validation (#1737).
 - Clarify that `oracle` and top-reasoning models are escalation tools, not routine fresh-review defaults.
+- Route untargeted RPC status through restored in-memory projections when safe while preserving executor-backed targeted status and transcript options (#1735).
 
 ## [0.60.0] - 2026-08-30
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -32,6 +32,7 @@ Method notes:
 - `steer` requires an async run `id` (plus optional child `index`) and a non-empty `message`; its reply preserves the normal acknowledged-delivery result. Optional `mode` values are `steer` (default), `follow_up`, and `auto`, and receipts include `deliveryStatus: "delivered" | "queued"`. RPC steering disables the direct tool's pause-and-revive recovery in every mode so an extension keeps authority over the exact child it spawned; `ping.capabilities.nonRecoveringSteer` advertises this guarantee.
 - `resume` requires a run target and non-empty `message`. It delegates to the existing revival path, which validates current-session ownership, persisted session/recovery metadata, stopped/live state, capability ceilings, and the exclusive session lease before returning the new async run details. Callers may request a `file-only` output path for the revived result without overriding its model, tools, or budgets. `ping.capabilities.resume` advertises this seam.
 - `stop` targets current-session top-level async runs through the stop control channel and records a `stopped` lifecycle instead of reporting a timeout.
+- `status` keeps targeted and rich requests on the executor-backed path. A request with no `id`, `runId`, `dir`, `index`, `view`, or `lines` may use the restored in-memory projections and a short summary; when the live state is missing, stale, session-mismatched, or not restored, it falls back to normal executor status. Status `view`, `lines`, and `index` are forwarded for targeted transcript/fleet requests. Successful replies retain `text`, `details`, `fleet`, and `asyncSnapshot`; the short summary intentionally omits canonical filesystem details, wait subscriptions, and budget annotations.
 
 Capability advertisements on `ping`:
 
@@ -42,6 +43,7 @@ Capability advertisements on `ping`:
 - `processTerminalProof` — the process-terminal proof status (see [observability.md](observability.md#process-terminal-proof)).
 - `nonRecoveringSteer` — RPC steering never pauses-and-revives.
 - `resume` — the revival seam described above.
+- `statusProjection: { version: 1, untargeted: "in-memory-when-ready", targeted: "executor" }` — untargeted status may use restored bounded projections; targeted or rich status remains executor-backed.
 - `fleetStatus: { version: 1 }` — successful `status` replies additionally include `data.fleet`.
 
 Structured delegation progress updates carry `runId` as soon as foreground execution allocates it, so a caller can retain the package-owned revival target even if its own tool turn is interrupted before the terminal response. Foreground `details.results[]` rows also include a numeric `index` that is unique within the run and stable across partial progress snapshots and the final result; use `(runId, index)` instead of row position to correlate single, counted parallel, and chain children.
@@ -53,6 +55,8 @@ When `ping.capabilities.fleetStatus` is `{ version: 1 }`, successful `status` re
 Entries are bounded, current-session public display records with an opaque reconciliation `key`, resolved `agent`, optional `role`, `model`, `effort`, caller-facing `goal`, safe `startedAt`, and `{ input, output, total }` tokens. `totalActive` and `omitted` preserve overflow information beyond the bounded entry window.
 
 The DTO intentionally never exposes run, async, or tool IDs. Clients must ignore unknown fields and fall back to status text when the capability is absent.
+
+`data.asyncSnapshot` is a separate bounded projection included on successful status replies when available. Its `runs[].id` contains the async run id; unlike the fleet DTO, it is not an opaque display key. Fleet keys remain opaque and must not be interpreted as run or async identifiers.
 
 ### Scope
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -438,6 +438,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const state: SubagentState = {
 		baseCwd: "",
 		currentSessionId: null,
+		statusProjectionSessionId: null,
 		completionOwnerId: currentCompletionOwnerId(),
 		artifactDirPreference: config.artifactDir ?? DEFAULT_ARTIFACT_CONFIG.dir,
 		...(config.authorityPolicy ? { authorityPolicy: config.authorityPolicy } : {}),
@@ -996,6 +997,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			promptTemplateBridge.dispose();
 			state.widgetsSuspended = false;
 			state.currentSessionId = null;
+			state.statusProjectionSessionId = null;
 			state.parentSessionFile = null;
 			parentSessionEnvValue = null;
 			if (shuttingDownParentSession && process.env[SUBAGENT_PARENT_SESSION_ENV] === shuttingDownParentSession) {

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -172,6 +172,8 @@ interface FleetCandidate {
 	goal?: unknown;
 }
 
+type StatusRpcParams = Pick<SubagentParamsLike, "id" | "runId" | "dir" | "index" | "view" | "lines">;
+
 function buildFleetStatus(
 	state: SubagentState | undefined,
 	keyState: FleetKeyState,
@@ -380,14 +382,50 @@ function failIfToolError(result: ToolResultWithError): void {
 	throw new SubagentRpcError("execution_failed", textFromToolResult(result) || "Subagent RPC execution failed.");
 }
 
-function normalizeTargetParams(params: unknown, method: SubagentRpcMethod): Pick<SubagentParamsLike, "id" | "runId" | "dir" | "index"> {
-	const input = assertRecordParams(params, method);
+function normalizeTargetParamsFromRecord(input: Record<string, unknown>): Pick<SubagentParamsLike, "id" | "runId" | "dir" | "index"> {
 	const output: Pick<SubagentParamsLike, "id" | "runId" | "dir" | "index"> = {};
 	if (input.id !== undefined) output.id = input.id as string;
 	if (input.runId !== undefined) output.runId = input.runId as string;
 	if (input.dir !== undefined) output.dir = input.dir as string;
 	if (input.index !== undefined) output.index = input.index as number;
 	return output;
+}
+
+function normalizeTargetParams(params: unknown, method: SubagentRpcMethod): Pick<SubagentParamsLike, "id" | "runId" | "dir" | "index"> {
+	return normalizeTargetParamsFromRecord(assertRecordParams(params, method));
+}
+
+function normalizeStatusParams(params: unknown): StatusRpcParams {
+	const input = assertRecordParams(params, "status");
+	const output: StatusRpcParams = normalizeTargetParamsFromRecord(input);
+	if (input.view !== undefined) output.view = input.view as StatusRpcParams["view"];
+	if (input.lines !== undefined) output.lines = input.lines as number;
+	return output;
+}
+
+function hasStatusTarget(params: StatusRpcParams): boolean {
+	return params.id !== undefined
+		|| params.runId !== undefined
+		|| params.dir !== undefined
+		|| params.index !== undefined
+		|| params.view !== undefined
+		|| params.lines !== undefined;
+}
+
+function canUseInMemoryStatus(state: SubagentState | undefined, sessionId: string | undefined): state is SubagentState {
+	return Boolean(
+		state
+			&& sessionId
+			&& state.currentSessionId === sessionId
+			&& state.statusProjectionSessionId === sessionId
+			&& state.foregroundControls instanceof Map
+			&& state.asyncJobs instanceof Map,
+	);
+}
+
+function inMemoryStatusSummary(fleet: SubagentRpcFleetStatus): string {
+	const noun = fleet.totalActive === 1 ? "child" : "children";
+	return `In-memory subagent status: ${fleet.totalActive} active ${noun}.`;
 }
 
 function sessionData(ctx: ExtensionContext | null): { cwd?: string; sessionId?: string; sessionFile?: string | null } {
@@ -405,6 +443,7 @@ function pingData(ctx: ExtensionContext | null) {
 		methods: [...SUBAGENT_RPC_METHODS],
 		capabilities: {
 			status: true,
+			statusProjection: { version: 1, untargeted: "in-memory-when-ready", targeted: "executor" },
 			managementActions: [...SUBAGENT_RPC_MANAGEMENT_ACTIONS],
 			fleetStatus: { version: 1 },
 			asyncStatusSnapshot: { kind: ASYNC_STATUS_SNAPSHOT_KIND, version: ASYNC_STATUS_SNAPSHOT_VERSION },
@@ -689,14 +728,33 @@ async function handleRequest(
 		return executeChecked(options, ctx, request.requestId, request.method, spawnParams(request.params));
 	}
 	if (request.method === "status") {
+		const statusParams = normalizeStatusParams(request.params);
+		let sessionId: string | undefined;
+		if (!hasStatusTarget(statusParams)) {
+			try {
+				sessionId = resolveCurrentSessionId(ctx.sessionManager);
+			} catch {
+				// Let the executor produce the canonical error when session identity is unavailable.
+			}
+			if (canUseInMemoryStatus(options.state, sessionId)) {
+				const fleet = buildFleetStatus(options.state, fleetKeys, sessionId);
+				const asyncSnapshot = buildAsyncStatusSnapshotForState(options.state, sessionId);
+				return {
+					text: inMemoryStatusSummary(fleet),
+					details: { mode: "management", results: [] },
+					fleet,
+					asyncSnapshot,
+				};
+			}
+		}
 		const status = await executeChecked(
 			options,
 			ctx,
 			request.requestId,
 			request.method,
-			{ action: "status", ...normalizeTargetParams(request.params, "status") },
+			{ action: "status", ...statusParams },
 		);
-		const sessionId = resolveCurrentSessionId(ctx.sessionManager);
+		sessionId ??= resolveCurrentSessionId(ctx.sessionManager);
 		return {
 			...status,
 			fleet: buildFleetStatus(

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -682,6 +682,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 
 	const resetJobs = (ctx?: ExtensionContext) => {
 		dispose();
+		state.statusProjectionSessionId = null;
 		for (const timer of state.cleanupTimers.values()) clearTimeout(timer);
 		state.cleanupTimers.clear();
 		state.asyncJobs.clear();
@@ -698,6 +699,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 
 	const restoreActiveJobs = (ctx?: ExtensionContext) => {
 		if (ctx?.hasUI) state.lastUiContext = ctx;
+		state.statusProjectionSessionId = null;
 		if (!state.currentSessionId) return;
 		let runs: AsyncRunSummary[];
 		try {
@@ -713,6 +715,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			rememberFleetJob(state, job);
 			watchJob(job);
 		}
+		state.statusProjectionSessionId = state.currentSessionId;
 		if (runs.length === 0) return;
 		ensurePoller();
 		rerenderLastWidget();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2117,6 +2117,8 @@ export interface ActiveAsyncCapacitySnapshot {
 export interface SubagentState {
 	baseCwd: string;
 	currentSessionId: string | null;
+	/** Session for which active status projections were restored successfully. */
+	statusProjectionSessionId?: string | null;
 	/** Reload-stable identity for this parent Pi process/window. */
 	completionOwnerId?: string;
 	/** Runtime-owned artifact resolution inputs used by Fleet transcript targeting. */

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -381,6 +381,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			assert.equal(job.runningSteps, 2);
 			assert.equal(job.completedSteps, 0);
 			assert.equal(job.activeParallelGroup, true);
+			assert.equal(state.statusProjectionSessionId, "session-restored");
 			assert.ok(state.poller, "expected restored active jobs to start polling");
 			assert.ok(ui.renderRequests >= 2, "expected reset and restore to request widget renders");
 			assert.equal(typeof ui.widgets.at(-1), "function", "expected restored jobs to render the widget");

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -113,6 +113,10 @@ describe("subagent extension RPC bridge", () => {
 			(reply as { data: { capabilities?: { asyncStatusSnapshot?: unknown } } }).data.capabilities?.asyncStatusSnapshot,
 			{ kind: "pi-subagents.async-status-snapshot", version: 1 },
 		);
+		assert.deepEqual(
+			(reply as { data: { capabilities?: { statusProjection?: unknown } } }).data.capabilities?.statusProjection,
+			{ version: 1, untargeted: "in-memory-when-ready", targeted: "executor" },
+		);
 
 		bridge.dispose();
 	});
@@ -159,9 +163,102 @@ describe("subagent extension RPC bridge", () => {
 		assert.equal(reply.success, true);
 		assert.deepEqual(executedParams, { action: "status", id: "abc123" });
 		assert.equal((reply as { data: { text?: string } }).data.text, "Run: abc123");
+		assert.deepEqual((reply as { data: { details?: unknown } }).data.details, { mode: "management", results: [] });
 		assert.deepEqual((reply as { data: { fleet?: unknown } }).data.fleet, {
 			version: 1, entries: [], totalActive: 0, topLevelAsyncCapacity: { used: 0, limit: 0 }, omitted: 0,
 		});
+
+		bridge.dispose();
+	});
+
+	it("serves untargeted status from restored in-memory projections", async () => {
+		const events = new FakeEvents();
+		const state = {
+			currentSessionId: "session-123",
+			statusProjectionSessionId: "session-123",
+			foregroundControls: new Map(),
+			asyncJobs: new Map([[
+				"private-id",
+				{ asyncId: "private-id", sessionId: "session-123", status: "running", mode: "single", startedAt: 100, agents: ["worker"] },
+			]]),
+		} as any;
+		let executeCalls = 0;
+		const bridge = registerSubagentRpcBridge({
+			events,
+			getContext: () => ctx("session-123", "session-123"),
+			state,
+			execute: async () => {
+				executeCalls += 1;
+				return assert.fail("restored untargeted status should not call executor");
+			},
+		});
+
+		const reply = await request(events, "status-memory", "status");
+
+		assert.equal(reply.success, true);
+		assert.equal(executeCalls, 0);
+		assert.equal((reply as { data: { text?: string } }).data.text, "In-memory subagent status: 1 active child.");
+		assert.deepEqual((reply as any).data.details, { mode: "management", results: [] });
+		assert.equal((reply as any).data.fleet.totalActive, 1);
+		assert.deepEqual((reply as any).data.asyncSnapshot.runs.map((run: { id: string }) => run.id), ["private-id"]);
+
+		bridge.dispose();
+	});
+
+	it("falls back to executor status when projections are not restored or session identity is stale", async () => {
+		const events = new FakeEvents();
+		const state = {
+			currentSessionId: "old-session",
+			statusProjectionSessionId: null,
+			foregroundControls: new Map(),
+			asyncJobs: new Map(),
+		} as any;
+		const executed: unknown[] = [];
+		const bridge = registerSubagentRpcBridge({
+			events,
+			getContext: () => ctx("session-123", "session-123"),
+			state,
+			execute: async (_id, params) => {
+				executed.push(params);
+				return { content: [{ type: "text", text: "canonical status" }], details: { mode: "single", results: [] } } as any;
+			},
+		});
+
+		const reply = await request(events, "status-fallback", "status");
+
+		assert.equal(reply.success, true);
+		assert.deepEqual(executed, [{ action: "status" }]);
+		assert.equal((reply as { data: { text?: string } }).data.text, "canonical status");
+
+		state.currentSessionId = "session-123";
+		executed.length = 0;
+		const notRestored = await request(events, "status-not-restored", "status");
+		assert.equal(notRestored.success, true);
+		assert.deepEqual(executed, [{ action: "status" }]);
+
+		bridge.dispose();
+	});
+
+	it("forwards and validates status view, lines, and index through the executor", async () => {
+		const events = new FakeEvents();
+		const executed: unknown[] = [];
+		const bridge = registerSubagentRpcBridge({
+			events,
+			getContext: () => ctx(),
+			execute: async (_id, params) => {
+				executed.push(params);
+				return { content: [{ type: "text", text: "transcript" }], details: { mode: "single", results: [] } } as any;
+			},
+		});
+
+		const reply = await request(events, "status-transcript", "status", { id: "run-1", view: "transcript", lines: 25, index: 2 });
+		assert.equal(reply.success, true);
+		assert.deepEqual(executed, [{ action: "status", id: "run-1", index: 2, view: "transcript", lines: 25 }]);
+
+		const invalid = await request(events, "status-invalid-lines", "status", { lines: 0 });
+		assert.equal(invalid.success, false);
+		assert.equal((invalid as { error: { code: string } }).error.code, "invalid_params");
+		assert.equal(executed.length, 1);
 
 		bridge.dispose();
 	});


### PR DESCRIPTION
## Summary
- add a restored-session-gated in-memory path for truly untargeted RPC status
- preserve executor-backed status for targeted/rich requests and forward `view`, `lines`, and `index`
- document the routing split plus Fleet/asyncSnapshot identity semantics

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/rpc.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Closes #1735.
