### PR TITLE
perf: cache trusted external-run Fleet records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - Pass the requested session and timestamp as optional context to background-work providers so they can avoid listing unrelated sessions while preserving strict snapshot validation (#1737).
+- Avoid repeating external-run display normalization during Fleet refresh while retaining validation for externally replaced or mutated records (#1736).
 - Clarify that `oracle` and top-reasoning models are escalation tools, not routine fresh-review defaults.
 - Route untargeted RPC status through restored in-memory projections when safe while preserving executor-backed targeted status and transcript options (#1735).
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -133,7 +133,7 @@ updateExternalRun(ctx.sessionManager.getSessionId(), "dependency-review", {
 unregisterExternalRun(ctx.sessionManager.getSessionId(), "dependency-review");
 ```
 
-The API validates and caches bounded display fields when the caller registers or updates a job. FleetView reads that cache only. It does not poll caller code. `snapshotExternalRuns(sessionId)` and `listExternalRuns(sessionId)` return bounded current-session snapshots. By default, malformed cached records throw with the validation error. Display-only Fleet callers can pass `{ ignoreMalformed: true, onMalformedRecord }` to remove bad records and keep rendering with a programmatic diagnostic.
+The API validates and caches bounded display fields when the caller registers or updates a job. FleetView reads that cache only. It does not poll caller code. `snapshotExternalRuns(sessionId)` and `listExternalRuns(sessionId)` return bounded current-session snapshots. Snapshots filter the session-qualified cache key before inspecting record fields; API-written records avoid repeated normalization through module-private provenance, while records replaced or mutated through the process-local registry are validated on demand. By default, malformed records for the requested session throw with the validation error. Display-only Fleet callers can pass `{ ignoreMalformed: true, onMalformedRecord }` to remove bad records and keep rendering with a programmatic diagnostic.
 
 External jobs are observational. The caller owns execution, persistence, cancellation, and result delivery. FleetView does not expose stop, steer, resume, cancel, or Herdr controls for them. Supplied report and transcript paths are shown as bounded text only; FleetView does not read arbitrary external paths.
 

--- a/src/api/external-runs.ts
+++ b/src/api/external-runs.ts
@@ -48,7 +48,16 @@ interface ExternalRunRegistry {
 	runs: Map<string, ExternalRun>;
 }
 
-const RUN_FIELDS = new Set([
+interface TrustedExternalRunRecord {
+	value: unknown;
+	normalized: ExternalRun;
+	keys: readonly string[];
+	values: readonly unknown[];
+}
+
+const trustedRecordsByRegistry = new WeakMap<object, Map<string, TrustedExternalRunRecord>>();
+
+const RUN_FIELD_NAMES = [
 	"id",
 	"sessionId",
 	"source",
@@ -61,7 +70,8 @@ const RUN_FIELDS = new Set([
 	"preview",
 	"reportPath",
 	"transcriptPath",
-]);
+] as const satisfies readonly (keyof ExternalRun)[];
+const RUN_FIELDS = new Set<string>(RUN_FIELD_NAMES);
 const UPDATE_FIELDS = new Set([...RUN_FIELDS].filter((field) => field !== "id" && field !== "sessionId" && field !== "source"));
 
 function registry(): ExternalRunRegistry {
@@ -77,6 +87,14 @@ function registry(): ExternalRunRegistry {
 	const candidate = existing as Partial<ExternalRunRegistry>;
 	if (candidate.version !== EXTERNAL_RUN_REGISTRY_VERSION || !(candidate.runs instanceof Map)) throw new Error(`Unsupported external-run registry at Symbol.for("${EXTERNAL_RUN_REGISTRY_KEY}").`);
 	return candidate as ExternalRunRegistry;
+}
+
+function trustedRecords(current: ExternalRunRegistry): Map<string, TrustedExternalRunRecord> {
+	const cached = trustedRecordsByRegistry.get(current);
+	if (cached) return cached;
+	const records = new Map<string, TrustedExternalRunRecord>();
+	trustedRecordsByRegistry.set(current, records);
+	return records;
 }
 
 function inputObject(value: unknown, field: string, allowed: Set<string>): Record<string, unknown> {
@@ -150,6 +168,41 @@ function clone(run: ExternalRun): ExternalRun {
 	return { ...run };
 }
 
+function trustedRecord(value: unknown, normalized: ExternalRun): TrustedExternalRunRecord {
+	const candidate = value as ExternalRun;
+	return {
+		value,
+		normalized,
+		keys: Object.keys(candidate),
+		values: RUN_FIELD_NAMES.map((field) => candidate[field]),
+	};
+}
+
+function trustedRecordValue(value: unknown, record: TrustedExternalRunRecord | undefined): ExternalRun | undefined {
+	if (!record || record.value !== value || !value || typeof value !== "object") return undefined;
+	try {
+		const candidate = value as ExternalRun;
+		const keys = Object.keys(candidate);
+		if (keys.length !== record.keys.length || keys.some((key, index) => key !== record.keys[index])) return undefined;
+		for (const [index, field] of RUN_FIELD_NAMES.entries()) {
+			if (candidate[field] !== record.values[index]) return undefined;
+		}
+		return record.normalized;
+	} catch {
+		return undefined;
+	}
+}
+
+function rememberTrustedRecord(current: ExternalRunRegistry, cacheKey: string, value: unknown, normalized: ExternalRun): void {
+	trustedRecords(current).set(cacheKey, trustedRecord(value, normalized));
+}
+
+function normalizeCachedRecord(current: ExternalRunRegistry, cacheKey: string, value: unknown): ExternalRun {
+	const run = validateRun(value);
+	rememberTrustedRecord(current, cacheKey, value, run);
+	return run;
+}
+
 /** Register one current-session external job. pi-subagents never controls the job. */
 export function registerExternalRun(input: ExternalRun): ExternalRun {
 	const run = validateRun(input);
@@ -158,6 +211,7 @@ export function registerExternalRun(input: ExternalRun): ExternalRun {
 	if (current.runs.has(runKey)) throw new Error(`External run '${run.id}' is already registered for session '${run.sessionId}'.`);
 	if (current.runs.size >= EXTERNAL_RUN_LIMITS.maxCachedRuns) throw new Error(`External-run registry supports at most ${EXTERNAL_RUN_LIMITS.maxCachedRuns} cached runs.`);
 	current.runs.set(runKey, run);
+	rememberTrustedRecord(current, runKey, run, run);
 	return clone(run);
 }
 
@@ -172,12 +226,17 @@ export function updateExternalRun(sessionId: string, id: string, update: Externa
 	if (!previous) throw new Error(`External run '${safeId}' is not registered for session '${safeSessionId}'.`);
 	const next = validateRun({ ...previous, ...patch });
 	current.runs.set(runKey, next);
+	rememberTrustedRecord(current, runKey, next, next);
 	return clone(next);
 }
 
 /** Remove a cached external job. The caller remains responsible for its process and artifacts. */
 export function unregisterExternalRun(sessionId: string, id: string): boolean {
-	return registry().runs.delete(key(identity(sessionId, "External run sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength), identity(id, "External run id")));
+	const current = registry();
+	const runKey = key(identity(sessionId, "External run sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength), identity(id, "External run id"));
+	const deleted = current.runs.delete(runKey);
+	if (deleted) trustedRecords(current).delete(runKey);
+	return deleted;
 }
 
 function snapshotBytes(runs: readonly ExternalRun[]): number {
@@ -192,15 +251,19 @@ function getErrorMessage(error: unknown): string {
 export function snapshotExternalRuns(sessionId: string, options: ExternalRunSnapshotOptions = {}): readonly ExternalRun[] {
 	const safeSessionId = identity(sessionId, "External-run snapshot sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength);
 	const current = registry();
+	const trusted = trustedRecords(current);
+	const sessionPrefix = `${safeSessionId}\0`;
 	const runs: ExternalRun[] = [];
 	for (const [cacheKey, value] of current.runs.entries()) {
+		if (typeof cacheKey !== "string" || !cacheKey.startsWith(sessionPrefix)) continue;
 		try {
-			const run = validateRun(value);
+			const run = trustedRecordValue(value, trusted.get(cacheKey)) ?? normalizeCachedRecord(current, cacheKey, value);
 			if (run.sessionId === safeSessionId) runs.push(run);
 		} catch (error) {
 			const message = `Malformed cached external run '${cacheKey}': ${getErrorMessage(error)}`;
 			if (!options.ignoreMalformed) throw new Error(message, { cause: error instanceof Error ? error : undefined });
 			current.runs.delete(cacheKey);
+			trusted.delete(cacheKey);
 			options.onMalformedRecord?.(message);
 		}
 	}

--- a/test/unit/external-runs.test.ts
+++ b/test/unit/external-runs.test.ts
@@ -9,10 +9,12 @@ import {
 	snapshotExternalRuns,
 	unregisterExternalRun,
 	updateExternalRun,
+	type ExternalRun,
 } from "../../src/api/external-runs.ts";
 
 function clearRegistry(): void {
 	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)];
+	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(`${EXTERNAL_RUN_REGISTRY_KEY}.trusted`)];
 }
 
 test("external runs register, update, list, and unregister cached display records", () => {
@@ -59,6 +61,106 @@ test("external runs register, update, list, and unregister cached display record
 	assert.equal(unregisterExternalRun("session-a", "review-1083"), false);
 	assert.deepEqual(snapshotExternalRuns("session-a"), []);
 	clearRegistry();
+});
+
+test("external snapshots reuse validated records, detect direct mutations, and clone reads", () => {
+	clearRegistry();
+	try {
+		const registered = registerExternalRun({
+			id: "trusted",
+			sessionId: "session-a",
+			source: "tool",
+			label: "Trusted run",
+			state: "running",
+			startedAt: 1,
+		});
+		const registry = (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)] as { runs: Map<string, ExternalRun> };
+		const stored = registry.runs.get("session-a\0trusted")!;
+		assert.notEqual(stored, registered, "callers receive a clone rather than the cached object");
+		const snapshot = snapshotExternalRuns("session-a");
+		assert.deepEqual(snapshot, [registered]);
+		(snapshot[0] as ExternalRun).label = "Changed outside the registry";
+		assert.equal(snapshotExternalRuns("session-a")[0]?.label, "Trusted run", "snapshot results remain cloned");
+
+		const changed = registry.runs.get("session-a\0trusted")!;
+		changed.label = "Directly changed";
+		assert.equal(snapshotExternalRuns("session-a")[0]?.label, "Directly changed");
+		const malformed = registry.runs.get("session-a\0trusted")!;
+		malformed.state = "invalid" as never;
+		assert.throws(() => snapshotExternalRuns("session-a"), /state is invalid/);
+		assert.deepEqual(snapshotExternalRuns("session-a", { ignoreMalformed: true }), []);
+	} finally {
+		clearRegistry();
+	}
+});
+
+test("external snapshots do not trust forged public-symbol metadata", () => {
+	clearRegistry();
+	try {
+		const malformed = {
+			id: "forged",
+			sessionId: "session-a",
+			source: "tool",
+			label: "Forged",
+			state: "invalid",
+			startedAt: 1,
+		};
+		const forgedNormalized = {
+			id: "forged",
+			sessionId: "session-a",
+			source: "tool",
+			label: "Forged trusted value",
+			state: "running",
+			startedAt: 1,
+		};
+		const registry = {
+			version: EXTERNAL_RUN_REGISTRY_VERSION,
+			runs: new Map<string, ExternalRun>([["session-a\0forged", malformed as unknown as ExternalRun]]),
+		};
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)] = registry;
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(`${EXTERNAL_RUN_REGISTRY_KEY}.trusted`)] = new Map([
+			["session-a\0forged", { value: malformed, normalized: forgedNormalized, keys: Object.keys(malformed), values: Object.values(malformed) }],
+		]);
+
+		assert.throws(() => snapshotExternalRuns("session-a"), /state is invalid/);
+		assert.deepEqual(snapshotExternalRuns("session-a", { ignoreMalformed: true }), []);
+	} finally {
+		clearRegistry();
+	}
+});
+
+test("external snapshots filter unrelated cache keys before normalizing records", () => {
+	clearRegistry();
+	try {
+		registerExternalRun({
+			id: "good",
+			sessionId: "session-a",
+			source: "tool",
+			label: "Good run",
+			state: "running",
+			startedAt: 1,
+		});
+		const malformed = {
+			id: "bad",
+			sessionId: "session-b",
+			source: "tool",
+			state: "running",
+			startedAt: 2,
+		} as Record<string, unknown>;
+		Object.defineProperty(malformed, "label", {
+			enumerable: true,
+			get() {
+				throw new Error("unrelated record was normalized");
+			},
+		});
+		const registry = (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_RUN_REGISTRY_KEY)] as { runs: Map<string, ExternalRun> };
+		registry.runs.set("session-b\0bad", malformed as unknown as ExternalRun);
+
+		assert.deepEqual(snapshotExternalRuns("session-a").map((run) => run.id), ["good"]);
+		assert.throws(() => snapshotExternalRuns("session-b"), /unrelated record was normalized/);
+	} finally {
+		clearRegistry();
+	}
 });
 
 test("external run validation is atomic and display text is bounded", () => {


### PR DESCRIPTION
## Summary
- avoid repeated external-run display normalization for trusted API-written Fleet records
- keep module-private provenance only, so external registry mutations still validate on demand
- preserve malformed-cache handling, caps/order/clone behavior, and Fleet rendering safety

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/external-runs.test.ts test/unit/fleet-status.test.ts test/unit/fleet.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Closes #1736.
