### PR TITLE
fix: preserve model fallback origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reduce async widget update churn during running workflows by repainting animation ticks without reinstalling the widget and coalescing close status refreshes (#1726).
 - Avoid repeated staged workflow projection during widget rendering. Thanks [@kkkhs](https://github.com/kkkhs) for #1730.
 - Preserve durable file-only child reports and continue read-only workflow review after malformed acceptance metadata (#1724).
+- Preserve model origins across fallback and fork preparation, allowing unavailable configured primaries and retryable valid explicit primaries to use eligible fallbacks while invalid explicit models remain fail-closed; also stop hidden 125ms spinner redraws while retaining progress refreshes and one-second animation frames ([#1747](https://github.com/nicobailon/pi-subagents/pull/1747) — thanks [@xz-dev](https://github.com/xz-dev)).
 
 ## [0.60.0] - 2026-08-30
 

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -5,7 +5,7 @@ import { discoverAgentSnapshot, findBlockingAgentDiagnostic, formatUnknownAgentE
 import { resolveExecutionAgentScope } from "../agents/agent-scope.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../agents/agent-memory.ts";
-import { buildModelCandidates, inheritsParentModel, resolveEffectiveSubagentModel, type AvailableModelInfo, type ParentModel } from "../runs/shared/model-fallback.ts";
+import { buildModelCandidates, inheritsParentModel, resolveEffectiveSubagentModel, resolveModelOrigin, type AvailableModelInfo, type ParentModel } from "../runs/shared/model-fallback.ts";
 import { resolveModelScopesForAgent } from "../runs/shared/model-scope.ts";
 import { applyThinkingSuffix, resolvePiLaunchToolPlan, type PiLaunchToolPlan } from "../runs/shared/pi-args.ts";
 import { injectOutputPathSystemPrompt, normalizeSingleOutputOverride, resolveSingleOutputPath } from "../runs/shared/single-output.ts";
@@ -317,9 +317,13 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	const availableModels = normalizeAvailableModels(input.availableModels);
 	const preferredProvider = agent.modelProvider ?? input.preferredProvider ?? input.parentModel?.provider;
 	const modelScopes = resolveModelScopesForAgent(discovered.modelScope, agent.name, input.parentModel);
+	const modelOrigin = resolveModelOrigin({ explicitModel: input.model, agentModel: agent.model, parentModel: input.parentModel });
 	const primaryModel = externalRunner
 		? undefined
-		: resolveEffectiveSubagentModel(input.model, agent.model, input.parentModel, availableModels, preferredProvider, { scope: modelScopes });
+		: resolveEffectiveSubagentModel(input.model, agent.model, input.parentModel, availableModels, preferredProvider, {
+			scope: modelScopes,
+			source: modelOrigin === "explicit" ? "explicit" : "inherited",
+		});
 	const effectiveThinkingConfig = input.thinking !== undefined ? input.thinking : agent.thinking;
 	const thinkingCeiling = externalRunner ? undefined : intersectThinkingCeilings(
 		discovered.maxThinking,
@@ -332,7 +336,8 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		? []
 		: buildModelCandidates(primaryModel, agent.fallbackModels, availableModels, preferredProvider, {
 			scope: modelScopes,
-			primaryModelFromParent: inheritsParentModel(input.model, agent.model, input.parentModel),
+			primaryModelFromParent: modelOrigin === "inherited" || inheritsParentModel(input.model, agent.model, input.parentModel),
+			origin: modelOrigin,
 		})
 			.map((candidate) => applyThinkingSuffix(candidate, effectiveThinkingConfig, input.thinking !== undefined) ?? candidate);
 	if (!externalRunner) {

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -26,7 +26,7 @@ import { backgroundProcessOptions } from "../shared/background-process-options.t
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../../agents/agent-memory.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV, PROMPT_REDACTED, resolveChildCwd } from "../../shared/utils.ts";
-import { buildModelCandidates, inheritsParentModel, resolveEffectiveSubagentModel, resolveSubagentModelOverride, type AvailableModelInfo, type ParentModel } from "../shared/model-fallback.ts";
+import { buildModelCandidates, resolveEffectiveSubagentModel, resolveModelOrigin, resolveSubagentModelOverride, type AvailableModelInfo, type ModelOrigin, type ParentModel } from "../shared/model-fallback.ts";
 import { resolveToolTimeoutMs, toolTimeoutFromEnv } from "../shared/tool-timeout.ts";
 import { resolveModelScopesForAgent, type ModelScopeConfig } from "../shared/model-scope.ts";
 import { findModelInfo, resolveEffectiveThinking } from "../../shared/model-info.ts";
@@ -235,6 +235,7 @@ interface AsyncSingleParams {
 	structuredOutputSchema?: JsonSchemaObject;
 	modelOverride?: string;
 	modelOverrideFromParent?: boolean;
+	modelOrigin?: ModelOrigin;
 	fast?: boolean;
 	thinkingOverride?: AgentConfig["thinking"];
 	availableModels?: AvailableModelInfo[];
@@ -857,14 +858,15 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const task = namespaceOutputPath ? taskText : injectSingleOutputInstruction(taskText, outputPath, a);
 
 		const modelScopes = resolveModelScopesForAgent(ctx.modelScope, a.name, ctx.currentModel);
-		const primaryModelFromParent = inheritsParentModel(s.model, a.model, ctx.currentModel);
+		const modelOrigin = resolveModelOrigin({ explicitModel: s.model, agentModel: a.model, parentModel: ctx.currentModel });
+		const primaryModelFromParent = modelOrigin === "inherited";
 		const primaryModel = externalRunner ? undefined : resolveEffectiveSubagentModel(
 			s.model,
 			a.model,
 			ctx.currentModel,
 			availableModels,
 			a.modelProvider ?? ctx.currentModelProvider,
-			{ scope: modelScopes },
+			{ scope: modelScopes, source: modelOrigin === "explicit" ? "explicit" : "inherited" },
 		);
 		const thinkingOverride = flatIndex === undefined ? undefined : thinkingOverridesByFlatIndex?.[flatIndex];
 		const effectiveThinking = externalRunner ? undefined : thinkingOverride ?? a.thinking;
@@ -884,15 +886,17 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		}
 		const agentContract = s.agentContract ?? params.agentContract;
 		const permissionRules = resolvePermissionRules(ctx.permissions, a.permissions);
-		const modelCandidates = externalRunner ? [] : buildModelCandidates(primaryModel, a.fallbackModels, availableModels, a.modelProvider ?? ctx.currentModelProvider, {
-			scope: modelScopes,
-			primaryModelFromParent,
-		}).flatMap((candidate) => {
-			const resolved = applyThinkingSuffix(candidate, effectiveThinking, thinkingOverride !== undefined);
-			return resolved ? [resolved] : [];
-		});
+		let modelCandidates: string[] = [];
 		if (!externalRunner) {
 			try {
+				modelCandidates = buildModelCandidates(primaryModel, a.fallbackModels, availableModels, a.modelProvider ?? ctx.currentModelProvider, {
+					scope: modelScopes,
+					primaryModelFromParent,
+					origin: modelOrigin,
+				}).flatMap((candidate) => {
+					const resolved = applyThinkingSuffix(candidate, effectiveThinking, thinkingOverride !== undefined);
+					return resolved ? [resolved] : [];
+				});
 				for (const candidate of modelCandidates) assertThinkingWithinCeiling({ model: candidate, configThinking: effectiveThinking, ceiling: thinkingCeiling, agent: a.name, runId: id });
 			} catch (error) {
 				throw new AsyncStartValidationError(error instanceof Error ? error.message : String(error));
@@ -1588,15 +1592,27 @@ export function executeAsyncSingle(
 		: "";
 	const taskText = readsInstruction + taskWithOutputInstruction;
 	const modelScopes = resolveModelScopesForAgent(ctx.modelScope, agentConfig.name, ctx.currentModel);
-	const primaryModel = externalRunner ? undefined : params.modelOverrideFromParent
-		? params.modelOverride
-		: resolveSubagentModelOverride(
-			params.modelOverride ?? agentConfig.model,
-			ctx.currentModel,
-			availableModels,
-			ctx.currentModelProvider,
-			{ scope: modelScopes },
-		);
+	const modelOrigin = resolveModelOrigin({
+		fromParent: params.modelOverrideFromParent,
+		storedOrigin: params.modelOrigin,
+		explicitModel: params.modelOverrideFromParent ? undefined : params.modelOverride,
+		agentModel: agentConfig.model,
+		parentModel: ctx.currentModel,
+	});
+	let primaryModel: string | undefined;
+	try {
+		primaryModel = externalRunner ? undefined : modelOrigin === "inherited"
+			? params.modelOverride ?? (ctx.currentModel ? `${ctx.currentModel.provider}/${ctx.currentModel.id}` : undefined)
+			: resolveSubagentModelOverride(
+				params.modelOverride ?? agentConfig.model,
+				ctx.currentModel,
+				availableModels,
+				ctx.currentModelProvider,
+				{ scope: modelScopes, source: modelOrigin === "explicit" ? "explicit" : "inherited" },
+			);
+	} catch (error) {
+		return formatAsyncStartError("single", error instanceof Error ? error.message : String(error));
+	}
 	const effectiveThinking = externalRunner ? undefined : params.thinkingOverride ?? agentConfig.thinking;
 	const model = externalRunner ? undefined : applyThinkingSuffix(primaryModel, effectiveThinking, params.thinkingOverride !== undefined);
 	const contextLimit = model ? findModelInfo(model, availableModels, agentConfig.modelProvider ?? ctx.currentModelProvider)?.contextWindow : undefined;
@@ -1633,18 +1649,17 @@ export function executeAsyncSingle(
 	const structuredOutput = params.structuredOutputSchema
 		? createStructuredOutputRuntime(params.structuredOutputSchema, path.join(asyncDir, "structured-output"), { captureAcceptanceReport: params.acceptance !== false })
 		: undefined;
-	const modelCandidates = externalRunner
-		? []
-		: buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, agentConfig.modelProvider ?? ctx.currentModelProvider, {
-			scope: modelScopes,
-			primaryModelFromParent: params.modelOverrideFromParent,
-		})
-			.flatMap((candidate) => {
+	let modelCandidates: string[] = [];
+	if (!externalRunner) {
+		try {
+			modelCandidates = buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, agentConfig.modelProvider ?? ctx.currentModelProvider, {
+				scope: modelScopes,
+				primaryModelFromParent: modelOrigin === "inherited",
+				origin: modelOrigin,
+			}).flatMap((candidate) => {
 				const resolved = applyThinkingSuffix(candidate, effectiveThinking, params.thinkingOverride !== undefined);
 				return resolved ? [resolved] : [];
 			});
-	if (!externalRunner) {
-		try {
 			for (const candidate of modelCandidates) assertThinkingWithinCeiling({ model: candidate, configThinking: effectiveThinking, ceiling: thinkingCeiling, agent: agentConfig.name, runId: id });
 		} catch (error) {
 			return formatAsyncStartError("single", error instanceof Error ? error.message : String(error));
@@ -1730,7 +1745,8 @@ export function executeAsyncSingle(
 		...(model ? { model } : {}),
 		...(params.fast ?? recoveryAgentConfig.fast ? { fast: params.fast ?? recoveryAgentConfig.fast } : {}),
 		...(recoveryAgentConfig.modelProvider ? { modelProvider: recoveryAgentConfig.modelProvider } : {}),
-		...(params.modelOverrideFromParent ? { modelOverrideFromParent: true } : {}),
+		...(modelOrigin === "inherited" ? { modelOverrideFromParent: true } : {}),
+		modelOrigin,
 		...(recoveryAgentConfig.fallbackModels ? { fallbackModels: [...recoveryAgentConfig.fallbackModels] } : {}),
 		...(effectiveThinking ? { thinking: resolveEffectiveThinking(model, effectiveThinking) } : {}),
 		...(thinkingCeiling ? { thinkingCeiling } : {}),
@@ -1799,7 +1815,7 @@ export function executeAsyncSingle(
 						thinking: resolveEffectiveThinking(model, effectiveThinking),
 						...(thinkingCeiling ? { thinkingCeiling } : {}),
 						modelCandidates,
-						...(params.modelOverrideFromParent ? { skipPrimaryModelVerification: true } : {}),
+						...(modelOrigin === "inherited" ? { skipPrimaryModelVerification: true } : {}),
 						...(availableModels && availableModels.length > 0 ? { modelVerificationRegistry: availableModels } : {}),
 						tools: agentConfig.tools,
 						allowNestedSubagents: agentConfig.allowNestedSubagents,

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -314,7 +314,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': expected an object.`);
 	const parsed = value as Record<string, unknown>;
 	const allowedFields = new Set([
-		"version", "launchContractDigest", "sourceRunId", "agentContract", "agent", "sessionFile", "cwd", "model", "modelProvider", "modelOverrideFromParent", "fallbackModels", "thinking", "thinkingCeiling", "tools", "allowNestedSubagents", "extensions",
+		"version", "launchContractDigest", "sourceRunId", "agentContract", "agent", "sessionFile", "cwd", "model", "modelProvider", "modelOverrideFromParent", "modelOrigin", "fallbackModels", "thinking", "thinkingCeiling", "tools", "allowNestedSubagents", "extensions",
 		"subagentOnlyExtensions", "mcpDirectTools", "mutationTools", "systemPrompt", "systemPromptMode", "inheritProjectContext", "inheritGlobalContext", "inheritSkills", "skills",
 		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "structuredOutputSchema", "acceptance", "sessionDir", "artifactConfig",
 		"artifactsDir", "maxOutput", "controlConfig", "context", "intercomBridge", "absoluteDeadlineAt", "initialTurnBudget", "initialToolBudget", "maxSubagentDepth", "share", "capabilityCeiling",
@@ -347,6 +347,8 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 	if (parsed.outputMode !== "inline" && parsed.outputMode !== "file-only") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': outputMode is invalid.`);
 	if (parsed.context !== undefined && parsed.context !== "fresh" && parsed.context !== "fork") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': context is invalid.`);
 	if (parsed.modelOverrideFromParent !== undefined && typeof parsed.modelOverrideFromParent !== "boolean") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': modelOverrideFromParent must be a boolean.`);
+	if (parsed.modelOrigin !== undefined && parsed.modelOrigin !== "explicit" && parsed.modelOrigin !== "inherited" && parsed.modelOrigin !== "configured") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': modelOrigin must be 'explicit', 'inherited', or 'configured'.`);
+	if (parsed.modelOrigin === undefined && parsed.model !== undefined) parsed.modelOrigin = parsed.modelOverrideFromParent ? "inherited" : "configured";
 	for (const field of ["inheritProjectContext", "inheritSkills", "share"] as const) {
 		if (typeof parsed[field] !== "boolean") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': ${field} must be a boolean.`);
 	}

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -5347,7 +5347,6 @@ async function runSubagent(
 			statusPayload.error = `Step failed: ${failedStep.agent}`;
 		}
 	}
-	writeStatusPayload();
 	try {
 		runPersistence.write(resultPath, {
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -1871,7 +1871,11 @@ async function runSyncCompletionInner(
 		agent.fallbackModels,
 		options.availableModels,
 		agent.modelProvider ?? options.preferredModelProvider,
-		{ scope: options.modelScope, primaryModelFromParent: options.modelOverrideFromParent },
+		{
+			scope: options.modelScope,
+			primaryModelFromParent: options.modelOverrideFromParent,
+			origin: options.modelOrigin ?? (options.modelOverrideFromParent ? "inherited" : "configured"),
+		},
 	);
 	if (options.workflowChildPermitLaunch && candidates.length > 1) {
 		const error = "Workflow child permit does not support model fallback.";

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -27,7 +27,7 @@ import { normalizePublicSubagentExecution } from "../../extension/public-executi
 import { runSync } from "./execution.ts";
 import { handleWatchdogToolAction, WATCHDOG_TOOL_ACTIONS } from "../../watchdog/tool-actions.ts";
 import type { MainWatchdogRuntime } from "../../watchdog/runtime.ts";
-import { buildModelCandidates, inheritsParentModel, normalizeParentModel, resolveEffectiveSubagentModel, type ParentModel } from "../shared/model-fallback.ts";
+import { buildModelCandidates, normalizeParentModel, resolveEffectiveSubagentModel, resolveModelOrigin, type ModelOrigin, type ParentModel } from "../shared/model-fallback.ts";
 import { formatRetainedChildren, listRetainedChildren } from "../background/retained-children.ts";
 import { resolveModelScopesForAgent, type ModelScopeConfig } from "../shared/model-scope.ts";
 import { recordRun } from "../shared/run-history.ts";
@@ -357,6 +357,8 @@ export interface SubagentParamsLike {
 	artifacts?: boolean;
 	includeProgress?: boolean;
 	model?: string;
+	/** Internal recovery provenance for a resolved model override. */
+	modelOrigin?: ModelOrigin;
 	fast?: boolean;
 	thinking?: string | false;
 	scope?: string;
@@ -418,9 +420,9 @@ interface ExecutorDeps {
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 }
 
-type ForkSessionFileForTask = (agentName: string, idx?: number, modelOverride?: string, modelOverrideFromParent?: boolean) => string | undefined;
-type PrepareForkSessionForTask = (agentName: string, idx?: number, modelOverride?: string, modelOverrideFromParent?: boolean) => Promise<void>;
-type ForkThinkingOverrideForTask = (agentName: string, idx?: number, modelOverride?: string, modelOverrideFromParent?: boolean) => AgentConfig["thinking"] | undefined;
+type ForkSessionFileForTask = (agentName: string, idx?: number, modelOverride?: string, modelOverrideFromParent?: boolean, modelOrigin?: ModelOrigin) => string | undefined;
+type PrepareForkSessionForTask = (agentName: string, idx?: number, modelOverride?: string, modelOverrideFromParent?: boolean, modelOrigin?: ModelOrigin) => Promise<void>;
+type ForkThinkingOverrideForTask = (agentName: string, idx?: number, modelOverride?: string, modelOverrideFromParent?: boolean, modelOrigin?: ModelOrigin) => AgentConfig["thinking"] | undefined;
 
 interface ExecutionContextData {
 	params: SubagentParamsLike;
@@ -2026,6 +2028,7 @@ async function resumeAsyncRun(input: {
 		modelOverride: recoveryDescriptor?.model ?? target.model,
 		fast: recoveryDescriptor?.fast,
 		modelOverrideFromParent: recoveryDescriptor?.modelOverrideFromParent,
+		modelOrigin: recoveryDescriptor?.modelOrigin ?? (recoveryDescriptor?.modelOverrideFromParent ? "inherited" : undefined),
 		thinkingOverride: recoveryDescriptor?.thinking ?? target.thinking,
 		thinkingCeiling: recoveryDescriptor?.thinkingCeiling ?? ("thinkingCeiling" in target ? target.thinkingCeiling : undefined),
 		extensionBindings: recoveryDescriptor?.extensionBindings ?? ("extensionBindings" in target ? target.extensionBindings : undefined),
@@ -2999,7 +3002,15 @@ async function preflightForkSessionsForStaticTasks(
 ): Promise<void> {
 	if (!contextPolicy.usesFork) return;
 	if (params.agent) {
-		if (shouldForkAgent(contextPolicy, params.agent)) await prepareSessionForTask(params.agent, 0, params.model);
+		if (shouldForkAgent(contextPolicy, params.agent)) {
+			await prepareSessionForTask(
+				params.agent,
+				0,
+				params.model,
+				params.modelOrigin === "inherited",
+				params.modelOrigin,
+			);
+		}
 		return;
 	}
 	if (params.tasks) {
@@ -3177,10 +3188,19 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			return buildRequestedModeError(params, `Agent '${a.name}' uses runner.type='${a.runner.type}' and does not support fast mode.`);
 		}
 		const modelScopes = resolveModelScopesForAgent(data.modelScope, a.name, parentModel);
+		const modelOrigin = resolveModelOrigin({
+			storedOrigin: params.modelOrigin as ModelOrigin | undefined,
+			explicitModel: params.model as string | undefined,
+			agentModel: a.model,
+			parentModel,
+		});
 		const modelOverride = a.runner?.type === "external-cli" || a.runner?.type === "external-job"
 			? params.model ?? (externalRunnerWithoutExplicitModel ? undefined : a.model)
-			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, a.modelProvider ?? currentProvider, modelScopes.length === 0 ? {} : { scope: modelScopes });
-		const modelOverrideFromParent = inheritsParentModel(params.model as string | undefined, a.model, parentModel);
+			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, a.modelProvider ?? currentProvider, {
+				...(modelScopes.length === 0 ? {} : { scope: modelScopes }),
+				source: modelOrigin === "explicit" ? "explicit" : "inherited",
+			});
+		const modelOverrideFromParent = modelOrigin === "inherited";
 		const asyncResult = executeAsyncSingle(id, compactOptional<Parameters<typeof executeAsyncSingle>[1]>({
 			agent: params.agent!,
 			task: shouldForkAgent(contextPolicy, params.agent!) ? wrapForkTask(params.task ?? "") : (params.task ?? ""),
@@ -3197,7 +3217,7 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			shareEnabled,
 			activeAsyncCapacity: data.activeAsyncCapacity,
 			sessionRoot,
-			sessionFile: sessionFileForTask(params.agent!, 0, modelOverride, modelOverrideFromParent),
+			sessionFile: sessionFileForTask(params.agent!, 0, modelOverride, modelOverrideFromParent, modelOrigin),
 			context: contextPolicy.contextForAgent(params.agent!),
 			skills,
 			output: effectiveOutput,
@@ -3208,7 +3228,8 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			modelOverride,
 			fast: params.fast,
 			modelOverrideFromParent,
-			thinkingOverride: externalRunnerWithoutExplicitModel ? undefined : thinkingOverrideForTask(params.agent!, 0, modelOverride, modelOverrideFromParent),
+			modelOrigin,
+			thinkingOverride: externalRunnerWithoutExplicitModel ? undefined : thinkingOverrideForTask(params.agent!, 0, modelOverride, modelOverrideFromParent, modelOrigin),
 			thinkingCeiling: a.maxThinking,
 			maxSubagentDepth,
 			waitToolEnabled: deps.waitToolEnabled,
@@ -3584,15 +3605,24 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const modelScopes = resolveModelScopesForAgent(data.modelScope, agentConfig.name, parentModel);
 	let task = typeof params.task === "string" ? params.task : "";
+	const modelOrigin = resolveModelOrigin({
+		storedOrigin: params.modelOrigin as ModelOrigin | undefined,
+		explicitModel: params.model as string | undefined,
+		agentModel: agentConfig.model,
+		parentModel,
+	});
 	let modelOverride: string | undefined = resolveEffectiveSubagentModel(
 		params.model as string | undefined,
 		agentConfig.model,
 		parentModel,
 		availableModels,
 		agentConfig.modelProvider ?? currentProvider,
-		modelScopes.length === 0 ? {} : { scope: modelScopes },
+		{
+			...(modelScopes.length === 0 ? {} : { scope: modelScopes }),
+			source: modelOrigin === "explicit" ? "explicit" : "inherited",
+		},
 	);
-	const modelOverrideFromParent = inheritsParentModel(params.model as string | undefined, agentConfig.model, parentModel);
+	const modelOverrideFromParent = modelOrigin === "inherited";
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 	let readsOverride: string[] | false | undefined = params.reads;
 	const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
@@ -3663,7 +3693,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	let detachForeground: ((reason?: string) => boolean) | undefined;
 	const foregroundControl = deps.state.foregroundControls.get(runId);
 	if (foregroundControl) {
-		const thinking = resolveEffectiveThinking(modelOverride, thinkingOverrideForTask(params.agent!, 0, modelOverride, modelOverrideFromParent));
+		const thinking = resolveEffectiveThinking(modelOverride, thinkingOverrideForTask(params.agent!, 0, modelOverride, modelOverrideFromParent, modelOrigin));
 		beginForegroundChild(foregroundControl, omitUndefinedProperties({
 			index: 0,
 			agent: params.agent!,
@@ -3715,7 +3745,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			intercomEvents: deps.pi.events,
 			runId,
 			sessionDir: sessionDirForIndex(0),
-			sessionFile: sessionFileForTask(params.agent!, 0, modelOverride, modelOverrideFromParent),
+			sessionFile: sessionFileForTask(params.agent!, 0, modelOverride, modelOverrideFromParent, modelOrigin),
 			share: shareEnabled,
 			artifactsDir: artifactConfig.enabled ? artifactsDir : undefined,
 			artifactConfig,
@@ -3737,7 +3767,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			modelOverride,
 			fast: params.fast,
 			modelOverrideFromParent,
-			thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride, modelOverrideFromParent),
+			modelOrigin,
+			thinkingOverride: thinkingOverrideForTask(params.agent!, 0, modelOverride, modelOverrideFromParent, modelOrigin),
 			thinkingCeiling: agentConfig.maxThinking,
 			extensionBindings: params.extensionBindings,
 			availableModels,
@@ -6215,34 +6246,47 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		let forkSessionFileForIndex: (idx?: number) => string | undefined = () => undefined;
 		let prepareForkSessionForIndex: (idx?: number) => Promise<void> = async () => {};
 		let forkThinkingOverrideForIndex: (idx?: number) => AgentConfig["thinking"] | undefined = () => undefined;
-		let prepareForkThinking = (_agentName: string, _index: number, _modelOverride?: string, _modelOverrideFromParent?: boolean): void => {};
+		let prepareForkThinking = (_agentName: string, _index: number, _modelOverride?: string, _modelOverrideFromParent?: boolean, _modelOrigin?: ModelOrigin): void => {};
 		const forkThinkingRequirements = new Map<number, boolean>();
 		const forkThinkingDowngrades = new Map<number, string>();
 		try {
 			const forkAvailableModels = contextPolicy.usesFork ? ctx.modelRegistry.getAvailable().map(toModelInfo) : [];
 			const parentModel = requestParentModel;
-			prepareForkThinking = (agentName, index, modelOverride, modelOverrideFromParent) => {
+			prepareForkThinking = (agentName, index, modelOverride, modelOverrideFromParent, storedOrigin) => {
 				const agentConfig = agents.find((agent) => agent.name === agentName);
 				if (agentConfig?.runner?.type === "external-cli" || agentConfig?.runner?.type === "external-job") {
 					forkThinkingRequirements.set(index, true);
 					return;
 				}
+				const effectiveStoredOrigin = storedOrigin === "configured" && modelOverride === undefined && agentConfig?.model === undefined
+					? undefined
+					: storedOrigin;
+				const origin = resolveModelOrigin({
+					fromParent: modelOverrideFromParent,
+					storedOrigin: effectiveStoredOrigin,
+					explicitModel: modelOverrideFromParent || effectiveStoredOrigin === "configured" ? undefined : modelOverride,
+					agentModel: agentConfig?.model,
+					parentModel,
+				});
 				const primaryModel = modelOverrideFromParent
 					? modelOverride
 					: resolveEffectiveSubagentModel(
-						modelOverride,
+						effectiveStoredOrigin === "configured" ? undefined : modelOverride,
 						agentConfig?.model,
 						parentModel,
 						forkAvailableModels,
 						agentConfig?.modelProvider ?? parentModel?.provider,
-						{ source: "inherited" },
+						{ source: origin === "explicit" ? "explicit" : "inherited" },
 					);
 				const candidates = buildModelCandidates(
 					primaryModel,
 					agentConfig?.fallbackModels,
 					forkAvailableModels,
 					agentConfig?.modelProvider ?? parentModel?.provider,
-					{ primaryModelFromParent: modelOverrideFromParent ?? inheritsParentModel(modelOverride, agentConfig?.model, parentModel) },
+					{
+						primaryModelFromParent: origin === "inherited",
+						origin,
+					},
 				);
 				forkThinkingRequirements.set(
 					index,
@@ -6360,25 +6404,25 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		}
 		const sessionDirForIndex = (idx?: number) =>
 			path.join(sessionRoot, `run-${idx ?? 0}`);
-		const forkSessionFileForTask: ForkSessionFileForTask = (agentName, idx = 0, modelOverride, modelOverrideFromParent) => {
+		const forkSessionFileForTask: ForkSessionFileForTask = (agentName, idx = 0, modelOverride, modelOverrideFromParent, modelOrigin) => {
 			if (!shouldForkAgent(contextPolicy, agentName)) return undefined;
-			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent);
+			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin);
 			return forkSessionFileForIndex(idx);
 		};
-		const prepareForkSessionForTask: PrepareForkSessionForTask = async (agentName, idx = 0, modelOverride, modelOverrideFromParent) => {
+		const prepareForkSessionForTask: PrepareForkSessionForTask = async (agentName, idx = 0, modelOverride, modelOverrideFromParent, modelOrigin) => {
 			if (!shouldForkAgent(contextPolicy, agentName)) return;
-			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent);
+			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin);
 			await prepareForkSessionForIndex(idx);
 		};
-		const forkThinkingOverrideForTask: ForkThinkingOverrideForTask = (agentName, idx = 0, modelOverride, modelOverrideFromParent) => {
+		const forkThinkingOverrideForTask: ForkThinkingOverrideForTask = (agentName, idx = 0, modelOverride, modelOverrideFromParent, modelOrigin) => {
 			if (!shouldForkAgent(contextPolicy, agentName)) return delegatedThinkingOverride;
-			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent);
+			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin);
 			const override = forkThinkingOverrideForIndex(idx);
 			if (override === "off") forkThinkingDowngrades.set(idx, agentName);
 			return override ?? delegatedThinkingOverride;
 		};
-		const childSessionFileForTask: ForkSessionFileForTask = (agentName, idx, modelOverride, modelOverrideFromParent) =>
-			forkSessionFileForTask(agentName, idx, modelOverride, modelOverrideFromParent) ?? path.join(sessionDirForIndex(idx), "session.jsonl");
+		const childSessionFileForTask: ForkSessionFileForTask = (agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin) =>
+			forkSessionFileForTask(agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin) ?? path.join(sessionDirForIndex(idx), "session.jsonl");
 		const childSessionFileForIndex = (idx?: number) =>
 			path.join(sessionDirForIndex(idx), "session.jsonl");
 		try {

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -321,15 +321,23 @@ export function resolveSubagentModelOverride(
 	const explicit = trimmed && trimmed !== INHERIT_MODEL ? trimmed : undefined;
 	if (!parentModel) throwForUnresolvedEnforcedInheritScope(options?.scope, explicit === undefined || options?.source === "inherited");
 	let resolved: string | undefined;
+	let resolvedFromRegistry = explicit === undefined;
 	if (explicit === undefined) {
 		resolved = parentModel ? `${parentModel.provider}/${parentModel.id}` : undefined;
 	} else {
-		resolved = resolveRequiredSubagentModelCandidate(explicit, availableModels, preferredProvider);
+		const candidate = resolveSubagentModelCandidate(explicit, availableModels, preferredProvider);
+		if (options?.source === "explicit") {
+			resolved = candidate ?? resolveRequiredSubagentModelCandidate(explicit, availableModels, preferredProvider);
+			throwForExplicitModelExclusion(resolved);
+			resolvedFromRegistry = true;
+		} else if (candidate) {
+			resolved = candidate;
+			resolvedFromRegistry = true;
+		} else {
+			resolved = explicit;
+		}
 	}
-	if (resolved && explicit !== undefined && options?.source === "explicit") {
-		throwForExplicitModelExclusion(resolved);
-	}
-	if (resolved && options?.scope) {
+	if (resolved && options?.scope && resolvedFromRegistry) {
 		const source: ModelSource = explicit === undefined ? "inherited" : (options.source ?? "inherited");
 		enforceModelScopes(resolved, options.scope, source, options.onWarn);
 	}
@@ -362,12 +370,33 @@ export function resolveEffectiveSubagentModel(
 	);
 }
 
+export type ModelOrigin = ModelSource | "configured";
+
 export interface BuildModelCandidatesOptions {
 	/** Fallback models warn by default and throw when strict scope enforcement is enabled. */
 	scope?: ModelScopeCheckRule | ModelScopeCheckRule[];
 	onWarn?: (violation: ModelScopeViolation) => void;
 	/** The primary model came from the running parent session, not configuration. */
 	primaryModelFromParent?: boolean;
+	/** How the primary model was selected. Explicit stays strict and does not rotate to fallbacks. */
+	origin?: ModelOrigin;
+}
+
+const ZERO_USABLE_MODEL_CANDIDATES_ERROR =
+	"No usable subagent models remain after registry, scope, and cached-exclusion filtering.";
+
+export function resolveModelOrigin(input: {
+	explicitModel?: string | boolean;
+	agentModel?: string | boolean;
+	parentModel?: ParentModel;
+	fromParent?: boolean;
+	storedOrigin?: ModelOrigin;
+}): ModelOrigin {
+	if (input.storedOrigin) return input.storedOrigin;
+	if (input.fromParent) return "inherited";
+	if (inheritsParentModel(input.explicitModel, input.agentModel, input.parentModel)) return "inherited";
+	const trimmed = typeof input.explicitModel === "string" ? input.explicitModel.trim() : "";
+	return trimmed && trimmed !== INHERIT_MODEL ? "explicit" : "configured";
 }
 
 export function inheritsParentModel(
@@ -388,36 +417,51 @@ export function buildModelCandidates(
 	options?: BuildModelCandidatesOptions,
 ): string[] {
 	if (!primaryModel) throwForUnresolvedEnforcedInheritScope(options?.scope, true);
+	const origin = options?.origin ?? (options?.primaryModelFromParent ? "inherited" : "configured");
+	const scopes = configuredScopes(options?.scope);
+	const warnCachedExclusion = (candidate: string, exclusion: NonNullable<ReturnType<typeof findModelExclusion>>) => {
+		const reason = redactSecretValues((exclusion.reason ?? "runtime-failure").replace(/[\u0000-\u001f\u007f]+/g, " ")).slice(0, 240);
+		console.warn(`[pi-subagents] Skipping model '${candidate}' due to a cached exclusion (reason: ${reason}; expires: ${new Date(exclusion.expiresAt).toISOString()}).`);
+	};
+	if (origin === "explicit" && primaryModel) {
+		const normalized = resolveRequiredSubagentModelCandidate(primaryModel.trim(), availableModels, preferredProvider);
+		throwForExplicitModelExclusion(normalized);
+		enforceModelScopes(normalized, scopes, "explicit", options?.onWarn);
+		primaryModel = normalized;
+	}
 	const seen = new Set<string>();
 	const candidates: string[] = [];
 	const rawCandidates = [primaryModel, ...(fallbackModels ?? [])];
+	let skippedPrimary: string | undefined;
 	for (let index = 0; index < rawCandidates.length; index++) {
 		const raw = rawCandidates[index];
 		if (!raw) continue;
 		const model = raw.trim();
-		const normalized = index === 0
-			? options?.primaryModelFromParent
-				? model
-				: resolveRequiredSubagentModelCandidate(model, availableModels, preferredProvider)
+		const normalized = index === 0 && (origin === "inherited" || origin === "explicit" || options?.primaryModelFromParent)
+			? model
 			: resolveSubagentModelCandidate(model, availableModels, preferredProvider);
 		if (!normalized) {
-			console.warn(`[pi-subagents] Skipping fallback model '${model}' because it is unavailable in this environment.`);
+			if (index === 0) skippedPrimary = model;
+			else console.warn(`[pi-subagents] Skipping fallback model '${model}' because it is unavailable in this environment.`);
 			continue;
 		}
 		if (seen.has(normalized)) continue;
-		const scopes = configuredScopes(options?.scope);
 		if (index > 0 || scopes.some((scope) => scope.enforce === true && scope.strict === true)) {
 			enforceModelScopes(normalized, scopes, "inherited", options?.onWarn);
 		}
 		seen.add(normalized);
 		candidates.push(normalized);
 	}
-	return filterFallbackCandidates(candidates, {
-		onExcluded(candidate, exclusion) {
-			const reason = redactSecretValues((exclusion.reason ?? "runtime-failure").replace(/[\u0000-\u001f\u007f]+/g, " ")).slice(0, 240);
-			console.warn(`[pi-subagents] Skipping model '${candidate}' due to a cached exclusion (reason: ${reason}; expires: ${new Date(exclusion.expiresAt).toISOString()}).`);
-		},
-	});
+	const resolved = filterFallbackCandidates(candidates, { onExcluded: warnCachedExclusion });
+	if (resolved.length === 0) {
+		if (skippedPrimary) resolveRequiredSubagentModelCandidate(skippedPrimary, availableModels, preferredProvider);
+		if (candidates.length > 0) throw new Error(ZERO_USABLE_MODEL_CANDIDATES_ERROR);
+		return resolved;
+	}
+	if (skippedPrimary) {
+		console.warn(`[pi-subagents] Skipping primary model '${skippedPrimary}' because it is unavailable in this environment.`);
+	}
+	return resolved;
 }
 
 const RETRYABLE_MODEL_FAILURE_PATTERNS = [

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -759,6 +759,7 @@ export interface SteeringRecoveryDescriptor {
 	model?: string;
 	modelProvider?: string;
 	modelOverrideFromParent?: boolean;
+	modelOrigin?: "explicit" | "inherited" | "configured";
 	fallbackModels?: string[];
 	fast?: boolean;
 	thinking?: string;
@@ -2336,6 +2337,8 @@ export interface RunSyncOptions {
 	fast?: boolean;
 	/** The override came from the running parent session, not configuration. */
 	modelOverrideFromParent?: boolean;
+	/** How the launch model was selected: explicit per-call, configured agent primary, or inherited parent. */
+	modelOrigin?: "explicit" | "inherited" | "configured";
 	/** LLM intent arbiter for the completion mutation guard (rescues read-only review runs). */
 	llmIntentArbiter?: import("../runs/shared/llm-intent-arbiter.ts").TaskMutationArbiter;
 	/** Override the agent's default thinking level for this run */

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -204,10 +204,7 @@ function runningSeed(...values: Array<number | undefined>): number | undefined {
 
 function runningGlyph(seed?: number): string {
 	if (seed === undefined) return STATIC_RUNNING_GLYPH;
-	// Free-running wall-clock spinner: advance ~8 fps regardless of model
-	// activity; keep the seed so parallel rows stay phase-offset.
-	const clock = Math.floor(Date.now() / 125);
-	return RUNNING_FRAMES[Math.abs(seed + clock) % RUNNING_FRAMES.length]!;
+	return RUNNING_FRAMES[Math.abs(seed) % RUNNING_FRAMES.length]!;
 }
 
 function animatedSeed(seed: number | undefined, frame: number | undefined): number | undefined {

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -27,6 +27,7 @@ import { discoverAgents } from "../../src/agents/agents.ts";
 import { runSync } from "../../src/runs/foreground/execution.ts";
 import { ACTIVE_ASYNC_CAPACITY_DIR, acquireActiveAsyncCapacity, activeAsyncCapacitySessionKey } from "../../src/runs/background/active-async-capacity.ts";
 import { deriveForkPromptCacheKey, SUBAGENT_FORK_CACHE_KEY_ENV } from "../../src/runs/shared/pi-args.ts";
+import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 
 interface LaunchResolvedExtensions {
 	version?: number;
@@ -450,9 +451,11 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 	beforeEach(() => {
 		tempDir = createTempDir();
 		mockPi.reset();
+		clearExclusions();
 	});
 
 	afterEach(() => {
+		clearExclusions();
 		removeTempDir(tempDir);
 	});
 
@@ -757,6 +760,143 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const recoveryCallArgs = readMockPiArgs(mockPi, 0);
 		assert.equal(recoveryCallArgs[recoveryCallArgs.indexOf("--tools") + 1], "read,intercom,contact_supervisor");
 		assert.deepEqual(readMockPiRequiredTools(mockPi, 0), ["read"]);
+	});
+
+	it("rejects an explicit unknown model before spawn even when a fallback exists", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		mockPi.onCall({ output: "should not spawn" });
+		const launch = executeAsyncSingle(`async-explicit-unknown-model-${Date.now().toString(36)}`, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { model: "mock/fallback", fallbackModels: ["mock/fallback"], completionGuard: false }),
+			modelOverride: "mock/does-not-exist",
+			modelOrigin: "explicit",
+			availableModels: [{ provider: "mock", id: "fallback", fullId: "mock/fallback" }],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+		assert.equal(launch.isError, true);
+		assert.match(launch.content[0]?.text ?? "", /Unknown subagent model 'mock\/does-not-exist'/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("retries configured fallbacks after a valid explicit primary fails", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [{
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "primary failed" }],
+					model: "openai/gpt-5-mini",
+					errorMessage: "rate limit exceeded",
+					usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.01 } },
+				},
+			}],
+			exitCode: 1,
+		});
+		mockPi.onCall({ output: "explicit fallback recovered" });
+		const id = `async-explicit-model-fallback-${Date.now().toString(36)}`;
+		const launch = executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { model: "mock/configured", fallbackModels: ["anthropic/claude-sonnet-4"], completionGuard: false }),
+			modelOverride: "openai/gpt-5-mini",
+			modelOrigin: "explicit",
+			availableModels: [
+				{ provider: "mock", id: "configured", fullId: "mock/configured" },
+				{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+				{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+			],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+
+		assert.equal(launch.isError, undefined, launch.content[0]?.text ?? "launch failed");
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, true);
+		assert.equal(payload.results[0]?.model, "anthropic/claude-sonnet-4");
+		assert.deepEqual(payload.results[0]?.attemptedModels, ["openai/gpt-5-mini", "anthropic/claude-sonnet-4"]);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("rejects an explicit cached-excluded model before spawn even when a fallback exists", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		recordModelFailure({ modelId: "blocked", provider: "mock", reason: "sk-secret-token-xyz" });
+		mockPi.onCall({ output: "should not spawn" });
+		const launch = executeAsyncSingle(`async-explicit-cached-excluded-${Date.now().toString(36)}`, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { model: "mock/fallback", fallbackModels: ["mock/fallback"], completionGuard: false }),
+			modelOverride: "mock/blocked",
+			modelOrigin: "explicit",
+			availableModels: [
+				{ provider: "mock", id: "blocked", fullId: "mock/blocked" },
+				{ provider: "mock", id: "fallback", fullId: "mock/fallback" },
+			],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+		assert.equal(launch.isError, true);
+		assert.match(launch.content[0]?.text ?? "", /is excluded and cannot be replaced by a fallback/);
+		assert.equal((launch.content[0]?.text ?? "").includes("sk-secret-token-xyz"), false);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("rejects an explicit non-strict out-of-scope model before spawn even when a fallback exists", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		mockPi.onCall({ output: "should not spawn" });
+		const launch = executeAsyncSingle(`async-explicit-scope-${Date.now().toString(36)}`, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { model: "mock/fallback", fallbackModels: ["mock/fallback"], completionGuard: false }),
+			modelOverride: "mock/blocked",
+			modelOrigin: "explicit",
+			availableModels: [
+				{ provider: "mock", id: "blocked", fullId: "mock/blocked" },
+				{ provider: "mock", id: "fallback", fullId: "mock/fallback" },
+			],
+			ctx: {
+				pi: { events: { emit() {} } },
+				cwd: tempDir,
+				currentSessionId: "session-1",
+				modelScope: { enforce: true, allow: ["mock/fallback"] },
+			},
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+		assert.equal(launch.isError, true);
+		assert.match(launch.content[0]?.text ?? "", /outside the configured subagent model scope/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
+	it("uses a configured fallback when the agent primary is unavailable", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const id = `async-configured-fallback-${Date.now().toString(36)}`;
+		mockPi.onCall({ output: "fallback model ran" });
+		const launch = executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { model: "mock/missing-primary", fallbackModels: ["mock/fallback"], completionGuard: false }),
+			modelOrigin: "configured",
+			availableModels: [{ provider: "mock", id: "fallback", fullId: "mock/fallback" }],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+		assert.equal(launch.isError, undefined, launch.content[0]?.text ?? "launch failed");
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, true);
+		assert.equal(payload.results[0]?.model, "mock/fallback");
+		assert.equal(mockPi.callCount(), 1);
 	});
 
 	it("rejects async thinking above maxThinking before child startup", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
@@ -4642,6 +4782,53 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(args[args.indexOf("--model") + 1], "deepseek/deepseek-v4-flash");
 	});
 
+	it("background forked runs use an available fallback when the configured primary is unavailable", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		mockPi.onCall({ output: "Forked async work" });
+		const parentSessionFile = path.join(tempDir, "parent-pruned-fallback.jsonl");
+		const forkedSessionFile = path.join(tempDir, "forked-pruned-fallback.jsonl");
+		const sessionHeader = { type: "session", version: 1, id: "child", cwd: fs.realpathSync(tempDir), parentSession: parentSessionFile };
+		fs.writeFileSync(parentSessionFile, `${JSON.stringify({ type: "session", version: 1, id: "parent", cwd: fs.realpathSync(tempDir) })}\n`, "utf-8");
+		fs.writeFileSync(forkedSessionFile, `${JSON.stringify(sessionHeader)}\n`, "utf-8");
+		const pruner = { provider: "test", id: "pruner", api: "faux", maxTokens: 1024 };
+		const ctx = {
+			...makeMinimalCtx(tempDir),
+			modelRegistry: {
+				getAvailable: () => [
+					{ provider: "mock", id: "fallback" },
+					pruner,
+				],
+				find: (provider: string, id: string) => provider === "test" && id === "pruner" ? pruner : undefined,
+				getApiKeyAndHeaders: async () => ({ ok: true as const, apiKey: "faux" }),
+			},
+			sessionManager: {
+				getSessionId: () => "session-configured-fallback",
+				getSessionFile: () => parentSessionFile,
+				getLeafId: () => "leaf-current",
+				openSession: () => ({ createBranchedSession: () => forkedSessionFile }),
+			},
+		};
+		const launch = await makeAsyncExecutor([
+			makeAgent("worker", {
+				model: "mock/missing-primary",
+				fallbackModels: ["mock/fallback"],
+				completionGuard: false,
+			}),
+		], { forkContext: { mode: "pruned", model: "test/pruner" } }).execute(
+			"forked-configured-fallback",
+			{ agent: "worker", task: "Do work", async: true, context: "fork" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		) as AsyncExecutionResult;
+		assert.ok(!launch.isError, launch.content[0]?.text);
+		assert.ok(launch.details.asyncId);
+		const payload = await readAsyncPayload(launch.details.asyncId);
+		assert.equal(payload.results[0]?.model, "mock/fallback");
+		assert.deepEqual(payload.results[0]?.attemptedModels, ["mock/fallback"]);
+		const args = readMockPiArgs(mockPi, 0);
+		assert.equal(args[args.indexOf("--model") + 1], "mock/fallback");
+	});
+
 	it("background forked runs inherit a parent model outside the registry", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		mockPi.onCall({ output: "Forked async work" });
 		const parentSessionFile = path.join(tempDir, "parent.jsonl");
@@ -4727,6 +4914,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		await readAsyncPayload(sourceId);
 		const descriptor = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, sourceId, "recovery-descriptor.json"), "utf-8"));
 		assert.equal(descriptor.modelOverrideFromParent, true);
+		assert.equal(descriptor.modelOrigin, "inherited");
 
 		mockPi.onCall({ output: "Revived async work" });
 		const result = await makeAsyncExecutor([makeAgent("worker")]).execute(

--- a/test/integration/fork-context-execution.test.ts
+++ b/test/integration/fork-context-execution.test.ts
@@ -527,6 +527,57 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		assert.equal(entries[3].thinkingLevel, "off");
 	});
 
+	it("uses an explicit Anthropic model for fork thinking preparation", async () => {
+		const parentSessionFile = path.join(tempDir, "parent.jsonl");
+		const childSessionFile = path.join(tempDir, "fork-explicit-anthropic.jsonl");
+		fs.writeFileSync(parentSessionFile, '{"type":"session","version":1,"id":"parent","timestamp":"2026-04-16T00:00:00.000Z","cwd":"/tmp"}\n', "utf-8");
+		const manager = {
+			getSessionId: () => "session-123",
+			getSessionFile: () => parentSessionFile,
+			getLeafId: () => "assistant-1",
+			openSession: () => ({
+				createBranchedSession: () => {
+					fs.writeFileSync(childSessionFile, [
+						{ type: "session", version: 1, id: "child", timestamp: "2026-04-16T00:00:00.000Z", cwd: "/tmp", parentSession: parentSessionFile },
+						{ type: "message", id: "assistant-1", parentId: null, timestamp: "2026-04-16T00:00:02.000Z", message: { role: "assistant", provider: "anthropic", api: "anthropic-messages", model: "anthropic/claude-sonnet-4-5", content: [{ type: "thinking", thinking: "private chain", thinkingSignature: "signed" }, { type: "text", text: "answer" }] } },
+					].map((entry) => JSON.stringify(entry)).join("\n") + "\n", "utf-8");
+					return childSessionFile;
+				},
+			}),
+		};
+		const executor = makeExecutorWithDiscoverAgents(() => ({
+			agents: [
+				{ name: "worker", description: "Worker", defaultContext: "fork", model: "openai/gpt-5-mini:high", thinking: "high" },
+			],
+			projectAgentsDir: null,
+		}));
+		const ctx = {
+			...makeCtx(manager),
+			modelRegistry: {
+				getAvailable: () => [
+					{ provider: "openai", id: "gpt-5-mini", api: "openai-responses", reasoning: true },
+					{ provider: "anthropic", id: "claude-sonnet-4-5", api: "anthropic-messages", reasoning: true },
+				],
+			},
+		};
+
+		const result = await executor.execute(
+			"id",
+			{ agent: "worker", task: "test", model: "anthropic/claude-sonnet-4-5:high" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+
+		assert.equal(result.isError, undefined);
+		const args = readCallArgs();
+		assert.equal(args[args.indexOf("--model") + 1], "anthropic/claude-sonnet-4-5:off");
+		const entries = fs.readFileSync(childSessionFile, "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+		assert.deepEqual(entries[1].message.content, [{ type: "text", text: "answer" }]);
+		assert.equal(entries[2].type, "thinking_level_change");
+		assert.equal(entries[2].thinkingLevel, "off");
+	});
+
 	it("forces every foreground fallback attempt off after sanitizing inherited signed thinking", async () => {
 		mockPi.reset();
 		mockPi.onCall({

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1926,7 +1926,7 @@ describe("subagent async widget rendering", () => {
 		);
 	});
 
-	it("advances running widget glyphs when the wall clock moves despite unchanged progress", () => {
+	it("keeps running widget glyphs stable across unrelated renders of the same frame", () => {
 		const originalNow = Date.now;
 		const job = {
 			asyncId: "run-stable",
@@ -1941,14 +1941,16 @@ describe("subagent async widget rendering", () => {
 		};
 		try {
 			Date.now = () => 1_000;
-			const first = buildWidgetLines([job], theme, 120);
+			const first = buildWidgetLines([job], theme, 120, false, 0);
 			Date.now = () => 1_125;
-			const second = buildWidgetLines([job], theme, 120);
+			const second = buildWidgetLines([job], theme, 120, false, 0);
+			const third = buildWidgetLines([job], theme, 120, false, 1);
 			const withoutRunningGlyphs = (lines: string[]) => lines.map((line) => line.replace(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/gu, ""));
 
-			assert.notDeepEqual(second, first);
-			assert.deepEqual(withoutRunningGlyphs(second), withoutRunningGlyphs(first), "only the running glyph should change");
-			assert.notEqual(firstGrapheme(first[1] ?? ""), firstGrapheme(second[1] ?? ""));
+			assert.deepEqual(second, first, "unrelated renders of the same frame must not retick the glyph");
+			assert.notDeepEqual(third, first);
+			assert.deepEqual(withoutRunningGlyphs(third), withoutRunningGlyphs(first), "only the running glyph should change");
+			assert.notEqual(firstGrapheme(first[1] ?? ""), firstGrapheme(third[1] ?? ""));
 		} finally {
 			Date.now = originalNow;
 		}

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -65,7 +65,7 @@ import { discardPreservedWorktrees } from "../../src/runs/shared/parallel-handof
 import { createWorktrees } from "../../src/runs/shared/worktree.ts";
 import { resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
 import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
-import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
+import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 import { createWorkflowChildPermit, workflowChildPermitConsumed } from "../../src/shared/workflow-child-permit.ts";
 import { toSubagentDelegationExecutionParams } from "../../src/slash/delegation-adapters.ts";
 
@@ -5641,6 +5641,34 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.content[0]?.text ?? "", /Invalid request: malformed payload/u);
 		assert.match(result.details.results[0]?.error ?? "", /Invalid request: malformed payload/u);
 		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("fails closed before spawn when cached exclusions leave zero launch candidates", async () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "sk-secret-token-xyz" });
+		recordModelFailure({ modelId: "claude-sonnet-4", provider: "anthropic", reason: "sk-secret-token-xyz" });
+		mockPi.onCall({ output: "should not spawn" });
+		const agents = [makeAgent("worker", {
+			model: "openai/gpt-5-mini",
+			fallbackModels: ["anthropic/claude-sonnet-4"],
+		})];
+
+		await assert.rejects(
+			runSync(tempDir, agents, "worker", "Do work", {
+				runId: "cached-exclusion-zero-candidates",
+				acceptance: false,
+				availableModels: [
+					{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" },
+					{ provider: "anthropic", id: "claude-sonnet-4", fullId: "anthropic/claude-sonnet-4" },
+				],
+			}),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.match(error.message, /No usable subagent models remain after registry, scope, and cached-exclusion filtering/);
+				assert.equal(error.message.includes("sk-secret-token-xyz"), false);
+				return true;
+			},
+		);
+		assert.equal(mockPi.callCount(), 0);
 	});
 
 	it("retries a zero-activity startup exit on the same model", async () => {

--- a/test/unit/async-recovery-descriptor.test.ts
+++ b/test/unit/async-recovery-descriptor.test.ts
@@ -74,6 +74,62 @@ describe("async recovery descriptor", () => {
 		}
 	});
 
+	it("defaults legacy non-parent models to configured origin", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-recovery-legacy-model-origin-"));
+		try {
+			fs.writeFileSync(path.join(root, "recovery-descriptor.json"), JSON.stringify({
+				version: 1,
+				runFanoutBudget: runFanoutBudget("run-legacy-model-origin"),
+				sourceRunId: "run-legacy-model-origin",
+				agent: "worker",
+				cwd: root,
+				model: "test/missing-primary",
+				fallbackModels: ["test/fallback"],
+				systemPromptMode: "replace",
+				inheritGlobalContext: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+			}), "utf-8");
+
+			const descriptor = readAsyncRecoveryDescriptor(root);
+
+			assert.equal(descriptor?.modelOrigin, "configured");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("defaults legacy parent models to inherited origin", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-recovery-legacy-parent-origin-"));
+		try {
+			fs.writeFileSync(path.join(root, "recovery-descriptor.json"), JSON.stringify({
+				version: 1,
+				runFanoutBudget: runFanoutBudget("run-legacy-parent-origin"),
+				sourceRunId: "run-legacy-parent-origin",
+				agent: "worker",
+				cwd: root,
+				model: "gateway/parent-model",
+				modelOverrideFromParent: true,
+				systemPromptMode: "replace",
+				inheritGlobalContext: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+			}), "utf-8");
+
+			const descriptor = readAsyncRecoveryDescriptor(root);
+
+			assert.equal(descriptor?.modelOrigin, "inherited");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects unresolved profile context values", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-recovery-bad-context-"));
 		try {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -213,6 +213,88 @@ describe("model fallback helpers", () => {
 		]);
 	});
 
+	it("skips an unavailable configured primary and continues to available fallbacks", () => {
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message: unknown) => warnings.push(String(message));
+		try {
+			assert.deepEqual(
+				buildModelCandidates("does-not-exist", ["anthropic/claude-sonnet-4"], availableModels),
+				["anthropic/claude-sonnet-4"],
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+		assert.deepEqual(warnings, [
+			"[pi-subagents] Skipping primary model 'does-not-exist' because it is unavailable in this environment.",
+		]);
+	});
+
+	it("fails closed when no configured candidate resolves", () => {
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message: unknown) => warnings.push(String(message));
+		try {
+			assert.throws(
+				() => buildModelCandidates("does-not-exist", ["also-unavailable"], availableModels),
+				/Unknown subagent model 'does-not-exist'/,
+			);
+			assert.throws(
+				() => buildModelCandidates("does-not-exist", undefined, availableModels),
+				/Unknown subagent model 'does-not-exist'/,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+		assert.ok(warnings.some((warning) => warning.includes("Skipping fallback model 'also-unavailable'")));
+		assert.equal(warnings.some((warning) => warning.includes("Skipping primary model 'does-not-exist'")), false);
+	});
+
+	it("keeps an explicit unknown primary strict even when fallbacks exist", () => {
+		assert.throws(
+			() => buildModelCandidates("does-not-exist", ["anthropic/claude-sonnet-4"], availableModels, undefined, { origin: "explicit" }),
+			/Unknown subagent model 'does-not-exist'/,
+		);
+	});
+
+	it("keeps eligible fallbacks after a valid explicit primary", () => {
+		assert.deepEqual(
+			buildModelCandidates("openai/gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels, undefined, { origin: "explicit" }),
+			["openai/gpt-5-mini", "anthropic/claude-sonnet-4"],
+		);
+	});
+
+	it("keeps an explicit cached-excluded primary strict even when fallbacks exist", () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "sk-secret-token-xyz" });
+		assert.throws(
+			() => buildModelCandidates("openai/gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels, undefined, { origin: "explicit" }),
+			/Requested subagent model 'openai\/gpt-5-mini' is excluded and cannot be replaced by a fallback/,
+		);
+	});
+
+	it("rejects an explicit non-strict out-of-scope primary before fallbacks", () => {
+		assert.throws(
+			() => buildModelCandidates("anthropic/claude-sonnet-4", ["openai/gpt-5-mini"], availableModels, undefined, {
+				origin: "explicit",
+				scope: { enforce: true, allow: ["openai/*"] },
+			}),
+			/outside the configured subagent model scope/,
+		);
+	});
+
+	it("fails closed with a sanitized error when cached exclusions leave zero candidates", () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "sk-secret-token-xyz" });
+		recordModelFailure({ modelId: "claude-sonnet-4", provider: "anthropic", reason: "sk-secret-token-xyz" });
+		assert.throws(
+			() => buildModelCandidates("openai/gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
+			(error: unknown) => {
+				const message = String(error);
+				return /No usable subagent models remain after registry, scope, and cached-exclusion filtering/.test(message)
+					&& !message.includes("sk-secret-token-xyz");
+			},
+		);
+	});
+
 	it("trusts an inherited parent model outside the registry", () => {
 		assert.deepEqual(
 			buildModelCandidates("gateway/parent-model", undefined, availableModels, undefined, { primaryModelFromParent: true }),
@@ -342,18 +424,18 @@ describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () 
 
 	it("rejects explicit models that the active registry cannot resolve", () => {
 		assert.throws(
-			() => resolveSubagentModelOverride("does-not-exist", parentModel, availableModels),
+			() => resolveSubagentModelOverride("does-not-exist", parentModel, availableModels, undefined, { source: "explicit" }),
 			/Unknown subagent model 'does-not-exist'/,
 		);
 		assert.throws(
-			() => resolveSubagentModelOverride("does-not-exist:high", parentModel, availableModels),
+			() => resolveSubagentModelOverride("does-not-exist:high", parentModel, availableModels, undefined, { source: "explicit" }),
 			/Unknown subagent model 'does-not-exist:high'/,
 		);
 	});
 
 	it("suggests a unique alternate provider without resolving across providers", () => {
 		assert.throws(
-			() => resolveSubagentModelOverride("openai/claude-sonnet-4:high", parentModel, availableModels),
+			() => resolveSubagentModelOverride("openai/claude-sonnet-4:high", parentModel, availableModels, undefined, { source: "explicit" }),
 			/Unknown subagent model 'openai\/claude-sonnet-4:high'.*Did you mean 'anthropic\/claude-sonnet-4:high'\?/,
 		);
 	});
@@ -364,11 +446,11 @@ describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () 
 			{ provider: "github-copilot", id: "claude-sonnet-4", fullId: "github-copilot/claude-sonnet-4" },
 		];
 		assert.throws(
-			() => resolveSubagentModelOverride("openai/claude-sonnet-4", parentModel, ambiguous),
+			() => resolveSubagentModelOverride("openai/claude-sonnet-4", parentModel, ambiguous, undefined, { source: "explicit" }),
 			(error: unknown) => !String(error).includes("Did you mean"),
 		);
 		assert.throws(
-			() => resolveSubagentModelOverride("openai/does-not-exist", parentModel, availableModels),
+			() => resolveSubagentModelOverride("openai/does-not-exist", parentModel, availableModels, undefined, { source: "explicit" }),
 			(error: unknown) => !String(error).includes("Did you mean"),
 		);
 	});
@@ -421,6 +503,20 @@ describe("resolveEffectiveSubagentModel", () => {
 		assert.equal(
 			resolveEffectiveSubagentModel(undefined, "gpt-5-mini", undefined, registry, "gpu-b"),
 			"gpu-b/gpt-5-mini",
+		);
+	});
+
+	it("does not throw for an unavailable inherited agent model", () => {
+		assert.equal(
+			resolveEffectiveSubagentModel(undefined, "does-not-exist", { provider: "openai", id: "gpt-5-mini" }, availableModels),
+			"does-not-exist",
+		);
+	});
+
+	it("still throws for an explicit unknown per-call model", () => {
+		assert.throws(
+			() => resolveEffectiveSubagentModel("does-not-exist", "openai/gpt-5-mini", { provider: "openai", id: "gpt-5-mini" }, availableModels),
+			/Unknown subagent model 'does-not-exist'/,
 		);
 	});
 });

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -7,6 +7,7 @@ import { registerSubagentCapabilityCeiling, resolveSubagentCapabilityCeiling } f
 import { resolveSubagentLaunchContract, SUBAGENT_LAUNCH_CONTRACT_VERSION } from "../../src/api/preflight.ts";
 import { clearSkillCache } from "../../src/agents/skills.ts";
 import { computeMcpServerHash } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
+import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 import { TEMP_ARTIFACTS_DIR } from "../../src/shared/types.ts";
 
 let tempDir = "";
@@ -59,10 +60,12 @@ describe("public launch contract preflight", () => {
 		process.env.USERPROFILE = home;
 		process.env.PI_CODING_AGENT_DIR = path.join(home, ".pi", "agent");
 		clearSkillCache();
+		clearExclusions();
 	});
 
 	afterEach(() => {
 		clearSkillCache();
+		clearExclusions();
 		if (previousHome === undefined) delete process.env.HOME;
 		else process.env.HOME = previousHome;
 		if (previousUserProfile === undefined) delete process.env.USERPROFILE;
@@ -296,6 +299,108 @@ Project prompt.
 				availableModels: [{ provider: "test", id: "primary", fullId: "test/primary" }],
 			}),
 			/Unknown subagent model 'fast'/,
+		);
+	});
+
+	it("uses an available configured fallback when the agent primary is unavailable", async () => {
+		const cwd = path.join(tempDir, "repo-unavailable-primary");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "scout.md"), `---
+name: scout
+description: Project scout
+model: test/missing-primary
+fallbackModels:
+  - test/fallback
+---
+Project prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({
+			agent: "scout",
+			cwd,
+			availableModels: [{ provider: "test", id: "fallback", fullId: "test/fallback" }],
+		});
+
+		assert.equal(result.ok, true);
+		assert.deepEqual(result.contract.modelCandidates, ["test/fallback"]);
+	});
+
+	it("rejects an explicit unknown per-call model even when a fallback is configured", async () => {
+		const cwd = path.join(tempDir, "repo-explicit-unknown-model");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "scout.md"), `---
+name: scout
+description: Project scout
+model: test/missing-primary
+fallbackModels:
+  - test/fallback
+---
+Project prompt.
+`);
+
+		await assert.rejects(
+			resolveSubagentLaunchContract({
+				agent: "scout",
+				cwd,
+				model: "test/does-not-exist",
+				availableModels: [{ provider: "test", id: "fallback", fullId: "test/fallback" }],
+			}),
+			/Unknown subagent model 'test\/does-not-exist'/,
+		);
+	});
+
+	it("fails closed when every configured candidate is unavailable", async () => {
+		const cwd = path.join(tempDir, "repo-all-unavailable-models");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "scout.md"), `---
+name: scout
+description: Project scout
+model: test/missing-primary
+fallbackModels:
+  - test/missing-fallback
+---
+Project prompt.
+`);
+
+		await assert.rejects(
+			resolveSubagentLaunchContract({
+				agent: "scout",
+				cwd,
+				availableModels: [{ provider: "test", id: "other", fullId: "test/other" }],
+			}),
+			/Unknown subagent model 'test\/missing-primary'/,
+		);
+	});
+
+	it("fails closed when cached exclusions leave zero launch candidates", async () => {
+		const cwd = path.join(tempDir, "repo-cached-excluded-models");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "scout.md"), `---
+name: scout
+description: Project scout
+model: test/primary
+fallbackModels:
+  - test/fallback
+---
+Project prompt.
+`);
+		recordModelFailure({ modelId: "primary", provider: "test", reason: "sk-secret-token-xyz" });
+		recordModelFailure({ modelId: "fallback", provider: "test", reason: "sk-secret-token-xyz" });
+
+		await assert.rejects(
+			resolveSubagentLaunchContract({
+				agent: "scout",
+				cwd,
+				availableModels: [
+					{ provider: "test", id: "primary", fullId: "test/primary" },
+					{ provider: "test", id: "fallback", fullId: "test/fallback" },
+				],
+			}),
+			(error: unknown) => {
+				const message = String(error);
+				return /No usable subagent models remain after registry, scope, and cached-exclusion filtering/.test(message)
+					&& !message.includes("sk-secret-token-xyz");
+			},
 		);
 	});
 

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -191,7 +191,7 @@ test("widget render keys keep compact payloads quiet and expanded payloads fresh
 	assert.notEqual(widgetRenderKey(warningDetailChange, true), widgetRenderKey(preflightJob, true));
 });
 
-test("seeded running glyphs advance at wall-clock frame boundaries while unseeded glyphs stay static", () => {
+test("seeded running glyphs stay stable until the supplied animation frame advances", () => {
 	const originalNow = Date.now;
 	const runningGlyph = (lines: string[]): string => lines
 		.map((line) => line.match(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏●]/u)?.[0])
@@ -212,16 +212,18 @@ test("seeded running glyphs advance at wall-clock frame boundaries while unseede
 
 	try {
 		Date.now = () => 1_000;
-		const seededBeforeBoundary = runningGlyph(buildWidgetLines([seededJob], theme, 180));
-		const unseededBeforeBoundary = runningGlyph(buildWidgetLines([unseededJob], theme, 180));
+		const seededFrame0 = runningGlyph(buildWidgetLines([seededJob], theme, 180, false, 0));
+		const unseededBefore = runningGlyph(buildWidgetLines([unseededJob], theme, 180));
 
 		Date.now = () => 1_125;
-		const seededAfterBoundary = runningGlyph(buildWidgetLines([seededJob], theme, 180));
-		const unseededAfterBoundary = runningGlyph(buildWidgetLines([unseededJob], theme, 180));
+		const seededSameFrame = runningGlyph(buildWidgetLines([seededJob], theme, 180, false, 0));
+		const unseededAfter = runningGlyph(buildWidgetLines([unseededJob], theme, 180));
+		const seededNextFrame = runningGlyph(buildWidgetLines([seededJob], theme, 180, false, 1));
 
-		assert.notEqual(seededAfterBoundary, seededBeforeBoundary);
-		assert.equal(unseededAfterBoundary, unseededBeforeBoundary);
-		assert.equal(unseededBeforeBoundary, "●");
+		assert.equal(seededSameFrame, seededFrame0);
+		assert.equal(unseededAfter, unseededBefore);
+		assert.equal(unseededBefore, "●");
+		assert.notEqual(seededNextFrame, seededFrame0);
 	} finally {
 		Date.now = originalNow;
 	}

--- a/test/unit/widget-nested-render.test.ts
+++ b/test/unit/widget-nested-render.test.ts
@@ -151,12 +151,14 @@ describe("nested widget rendering", () => {
 		assert.match(expanded, /\[\d{2}:\d{2}:\d{2}\] . completed-step: Finalize report · completed/);
 	});
 
-	it("keeps event-time timestamps stable while running glyphs use wall time", () => {
+	it("keeps event-time timestamps stable while nested running glyphs use the supplied frame", () => {
 		const state = job(nested("nested-reviewer", "root-run", "running", { currentTool: "read", currentToolStartedAt: 0 }));
-		const first = withMockedDateNow(0, () => buildWidgetLines([state], theme as any, 120, true));
-		const second = withMockedDateNow(1_125, () => buildWidgetLines([state], theme as any, 120, true));
-		assert.notDeepEqual(second, first);
-		assert.deepEqual(withoutRunningGlyphs(second), withoutRunningGlyphs(first));
+		const first = withMockedDateNow(0, () => buildWidgetLines([state], theme as any, 120, true, 0));
+		const unrelatedRender = withMockedDateNow(125, () => buildWidgetLines([state], theme as any, 120, true, 0));
+		const nextFrame = withMockedDateNow(1_000, () => buildWidgetLines([state], theme as any, 120, true, 1));
+		assert.deepEqual(unrelatedRender, first);
+		assert.notDeepEqual(nextFrame, first);
+		assert.deepEqual(withoutRunningGlyphs(nextFrame), withoutRunningGlyphs(first));
 	});
 
 	it("rerenders when only nested state changes", () => {

--- a/test/unit/windows-hide-spawn.test.ts
+++ b/test/unit/windows-hide-spawn.test.ts
@@ -16,6 +16,18 @@ function assertNestedPiSpawnHidesWindows(sourcePath: string): void {
 }
 
 describe("nested child Pi process visibility", () => {
+	it("publishes detached terminal results before terminal status", () => {
+		const sourcePath = "src/runs/background/subagent-runner.ts";
+		const source = fs.readFileSync(path.join(projectRoot, sourcePath), "utf-8");
+		const terminalBlockStart = source.indexOf("\tstatusPayload.endedAt = runEndedAt;");
+		const resultWrite = source.indexOf("\trunPersistence.write(resultPath, {", terminalBlockStart);
+		const terminalStatusWrite = source.indexOf("\twriteStatusPayload();", terminalBlockStart);
+
+		assert.ok(terminalBlockStart >= 0, `${sourcePath} terminal block should exist`);
+		assert.ok(resultWrite > terminalBlockStart, `${sourcePath} should publish the terminal result`);
+		assert.ok(terminalStatusWrite > resultWrite, `${sourcePath} must not expose terminal status before the terminal result`);
+	});
+
 	it("hides foreground child Pi process windows on Windows", () => {
 		assertNestedPiSpawnHidesWindows("src/runs/foreground/execution.ts");
 	});


### PR DESCRIPTION
## Summary

- preserve explicit, configured, and inherited model origins through preflight, foreground, async recovery, and fork preparation
- allow unavailable configured primaries and valid explicit-primary runtime failures to use eligible fallbacks while keeping invalid explicit models fail-closed
- remove hidden 125 ms async spinner redraws while preserving progress refreshes and one-second animation frames

## Validation

- `npm run typecheck`
- `npm test`: 2763 passed, 4 skipped
- `npm run test:integration`: 875 passed, 6 skipped
- `npm run test:e2e`: exits successfully; the repository's intentional local coding-agent shim registered zero optional real-session tests
- GitHub Actions Bun parity subset: 21 passed
- independent final review: approved with the E2E shim limitation recorded above

## Notes

Explicit unknown, cached-excluded, and out-of-scope per-call models still fail before child spawn. A valid explicit model keeps configured fallbacks for retryable provider failures. Pruned and regular fork preparation preserve the selected model origin and thinking-safety behavior.
