### PR TITLE
perf: reduce async widget update churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Make `bg_wait` the primary background-work wait tool, retain `subagent_wait` as a deprecated compatibility alias, and stop ordinary async handoffs from encouraging redundant wait subscriptions (#1729).
 
 ### Fixed
+- Reduce async widget update churn during running workflows by repainting animation ticks without reinstalling the widget and coalescing close status refreshes (#1726).
 - Avoid repeated staged workflow projection during widget rendering. Thanks [@kkkhs](https://github.com/kkkhs) for #1730.
 - Preserve durable file-only child reports and continue read-only workflow review after malformed acceptance metadata (#1724).
 

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -73,6 +73,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const steeringNoticeSeen = new Map<string, number>();
 	const jobWatchers = new Map<string, { watchers: Map<string, fs.FSWatcher>; retryTimer?: ReturnType<typeof setTimeout> }>();
 	const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	let widgetRerenderTimer: ReturnType<typeof setTimeout> | undefined;
 	const runningJobIds = new Set<string>();
 	const externalJobBridgeRuns = new Set<string>();
 	const externalJobBridgeEligibility = (steps: AsyncJobState["steps"]): "required" | "not-required" | "unknown" => {
@@ -108,9 +109,22 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	const rerenderLastWidget = (jobs = Array.from(state.asyncJobs.values())) => {
 		withLastUiContext((ctx) => rerenderWidget(ctx, jobs));
 	};
+	const scheduleLastWidgetRerender = () => {
+		if (widgetRerenderTimer) return;
+		widgetRerenderTimer = setTimeout(() => {
+			widgetRerenderTimer = undefined;
+			rerenderLastWidget();
+		}, EVENT_REFRESH_DEBOUNCE_MS);
+		widgetRerenderTimer.unref?.();
+	};
 	const requestLastWidgetRender = () => {
 		if (options.widgetEnabled === false) return;
-		rerenderLastWidget();
+		withLastUiContext((ctx) => {
+			if (state.widgetsSuspended) return;
+			const requestRender = (ctx.ui as { requestRender?: () => void }).requestRender;
+			if (requestRender) requestRender.call(ctx.ui);
+			else renderWidget(ctx, Array.from(state.asyncJobs.values()));
+		});
 	};
 	const refreshWidget = (ctx: ExtensionContext) => rerenderWidget(ctx);
 	const restoredControlEventCursor = (asyncDir: string) => {
@@ -511,7 +525,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		const timer = setTimeout(() => {
 			refreshTimers.delete(asyncId);
 			const job = state.asyncJobs.get(asyncId);
-			if (job && refreshJob(job)) rerenderLastWidget();
+			if (job && refreshJob(job)) scheduleLastWidgetRerender();
 		}, delayMs);
 		timer.unref?.();
 		refreshTimers.set(asyncId, timer);
@@ -716,6 +730,8 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		for (const asyncId of jobWatchers.keys()) closeJobWatcher(asyncId);
 		for (const timer of refreshTimers.values()) clearTimeout(timer);
 		refreshTimers.clear();
+		if (widgetRerenderTimer) clearTimeout(widgetRerenderTimer);
+		widgetRerenderTimer = undefined;
 		runningJobIds.clear();
 		externalJobBridgeRuns.clear();
 	};

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -2386,19 +2386,29 @@ function fitAdaptiveWidgetLines(jobs: AsyncJobState[], buildLines: () => string[
 	return rendered.lines;
 }
 
-function buildWidgetComponent(jobs: AsyncJobState[], expanded: boolean): (_tui: unknown, theme: Theme) => Component {
+function buildWidgetComponent(jobs: AsyncJobState[], isExpanded: () => boolean): (_tui: unknown, theme: Theme) => Component {
 	return (_tui, theme) => {
 		const container = new Container();
+		let cachedRenderWidth: number | undefined;
+		let cachedFrame: number | undefined;
+		let cachedExpanded: boolean | undefined;
+		let cachedLines: string[] | undefined;
 		container.render = (renderWidth: number): string[] => {
-			const width = Math.max(0, renderWidth - 2);
 			const frame = Math.floor(Date.now() / WIDGET_ANIMATION_INTERVAL_MS);
+			const expanded = isExpanded();
+			if (cachedLines && cachedRenderWidth === renderWidth && cachedFrame === frame && cachedExpanded === expanded) return cachedLines;
+			const width = Math.max(0, renderWidth - 2);
 			const projectionFor = workflowWidgetProjectionLookup();
 			const buildLines = (): string[] => expanded
 				? buildWidgetLinesWithProjection(jobs, theme, width, true, frame, projectionFor)
 				: jobs.length === 1
 					? compactSingleWidgetLines(jobs[0]!, theme, width, frame, projectionFor(jobs[0]!))
 					: buildWidgetLinesWithProjection(jobs, theme, width, false, frame, projectionFor);
-			return fitAdaptiveWidgetLines(jobs, buildLines, theme, width, expanded, frame, projectionFor).map((line) => paddedWidgetLine(line, renderWidth));
+			cachedRenderWidth = renderWidth;
+			cachedFrame = frame;
+			cachedExpanded = expanded;
+			cachedLines = fitAdaptiveWidgetLines(jobs, buildLines, theme, width, expanded, frame, projectionFor).map((line) => paddedWidgetLine(line, renderWidth));
+			return cachedLines;
 		};
 		return container;
 	};
@@ -2492,7 +2502,7 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 		ctx.ui.setWidget(WIDGET_KEY, encodeAsyncStatusSnapshotWidget(jobs));
 		return;
 	}
-	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui.getToolsExpanded?.() ?? false));
+	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, () => ctx.ui.getToolsExpanded?.() ?? false));
 }
 
 function renderSingleCompact(

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -1044,7 +1044,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("rebuilds unchanged running widgets for quiet animation ticks and stops at terminal status", async () => {
+	it("requests quiet animation repaints without rebuilding widgets and stops at terminal status", async () => {
 		const asyncRoot = createTempDir("pi-async-job-tracker-");
 		let tracker: ReturnType<AsyncJobTrackerModule["createAsyncJobTracker"]> | undefined;
 		try {
@@ -1072,7 +1072,7 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 
 			const requestsAfterStart = ui.renderRequests;
 			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.updatedAt === 2000, "first status load");
-			assert.ok(ui.renderRequests > requestsAfterStart, "first status load should redraw the widget");
+			await waitForCondition(() => ui.renderRequests > requestsAfterStart, "first status load widget redraw");
 
 			const requestsAfterStatusLoaded = ui.renderRequests;
 			const widgetsAfterStatusLoaded = ui.widgets.length;
@@ -1089,12 +1089,12 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 				},
 			})}\n`, "utf-8");
 			await waitForCondition(() => recorder.events.some((event) => event.channel === "subagent:control-event"), "control event delivery");
-			await waitForCondition(() => ui.widgets.length > widgetsAfterStatusLoaded, "running widget cadence rebuild");
-			assert.ok(ui.renderRequests > requestsAfterStatusLoaded, "running widget cadence rebuild should request a repaint when the bridge supports it");
+			await waitForCondition(() => ui.renderRequests > requestsAfterStatusLoaded, "running widget cadence repaint");
+			assert.equal(ui.widgets.length, widgetsAfterStatusLoaded, "animation-only ticks should not replace the widget component when the bridge supports repaint requests");
 
 			writeStatus(3000, 1);
 			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.toolCount === 1, "changed status load");
-			assert.ok(ui.widgets.length > widgetsAfterStatusLoaded, "changed status should replace the widget component");
+			await waitForCondition(() => ui.widgets.length > widgetsAfterStatusLoaded, "changed status widget replacement");
 
 			writeStatus(4000, 1, "complete");
 			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.status === "complete", "terminal status load");
@@ -1103,6 +1103,56 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			await new Promise((resolve) => setTimeout(resolve, 35));
 			assert.equal(ui.widgets.length, widgetsAfterTerminal, "terminal-only jobs must not rebuild on the cadence");
 			assert.equal(ui.renderRequests, requestsAfterTerminal, "terminal-only jobs must not request cadence repaints");
+		} finally {
+			tracker?.resetJobs();
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("coalesces close per-job status refreshes into one widget replacement", async () => {
+		const asyncRoot = createTempDir("pi-async-job-tracker-coalesce-");
+		let tracker: ReturnType<AsyncJobTrackerModule["createAsyncJobTracker"]> | undefined;
+		try {
+			const runA = path.join(asyncRoot, "run-a");
+			const runB = path.join(asyncRoot, "run-b");
+			fs.mkdirSync(runA, { recursive: true });
+			fs.mkdirSync(runB, { recursive: true });
+			const writeStatus = (runDir: string, id: string, lastUpdate: number) => fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+				runId: id,
+				mode: "single",
+				state: "running",
+				startedAt: 1000,
+				lastUpdate,
+				steps: [{ agent: id, status: "running", startedAt: 1000 }],
+			}), "utf-8");
+			writeStatus(runA, "run-a", 2000);
+			writeStatus(runB, "run-b", 2000);
+
+			const watchCallbacks: Array<(event: string, file?: string) => void> = [];
+			const watch: typeof fs.watch = ((watchPath: fs.PathLike, listener: fs.WatchListener<string>) => {
+				if (String(watchPath).includes("run-")) watchCallbacks.push((event, file) => listener(event as fs.WatchEventType, file));
+				return { close() {}, on() { return this; }, unref() {} } as unknown as fs.FSWatcher;
+			}) as typeof fs.watch;
+			const state = createState();
+			const ui = createUiContext();
+			const recorder = createEventRecorder();
+			tracker = createTracker(recorder.pi, state as never, asyncRoot, { pollIntervalMs: 10000, watch });
+			tracker.resetJobs(ui.ctx as never);
+			tracker.handleStarted({ id: "run-a", asyncDir: runA, agent: "worker" });
+			tracker.handleStarted({ id: "run-b", asyncDir: runB, agent: "reviewer" });
+			await waitForCondition(() => state.asyncJobs.get("run-a")?.updatedAt === 2000 && state.asyncJobs.get("run-b")?.updatedAt === 2000, "initial status loads");
+			await waitForCondition(() => watchCallbacks.length > 0, "watch callbacks");
+			await new Promise((resolve) => setTimeout(resolve, 60));
+			const widgetsAfterInitial = ui.widgets.length;
+
+			writeStatus(runA, "run-a", 3000);
+			writeStatus(runB, "run-b", 3000);
+			for (const callback of [...watchCallbacks]) callback("change", "status.json");
+
+			await waitForCondition(() => state.asyncJobs.get("run-a")?.updatedAt === 3000 && state.asyncJobs.get("run-b")?.updatedAt === 3000, "coalesced status loads");
+			await waitForCondition(() => ui.widgets.length === widgetsAfterInitial + 1, "coalesced widget replacement");
+			await new Promise((resolve) => setTimeout(resolve, 60));
+			assert.equal(ui.widgets.length, widgetsAfterInitial + 1, "close status refreshes should share one widget replacement");
 		} finally {
 			tracker?.resetJobs();
 			removeTempDir(asyncRoot);

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -1103,6 +1103,38 @@ describe("subagent async widget rendering", () => {
 		resetWidgetLayout();
 	});
 
+	it("updates component expansion state without reinstalling the widget", () => {
+		resetWidgetLayout();
+		withStdoutSize(20, 120, () => {
+			const ui = createUiContext();
+			let expanded = false;
+			ui.ctx.ui.getToolsExpanded = () => expanded;
+			renderWidget(ui.ctx as never, [{
+				asyncId: "run-toggle-expanded",
+				asyncDir: "/tmp/run-toggle-expanded",
+				status: "running",
+				mode: "parallel",
+				agents: ["reviewer"],
+				activeParallelGroup: true,
+				runningSteps: 1,
+				completedSteps: 0,
+				stepsTotal: 1,
+				steps: [{ index: 0, agent: "reviewer", status: "running", currentTool: "read" }],
+			}]);
+			const component = (ui.widgets.at(-1) as (_tui: unknown, widgetTheme: typeof theme) => { render(width: number): string[] })(undefined, theme);
+
+			const collapsed = component.render(180).join("\n");
+			expanded = true;
+			const expandedText = component.render(180).join("\n");
+
+			assert.match(collapsed, /subagents \(1\/1 running\)/);
+			assert.doesNotMatch(collapsed, /parallel group · 1 agent running/);
+			assert.match(expandedText, /parallel group · 1 agent running · 0\/1 done/);
+			assert.match(expandedText, /reviewer · running/);
+		});
+		resetWidgetLayout();
+	});
+
 	it("shows per-agent detail for active async parallel widget rows", () => {
 		const now = Date.now();
 		const lines = buildWidgetLines([
@@ -1968,6 +2000,40 @@ describe("subagent async widget rendering", () => {
 				firstRunningGlyph(second.find((line) => line.includes("reviewer · running")) ?? ""),
 				"step glyph should advance",
 			);
+		} finally {
+			Date.now = originalNow;
+			renderWidget(createUiContext().ctx as never, []);
+		}
+	});
+
+	it("memoizes component render output by width and animation frame", () => {
+		const originalNow = Date.now;
+		let themeCalls = 0;
+		const countingTheme = {
+			fg: (_name: string, text: string) => {
+				themeCalls += 1;
+				return text;
+			},
+			bold: (text: string) => text,
+		};
+		try {
+			Date.now = () => 1_000;
+			const ui = createUiContext();
+			renderWidget(ui.ctx as never, [{ asyncId: "run-stable", asyncDir: "/tmp/run", status: "running", agents: ["scout"], updatedAt: 1_000 }]);
+			const component = (ui.widgets.at(-1) as (_tui: unknown, widgetTheme: typeof theme) => { render(width: number): string[] })(undefined, countingTheme);
+			const first = component.render(180);
+			const callsAfterFirst = themeCalls;
+
+			assert.equal(component.render(180), first);
+			assert.equal(themeCalls, callsAfterFirst, "same width and frame should reuse the rendered lines");
+
+			component.render(120);
+			assert.ok(themeCalls > callsAfterFirst, "a width change should rebuild lines");
+			const callsAfterWidthChange = themeCalls;
+
+			Date.now = () => 2_000;
+			component.render(120);
+			assert.ok(themeCalls > callsAfterWidthChange, "an animation-frame change should rebuild lines");
 		} finally {
 			Date.now = originalNow;
 			renderWidget(createUiContext().ctx as never, []);


### PR DESCRIPTION
Fixes #1726.

## Summary
- repaint running async widget animation ticks through `ctx.ui.requestRender()` when available instead of reinstalling the widget component
- keep the legacy no-`requestRender` fallback rebuilding path
- coalesce close per-job status refreshes into one widget replacement
- memoize component widget rendering by width, animation frame, and expanded state

## Validation
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts test/integration/render-widget.test.ts` (111 pass)
- `npm run typecheck`
- `git diff --check origin/main..HEAD`
- fresh reviewer: No issues found (`issue-1726-widget-churn-review-754345d.md`)