### PR TITLE
perf: coalesce structured delegation heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Coalesce unchanged structured-delegation heartbeat snapshots while retaining ordinary foreground heartbeats and complete terminal responses (#1739).
 - Clarify that `fallbackModels` handles provider/model timeouts but not run-level `timeoutMs` / `maxRuntimeMs` expiry. Thanks [@kaplan-shaked](https://github.com/kaplan-shaked) for #1745.
 - Pass the requested session and timestamp as optional context to background-work providers so they can avoid listing unrelated sessions while preserving strict snapshot validation (#1737).
 - Avoid repeating external-run display normalization during Fleet refresh while retaining validation for externally replaced or mutated records (#1736).

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -233,6 +233,8 @@ Results:
 - Result mode is explicit. Text remains literal even when it looks like JSON. Structured mode returns the separately captured, schema-validated JSON value.
 - Terminal usage reports input, output, cache-read, cache-write, cost, turns, tool calls, and duration alongside the effective model and thinking level when known.
 
+Live update events are bounded progress snapshots, not patches, so consumers should replace the prior snapshot rather than merge it as a delta. Structured delegation coalesces heartbeats whose delegation-visible progress and recent output are unchanged; a duration-only heartbeat therefore does not produce another update. The terminal response remains authoritative for the complete result, error, and final usage details.
+
 Bounds:
 
 - Schemas are capped at 64 KiB; tasks and returned text/structured values are capped at 1 MiB, with smaller bounds on identity/configuration strings and a maximum `timeoutMs` of 2,147,483,647.

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -49,6 +49,7 @@ import {
 	formatEmptyTerminalAssistantResponseError,
 	extractToolArgsPreview,
 	extractTextFromContent,
+	MAX_STREAMED_RECENT_TOOLS,
 	boundStreamedRecentTools,
 	boundStreamedRecentOutput,
 	boundStreamedToolCalls,
@@ -295,6 +296,55 @@ function snapshotStreamResult(result: SingleResult, progress: AgentProgress): Si
 	snapshot.messages = undefined;
 	snapshot.toolCalls = boundStreamedToolCalls(result);
 	return snapshot;
+}
+
+interface StructuredDelegationProgressState {
+	currentTool?: string;
+	currentToolArgs?: string;
+	recentOutput: string[];
+	recentTools: Array<{ tool: string; args: string }>;
+	activityState?: AgentProgress["activityState"];
+	model?: string;
+	toolCount: number;
+	tokens: number;
+}
+
+function captureStructuredDelegationProgressState(progress: AgentProgress, result: SingleResult): StructuredDelegationProgressState {
+	return {
+		currentTool: progress.currentTool,
+		currentToolArgs: progress.currentToolArgs,
+		recentOutput: [...progress.recentOutput],
+		recentTools: progress.recentTools.slice(-MAX_STREAMED_RECENT_TOOLS).map(({ tool, args }) => ({ tool, args })),
+		activityState: progress.activityState,
+		model: progress.model ?? result.model,
+		toolCount: progress.toolCount,
+		tokens: progress.tokens,
+	};
+}
+
+function structuredDelegationProgressChanged(
+	previous: StructuredDelegationProgressState,
+	progress: AgentProgress,
+	result: SingleResult,
+): boolean {
+	if (previous.currentTool !== progress.currentTool
+		|| previous.currentToolArgs !== progress.currentToolArgs
+		|| previous.activityState !== progress.activityState
+		|| previous.model !== (progress.model ?? result.model)
+		|| previous.toolCount !== progress.toolCount
+		|| previous.tokens !== progress.tokens
+		|| previous.recentOutput.length !== progress.recentOutput.length) return true;
+	for (let index = 0; index < progress.recentOutput.length; index++) {
+		if (previous.recentOutput[index] !== progress.recentOutput[index]) return true;
+	}
+	const recentToolsStart = Math.max(0, progress.recentTools.length - MAX_STREAMED_RECENT_TOOLS);
+	if (previous.recentTools.length !== progress.recentTools.length - recentToolsStart) return true;
+	for (let index = recentToolsStart; index < progress.recentTools.length; index++) {
+		const previousTool = previous.recentTools[index - recentToolsStart];
+		const currentTool = progress.recentTools[index];
+		if (previousTool?.tool !== currentTool?.tool || previousTool?.args !== currentTool?.args) return true;
+	}
+	return false;
 }
 
 const AFTER_COMPACTION_SETTLEMENT = Symbol("afterCompactionSettlement");
@@ -936,6 +986,7 @@ async function runSingleAttempt(
 		};
 
 
+		let lastStructuredDelegationProgressState: StructuredDelegationProgressState | undefined;
 		const emitUpdateSnapshot = (text: string) => {
 			if (!options.onUpdate || processClosed) return;
 			const progressSnapshot = snapshotProgress(progress);
@@ -955,6 +1006,10 @@ async function runSingleAttempt(
 		const fireUpdate = () => {
 			if (!options.onUpdate || processClosed) return;
 			progress.durationMs = Date.now() - startTime;
+			if (options.suppressUnchangedDelegationUpdates) {
+				if (lastStructuredDelegationProgressState && !structuredDelegationProgressChanged(lastStructuredDelegationProgressState, progress, result)) return;
+				lastStructuredDelegationProgressState = captureStructuredDelegationProgressState(progress, result);
+			}
 			const output = result.timedOut && result.finalOutput ? result.finalOutput : getFinalOutput(result.messages ?? []);
 			emitUpdateSnapshot(output || "(running...)");
 		};

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -447,6 +447,8 @@ interface ExecutionContextData {
 	effectiveAsync: boolean;
 	asyncRunId: string;
 	controlConfig: ResolvedControlConfig;
+	/** Structured delegation consumers do not need duration-only heartbeat snapshots. */
+	suppressUnchangedDelegationUpdates?: boolean;
 	intercomBridge: IntercomBridgeState;
 	nestedRoute?: NestedRouteInfo;
 	timeoutMs?: number;
@@ -3552,6 +3554,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		onUpdate,
 		controlConfig,
 		contextPolicy,
+		suppressUnchangedDelegationUpdates,
 	} = data;
 	let lane: import("../../shared/types.ts").WorkflowLaneMetadata | undefined;
 	try {
@@ -3724,6 +3727,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			waitToolEnabled: deps.waitToolEnabled,
 			waitToolDefaultTimeoutMs: deps.waitToolDefaultTimeoutMs,
 			onUpdate: forwardSingleUpdate,
+			suppressUnchangedDelegationUpdates,
 			controlConfig,
 			onControlEvent,
 			intercomSessionName: childIntercomTarget,
@@ -6468,6 +6472,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			effectiveAsync,
 			asyncRunId,
 			controlConfig,
+			...(delegatedExecution ? { suppressUnchangedDelegationUpdates: true } : {}),
 			intercomBridge,
 			nestedRoute,
 			timeoutMs: foregroundTimeout.timeoutMs,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2299,6 +2299,8 @@ export interface RunSyncOptions {
 	allowIntercomDetach?: boolean;
 	intercomEvents?: IntercomEventBus;
 	onUpdate?: (r: import("@earendil-works/pi-agent-core").AgentToolResult<Details>) => void;
+	/** Internal structured-delegation transport optimization: skip unchanged live snapshots. */
+	suppressUnchangedDelegationUpdates?: boolean;
 	onControlEvent?: (event: ControlEvent) => void;
 	/** Exposes a non-terminating detach callback while the child is active. */
 	onDetachReady?: (detach: (reason?: string) => boolean) => void;

--- a/src/slash/prompt-template-bridge.ts
+++ b/src/slash/prompt-template-bridge.ts
@@ -7,6 +7,7 @@ import {
 	type SubagentDelegationInvalidResponse,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
+	type SubagentDelegationUpdate,
 } from "../api/delegation.ts";
 import { parseSubagentDelegationRequest } from "./delegation-request.ts";
 import {
@@ -64,6 +65,37 @@ function hasStructuredDelegationMarker(data: unknown): boolean {
 
 function validId(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0 && value.length <= 256 && !/[\r\n]/.test(value);
+}
+
+function sameStringArray(left: string[] | undefined, right: string[] | undefined): boolean {
+	if (left === right) return true;
+	if (!left || !right || left.length !== right.length) return false;
+	return left.every((value, index) => value === right[index]);
+}
+
+function sameRecentTools(
+	left: Array<{ tool: string; args: string }> | undefined,
+	right: Array<{ tool: string; args: string }> | undefined,
+): boolean {
+	if (left === right) return true;
+	if (!left || !right || left.length !== right.length) return false;
+	return left.every((tool, index) => tool.tool === right[index]?.tool && tool.args === right[index]?.args);
+}
+
+/** Duration is a heartbeat clock, not delegation-visible progress; terminal usage remains authoritative. */
+function sameStructuredDelegationUpdateProgress(left: SubagentDelegationUpdate, right: SubagentDelegationUpdate): boolean {
+	return left.requestId === right.requestId
+		&& left.ownerRunId === right.ownerRunId
+		&& left.nodeId === right.nodeId
+		&& left.runId === right.runId
+		&& left.currentTool === right.currentTool
+		&& left.currentToolArgs === right.currentToolArgs
+		&& left.recentOutput === right.recentOutput
+		&& sameStringArray(left.recentOutputLines, right.recentOutputLines)
+		&& sameRecentTools(left.recentTools, right.recentTools)
+		&& left.model === right.model
+		&& left.toolCount === right.toolCount
+		&& left.tokens === right.tokens;
 }
 
 export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: string }>(
@@ -298,6 +330,7 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 			const executeRequest = structuredRequest && options.executeStructured
 				? options.executeStructured
 				: options.execute;
+			let lastStructuredUpdate: SubagentDelegationUpdate | undefined;
 			const result = await executeRequest(
 				requestId,
 				params,
@@ -307,7 +340,10 @@ export function registerPromptTemplateDelegationBridge<Ctx extends { cwd?: strin
 					if (key ? !ownsAttempt(key, controller) : !ownsLegacyRequest(requestId, controller)) return;
 					if (structuredRequest) {
 						const payload = toSubagentDelegationUpdate(structuredRequest, update);
-						if (payload) options.events.emit(SUBAGENT_DELEGATION_UPDATE_EVENT, payload);
+						if (payload && (!lastStructuredUpdate || !sameStructuredDelegationUpdateProgress(lastStructuredUpdate, payload))) {
+							lastStructuredUpdate = payload;
+							options.events.emit(SUBAGENT_DELEGATION_UPDATE_EVENT, payload);
+						}
 						return;
 					}
 					const payload = toDelegationUpdate(requestId, update);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -6541,6 +6541,95 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok((runningUpdates.at(-1)?.durationMs ?? 0) > (runningUpdates[0]?.durationMs ?? 0), "expected heartbeat duration to advance");
 	});
 
+	it("suppresses unchanged delegated heartbeats without changing ordinary foreground updates", async () => {
+		const updates: Array<{ text: string; durationMs: number | undefined }> = [];
+		const releasePath = path.join(tempDir, "release-delegated-progress");
+		mockPi.onCall({ output: "Done", waitForPath: releasePath });
+
+		const runPromise = runSync!(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			suppressUnchangedDelegationUpdates: true,
+			onUpdate: (update: { content: Array<{ type: string; text?: string }>; details?: { progress?: ProgressSummary[] } }) => {
+				updates.push({
+					text: update.content[0]?.text ?? "",
+					durationMs: update.details?.progress?.[0]?.durationMs,
+				});
+			},
+		});
+		const initialDeadline = Date.now() + 5_000;
+		while (updates.filter((update) => update.text === "(running...)").length < 1 && Date.now() < initialDeadline) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+		await new Promise((resolve) => setTimeout(resolve, 1_200));
+		assert.equal(updates.filter((update) => update.text === "(running...)").length, 1, "duration-only delegated heartbeats should be coalesced");
+
+		fs.writeFileSync(releasePath, "release", "utf-8");
+		const result = await runPromise;
+		assert.equal(result.exitCode, 0);
+		assert.ok(updates.some((update) => update.text === "Done"), "changed terminal output should still be delivered");
+	});
+
+	it("delivers delegated activity-state transitions despite heartbeat suppression", async () => {
+		const attentionUpdates: Array<{ details?: { progress?: ProgressSummary[] } }> = [];
+		const attentionReleasePath = path.join(tempDir, "release-delegated-attention");
+		mockPi.onCall({ output: "Done", waitForPath: attentionReleasePath });
+		const attentionRun = runSync!(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			suppressUnchangedDelegationUpdates: true,
+			controlConfig: {
+				enabled: true,
+				needsAttentionAfterMs: 200,
+				activeNoticeAfterMs: 999_999,
+				activeNoticeAfterTurns: 999_999,
+				activeNoticeAfterTokens: 999_999,
+				notifyOn: ["needs_attention"],
+				notifyChannels: ["event"],
+			},
+			onUpdate: (update: { details?: { progress?: ProgressSummary[] } }) => attentionUpdates.push(update),
+		});
+		try {
+			const deadline = Date.now() + 5_000;
+			while (!attentionUpdates.some((update) => update.details?.progress?.[0]?.activityState === "needs_attention") && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+			assert.ok(attentionUpdates.some((update) => update.details?.progress?.[0]?.activityState === "needs_attention"), "needs_attention transition should not be coalesced");
+		} finally {
+			fs.writeFileSync(attentionReleasePath, "release", "utf-8");
+			await attentionRun;
+		}
+
+		const activeUpdates: Array<{ details?: { progress?: ProgressSummary[] } }> = [];
+		const activeReleasePath = path.join(tempDir, "release-delegated-active");
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.toolStart("contact_supervisor", { message: "waiting" })] },
+				{ waitForPath: activeReleasePath, jsonl: [events.toolEnd("contact_supervisor"), events.toolResult("contact_supervisor", "done")] },
+				{ jsonl: [events.assistantMessage("Done")] },
+			],
+		});
+		const activeRun = runSync!(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			suppressUnchangedDelegationUpdates: true,
+			controlConfig: {
+				enabled: true,
+				needsAttentionAfterMs: 999_999,
+				activeNoticeAfterMs: 200,
+				activeNoticeAfterTurns: 999_999,
+				activeNoticeAfterTokens: 999_999,
+				notifyOn: ["active_long_running"],
+				notifyChannels: ["event"],
+			},
+			onUpdate: (update: { details?: { progress?: ProgressSummary[] } }) => activeUpdates.push(update),
+		});
+		try {
+			const deadline = Date.now() + 5_000;
+			while (!activeUpdates.some((update) => update.details?.progress?.[0]?.activityState === "active_long_running") && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+			assert.ok(activeUpdates.some((update) => update.details?.progress?.[0]?.activityState === "active_long_running"), "active_long_running transition should not be coalesced");
+		} finally {
+			fs.writeFileSync(activeReleasePath, "release", "utf-8");
+			await activeRun;
+		}
+	});
+
 	it("reports foreground context window usage without changing cumulative spend", async () => {
 		mockPi.onCall({
 			jsonl: [{

--- a/test/unit/delegation-api.test.ts
+++ b/test/unit/delegation-api.test.ts
@@ -9,6 +9,7 @@ import {
 	SUBAGENT_DELEGATION_UPDATE_EVENT,
 	type SubagentDelegationRequest,
 	type SubagentDelegationResponse,
+	type SubagentDelegationUpdate,
 } from "../../src/api/delegation.ts";
 import { parseSubagentDelegationRequest } from "../../src/slash/delegation-request.ts";
 import {
@@ -195,6 +196,121 @@ describe("public subagent delegation contract", () => {
 			foregroundOnly: true,
 			clarify: false,
 		});
+		bridge.dispose();
+	});
+
+	it("suppresses unchanged structured delegation heartbeat snapshots", async () => {
+		const events = new FakeEvents();
+		const updates: SubagentDelegationUpdate[] = [];
+		events.on(SUBAGENT_DELEGATION_UPDATE_EVENT, (payload) => updates.push(payload as SubagentDelegationUpdate));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("legacy executor must remain separate"); },
+			executeStructured: async (_id, _params, _signal, _ctx, onUpdate) => {
+				const progress = {
+					index: 0,
+					agent: "reviewer",
+					currentTool: "read",
+					currentToolArgs: "{\"path\":\"evidence.md\"}",
+					recentOutput: ["Reading evidence"],
+					recentTools: [{ tool: "read", args: "evidence.md" }],
+					model: "openai/gpt-5",
+					toolCount: 1,
+					durationMs: 1_000,
+					tokens: 8,
+				};
+				onUpdate({ details: { mode: "single", runId: "run-heartbeat", results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [progress] } });
+				onUpdate({ details: { mode: "single", runId: "run-heartbeat", results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [{ ...progress, durationMs: 2_000 }] } });
+				return {
+					details: {
+						mode: "single",
+						runId: "run-heartbeat",
+						results: [{ agent: "reviewer", exitCode: 0, model: "openai/gpt-5", finalOutput: "done", usage: { input: 4, output: 4, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 } }],
+					},
+				};
+			},
+		});
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, result: { kind: "text" as const } });
+		const response = await responsePromise as SubagentDelegationResponse;
+		assert.equal(updates.length, 1);
+		assert.equal(updates[0]?.durationMs, 1_000);
+		assert.equal(response.status, "completed");
+		bridge.dispose();
+	});
+
+	it("delivers structured delegation updates when progress or bounded output changes", async () => {
+		const events = new FakeEvents();
+		const updates: SubagentDelegationUpdate[] = [];
+		events.on(SUBAGENT_DELEGATION_UPDATE_EVENT, (payload) => updates.push(payload as SubagentDelegationUpdate));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("legacy executor must remain separate"); },
+			executeStructured: async (_id, _params, _signal, _ctx, onUpdate) => {
+				const common = {
+					index: 0,
+					agent: "reviewer",
+					model: "openai/gpt-5",
+					toolCount: 1,
+					tokens: 8,
+				};
+				onUpdate({ details: { mode: "single", runId: "run-progress", results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [{ ...common, currentTool: "read", recentOutput: ["Reading evidence"], recentTools: [{ tool: "read", args: "evidence.md" }], durationMs: 1_000 }] } });
+				onUpdate({ details: { mode: "single", runId: "run-progress", results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [{ ...common, currentTool: "read", recentOutput: ["Reading evidence"], recentTools: [{ tool: "read", args: "evidence.md" }], durationMs: 2_000 }] } });
+				onUpdate({ details: { mode: "single", runId: "run-progress", results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [{ ...common, currentTool: "write", currentToolArgs: "{\"path\":\"report.md\"}", recentOutput: ["Wrote report"], recentOutputLines: ["Wrote report"], recentTools: [{ tool: "read", args: "evidence.md" }, { tool: "write", args: "report.md" }], toolCount: 2, tokens: 16, durationMs: 3_000 }] } });
+				return { details: { mode: "single", runId: "run-progress", results: [{ agent: "reviewer", exitCode: 0, model: "openai/gpt-5", finalOutput: "done", usage: { input: 8, output: 8, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 } }] } };
+			},
+		});
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, result: { kind: "text" as const } });
+		assert.equal((await responsePromise as SubagentDelegationResponse).status, "completed");
+		assert.equal(updates.length, 2);
+		assert.equal(updates[1]?.currentTool, "write");
+		assert.equal(updates[1]?.recentOutput, "Wrote report");
+		assert.deepEqual(updates[1]?.recentTools, [{ tool: "read", args: "evidence.md" }, { tool: "write", args: "report.md" }]);
+		bridge.dispose();
+	});
+
+	it("always delivers the complete structured terminal error after quiet heartbeats", async () => {
+		const events = new FakeEvents();
+		const updates: SubagentDelegationUpdate[] = [];
+		events.on(SUBAGENT_DELEGATION_UPDATE_EVENT, (payload) => updates.push(payload as SubagentDelegationUpdate));
+		const bridge = registerPromptTemplateDelegationBridge({
+			events,
+			getContext: () => ({ cwd: "/repo" }),
+			execute: async () => { throw new Error("legacy executor must remain separate"); },
+			executeStructured: async (_id, _params, _signal, _ctx, onUpdate) => {
+				const progress = { index: 0, agent: "reviewer", currentTool: "read", recentOutput: ["Reading evidence"], toolCount: 1, tokens: 8, durationMs: 1_000 };
+				onUpdate({ details: { mode: "single", runId: "run-error", results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [progress] } });
+				onUpdate({ details: { mode: "single", runId: "run-error", results: [{ agent: "reviewer", model: "openai/gpt-5" }], progress: [{ ...progress, durationMs: 2_000 }] } });
+				return {
+					isError: true,
+					content: [{ type: "text", text: "full provider error" }],
+					details: {
+						mode: "single",
+						runId: "run-error",
+						results: [{ agent: "reviewer", exitCode: 1, error: "full provider error", model: "openai/gpt-5", usage: { input: 4, output: 2, cacheRead: 1, cacheWrite: 0, cost: 0.01, turns: 1 } }],
+					},
+				};
+			},
+		});
+		const responsePromise = once(events, SUBAGENT_DELEGATION_RESPONSE_EVENT);
+		events.emit(SUBAGENT_DELEGATION_REQUEST_EVENT, { ...request, result: { kind: "text" as const } });
+		const response = await responsePromise as SubagentDelegationResponse;
+		assert.equal(updates.length, 1);
+		assert.deepEqual(response, {
+			requestId: "attempt-1",
+			ownerRunId: "owner-1",
+			nodeId: "node-1",
+			status: "failed",
+			runId: "run-error",
+			agent: "reviewer",
+			model: "openai/gpt-5",
+			exitCode: 1,
+			error: "full provider error",
+			usage: { input: 4, output: 2, cacheRead: 1, cacheWrite: 0, cost: 0.01, turns: 1, toolCalls: 0, durationMs: 0 },
+		} satisfies SubagentDelegationResponse);
 		bridge.dispose();
 	});
 


### PR DESCRIPTION
Fixes #1739.

## Summary
- suppress duration-only structured delegation heartbeat snapshots at the foreground source
- keep ordinary foreground heartbeat updates unchanged
- preserve delegated progress/output/tool changes, activity-state transitions, and full terminal result/error delivery
- coalesce duplicate structured delegation snapshots at the prompt-template bridge boundary

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/delegation-api.test.ts` (13 pass)
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='(suppresses unchanged delegated heartbeats|delivers delegated activity-state transitions)' test/integration/single-execution.test.ts` (2 pass)
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/single-execution.test.ts` (280 pass, by writer/challenge)
- `npm run typecheck`
- `git diff --check origin/main..HEAD`
- retained deletion-first challenge completed and amended activity-state safety fix
- fresh reviewer: No issues found