### PR TITLE
fix: trim default subagent prompt guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Trim default subagent prompt guidelines to five parent-facing entries while keeping advanced workflow details in the packaged guide. Thanks [@Ran-Xing](https://github.com/Ran-Xing) for #1746.
 - Add extension-owned named workflow resources so permission/policy extensions can distinguish resolved provenance from raw workflow scripts and enforce resource-scoped host command authority. Thanks [@mathiasloh](https://github.com/mathiasloh) for #1751.
 - Coalesce unchanged structured-delegation heartbeat snapshots while retaining ordinary foreground heartbeats and complete terminal responses (#1739).
 - Clarify that `fallbackModels` handles provider/model timeouts but not run-level `timeoutMs` / `maxRuntimeMs` expiry. Thanks [@kaplan-shaked](https://github.com/kaplan-shaked) for #1745.

--- a/src/extension/tool-description.ts
+++ b/src/extension/tool-description.ts
@@ -12,27 +12,17 @@ const WORKFLOW_LANES_GUIDANCE = "For bounded parallel sequential chains, use run
 const WORKFLOW_SCRIPT_PORTABILITY_GUIDANCE = "workflowScript rejects nested async function, arrow, and method helpers; use top-level await, plain helper functions that return runs.run(...), or explicit Promise chains instead.";
 const WORKFLOW_RESOURCE_GUIDANCE = "For permission/policy-extension interoperability, use an extension-owned named resource such as {workflow:'review',args:{task:'...'}} or {workflow:'run-ci',args:{command:'npm test'}}. The host resolves the script and authority internally so policy can distinguish it from raw workflowScript/workflowScriptPath; args are bounded plain data, and do not combine workflow with agent, task, workflowScript, or workflowScriptPath.";
 const WORKFLOW_HOST_GUIDANCE = "For permission-sensitive host calls, use an extension-owned resource such as {workflow:'run-ci',args:{command:'npm test'}}; raw workflowScript/workflowScriptPath have unknown resource provenance and cannot use runs.host. In a resource that grants it, await runs.host(key,{kind:'command',command,timeoutMs,output?,role?,provider?}). runs.host has no per-step cwd: commands and relative output paths use the workflow cwd; set cwd on the outer subagent request instead (for example, {cwd:'/path/to/worktree',workflowScript:'...'}), or put a trusted directory change in the command (for example, 'cd /path/to/worktree && npm test'). v1 supports only command steps; output is bounded and command failure fails the workflow.";
-const AGENT_CAPABILITY_GUIDANCE = "For capability selection, use { action: \"list\", capabilities: true } for compact prompt-free rows.";
 
 export const DEFAULT_SUBAGENT_TOOL_DESCRIPTION = `Delegate to configured subagents. For execution, omit action and use {agent, task?} for one child, workflowScript for inline orchestration, workflowScriptPath to load a script from the request cwd, or a named workflow resource for permission/policy-aware execution. ${WORKFLOW_RESOURCE_GUIDANCE} The script inputs are mutually exclusive. Use action:'validate' with either script input to check it without launching children. For multi-step or parallel work, make exactly one top-level subagent call with async:true; launch children only inside that workflow and do not make another top-level call for them. Use runs.run('key',{agent,task}) for one child, await runs.all([{key:'a',agent:'reviewer',task:'...'},{key:'b',agent:'reviewer',task:'...'}]) for ordinary parallel children, and read its ordered array result with indexes, destructuring, or .map(...), not by key property. ${WORKFLOW_SCRIPT_PORTABILITY_GUIDANCE} ${WORKFLOW_LANES_GUIDANCE} ${WORKFLOW_HOST_GUIDANCE} ${EXTERNAL_CLI_RUNNER_GUIDANCE} Use action only for management/control. Use guide or the pi-subagents skill for advanced workflow details.`;
 
 export const SUBAGENT_TOOL_PROMPT_SNIPPET = "Delegate to subagents; orchestrate in one workflowScript call.";
 
 export const SUBAGENT_TOOL_PROMPT_GUIDELINES = [
-	`Use subagent only when delegation is needed. Before executing, call { action: "list" } and run only executable, non-disabled agents. ${AGENT_CAPABILITY_GUIDANCE}`,
-	"Omit action for execution. Use { agent, task? } only for one child; use workflowScript for multi-step or parallel work.",
-	WORKFLOW_RESOURCE_GUIDANCE,
-	"workflowScript means exactly one top-level subagent tool call with async:true. Inside it, use runs.run/runs.all to launch children; do not make another top-level subagent call for those children.",
-	WORKFLOW_SCRIPT_PORTABILITY_GUIDANCE,
-	WORKFLOW_LANES_GUIDANCE,
-	WORKFLOW_HOST_GUIDANCE,
-	WORKFLOW_RESUME_KEY_GUIDANCE,
-	WORKFLOW_OUTPUT_BINDING_GUIDANCE,
-	"For ordinary parallel work, use await runs.all([{key,agent,task}, ...]); it resolves to an ordered array, not a key map, so use results[0], destructuring, or results.map(...), not results.<key>. Do not read .output from unawaited runs.run launches. Stored runs.run promises are only for advanced rolling fanout and each must later be observed with direct await, Promise.race, or Promise.all.",
-	"Keep one writer per cwd/worktree unless writers run in isolated worktrees.",
-	"To pass an explicit model to a child, first call { action: \"models\" } and copy an exact provider/id (e.g. provider/model-id); bare ids resolve only when unique in the registry, and agent names (gpt-pro, advisor) are not model ids. Set per-run thinking with a suffix on the model string (e.g. provider/model-id:high; off/minimal/low/medium/high/xhigh/max); the suffix wins over the agent's thinking default. The thinking field only applies to action='watchdog.configure' and is ignored on dispatch.",
-	EXTERNAL_CLI_RUNNER_GUIDANCE,
-	"Use guide or the pi-subagents skill for advanced scheduling, missions, steering, and retention.",
+	'Use subagent only when delegation is needed. Before execution, call { action: "list" } and run only executable, non-disabled agents.',
+	'Omit action for execution; use { agent, task? } for one child. For multi-step or parallel work, make exactly one top-level { workflowScript, async: true } call and launch children only inside it. Use action only for management/control.',
+	"workflowScript rejects nested async function, arrow, and method helpers; use top-level await, plain helper functions, or explicit Promise chains.",
+	"Inside workflowScript, use runs.run/runs.all and await their results. runs.all returns an ordered array, not a key map; stored runs.run promises must later be observed with direct await, Promise.race, or Promise.all.",
+	'Keep one writer per cwd/worktree; isolate concurrent writers. For durable files, set output on runs.run/runs.all and return the child\'s outputReference, outputPathMapping, or artifactPaths. For advanced workflows, read the bundled pi-subagents skill or call { action: "guide", topic: "workflows" }.',
 ];
 
 export const SUBAGENT_SAFETY_GUIDANCE = `SAFETY-CRITICAL SUBAGENT GUIDANCE:

--- a/test/unit/subagent-guide.test.ts
+++ b/test/unit/subagent-guide.test.ts
@@ -26,4 +26,12 @@ describe("subagent guide", () => {
 		assert.match(readSubagentGuide("tool-reference"), /External CLI agent profiles[\s\S]*native Pi child options[\s\S]*model override[\s\S]*native Pi tools/);
 		assert.match(readSubagentGuide("agents"), /External CLI agents use their own runner contract[\s\S]*native Pi child options/);
 	});
+
+	it("keeps advanced workflow details in the packaged guide", () => {
+		const guide = readSubagentGuide("workflows");
+
+		assert.match(guide, /### Parallel sequential lanes[\s\S]*runs\.lanes/);
+		assert.match(guide, /### Host command steps[\s\S]*runs\.host/);
+		assert.match(guide, /### Advanced rolling child runs[\s\S]*Promise\.race[\s\S]*Promise\.all/);
+	});
 });

--- a/test/unit/tool-description.test.ts
+++ b/test/unit/tool-description.test.ts
@@ -46,26 +46,25 @@ describe("registered subagent tool description", () => {
 		assert.match(description, /no per-step cwd.*workflow cwd.*outer subagent request.*cd \/path\/to\/worktree/i);
 		assert.equal(metadata.promptSnippet, SUBAGENT_TOOL_PROMPT_SNIPPET);
 		assert.equal(Buffer.byteLength(metadata.promptSnippet!), 62);
-		assert.equal(Buffer.byteLength(metadata.promptGuidelines!.join("\n")), 4111);
-		assert.deepEqual(metadata.promptGuidelines, SUBAGENT_TOOL_PROMPT_GUIDELINES);
-		assert.match(metadata.promptGuidelines!.join("\n"), /Use subagent only when delegation is needed/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /action: \"list\".*executable, non-disabled/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /action: \"list\", capabilities: true.*compact prompt-free rows/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /workflowScript for multi-step or parallel work/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /workflowScript means exactly one top-level subagent tool call with async:true/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /Inside it, use runs\.run\/runs\.all to launch children/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /nested async function.*plain helper functions.*Promise chains/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /no per-step cwd.*workflow cwd.*outer subagent request.*cd \/path\/to\/worktree/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /runs\.lanes\(\[\{key,stages:.*first stages run together/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /Each workflow key identifies one result lane.*new stable workflow key.*retained resume pass/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /output.*not an output declaration.*outputReference.*outputPathMapping.*artifactPaths/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /do not make another top-level subagent call for those children/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /await runs\.all.*do not read \.output from unawaited runs\.run launches/i);
+		assert.equal(metadata.promptGuidelines!.length, 5);
+		assert.equal(Buffer.byteLength(metadata.promptGuidelines!.join("\n")), 1030);
+		assert.deepEqual(metadata.promptGuidelines, [
+			'Use subagent only when delegation is needed. Before execution, call { action: "list" } and run only executable, non-disabled agents.',
+			'Omit action for execution; use { agent, task? } for one child. For multi-step or parallel work, make exactly one top-level { workflowScript, async: true } call and launch children only inside it. Use action only for management/control.',
+			"workflowScript rejects nested async function, arrow, and method helpers; use top-level await, plain helper functions, or explicit Promise chains.",
+			"Inside workflowScript, use runs.run/runs.all and await their results. runs.all returns an ordered array, not a key map; stored runs.run promises must later be observed with direct await, Promise.race, or Promise.all.",
+			'Keep one writer per cwd/worktree; isolate concurrent writers. For durable files, set output on runs.run/runs.all and return the child\'s outputReference, outputPathMapping, or artifactPaths. For advanced workflows, read the bundled pi-subagents skill or call { action: "guide", topic: "workflows" }.',
+		]);
+		const promptGuidelines = metadata.promptGuidelines!.join("\n");
+		assert.match(promptGuidelines, /Use subagent only when delegation is needed/i);
+		assert.match(promptGuidelines, /workflowScript rejects nested async function, arrow, and method helpers/i);
+		assert.match(promptGuidelines, /runs\.all returns an ordered array, not a key map/i);
+		assert.match(promptGuidelines, /stored runs\.run promises must later be observed with direct await, Promise\.race, or Promise\.all/i);
+		assert.match(promptGuidelines, /outputReference.*outputPathMapping.*artifactPaths/i);
+		assert.match(promptGuidelines, /advanced workflows.*action: \"guide\", topic: \"workflows\"/i);
+		assert.doesNotMatch(promptGuidelines, /capabilities: true|runs\.lanes|runs\.host|workflow key identifies one result lane|action: \"models\"|External CLI agents|ordinary child subagents/i);
 		assert.match(description, /External CLI agents.*model override.*native Pi tools/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /External CLI agents.*model override.*native Pi tools/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /suffix on the model string.*off\/minimal\/low\/medium\/high\/xhigh\/max/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /suffix wins over the agent's thinking default/i);
-		assert.match(metadata.promptGuidelines!.join("\n"), /watchdog\.configure' and is ignored on dispatch/i);
+		assert.doesNotMatch(promptGuidelines, /ordinary children are not orchestrators/i);
 	});
 
 	it("keeps the full description when configured", () => {


### PR DESCRIPTION
## Summary
- trims default `promptGuidelines` to the five approved parent-facing B-lite entries
- keeps advanced workflow detail discoverable in the packaged guide instead of always-on prompt prose
- credits [@Ran-Xing](https://github.com/Ran-Xing) for #1746

Closes #1746.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/tool-description.test.ts test/unit/subagent-guide.test.ts`
- `npm run typecheck`
- `git diff --check origin/main..HEAD`
- Fresh reviewer: No issues found

Note: local `npm run test:unit` currently has one unrelated environment failure because `node_modules/oxlint/bin/oxlint` is missing in this checkout. CI will run the full install-backed suite.
