### PR TITLE
fix: isolate corrupt async status during restore

### DIFF
--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -173,6 +173,10 @@ function isNotFoundError(error: unknown): boolean {
 		&& (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
+function isAsyncStatusParseError(error: unknown): boolean {
+	return error instanceof Error && error.message.startsWith("Failed to parse async status file '");
+}
+
 function isAsyncRunDir(root: string, entry: string): boolean {
 	const entryPath = path.join(root, entry);
 	try {
@@ -499,10 +503,26 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 	};
 	for (const entry of entries) {
 		const asyncDir = path.join(asyncDirRoot, entry);
-		const reconciliation = options.reconcile === false
-			? undefined
-			: reconcileAsyncRun(asyncDir, { resultsDir: options.resultsDir, kill: options.kill, now: options.now });
-		const status = (reconciliation?.status ?? readStatus(asyncDir)) as (AsyncStatus & { cwd?: string }) | null;
+		let status: (AsyncStatus & { cwd?: string }) | null;
+		try {
+			const reconciliation = options.reconcile === false
+				? undefined
+				: reconcileAsyncRun(asyncDir, { resultsDir: options.resultsDir, kill: options.kill, now: options.now });
+			status = (reconciliation?.status ?? readStatus(asyncDir)) as (AsyncStatus & { cwd?: string }) | null;
+		} catch (error) {
+			// Active-run restoration is best-effort per run. A corrupt persisted
+			// status must not prevent unrelated jobs from being restored, while
+			// targeted and repair scans and semantic validation failures still
+			// surface the underlying error.
+			if (!activeEntries.has(entry) || !isAsyncStatusParseError(error)) throw error;
+			console.error(`Skipping unreadable active async run '${entry}' in '${asyncDirRoot}': ${getErrorMessage(error)}`);
+			try {
+				releaseActiveRunIndex(asyncDir);
+			} catch (releaseError) {
+				console.error(`Failed to release unreadable async run '${entry}' from the active-run index: ${getErrorMessage(releaseError)}`);
+			}
+			continue;
+		}
 		if (!status) {
 			if (activeEntries.has(entry)) updateActiveRunIndex(asyncDir, "failed");
 			continue;

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -930,14 +930,25 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("does not throw during restore when a persisted async status is malformed", () => {
+	it("restores valid jobs when another persisted async status is malformed", () => {
 		const asyncRoot = createTempDir("pi-async-job-restore-bad-status-");
 		const originalError = console.error;
 		try {
-			const runDir = path.join(asyncRoot, "run-bad-status");
-			fs.mkdirSync(runDir, { recursive: true });
-			fs.writeFileSync(path.join(runDir, "status.json"), "{bad json", "utf-8");
-			updateActiveRunIndex(runDir, "running");
+			const validDir = path.join(asyncRoot, "run-valid-status");
+			fs.mkdirSync(validDir, { recursive: true });
+			fs.writeFileSync(path.join(validDir, "status.json"), JSON.stringify({
+				runId: "run-valid-status",
+				sessionId: "session-bad",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			}), "utf-8");
+			updateActiveRunIndex(validDir, "running");
+			const badDir = path.join(asyncRoot, "run-bad-status");
+			fs.mkdirSync(badDir, { recursive: true });
+			fs.writeFileSync(path.join(badDir, "status.json"), Buffer.alloc(64));
+			updateActiveRunIndex(badDir, "running");
 
 			const state = createState();
 			state.currentSessionId = "session-bad";
@@ -953,9 +964,10 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			});
 			tracker.resetJobs(ui.ctx as never);
 			assert.doesNotThrow(() => tracker.restoreActiveJobs(ui.ctx as never));
-			assert.equal(state.asyncJobs.size, 0);
-			assert.equal(state.poller, null);
-			assert.match(String(errors[0]?.[0] ?? ""), /Failed to restore active async jobs/);
+			assert.deepEqual([...state.asyncJobs.keys()], ["run-valid-status"]);
+			assert.notEqual(state.poller, null);
+			assert.match(String(errors[0]?.[0] ?? ""), /Skipping unreadable active async run 'run-bad-status'/);
+			tracker.dispose();
 		} finally {
 			console.error = originalError;
 			removeTempDir(asyncRoot);

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -610,6 +610,38 @@ describe("async status helpers", () => {
 		}
 	});
 
+	it("isolates unreadable active status files while restoring valid runs", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-active-bad-status-"));
+		const originalError = console.error;
+		try {
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const badDir = path.join(root, "bad-run");
+			fs.mkdirSync(badDir, { recursive: true });
+			fs.writeFileSync(path.join(badDir, "status.json"), Buffer.alloc(64));
+			updateActiveRunIndex(badDir, "running");
+			const errors: unknown[][] = [];
+			console.error = (...args: unknown[]) => {
+				errors.push(args);
+			};
+
+			const runs = listAsyncRuns(root, { states: ["running"], reconcile: false });
+
+			assert.deepEqual(runs.map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-run")), false);
+			assert.equal(fs.existsSync(path.join(badDir, "status.json")), true);
+			assert.match(String(errors[0]?.[0] ?? ""), /Skipping unreadable active async run 'bad-run'/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects malformed persisted session ids", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-bad-session-id-"));
 		try {


### PR DESCRIPTION
## Summary

- isolate corrupt active-run `status.json` failures during async run listing;
- release the affected active-run marker while preserving the run directory;
- continue restoring unrelated valid active runs;
- retain strict failures for repair scans, targeted runs, and semantic status validation;
- add regression coverage for both the run-list and job-tracker restore paths.

Fixes #1756

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-status.test.ts test/integration/async-job-tracker.test.ts`