### PR TITLE
fix: isolate corrupt async status restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Make `bg_wait` the primary background-work wait tool, retain `subagent_wait` as a deprecated compatibility alias, and stop ordinary async handoffs from encouraging redundant wait subscriptions (#1729).
 
 ### Fixed
+- Isolate corrupt active async status files during restoration so valid runs remain available and corrupt run artifacts are preserved. Thanks [@zhexulong](https://github.com/zhexulong) for #1756.
 - Reduce async widget update churn during running workflows by repainting animation ticks without reinstalling the widget and coalescing close status refreshes (#1726).
 - Avoid repeated staged workflow projection during widget rendering. Thanks [@kkkhs](https://github.com/kkkhs) for #1730.
 - Preserve durable file-only child reports and continue read-only workflow review after malformed acceptance metadata (#1724).

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -166,6 +166,40 @@ function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+function isAsyncStatusIsolationError(asyncDir: string, error: unknown): boolean {
+	const statusPath = path.join(asyncDir, "status.json");
+	const message = getErrorMessage(error);
+	return /^(?:Failed to (?:inspect|read|parse|validate) async status file|Invalid async status file) '/.test(message)
+		|| message.startsWith(`Invalid async status '${statusPath}'`)
+		|| message.startsWith(`Invalid host step '${statusPath}`)
+		|| /^(workflowChildren|Invalid workflowChildren)/.test(message);
+}
+
+function isolateCorruptActiveRun(asyncDir: string, runId: string, error: unknown, now?: () => number): void {
+	const statusPath = path.join(asyncDir, "status.json");
+	const processTerminal = readProcessTerminal(asyncDir, { runId });
+	let markerAge: number | undefined;
+	try {
+		markerAge = activeRunMarkerAgeMs(asyncDir, now?.());
+	} catch (markerError) {
+		console.error(`Failed to inspect corrupt async active-run marker for '${runId}':`, markerError);
+	}
+	const markerCanBeReleased = processTerminal?.state === "observed"
+		|| (markerAge !== undefined && markerAge > DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS);
+	let markerAction = "active marker retained because runner liveness is unknown";
+	if (markerCanBeReleased) {
+		try {
+			releaseActiveRunIndex(asyncDir);
+			markerAction = processTerminal?.state === "observed"
+				? "active marker released after observed process-terminal proof"
+				: "stale active marker released";
+		} catch (releaseError) {
+			markerAction = `failed to release active marker: ${getErrorMessage(releaseError)}`;
+		}
+	}
+	console.error(`[pi-subagents] Skipping corrupt active async run '${runId}' at '${statusPath}': ${getErrorMessage(error)}; ${markerAction}.`);
+}
+
 function isNotFoundError(error: unknown): boolean {
 	return typeof error === "object"
 		&& error !== null
@@ -250,14 +284,16 @@ function deriveAsyncActivityState(asyncDir: string, status: AsyncStatus): { acti
 }
 
 function statusToSummary(asyncDir: string, status: AsyncStatus & { cwd?: string }, nestedWarnings: string[] = [], nestedRoute?: NestedRoute): AsyncRunSummary {
-	validateAsyncStatusLaneMetadata(status, `Invalid async status '${path.join(asyncDir, "status.json")}'`);
+	const statusPath = path.join(asyncDir, "status.json");
+	validateAsyncStatusLaneMetadata(status, `Invalid async status '${statusPath}'`);
 	const workflowChildren = parseWorkflowChildSummary(status.workflowChildren);
-	if (workflowChildren && workflowChildren.workflowRunId !== status.runId) throw new Error(`Invalid async status '${path.join(asyncDir, "status.json")}': workflowChildren.workflowRunId does not match.`);
-	assertWorkflowGraphHostSteps(status.workflowGraph, path.join(asyncDir, "status.json"), status.runId);
+	if (workflowChildren && workflowChildren.workflowRunId !== status.runId) throw new Error(`Invalid async status '${statusPath}': workflowChildren.workflowRunId does not match.`);
+	assertWorkflowGraphHostSteps(status.workflowGraph, statusPath, status.runId);
 	const hostSteps = validHostStepNodes(status.workflowGraph);
 	if (status.sessionId !== undefined && typeof status.sessionId !== "string") {
-		throw new Error(`Invalid async status '${path.join(asyncDir, "status.json")}': sessionId must be a string.`);
+		throw new Error(`Invalid async status '${statusPath}': sessionId must be a string.`);
 	}
+	if (status.outputFile !== undefined && typeof status.outputFile !== "string") throw new Error(`Invalid async status '${statusPath}': outputFile must be a string.`);
 	const { activityState, lastActivityAt } = deriveAsyncActivityState(asyncDir, status);
 	const processTerminal = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId })
 		?? sanitizeProcessTerminal(status.processTerminal, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId }, path.join(asyncDir, "status.json"));
@@ -499,10 +535,17 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 	};
 	for (const entry of entries) {
 		const asyncDir = path.join(asyncDirRoot, entry);
-		const reconciliation = options.reconcile === false
-			? undefined
-			: reconcileAsyncRun(asyncDir, { resultsDir: options.resultsDir, kill: options.kill, now: options.now });
-		const status = (reconciliation?.status ?? readStatus(asyncDir)) as (AsyncStatus & { cwd?: string }) | null;
+		let status: (AsyncStatus & { cwd?: string }) | null;
+		try {
+			const reconciliation = options.reconcile === false
+				? undefined
+				: reconcileAsyncRun(asyncDir, { resultsDir: options.resultsDir, kill: options.kill, now: options.now });
+			status = (reconciliation?.status ?? readStatus(asyncDir)) as (AsyncStatus & { cwd?: string }) | null;
+		} catch (error) {
+			if (!activeEntries.has(entry) || !isAsyncStatusIsolationError(asyncDir, error)) throw error;
+			isolateCorruptActiveRun(asyncDir, entry, error, options.now);
+			continue;
+		}
 		if (!status) {
 			if (activeEntries.has(entry)) updateActiveRunIndex(asyncDir, "failed");
 			continue;
@@ -528,7 +571,14 @@ export function listAsyncRuns(asyncDirRoot: string, options: AsyncRunListOptions
 				nestedWarnings.push(`Nested status unavailable: ${getErrorMessage(error)}`);
 			}
 		}
-		const summary = statusToSummary(asyncDir, status, nestedWarnings, nestedRoute);
+		let summary: AsyncRunSummary;
+		try {
+			summary = statusToSummary(asyncDir, status, nestedWarnings, nestedRoute);
+		} catch (error) {
+			if (!activeEntries.has(entry) || !isAsyncStatusIsolationError(asyncDir, error)) throw error;
+			isolateCorruptActiveRun(asyncDir, entry, error, options.now);
+			continue;
+		}
 		runs.push(summary);
 	}
 

--- a/src/runs/shared/host-step-status.ts
+++ b/src/runs/shared/host-step-status.ts
@@ -144,6 +144,7 @@ export function validHostStepNodes(graph: WorkflowGraphSnapshot | undefined): Ho
 export function assertWorkflowGraphHostSteps(graph: WorkflowGraphSnapshot | undefined, source = "status", expectedRunId?: string): void {
 	if (!graph) return;
 	if (expectedRunId !== undefined && graph.runId !== expectedRunId) throw new Error(`Invalid host step '${source}': workflowGraph.runId does not match the status run id.`);
+	if (!Array.isArray(graph.nodes)) throw new Error(`Invalid host step '${source}.workflowGraph': nodes must be an array.`);
 	const hostStepCount = graph.nodes.filter((node) => node.kind === "host-step").length;
 	if (hostStepCount > HOST_STEP_MAX_COUNT) throw new Error(`Invalid host step '${source}': workflowGraph contains more than ${HOST_STEP_MAX_COUNT} host steps.`);
 	const hostSteps: HostStepNodeV1[] = [];

--- a/src/workflows/workflow-child-summary.ts
+++ b/src/workflows/workflow-child-summary.ts
@@ -117,5 +117,5 @@ export function parseWorkflowChildSummary(value: unknown): WorkflowChildSummaryV
 	if (new Set(children.map((child) => child.childId)).size !== children.length) throw new Error("workflowChildren has duplicate childId values.");
 	if (typeof input.parentToolCallId !== "string") throw new Error("workflowChildren.parentToolCallId is invalid.");
 	if (typeof input.workflowRunId !== "string") throw new Error("workflowChildren.workflowRunId is invalid.");
-	return { version: 1, parentToolCallId: requiredId(input.parentToolCallId, "parentToolCallId"), workflowRunId: requiredId(input.workflowRunId, "workflowRunId"), inventoryComplete: input.inventoryComplete, workflowState, children };
+	return { version: 1, parentToolCallId: requiredId(input.parentToolCallId, "workflowChildren.parentToolCallId"), workflowRunId: requiredId(input.workflowRunId, "workflowChildren.workflowRunId"), inventoryComplete: input.inventoryComplete, workflowState, children };
 }

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, it } from "node:test";
 import { registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
 import { getArtifactsDir } from "../../src/shared/artifacts.ts";
 import { SUBAGENT_CHILD_STATUS_EVENT } from "../../src/shared/types.ts";
-import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { ACTIVE_RUN_INDEX_DIR, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR } from "../../src/runs/shared/external-job-bridge.ts";
 import { SubagentFleetComponent } from "../../src/tui/fleet.ts";
 import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
@@ -955,7 +955,11 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			assert.doesNotThrow(() => tracker.restoreActiveJobs(ui.ctx as never));
 			assert.equal(state.asyncJobs.size, 0);
 			assert.equal(state.poller, null);
-			assert.match(String(errors[0]?.[0] ?? ""), /Failed to restore active async jobs/);
+			assert.match(String(errors[0]?.[0] ?? ""), /Skipping corrupt active async run 'run-bad-status'/);
+			assert.match(String(errors[0]?.[0] ?? ""), /status\.json/);
+			assert.match(String(errors[0]?.[0] ?? ""), /active marker retained because runner liveness is unknown/);
+			assert.equal(fs.existsSync(runDir), true);
+			assert.equal(fs.existsSync(path.join(asyncRoot, ACTIVE_RUN_INDEX_DIR, "run-bad-status")), true);
 		} finally {
 			console.error = originalError;
 			removeTempDir(asyncRoot);

--- a/test/integration/async-status.test.ts
+++ b/test/integration/async-status.test.ts
@@ -241,7 +241,8 @@ describe("async status helpers", () => {
 					nodes: [{ id: "bad", kind: "host-step", label: "bad", status: "running" }],
 				},
 			});
-			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false }), /host step.*expected an object/);
+			fs.rmSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "workflow-host-invalid"));
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false, repairScan: true }), /host step.*expected an object/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -285,7 +286,8 @@ describe("async status helpers", () => {
 				startedAt: 100,
 				steps: [{ agent: "worker", workflowKey: "writer", lane: { version: 1, key: "other" }, status: "running" }],
 			});
-			assert.throws(() => listAsyncRuns(root, { states: ["running"] }), /does not match workflow key/);
+			fs.rmSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "run-lane-invalid"));
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], repairScan: true }), /does not match workflow key/);
 			assert.equal(fs.existsSync(path.join(runDir, "status.json")), true);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
@@ -621,9 +623,10 @@ describe("async status helpers", () => {
 				startedAt: 100,
 				steps: [{ agent: "worker", status: "running" }],
 			});
+			fs.rmSync(path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-session"));
 
 			assert.throws(
-				() => listAsyncRuns(root),
+				() => listAsyncRuns(root, { repairScan: true }),
 				/sessionId must be a string/,
 			);
 		} finally {
@@ -865,6 +868,322 @@ describe("async status helpers", () => {
 
 			assert.deepEqual(runs.map((run) => run.id), ["active"]);
 		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates corrupt active status while restoring valid runs and releases an aged marker", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-corrupt-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const corruptDir = path.join(root, "bad-run");
+			const corruptStatusPath = path.join(corruptDir, "status.json");
+			fs.mkdirSync(corruptDir, { recursive: true });
+			fs.writeFileSync(corruptStatusPath, Buffer.from([0, 0, 0]));
+			fs.writeFileSync(path.join(corruptDir, "runner.stderr.log"), "runner stopped unexpectedly\n", "utf-8");
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-run");
+			fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+			fs.writeFileSync(markerPath, "", "utf-8");
+			fs.utimesSync(markerPath, new Date(1_000), new Date(1_000));
+
+			const runs = listAsyncRuns(root, {
+				states: ["running"],
+				reconcile: false,
+				now: () => 1_000 + DEFAULT_STALE_TERMINAL_ACTIVE_MARKER_MS + 1,
+			});
+
+			assert.deepEqual(runs.map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(corruptDir), true);
+			assert.deepEqual(fs.readFileSync(corruptStatusPath), Buffer.from([0, 0, 0]));
+			assert.equal(fs.readFileSync(path.join(corruptDir, "runner.stderr.log"), "utf-8"), "runner stopped unexpectedly\n");
+			assert.equal(fs.existsSync(markerPath), false);
+			assert.ok(diagnostics.some((message) => message.includes("bad-run") && message.includes(corruptStatusPath) && message.includes("Failed to parse async status file")));
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates active status validation failures while preserving ordinary validation errors", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-invalid-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const invalidDir = createAsyncDir(root, "bad-validation", {
+				runId: "bad-validation",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", workflowKey: "writer", lane: { version: 1, key: "other" }, status: "running" }],
+			});
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-validation");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }).map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(invalidDir), true);
+			assert.equal(fs.existsSync(markerPath), true);
+			assert.ok(diagnostics.some((message) => message.includes("bad-validation") && message.includes("Failed to validate async status file")));
+
+			fs.rmSync(markerPath);
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false, repairScan: true }), /Failed to validate async status file/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates active reconciliation validation failures while preserving ordinary failures", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-reconcile-invalid-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const invalidDir = createAsyncDir(root, "bad-reconcile", {
+				runId: "bad-reconcile",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", model: 123, status: "running" }],
+			});
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-reconcile");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"] }).map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(invalidDir), true);
+			assert.equal(fs.existsSync(markerPath), true);
+			assert.ok(diagnostics.some((message) => message.includes("bad-reconcile") && message.includes("steps[0].model must be a string")));
+
+			fs.rmSync(markerPath);
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], repairScan: true }), /steps\[0\]\.model must be a string/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates active status summary projection failures while preserving ordinary projection errors", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-summary-invalid-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const invalidDir = createAsyncDir(root, "bad-summary", {
+				runId: "bad-summary",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+				workflowChildren: {
+					version: 1,
+					parentToolCallId: "call_123",
+					workflowRunId: "other-run",
+					inventoryComplete: true,
+					workflowState: "running",
+					children: [],
+				},
+			});
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-summary");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }).map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(invalidDir), true);
+			assert.equal(fs.existsSync(markerPath), true);
+			assert.ok(diagnostics.some((message) => message.includes("bad-summary") && message.includes("workflowChildren.workflowRunId does not match")));
+
+			fs.rmSync(markerPath);
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false, repairScan: true }), /workflowChildren\.workflowRunId does not match/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates active workflowChildren identifier projection failures while preserving ordinary failures", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-child-id-invalid-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const invalidDir = createAsyncDir(root, "bad-child-id", {
+				runId: "bad-child-id",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+				workflowChildren: {
+					version: 1,
+					parentToolCallId: "   ",
+					workflowRunId: "bad-child-id",
+					inventoryComplete: true,
+					workflowState: "running",
+					children: [],
+				},
+			});
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-child-id");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }).map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(invalidDir), true);
+			assert.equal(fs.existsSync(markerPath), true);
+			assert.ok(diagnostics.some((message) => message.includes("bad-child-id") && message.includes("workflowChildren.parentToolCallId must be a non-empty identifier")));
+
+			fs.rmSync(markerPath);
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false, repairScan: true }), /workflowChildren\.parentToolCallId must be a non-empty identifier/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates active output file projection failures while preserving ordinary failures", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-output-file-invalid-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const invalidDir = createAsyncDir(root, "bad-output-file", {
+				runId: "bad-output-file",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				outputFile: { path: "output.txt" },
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-output-file");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }).map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(invalidDir), true);
+			assert.equal(fs.existsSync(markerPath), true);
+			assert.ok(diagnostics.some((message) => message.includes("bad-output-file") && message.includes("outputFile must be a string")));
+
+			fs.rmSync(markerPath);
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false, repairScan: true }), /outputFile must be a string/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates active workflowGraph host-step projection failures while preserving ordinary failures", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-host-step-invalid-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const invalidDir = createAsyncDir(root, "bad-host-step", {
+				runId: "bad-host-step",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+				workflowGraph: {
+					runId: "bad-host-step",
+					mode: "workflow",
+					phases: [],
+					nodes: [{ id: "gate", kind: "host-step", label: "gate", status: "running" }],
+				},
+			});
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-host-step");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"], reconcile: false }).map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(invalidDir), true);
+			assert.equal(fs.existsSync(markerPath), true);
+			assert.ok(diagnostics.some((message) => message.includes("bad-host-step") && message.includes("hostStep': expected an object")));
+
+			fs.rmSync(markerPath);
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], reconcile: false, repairScan: true }), /hostStep': expected an object/);
+		} finally {
+			console.error = originalError;
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("isolates active workflowGraph container validation failures while preserving ordinary failures", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-status-workflow-graph-invalid-active-"));
+		const originalError = console.error;
+		const diagnostics: string[] = [];
+		try {
+			console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(" "));
+			createAsyncDir(root, "good-run", {
+				runId: "good-run",
+				mode: "single",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+			});
+			const invalidDir = createAsyncDir(root, "bad-workflow-graph", {
+				runId: "bad-workflow-graph",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				steps: [{ agent: "worker", status: "running" }],
+				workflowGraph: {
+					runId: "bad-workflow-graph",
+					mode: "workflow",
+					phases: [],
+					nodes: null,
+				},
+			});
+			const markerPath = path.join(root, ACTIVE_RUN_INDEX_DIR, "bad-workflow-graph");
+
+			assert.deepEqual(listAsyncRuns(root, { states: ["running"] }).map((run) => run.id), ["good-run"]);
+			assert.equal(fs.existsSync(invalidDir), true);
+			assert.equal(fs.existsSync(markerPath), true);
+			assert.ok(diagnostics.some((message) => message.includes("bad-workflow-graph") && message.includes("workflowGraph': nodes must be an array")));
+
+			fs.rmSync(markerPath);
+			assert.throws(() => listAsyncRuns(root, { states: ["running"], repairScan: true }), /workflowGraph': nodes must be an array/);
+		} finally {
+			console.error = originalError;
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});


### PR DESCRIPTION
## Summary
- isolates corrupt active async `status.json` files per run so valid active runs still restore
- preserves corrupt run artifacts while releasing only aged or process-terminal-proven active markers
- adds focused restoration regressions and credits [@zhexulong](https://github.com/zhexulong) for #1756

Closes #1756.

## Validation
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-status.test.ts test/integration/async-job-tracker.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/stale-run-reconciler.test.ts`
- `npm run typecheck`
- `git diff --check origin/main..HEAD`
- Fresh reviewer: No issues found

Note: local full unit still has the unrelated missing `node_modules/oxlint/bin/oxlint` environment failure; CI will run the full install-backed suite.
