### PR TITLE
fix: resolve models for discovered agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Changed
+- Show effective model mappings for discovered and runtime-registered subagents through management and `/subagents-models`. Thanks [@RapierCraft](https://github.com/RapierCraft) for #1732.
 - Trim default subagent prompt guidelines to five parent-facing entries while keeping advanced workflow details in the packaged guide. Thanks [@Ran-Xing](https://github.com/Ran-Xing) for #1746.
 - Add extension-owned named workflow resources so permission/policy extensions can distinguish resolved provenance from raw workflow scripts and enforce resource-scoped host command authority. Thanks [@mathiasloh](https://github.com/mathiasloh) for #1751.
 - Coalesce unchanged structured-delegation heartbeat snapshots while retaining ordinary foreground heartbeats and complete terminal responses (#1739).

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -7,7 +7,6 @@ import {
 	type AgentDiscoveryDiagnostic,
 	type AgentScope,
 	type AgentSource,
-	BUILTIN_AGENT_NAMES,
 	defaultInheritProjectContext,
 	defaultInheritSkills,
 	defaultSystemPromptMode,
@@ -28,7 +27,7 @@ import {
 	buildProactiveSkillSubagentRecommendationLines,
 } from "./proactive-skills.ts";
 import { parseFrontmatter, parseFrontmatterList } from "./frontmatter.ts";
-import { toModelInfo } from "../shared/model-info.ts";
+import { resolveEffectiveThinking, toModelInfo } from "../shared/model-info.ts";
 import { resolveSubagentModelOverride, type ParentModel } from "../runs/shared/model-fallback.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
@@ -37,7 +36,7 @@ import type { AcceptanceInput, AgentCapabilitiesSnapshot, AgentCapabilityRow, De
 import { getProjectConfigDir } from "../shared/utils.ts";
 import { previewDisplayText } from "../shared/display-text.ts";
 import { capabilityCeilingAgentRestrictionSources, isAgentAllowedByCapabilityCeiling, resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
-import { listRuntimeAgentConfigs, mergeRuntimeAgents, type RuntimeAgentOwner } from "./runtime-agent-registry.ts";
+import { mergeRuntimeAgents, type RuntimeAgentOwner } from "./runtime-agent-registry.ts";
 import { listExternalJobProviders } from "../api/external-job-provider.ts";
 
 type ManagementAction = "list" | "get" | "models" | "create" | "update" | "delete" | "eject" | "disable" | "enable" | "reset";
@@ -129,18 +128,39 @@ function allAgents(d: { builtin: AgentConfig[]; package: AgentConfig[]; user: Ag
 	return [...d.builtin, ...d.package, ...d.user, ...d.project];
 }
 
-function availableAgentNamesFromDiscovery(d: { builtin: AgentConfig[]; package: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] }): string[] {
-	return [...new Set(allAgents(d).map((agent) => agent.name))].sort((a, b) => a.localeCompare(b));
+function effectiveAgentsForScope(
+	scope: AgentScope,
+	d: { builtin: AgentConfig[]; package: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] },
+	runtimeAgentOwner?: RuntimeAgentOwner,
+): AgentConfig[] {
+	let agents = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package);
+	if (runtimeAgentOwner) {
+		agents = mergeRuntimeAgents(runtimeAgentOwner, { agents }, allAgents(d)).agents;
+	}
+	return agents;
+}
+
+function availableAgentNamesFromDiscovery(
+	d: { builtin: AgentConfig[]; package: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] },
+	runtimeAgentOwner?: RuntimeAgentOwner,
+): string[] {
+	const agents = runtimeAgentOwner ? effectiveAgentsForScope("both", d, runtimeAgentOwner) : allAgents(d);
+	return [...new Set(agents.map((agent) => agent.name))].sort((a, b) => a.localeCompare(b));
 }
 
 function availableAgentNames(cwd: string): string[] {
 	return availableAgentNamesFromDiscovery(discoverAgentsAll(cwd));
 }
 
-function findAgentsInDiscovery(name: string, d: { builtin: AgentConfig[]; package: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] }, scope: AgentScope = "both"): AgentConfig[] {
+function findAgentsInDiscovery(
+	name: string,
+	d: { builtin: AgentConfig[]; package: AgentConfig[]; user: AgentConfig[]; project: AgentConfig[] },
+	scope: AgentScope = "both",
+	runtimeAgentOwner?: RuntimeAgentOwner,
+): AgentConfig[] {
 	const raw = name.trim();
 	const sanitized = sanitizeName(raw);
-	const scoped = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package);
+	const scoped = effectiveAgentsForScope(scope, d, runtimeAgentOwner);
 	let resolved = resolveAgentName(raw, scoped);
 	if (!resolved.agent && !resolved.error && sanitized !== raw) resolved = resolveAgentName(sanitized, scoped);
 	if (resolved.agent) return scoped.filter((agent) => agent.name === resolved.agent!.name).sort((a, b) => a.source.localeCompare(b.source));
@@ -863,16 +883,7 @@ function formatAgentDetail(agent: AgentConfig): string {
 export function handleList(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	const scope = normalizeListScope(params.agentScope) ?? "both";
 	const d = discoverAgentsAll(ctx.cwd, ctx.model?.provider);
-	let scopedAgents = mergeAgentsForScope(scope, d.user, d.project, d.builtin, d.package);
-	if (ctx.runtimeAgentOwner && listRuntimeAgentConfigs(ctx.runtimeAgentOwner).length > 0) {
-		const configuredAgents: AgentConfig[] = [
-			...d.builtin,
-			...d.package,
-			...d.user,
-			...d.project,
-		];
-		scopedAgents = mergeRuntimeAgents(ctx.runtimeAgentOwner, { agents: scopedAgents }, configuredAgents).agents;
-	}
+	let scopedAgents = effectiveAgentsForScope(scope, d, ctx.runtimeAgentOwner);
 	scopedAgents = scopedAgents
 		.sort((a, b) => a.name.localeCompare(b.name));
 	const capabilityCeiling = resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId);
@@ -913,80 +924,108 @@ function formatModelSource(agent: AgentConfig, currentModel: ParentModel | undef
 	if (agent.modelSource?.type === "subagents.defaultModel" && agent.model === agent.modelSource.model) {
 		return `${agent.modelSource.scope} defaultModel`;
 	}
-	if (agent.model) return "builtin agent config";
+	if (agent.model) return `${agent.source} agent config`;
 	if (currentModel) return "inherits current session model";
 	return "inherit requested, but no current session model is available";
 }
 
 function handleModels(params: ManagementParams, ctx: ManagementContext): AgentToolResult<Details> {
 	const requestedAgent = params.agent?.trim();
-	if (requestedAgent && !(BUILTIN_AGENT_NAMES as readonly string[]).includes(requestedAgent)) {
-		return result(`Builtin agent '${requestedAgent}' not found. Available: ${BUILTIN_AGENT_NAMES.join(", ")}.`, true);
-	}
+	const scope = normalizeListScope(params.agentScope);
+	if (!scope) return result("agentScope must be 'user', 'project', or 'both' for models.", true);
 
 	const discovered = discoverAgentsAll(ctx.cwd, ctx.model?.provider);
-	const builtinByName = new Map(discovered.builtin.map((agent) => [agent.name, agent]));
-	const resolveBuiltinModelAgent = (name: string): AgentConfig | undefined => builtinByName.get(name) ?? resolveAgentName(name, discovered.builtin).agent;
+	const effectiveAgents = effectiveAgentsForScope(scope, discovered, ctx.runtimeAgentOwner)
+		.sort((a, b) => a.name.localeCompare(b.name));
 	const availableModels = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const currentModel = ctx.model ? { provider: ctx.model.provider, id: ctx.model.id } : undefined;
 	const preferredProvider = ctx.model?.provider;
-	const names = requestedAgent ? [requestedAgent] : [...BUILTIN_AGENT_NAMES];
+	const capabilityCeiling = resolveCurrentSubagentCapabilityCeiling(ctx.currentSessionId);
 
+	let selectedAgents = effectiveAgents;
 	if (requestedAgent) {
-		const agent = resolveBuiltinModelAgent(requestedAgent);
-		if (!agent) return result(`Builtin agent '${requestedAgent}' not found.`, true);
-		const resolvedModel = resolveSubagentModelOverride(agent.model, currentModel, availableModels, preferredProvider);
-		const lines = [
-			"Builtin subagent model",
-			"",
-			`Agent: ${requestedAgent}`,
-			"Effective model:",
-			`  ${resolvedModel ?? "(unresolved)"}`,
-			`Source: ${formatModelSource(agent, currentModel)}`,
-		];
-		if (agent.override) {
-			lines.push("Override file:");
-			lines.push(`  ${agent.override.path}`);
+		const matches = findAgentsInDiscovery(requestedAgent, discovered, scope, ctx.runtimeAgentOwner);
+		const diagnostics = diagnosticsForScope(discovered.agentDiagnostics, scope);
+		const normalizedName = sanitizeName(requestedAgent);
+		const diagnostic = findBlockingAgentDiagnostic(requestedAgent, matches, diagnostics)
+			?? (normalizedName !== requestedAgent ? findBlockingAgentDiagnostic(normalizedName, matches, diagnostics) : undefined);
+		if (diagnostic) return result(`Agent '${params.agent}' has invalid configuration: ${diagnostic.error}`, true);
+		const distinctNames = [...new Set(matches.map((agent) => agent.name))];
+		if (distinctNames.length > 1) return result(`Ambiguous agent alias or name '${params.agent}': ${distinctNames.sort((a, b) => a.localeCompare(b)).join(", ")}`, true);
+		if (!matches.length) {
+			return result(`Agent '${params.agent}' not found. Available: ${availableAgentNamesFromDiscovery(discovered, ctx.runtimeAgentOwner).join(", ") || "none"}.`, true);
 		}
-		if (agent.model && resolvedModel && agent.model !== resolvedModel) {
-			lines.push("Requested model setting:");
-			lines.push(`  ${agent.model}`);
-		}
-		if (agent.disabled) lines.push("Disabled: true");
-		lines.push("Current session model:");
-		lines.push(`  ${currentModel ? `${currentModel.provider}/${currentModel.id}` : "(unavailable)"}`);
-		return result(lines.join("\n"));
+		selectedAgents = [matches[0]!];
 	}
 
 	const lines = [
-		"Builtin subagent models",
+		requestedAgent ? "Subagent model" : "Subagent models",
 		"",
-		"Current session model:",
-		`  ${currentModel ? `${currentModel.provider}/${currentModel.id}` : "(unavailable)"}`,
-		"",
+		...(requestedAgent ? [] : [
+			"Current session model:",
+			`  ${currentModel ? `${currentModel.provider}/${currentModel.id}` : "(unavailable)"}`,
+			"",
+		]),
 	];
 
-	for (const name of names) {
-		const agent = resolveBuiltinModelAgent(name);
-		if (!agent) {
-			lines.push(name);
-			lines.push("  model:");
-			lines.push("    (builtin definition not found)");
-			lines.push("  source: missing");
-			lines.push("");
-			continue;
+	const modelEntries = selectedAgents.flatMap((agent) => requestedAgent
+		? [{ agent, name: requestedAgent }]
+		: [{ agent, name: agent.name }, ...(agent.aliases ?? []).map((name) => ({ agent, name }))]);
+	for (const { agent, name } of modelEntries) {
+		const resolvedModel = resolveSubagentModelOverride(agent.model, currentModel, availableModels, agent.modelProvider ?? preferredProvider);
+		const effectiveThinking = resolveEffectiveThinking(resolvedModel, agent.thinking)
+			?? (agent.thinking === false ? "off" : undefined);
+		const source = `${formatModelSource(agent, currentModel)}${agent.disabled ? "; disabled" : ""}${isAgentAllowedByCapabilityCeiling(agent.name, capabilityCeiling) ? "" : "; restricted"}`;
+		if (requestedAgent) {
+			lines.push(`Agent: ${requestedAgent}`);
+			lines.push("Effective model:");
+			lines.push(`  ${resolvedModel ?? "(unresolved)"}`);
+			lines.push(`Source: ${source}`);
+			lines.push(`Thinking: ${effectiveThinking ?? "default"}`);
+			if (agent.fallbackModels?.length) {
+				lines.push("Fallback models:");
+				for (const fallback of agent.fallbackModels) {
+					lines.push(`  ${resolveSubagentModelOverride(fallback, currentModel, availableModels, agent.modelProvider ?? preferredProvider) ?? fallback}`);
+				}
+			}
+			if (agent.override) {
+				lines.push("Override file:");
+				lines.push(`  ${agent.override.path}`);
+			}
+			if (agent.model && resolvedModel && agent.model !== resolvedModel) {
+				lines.push("Requested model setting:");
+				lines.push(`  ${agent.model}`);
+			}
+			if (agent.disabled) lines.push("Disabled: true");
+			if (!isAgentAllowedByCapabilityCeiling(agent.name, capabilityCeiling)) lines.push("Restricted: true");
+			lines.push("Current session model:");
+			lines.push(`  ${currentModel ? `${currentModel.provider}/${currentModel.id}` : "(unavailable)"}`);
+			break;
 		}
-		const resolvedModel = resolveSubagentModelOverride(agent.model, currentModel, availableModels, preferredProvider);
-		const source = `${formatModelSource(agent, currentModel)}${agent.disabled ? "; disabled" : ""}`;
 		lines.push(name);
 		lines.push("  model:");
 		lines.push(`    ${resolvedModel ?? "(unresolved)"}`);
 		lines.push(`  source: ${source}`);
+		lines.push(`  thinking: ${effectiveThinking ?? "default"}`);
+		if (agent.fallbackModels?.length) {
+			lines.push("  fallback models:");
+			for (const fallback of agent.fallbackModels) {
+				lines.push(`    ${resolveSubagentModelOverride(fallback, currentModel, availableModels, agent.modelProvider ?? preferredProvider) ?? fallback}`);
+			}
+		}
+		if (agent.override) {
+			lines.push("  override file:");
+			lines.push(`    ${agent.override.path}`);
+		}
+		if (agent.model && resolvedModel && agent.model !== resolvedModel) {
+			lines.push("  requested model setting:");
+			lines.push(`    ${agent.model}`);
+		}
 		lines.push("");
 	}
 
 	const availableFullIds = availableModels.map((m) => m.fullId).sort();
-	if (availableFullIds.length > 0) {
+	if (!requestedAgent && availableFullIds.length > 0) {
 		lines.push("Available models in this session's registry (copy an exact provider/id when passing model):");
 		lines.push("");
 		const shown = availableFullIds.slice(0, 80);
@@ -995,7 +1034,7 @@ function handleModels(params: ManagementParams, ctx: ManagementContext): AgentTo
 		lines.push("");
 		lines.push("Use an exact provider/id from this list when you pass model; bare ids resolve only when unique in the registry.");
 	}
-
+	if (!requestedAgent) appendAgentDiagnosticLines(lines, diagnosticsForScope(discovered.agentDiagnostics, scope));
 	return result(lines.join("\n"));
 }
 

--- a/src/slash/slash-commands.ts
+++ b/src/slash/slash-commands.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { keyText, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Key, matchesKey, truncateToWidth, type Component, type KeyId, type TUI } from "@earendil-works/pi-tui";
-import { BUILTIN_AGENT_NAMES, discoverAgentSnapshot, discoverAgents, findBlockingAgentDiagnostic, formatUnknownAgentError, resolveAgentName, unknownAgentDiagnosticContext, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope, type UnknownAgentDiagnosticContext } from "../agents/agents.ts";
+import { discoverAgentSnapshot, discoverAgents, findBlockingAgentDiagnostic, formatUnknownAgentError, resolveAgentName, unknownAgentDiagnosticContext, type AgentConfig, type AgentDiscoveryDiagnostic, type AgentScope, type UnknownAgentDiagnosticContext } from "../agents/agents.ts";
 import { listRuntimeAgentConfigs, mergeRuntimeAgents } from "../agents/runtime-agent-registry.ts";
 import { resolveExistingReadPaths } from "../shared/settings.ts";
 import {
@@ -135,13 +135,6 @@ const makeAgentCompletions = (pi: ExtensionAPI, state: SubagentState) => (prefix
 	return discoverSlashAgents(pi, state.baseCwd, "both").agents
 		.filter((agent) => agent.name.startsWith(prefix))
 		.map((agent) => ({ value: agent.name, label: agent.name }));
-};
-
-const makeBuiltinAgentNameCompletions = () => (prefix: string) => {
-	if (prefix.includes(" ")) return null;
-	return BUILTIN_AGENT_NAMES
-		.filter((name) => name.startsWith(prefix))
-		.map((name) => ({ value: name, label: name }));
 };
 
 const makeProviderCompletions = (state: SubagentState) => (prefix: string) => {
@@ -1144,25 +1137,20 @@ export function registerSlashCommands(
 	});
 
 	pi.registerCommand("subagents-models", {
-		description: "Show runtime-loaded builtin subagent models",
-		getArgumentCompletions: makeBuiltinAgentNameCompletions(),
-			handler: async (args, ctx) => {
-				const trimmed = args.trim();
-				if (!trimmed) {
-					await runCommand(ctx, { action: "models" });
+		description: "Show model mappings for discovered subagents",
+		getArgumentCompletions: makeAgentCompletions(pi, state),
+		handler: async (args, ctx) => {
+			const trimmed = args.trim();
+			if (!trimmed) {
+				await runCommand(ctx, { action: "models" });
 				return;
 			}
 			const parts = trimmed.split(/\s+/).filter(Boolean);
 			if (parts.length !== 1) {
-				ctx.ui.notify("Usage: /subagents-models [builtin-agent-name]", "error");
+				ctx.ui.notify("Usage: /subagents-models [agent-name]", "error");
 				return;
 			}
-			const agent = parts[0]!;
-			if (!(BUILTIN_AGENT_NAMES as readonly string[]).includes(agent)) {
-				ctx.ui.notify(`Unknown builtin agent: ${agent}`, "error");
-				return;
-			}
-			await runCommand(ctx, { action: "models", agent });
+			await runCommand(ctx, { action: "models", agent: parts[0]! });
 		},
 	});
 

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -1122,6 +1122,51 @@ describe("slash command custom message delivery", { skip: !available ? "slash-co
 		});
 	});
 
+	it("/subagents-models accepts discovered and runtime agent names", async () => {
+		await withTempProject("pi-slash-models-agent-", async (root) => {
+			fs.writeFileSync(path.join(root, ".pi", "agents", "project-helper.md"), "---\nname: project-helper\ndescription: Project helper\n---\nProject helper.\n", "utf-8");
+			const runtimeRun = await captureSlashCommandParams("subagents-models", "runtime-helper", root, (pi) => {
+				registerAgent({
+					pi: pi as never,
+					name: "runtime-helper",
+					definition: { description: "Runtime helper", systemPrompt: "Help at runtime." },
+				});
+			});
+			assert.deepEqual(runtimeRun.params, { action: "models", agent: "runtime-helper" });
+
+			const projectRun = await captureSlashCommandParams("subagents-models", "project-helper", root);
+			assert.deepEqual(projectRun.params, { action: "models", agent: "project-helper" });
+
+			await withIsolatedHome(async () => {
+				const commands = new Map<string, RegisteredSlashCommand>();
+				const pi = {
+					events: createEventBus(),
+					on() { return () => {}; },
+					registerTool() {},
+					registerCommand(name: string, spec: RegisteredSlashCommand) { commands.set(name, spec); },
+					registerShortcut() {},
+					sendMessage() {},
+				};
+				const registration = registerAgent({
+					pi: pi as never,
+					name: "runtime-helper",
+					definition: { description: "Runtime helper", systemPrompt: "Help at runtime." },
+				});
+				try {
+					const disposer = registerSlashCommands!(pi, createState(root));
+					try {
+						const completions = commands.get("subagents-models")!.getArgumentCompletions!("runtime-") as Array<{ value: string }>;
+						assert.deepEqual(completions.map(({ value }) => value), ["runtime-helper"]);
+					} finally {
+						disposer.dispose();
+					}
+				} finally {
+					registration.dispose();
+				}
+			});
+		});
+	});
+
 	it("/run preserves existing relative reads and omits missing reads", async () => {
 		await withTempProject("pi-slash-reads-", async (root) => {
 			fs.writeFileSync(path.join(root, ".pi", "agents", "scout.md"), `---

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -1048,7 +1048,7 @@ Drive the failing test first.
 		const result = handleManagementAction("models", {}, ctx);
 		const text = readText(result);
 		assert.equal(result.isError, false);
-		assert.match(text, /^Builtin subagent models/m);
+		assert.match(text, /^Subagent models/m);
 		assert.match(text, /Current session model:\n  openai\/gpt-5-mini/);
 		assert.match(text, /(?:^|\n)scout\n  model:\n    openai\/gpt-5-mini\n  source: inherits current session model(?:\n|$)/);
 		assert.match(text, /(?:^|\n)advisor\n  model:\n    openai\/gpt-5-mini\n  source: inherits current session model(?:\n|$)/);
@@ -1069,6 +1069,66 @@ Drive the failing test first.
 		assert.match(text, /Agent: advisor/);
 		assert.match(text, /Effective model:\n  openai\/gpt-5-mini/);
 		assert.doesNotMatch(text, /Builtin agent 'advisor' not found|source: missing/);
+	});
+
+	it("reports effective model mappings for discovered package, user, and project agents", () => {
+		const projectAgentsDir = path.join(tempDir, ".pi", "agents");
+		const userAgentsDir = path.join(tempDir, "agent-home", "agents");
+		const packageDir = path.join(tempDir, ".pi", "npm", "node_modules", "model-agents");
+		fs.mkdirSync(projectAgentsDir, { recursive: true });
+		fs.mkdirSync(userAgentsDir, { recursive: true });
+		fs.mkdirSync(path.join(packageDir, "agents"), { recursive: true });
+		fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({
+			name: "model-agents",
+			version: "1.2.3",
+			pi: { subagents: { agents: ["agents"] } },
+		}));
+		const writeAgent = (dir: string, name: string, model: string, thinking: string, fallback: string) => fs.writeFileSync(path.join(dir, `${name}.md`), [
+			"---",
+			`name: ${name}`,
+			`description: ${name} model mapping`,
+			`model: ${model}`,
+			`thinking: ${thinking}`,
+			`fallbackModels: ${fallback}`,
+			"---",
+			"Model mapping test agent.",
+		].join("\n"));
+		writeAgent(path.join(packageDir, "agents"), "package-worker", "anthropic/claude-sonnet-4", "low", "openai/gpt-5-mini");
+		writeAgent(userAgentsDir, "user-worker", "gpt-5-mini", "medium", "claude-sonnet-4");
+		writeAgent(userAgentsDir, "shadowed", "openai/gpt-5-mini", "low", "anthropic/claude-sonnet-4");
+		writeAgent(projectAgentsDir, "project-worker", "anthropic/claude-sonnet-4", "high", "openai/gpt-5-mini");
+		writeAgent(projectAgentsDir, "shadowed", "openai/gpt-5-mini", "high", "anthropic/claude-sonnet-4");
+		fs.writeFileSync(path.join(projectAgentsDir, "off-worker.md"), [
+			"---",
+			"name: off-worker",
+			"description: off-worker model mapping",
+			"model: openai/gpt-5-mini",
+			"thinking: false",
+			"---",
+			"Explicitly disable thinking.",
+		].join("\n"));
+		const settingsPath = path.join(tempDir, ".pi", "settings.json");
+		fs.writeFileSync(settingsPath, JSON.stringify({ subagents: { agentOverrides: { reviewer: { disabled: true } } } }));
+
+		const ctx = {
+			cwd: tempDir,
+			modelRegistry: { getAvailable: () => [
+				{ provider: "openai", id: "gpt-5-mini" },
+				{ provider: "anthropic", id: "claude-sonnet-4" },
+			] },
+			model: { provider: "openai", id: "gpt-5-mini" },
+		};
+		const result = handleManagementAction("models", {}, ctx);
+		const text = readText(result);
+		assert.equal(result.isError, false);
+		assert.match(text, /package-worker\n  model:\n    anthropic\/claude-sonnet-4\n  source: package agent config\n  thinking: low\n  fallback models:\n    openai\/gpt-5-mini/);
+		assert.match(text, /user-worker\n  model:\n    openai\/gpt-5-mini\n  source: user agent config\n  thinking: medium/);
+		assert.match(text, /project-worker\n  model:\n    anthropic\/claude-sonnet-4\n  source: project agent config\n  thinking: high/);
+		assert.match(text, /off-worker\n  model:\n    openai\/gpt-5-mini\n  source: project agent config\n  thinking: off/);
+		assert.match(text, /shadowed\n  model:\n    openai\/gpt-5-mini\n  source: project agent config/);
+		assert.doesNotMatch(text, /shadowed\n  model:\n    openai\/gpt-5-mini\n  source: user agent config/);
+		assert.match(text, /reviewer\n  model:\n    openai\/gpt-5-mini\n  source: inherits current session model; disabled/);
+		assert.doesNotMatch(text, /api[_-]?key|token|secret/i);
 	});
 
 	it("reports override source and disabled builtin state in runtime model mappings", () => {
@@ -1096,7 +1156,7 @@ Drive the failing test first.
 		const result = handleManagementAction("models", { agent: "reviewer" }, ctx);
 		const text = readText(result);
 		assert.equal(result.isError, false);
-		assert.match(text, /^Builtin subagent model/m);
+		assert.match(text, /^Subagent model/m);
 		assert.match(text, /Agent: reviewer/);
 		assert.match(text, /Effective model:\n  anthropic\/claude-sonnet-4/);
 		assert.match(text, /Source: project override/);
@@ -1105,14 +1165,14 @@ Drive the failing test first.
 		assert.match(text.replaceAll("\\", "/"), /Override file:\n  .*\.pi\/settings\.json/);
 	});
 
-	it("rejects unknown builtin filters for runtime model mappings", () => {
+	it("rejects unknown agents for runtime model mappings", () => {
 		const result = handleManagementAction("models", { agent: "not-a-builtin" }, {
 			cwd: tempDir,
 			modelRegistry: { getAvailable: () => [] },
 		});
 
 		assert.equal(result.isError, true);
-		assert.match(readText(result), /Builtin agent 'not-a-builtin' not found/);
+		assert.match(readText(result), /Agent 'not-a-builtin' not found/);
 	});
 
 	it("creates delegate with its builtin prompt defaults", () => {

--- a/test/unit/runtime-agent-registration.test.ts
+++ b/test/unit/runtime-agent-registration.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { RUNTIME_AGENT_REGISTER_EVENT, registerAgent, registerAgentViaEvents, type RuntimeAgentRegistrationRequest } from "../../src/api/agents.ts";
 import { registerRuntimeAgentEventListener } from "../../src/agents/runtime-agent-events.ts";
-import { handleList } from "../../src/agents/agent-management.ts";
+import { handleList, handleManagementAction } from "../../src/agents/agent-management.ts";
 import { discoverAgents, discoverAgentsAll } from "../../src/agents/agents.ts";
 import { clearRuntimeAgentsForPi, mergeRuntimeAgents } from "../../src/agents/runtime-agent-registry.ts";
 
@@ -210,6 +210,48 @@ describe("runtime agent registration", () => {
 		const listed = handleList({}, { cwd: tempProject, modelRegistry: { getAvailable: () => [] }, runtimeAgentOwner: pi });
 		const text = listed.content.map((part) => part.type === "text" ? part.text ?? "" : "").join("\n");
 		assert.match(text, /- runtime-helper \(runtime, aliases: helper\): Runtime helper/);
+	});
+
+	it("reports runtime agent model mappings by name and alias", () => {
+		const registration = registerAgent({
+			pi,
+			name: "runtime-model-helper",
+			definition: {
+				description: "Runtime model helper",
+				systemPrompt: "Help with model routing.",
+				aliases: ["model-helper"],
+				model: "openai/gpt-5-mini",
+				fallbackModels: ["anthropic/claude-sonnet-4"],
+				thinking: "high",
+			},
+		});
+		try {
+			const ctx = {
+				cwd: tempProject,
+				modelRegistry: {
+					getAvailable: () => [
+						{ provider: "openai", id: "gpt-5-mini" },
+						{ provider: "anthropic", id: "claude-sonnet-4" },
+					],
+				},
+				model: { provider: "openai", id: "gpt-5-mini" },
+				runtimeAgentOwner: pi,
+			};
+			const all = handleManagementAction("models", {}, ctx);
+			const allText = all.content.map((part) => part.type === "text" ? part.text ?? "" : "").join("\n");
+			assert.equal(all.isError, false);
+			assert.match(allText, /runtime-model-helper\n  model:\n    openai\/gpt-5-mini\n  source: runtime agent config\n  thinking: high\n  fallback models:\n    anthropic\/claude-sonnet-4/);
+
+			const filtered = handleManagementAction("models", { agent: "model-helper" }, ctx);
+			const filteredText = filtered.content.map((part) => part.type === "text" ? part.text ?? "" : "").join("\n");
+			assert.equal(filtered.isError, false);
+			assert.match(filteredText, /Agent: model-helper/);
+			assert.match(filteredText, /Effective model:\n  openai\/gpt-5-mini/);
+			assert.match(filteredText, /Source: runtime agent config/);
+			assert.match(filteredText, /Fallback models:\n  anthropic\/claude-sonnet-4/);
+		} finally {
+			registration.dispose();
+		}
 	});
 
 	it("fails closed for builtin and duplicate runtime identities", () => {


### PR DESCRIPTION
## Summary
- includes effective package, user, project, and runtime-registered agents in `action: "models"`
- lets `/subagents-models <agent>` route discovered/runtime agents instead of rejecting non-builtin names
- preserves existing inherited/configured model fallback display semantics
- credits [@RapierCraft](https://github.com/RapierCraft) for the original PR #1732

Supersedes #1732.

## Validation
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/agent-management.test.ts test/unit/runtime-agent-registration.test.ts test/integration/slash-commands.test.ts`
- `npm run typecheck`
- `git diff --check origin/main..HEAD`
- `git diff --check`
- retained deletion-first challenge
- fresh exact-head review after rebase: No issues found
