### PR TITLE
docs: clarify hard cutover policy

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -32,6 +32,17 @@ When behavior cannot be proven, the system fails closed instead of reporting opt
 Existing primitives come first.
 A new mode, runner, or abstraction is justified only when current primitives cannot honestly express the needed behavior.
 
+## Compatibility is explicit
+
+Default to hard cutovers when replacing a tool, option, behavior, or public surface.
+Do not keep aliases, migration shims, legacy code paths, or compatibility modes unless the owner asks for them or the release contract requires them.
+Compatibility has a cost: extra docs, tests, status text, support paths, and future ambiguity.
+When that cost is not deliberately accepted, remove the old path cleanly and make the new contract obvious.
+
+Tests should prove the current contract.
+Do not add defensive tests that preserve removed behavior, stale migration paths, or compatibility the project no longer wants.
+For removals, update or delete obsolete assertions instead of making production code serve them.
+
 ## Scope must earn size
 
 Pull requests should be narrow enough to review with confidence.


### PR DESCRIPTION
## Summary
- documents that compatibility retention must be explicit
- says aliases, shims, and legacy paths should be removed by default when a tool or surface is replaced
- clarifies that tests should prove the current contract, not preserve removed behavior

## Validation
- `git diff --check -- VISION.md`
