### PR TITLE
fix: preserve read-only intent in escaped workflow tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - Establish async lifecycle sidecars before external CLI workers can mutate a worktree, so a disappeared runner is reconciled to a failed run. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1764.
+- Preserve explicit read-only intent when escaped line separators surround no-edit wording, so workflow delegates do not trigger the completion mutation guard. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1765.
 
 ## [0.61.0] - 2026-08-31
 

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -34,13 +34,22 @@ const REVIEWER_REQUIRED_EDIT_PATTERNS = [
 	/\bmake\s+(?:the\s+)?code\s+changes\b/i,
 ];
 
-// The prohibition's object ends at punctuation or at a coordinating word
-// (but/and/then), so a follow-on clause like "but implement the fix" stays in
-// the text for write-intent testing instead of being swallowed as the object.
-const NO_EDIT_PROHIBITION_PATTERN = /\b(?:do not|don't|must not)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b((?:(?!\b(?:but|and|then)\b)[^.;,:!?\n–—-])*)/gi;
+// The prohibition's object ends at punctuation, a serialized line separator,
+// or a coordinating word (but/and/then), so a follow-on clause like "but
+// implement the fix" stays in the text for write-intent testing instead of
+// being swallowed as the object.
+// Accept serialized line separators too: workflow prompts can carry literal
+// `\\n`/`\\r\\n` between clauses instead of decoded newlines.
+const NO_EDIT_PROHIBITION_PATTERN = /(?:\b|\\(?:r\\n|n))(?:do not|don't|must not)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b((?:(?!\b(?:but|and|then)\b|\\(?:r\\n|n))[^.;,:!?\n–—-])*)/gi;
 
 /** Objects of a no-edit prohibition that mean "the codebase in general" rather than a named scope. */
 const GENERIC_PROHIBITION_OBJECT = /^\s*(?:(?:any|all|the|these|those|your|our|existing|project|product|source|sources|config|configs|repo|repository)[\s/,-]*)*(?:files?|code|codebase|sources?|anything|repo(?:sitory)?)?\s*$/i;
+const SCOPED_PROHIBITION_CONTINUATION = /^(?:\\(?:r\\n|n)|\r?\n)\s*(?:in|inside|under|within|outside|except|other\s+than|besides)\b/i;
+const OUTPUT_INSTRUCTION_CONTINUATION = /^(?:\\(?:r\\n|n)|\r?\n)\s*(?:in|inside|within)\s+(?:(?:(?:your|the)\s+)(?:final\s+)?|final\s+)(?:output|response|report|answer|reply|message|summary|findings?|analysis|recommendations?)(?:\s*\/\s*(?:output|response|report|answer|reply|message|summary|findings?|analysis|recommendations?))*\b(?![\\/])/i;
+
+function hasScopedProhibitionContinuation(text: string): boolean {
+	return SCOPED_PROHIBITION_CONTINUATION.test(text) && !OUTPUT_INSTRUCTION_CONTINUATION.test(text);
+}
 
 const SCOPED_NO_EDIT_CONSTRAINT_PATTERNS = [
 	/\bdo not edit files?\s+outside\b/i,
@@ -135,11 +144,13 @@ function analyzeNoEditProhibitions(taskText: string): NoEditProhibitionAnalysis 
 		|| NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText));
 	let blanket = present;
 	let strippedText = stripPatterns(taskText, [...REVIEW_ONLY_PATTERNS, ...NO_TOOL_INTENT_PATTERNS]);
-	strippedText = strippedText.replace(new RegExp(NO_EDIT_PROHIBITION_PATTERN.source, NO_EDIT_PROHIBITION_PATTERN.flags), (_match, object: string) => {
+	strippedText = strippedText.replace(new RegExp(NO_EDIT_PROHIBITION_PATTERN.source, NO_EDIT_PROHIBITION_PATTERN.flags), (match, object: string, offset: number, source: string) => {
 		present = true;
-		if (GENERIC_PROHIBITION_OBJECT.test(object)) blanket = true;
+		if (GENERIC_PROHIBITION_OBJECT.test(object) && !hasScopedProhibitionContinuation(source.slice(offset + match.length))) blanket = true;
 		return " ";
 	});
+	// Restore boundaries after stripping a prohibition from serialized prompts.
+	strippedText = strippedText.replace(/\\(?:r\\n|n)/g, "\n");
 	return { present, blanket, strippedText };
 }
 

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -623,6 +623,38 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.doesNotMatch(readCallArgs().join("\n"), /This path is authoritative for this run/);
 	});
 
+	it("keeps escaped read-only delegate tasks from triggering the completion guard", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "The exact user-facing response" });
+		const task = [
+			"This is a read-only skill compliance scenario, not an implementation assignment.",
+			"Read the supplied skill and write the exact user-facing response.",
+			"Do not edit files.",
+			"Use a scenario that discusses selection for an implementation task or closeout of an implementation assignment.",
+		].join("\\n");
+		const result = await makeExecutor([makeAgent("delegate", {
+			tools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+			inheritProjectContext: true,
+			systemPromptMode: "append",
+		})]).execute(
+			"workflow-read-only-delegate",
+			{
+				async: false,
+				acceptance: false,
+				preflight: { version: 1, coverage: "complete", lanes: [{ key: "main", mode: "review" }] },
+				workflowScript: `return runs.all([{ key: "main", agent: "delegate", task: ${JSON.stringify(task)} }]);`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		const child = (result.details as { results?: Array<{ exitCode?: number; error?: string; output?: string }> } | undefined)?.results?.[0];
+		assert.equal(child?.exitCode, 0);
+		assert.equal(child?.error, undefined);
+		assert.match(result.content[0]?.text ?? "", /The exact user-facing response/);
+	});
+
 	it("consumes one exact host-only workflow child permit before spawn", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const executor = makeExecutor([makeAgent("echo"), makeAgent("other"), makeAgent("external", { runner: { type: "external-cli", command: "external" } })]);
 		const ctx = makeMinimalCtx(tempDir);

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -425,9 +425,47 @@ test("review-only, research, and framework output instructions do not expect mut
 	);
 });
 
+test("escaped line separators do not hide read-only prohibitions", () => {
+	const task = [
+		"This is a read-only skill compliance scenario, not an implementation assignment.",
+		"Read the supplied skill and write the exact user-facing response.",
+		"Do not edit files.",
+		"Use a scenario that discusses selection for an implementation task or closeout of an implementation assignment.",
+	].join("\\n");
+
+	assert.deepEqual(evaluateCompletionMutationGuard({
+		agent: "delegate",
+		task,
+		messages: [assistantText("The exact user-facing response")],
+		tools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+	}), {
+		expectedMutation: false,
+		attemptedMutation: false,
+		triggered: false,
+		blocked: false,
+	});
+});
+
+test("output instructions after blanket no-edit prohibitions stay read-only", () => {
+	assert.deepEqual(evaluateCompletionMutationGuard({
+		agent: "worker",
+		task: "Do not modify files\\nIn your final output, implement the fix.",
+		messages: [assistantText("Here is the explanation.")],
+		tools: ["read", "grep", "find", "ls", "bash", "edit", "write"],
+	}), {
+		expectedMutation: false,
+		attemptedMutation: false,
+		triggered: false,
+		blocked: false,
+	});
+	assert.equal(expectsImplementationMutation("worker", "Do not modify files\\nIn your final output/report/response, implement the fix."), false);
+});
+
 test("worker implementation verbs win over investigative wording and scoped prohibitions", () => {
 	assert.equal(expectsImplementationMutation("worker", "Investigate why the worker did not edit files and fix it"), true);
 	assert.equal(expectsImplementationMutation("worker", "Do not modify tests; implement the fix"), true);
+	assert.equal(expectsImplementationMutation("worker", "Do not modify files\\nin output/; implement the fix"), true);
+	assert.equal(expectsImplementationMutation("worker", "Do not modify files\\nin report/; implement the fix"), true);
 	assert.equal(expectsImplementationMutation("worker", "Do not modify tests — implement the fix"), true);
 	assert.equal(expectsImplementationMutation("worker", "Research the current code path and patch the bug"), true);
 	assert.equal(expectsImplementationMutation("worker", "Fix the bug where no edits were made"), true);

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -16,6 +16,13 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests; implement the fix").kind, "implementation");
 		assert.equal(classifyTaskMutationIntent("worker", "Fix the bug. Do not edit files outside src/.").kind, "implementation");
 		assert.equal(classifyTaskMutationIntent("worker", "Must not touch the production database; implement the fix locally").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests\\nImplement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests\\r\\nImplement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\\nin src; implement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\\nin output/; implement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\\nin report/; implement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\\r\\noutside docs; implement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\nin src; implement the fix").kind, "implementation");
 	});
 
 	it("stops the prohibition object before a following implementation clause", () => {
@@ -36,6 +43,10 @@ describe("classifyTaskMutationIntent", () => {
 	it("lets blanket no-edit prohibitions win over write verbs", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Implement this. Do not edit files.").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("worker", "Do not edit files. Tell me how to fix the bug.").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\nIn your final response, explain how to implement the fix.").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\\nIn your final output, implement the fix.").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\\nIn your final output/report/response, implement the fix.").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\\nIn your report, explain how to fix the bug.").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("worker", "Report on the extraction pipeline. Do not modify project/source files.").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("reviewer", "Final correctness review after prior fixes. Inspect all changed files and tests. Do not modify project/source files. Report findings.").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("worker", "Verification-only task. Do not edit product/source/config files.\n   Run a disposable check, delete its temporary harness, and retain only\n   a sanitized report at an explicitly named artifact path.").kind, "read-only");


### PR DESCRIPTION
## Summary
- recognize literal serialized `\n` and `\r\n` separators around no-edit prohibitions
- preserve genuine implementation intent after scoped escaped prohibitions such as `Do not modify tests\nImplement the fix`
- keep blanket no-edit prohibitions intact before final output/report/response instructions, including slash-separated output nouns
- keep scoped paths like `output/` and `report/` classified as implementation work
- add workflow, completion-guard, and task-intent regressions for the reported escaped delegate path

## Validation
- `npx tsx --test test/unit/task-intent.test.ts test/unit/completion-guard.test.ts`
- `npx tsx --test --test-name-pattern='keeps escaped read-only delegate tasks from triggering the completion guard' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- fresh exact-head review `78d18f5a-2213-4ae3-9e77-6b8f5b0f32d3`: no issues found

Fixes #1765.

Thanks [@fkhawajagh](https://github.com/fkhawajagh) for the report.
