### PR TITLE
feat: add acceptance.report structured delivery switch

### DIFF
--- a/docs/design/acceptance-report-structured-channel.md
+++ b/docs/design/acceptance-report-structured-channel.md
@@ -1,0 +1,199 @@
+# Design: Acceptance Report Delivery via `acceptance.report` Switch (tool + prompt)
+
+```text
+Status:   draft — implementation not started
+Scope:    local change to pi-subagents (this repository), not upstream yet
+Context:  evolved from issue #499 / PR #577 post-mortem discussions (2026-08)
+```
+
+---
+
+## 1. Problem
+
+Acceptance reports today reach the parent through two mechanisms:
+
+1. **Fenced JSON text (default)** — `formatAcceptancePrompt` (src/runs/shared/acceptance.ts:407)
+   injects a ` ```acceptance-report ` fence template into the child prompt; the parent recovers it
+   with a fault-tolerant regex/normalization pipeline (acceptance.ts:487–749: wrapper-key aliases,
+   inline `ACCEPTANCE_REPORT:` markers, fence-scanning fallbacks). This is the #499 lesion:
+   free-text delivery means fields can be dropped, and malformed reports become parse errors.
+2. **`structured_output` piggyback (conditional)** — when the task already has `outputSchema`,
+   the child-side `structured_output` tool grows an optional `acceptanceReport` parameter
+   (structured-output.ts:64, subagent-prompt-runtime.ts:735–757), validated as an opaque object
+   and captured to `acceptance-report.json` (structured-output.ts:140). The parent prefers this
+   capture over text parsing (execution.ts:1479–1481, 2159–2160).
+
+The gap: the piggyback path only exists when the parent supplies an `outputSchema`. Tasks
+**without** `outputSchema` are locked to the text channel regardless of harness capability.
+The piggyback `acceptanceReport` parameter is also only `type: "object"` — it is never
+validated against the acceptance report shape.
+
+## 2. Goal
+
+Add a task-level switch `acceptance.report: "on" | "off"` (default unchanged → current behavior):
+
+- **`on`** — the child MUST deliver the acceptance report through the structured channel
+  (`structured_output` tool with a schema-validated `acceptanceReport` parameter) **plus** the
+  text prompt contract; if the task has no `outputSchema`, a dedicated `structured_output`
+  tool is still registered solely to carry the report.
+- **`off`** — equivalent to today's no-`outputSchema` behavior: no structured channel for the
+  report; the text fence channel remains the only self-report path (and hosts that prefer
+  verify/gate-only evidence can stop requesting child reports at the `acceptance` level).
+
+Key rules from the design discussion:
+
+- **The switch has exactly two values.** No `prompt`/`tool` split: `on` means
+  tool *and* prompt together (prompt explains the contract, tool enforces it); `off` means the
+  report is delivered only if an existing text/manual path already would be, with no new
+  machinery.
+- **Structured-output hook augmentation.** The child-side `structured_output` tool registration
+  gains a check: when acceptance report requirements are active (`on`), the tool (a) warns/
+  instructs the child to fill `acceptanceReport`, and (b) validates the report against the real
+  `AcceptanceReport` shape instead of `type: "object"`. When the requirement is off, the tool
+  behaves exactly as the existing structured-output path does (unchanged).
+- **A dedicated `structured_output` tool is registered whenever `report: "on"` is active**,
+  even when the task has no `outputSchema`. In that case the tool carries only the
+  `acceptanceReport` parameter. The tool still terminates the step on successful submission.
+- **Steer-back gating changes under `on`.** When report requirements are active, the condition
+  for the child to steer back / return control to the parent is
+  **`structured output call` + `acceptance report` both present** (i.e. a successful
+  `structured_output` call that includes a valid `acceptanceReport` is the child's terminal,
+  parent-notifying action). Without `on`, steer-back conditions remain exactly as today.
+
+## 3. Non-Goals
+
+- No change to acceptance **semantics**: levels, criteria, evidence, verify commands, gate,
+  memoization, host-side spawning, and the rejection-vs-report decision boundary are untouched.
+- No version negotiation or `agentContract` coupling; this is a plain per-task field.
+- The fenced-text channel and its tolerant parsing are **kept** (fallback for external CLI
+  runners without tool-registration surfaces, and for `off`).
+- No global settings-level default in this iteration (can follow later).
+
+## 4. Design
+
+### 4.1 Schema surface
+
+`AcceptanceOverride` gains:
+
+```ts
+report?: "on" | "off";   // optional; omitted = current behavior (structured channel only
+                         // when outputSchema present; text fence otherwise)
+```
+
+Surfaces to update: `src/extension/schemas.ts` (delegation/chain/parallel/dynamic +
+workflowScript child fields), `src/shared/types.ts`, and the `acceptance` field description
+in the tool schema (mention the switch and its default).
+
+### 4.2 Runtime flag resolution
+
+New resolver alongside `resolveEffectiveAcceptance`:
+
+```
+reportMode =
+  acceptanceOverride.report === "on"  ? "required-structured" :
+  acceptanceOverride.report === "off" ? "text-only" :
+  /* omitted */                        structuredOutputPresent ? "piggyback" : "text-only"
+```
+
+`reportMode` is computed once per step in the two execution paths
+(foreground `subagent-executor.ts` around :1985/:3641; async `async-execution.ts` around
+:1001/:1634) and threaded into:
+
+- `createStructuredOutputRuntime(..., { captureAcceptanceReport, reportRequired })`
+- `formatAcceptancePrompt(..., { reportMode })`
+- `buildPiArgs`/env construction (pi-args.ts:1005 area)
+
+### 4.3 Child-side tool (the "hook")
+
+In `subagent-prompt-runtime.ts` (structured_output registration block, :613 / :735–757):
+
+- Add an env flag, e.g. `PI_SUBAGENT_ACCEPTANCE_REPORT_REQUIRED=1`, set by the parent when
+  `report: "on"` (with or without an `outputSchema`).
+- When `reportRequired` and no `outputSchema`: register a `structured_output` tool whose
+  parameters contain **only** the `acceptanceReport` property; description tells the child
+  this is the required acceptance report submission that ends the step.
+- When `reportRequired` and `outputSchema` exists: keep one tool; the `acceptanceReport`
+  property is upgraded from `{ type: "object" }` to a full JSON Schema materialization of
+  `AcceptanceReport`, and the tool description is extended: "The `acceptanceReport` property
+  is REQUIRED for this step; it will be validated on submission."
+- Validation: run the existing `validateAcceptanceInput`-equivalent shape check on the
+  `acceptanceReport` value inside the tool's `execute`. Invalid → throw the same
+  "Structured output validation failed: …" style error so the child corrects and re-calls
+  in-session (the cheap retry loop). Valid → write `acceptance-report.json`, then terminate.
+- When `reportRequired` is false: zero behavioral change (the check is skipped; the optional
+  `acceptanceReport` property stays as-is when a capture path exists).
+
+### 4.4 Parent-side consumption
+
+`evaluateAcceptance` already prefers `report` (the structured capture) over text parsing.
+Changes needed:
+
+- `readStructuredOutputAcceptanceReport` gains a required-mode branch: in required mode a
+  missing capture file is surfaced as `reportError = "Missing acceptance report; the child
+  must submit it via structured_output"` instead of silently falling back to text scraping.
+- The steer-back condition: in required mode the run's completion/attention signal to the
+  parent requires both the structured output call and a valid report. Concretely, the
+  `structured_output` tool's `terminate: true` already ends the child step; add: if the
+  required report is absent or invalid at terminate time, the tool call errors (no terminate),
+  so the child keeps working until it produces a valid one — the parent is only notified on
+  the valid pair.
+
+### 4.5 Prompt (`formatAcceptancePrompt`)
+
+Extend `options.structuredOutput` (boolean) into `reportMode`:
+
+- `required-structured`: keep the full contract text (criteria/evidence/verify), replace the
+  fence block with "End by calling `structured_output` with the required `acceptanceReport`
+  property (validated on submission)". No ` ```acceptance-report ` fence is emitted.
+- `piggyback` (today's `structuredOutput: true`): unchanged from current behavior.
+- `text-only` (today's `structuredOutput: false`): unchanged fence template.
+
+### 4.6 Async path
+
+`async-execution.ts` mirrors foreground: pass `reportRequired` into runtime creation and env
+construction (:1001, :1634); recovery/reattach validation reads the same capture files, so no
+extra state is needed.
+
+## 5. Acceptance Criteria
+
+1. **Back-compat:** with `report` omitted, all existing tests pass and runtime behavior is
+   byte-identical to v0.60.0 (prompt bytes, env vars, tool parameters).
+2. **`report: "on"` without `outputSchema`:** child sees a `structured_output` tool carrying
+   only `acceptanceReport`; submitting an invalid report errors in-session; a valid
+   submission captures `acceptance-report.json` and terminates the step; the parent's
+   `evaluateAcceptance` consumes the capture; no fence template is injected.
+3. **`report: "on"` with `outputSchema`:** single `structured_output` tool; `acceptanceReport`
+   is schema-validated (not `{type:"object"}`); steer-back to the parent happens only after a
+   valid value+report pair.
+4. **`report: "off"`:** no structured channel for the report even if the harness supports it;
+   text fence behavior identical to today's no-`outputSchema` case; verify/gate-only
+   workflows unaffected.
+5. External CLI runner steps ignore the structured channel (no pi runtime) and behave as
+   `text-only` regardless of the flag (documented).
+
+## 6. Test Plan
+
+- Unit: `reportMode` resolution matrix (override × outputSchema presence).
+- Unit: tool parameter generation — report-only tool vs piggyback vs unchanged.
+- Unit: `validateAcceptanceReportValue` shape validation; invalid field statuses rejected
+  in-session; capture file written only on valid.
+- Unit: `formatAcceptancePrompt` snapshots for the three modes.
+- Unit: `evaluateAcceptance` required-mode missing-capture error; piggyback precedence intact.
+- Integration (foreground + async): `report: "on"` run captures report, ledger reflects it,
+  steer-back/completion gated on the valid pair; `report: "off"` produces no capture file and
+  no structured tool.
+- Regression: full existing suite green with the field omitted.
+
+## 7. Implementation Checklist
+
+- [ ] `AcceptanceOverride.report` in types + extension schemas (+ description text)
+- [ ] `reportMode` resolver; thread through foreground + async execution paths
+- [ ] `createStructuredOutputRuntime` `reportRequired` option; env var
+      `PI_SUBAGENT_ACCEPTANCE_REPORT_REQUIRED`
+- [ ] Child-side: report-only tool registration; schema-validated `acceptanceReport`
+      parameter; required-mode description; terminate gating
+- [ ] `formatAcceptancePrompt` mode-aware template
+- [ ] `readStructuredOutputAcceptanceReport` required-mode error; `evaluateAcceptance` wiring
+- [ ] `buildPiArgs` env propagation
+- [ ] Tests per §6; docs touch: `docs/tool-reference.md` acceptance section,
+      `docs/configuration.md` if a default is added later

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -422,6 +422,8 @@ Acceptance provenance is stored separately from child prose. `evidenceStatus` pr
 
 For `attested` or stricter levels, the child prompt includes a standardized acceptance section and asks for a fenced `acceptance-report` JSON block.
 
+Set `acceptance.report: "on"` to require the report as **validated structured output** instead of a fenced text block: with `outputSchema` the final `structured_output` call must carry an `acceptanceReport` object matching the report schema; without `outputSchema` a standalone `structured_output` tool delivers the report as its `value`. Invalid reports are rejected in-session for correction, and only a valid delivery terminates the step. `report: "off"` forces the legacy text channel; omitting `report` keeps current behavior.
+
 The parser canonicalizes known enum synonyms, snake_case report keys and wrappers, underscore fence tags, unambiguous scalar arrays, string booleans, and criterion-id separators. Unknown or ambiguous keys and enum values fail with field-level diagnostics. Explicit empty `changedFiles` and `testsAddedOrUpdated` arrays are recorded as not applicable; missing fields and empty required command or validation evidence still fail.
 
 Acceptance fences are removed from normal output artifacts, while the raw child transcript remains intact and per-child metadata stores the complete acceptance ledger and parsed report. Explicit failed gates fail the run. Inferred gates remain observable without failing the run.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -35,7 +35,7 @@ import { resolveExpectedWorktreeAgentCwd } from "../shared/worktree.ts";
 import { buildWorkflowGraphSnapshot } from "../shared/workflow-graph.ts";
 import { ChainOutputValidationError, validateChainOutputBindings } from "../shared/chain-outputs.ts";
 import { createStructuredOutputRuntime } from "../shared/structured-output.ts";
-import { resolveEffectiveAcceptance, validateAcceptanceInput, validateExecutionAcceptance } from "../shared/acceptance.ts";
+import { resolveAcceptanceReportMode, resolveEffectiveAcceptance, validateAcceptanceInput, validateExecutionAcceptance } from "../shared/acceptance.ts";
 import { createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
 import { validateImplementationToolContract } from "../shared/completion-guard.ts";
 import {
@@ -1002,7 +1002,13 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			acceptanceRole: a.acceptanceRole,
 			...(s.gateOn ? { gateOn: s.gateOn } : {}),
 			...(s.outputSchema ? { structuredOutputSchema: s.outputSchema } : {}),
-			...(s.outputSchema ? { structuredOutput: createStructuredOutputRuntime(s.outputSchema, path.join(asyncDir, "structured-output"), { captureAcceptanceReport: s.acceptance !== false }) } : {}),
+			...(s.outputSchema || resolveAcceptanceReportMode(s.acceptance) === "structured"
+				? { structuredOutput: createStructuredOutputRuntime(
+					s.outputSchema,
+					path.join(asyncDir, "structured-output"),
+					{ captureAcceptanceReport: s.acceptance !== false, acceptanceReportRequired: resolveAcceptanceReportMode(s.acceptance) === "structured" },
+				) }
+				: {}),
 			...(resolvedToolBudget.budget ? { toolBudget: resolvedToolBudget.budget } : {}),
 			...(s.worktree ? { worktree: true } : {}),
 		};
@@ -1647,8 +1653,10 @@ export function executeAsyncSingle(
 	const initialUsageBudget = usageBudgetState(params.usageBudget, undefined);
 	const resolvedSessionDir = params.sessionDir ?? (sessionRoot ? path.join(sessionRoot, `async-${id}`) : undefined);
 	const structuredOutput = params.structuredOutputSchema
-		? createStructuredOutputRuntime(params.structuredOutputSchema, path.join(asyncDir, "structured-output"), { captureAcceptanceReport: params.acceptance !== false })
-		: undefined;
+		? createStructuredOutputRuntime(params.structuredOutputSchema, path.join(asyncDir, "structured-output"), { captureAcceptanceReport: params.acceptance !== false, acceptanceReportRequired: resolveAcceptanceReportMode(params.acceptance) === "structured" })
+		: resolveAcceptanceReportMode(params.acceptance) === "structured"
+			? createStructuredOutputRuntime(undefined, path.join(asyncDir, "structured-output"), { captureAcceptanceReport: true, acceptanceReportRequired: true })
+			: undefined;
 	let modelCandidates: string[] = [];
 	if (!externalRunner) {
 		try {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -79,7 +79,7 @@ import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, deriveForkPromptCache
 import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/chain-outputs.ts";
-import { createStructuredOutputRuntime, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
+import { createStructuredOutputRuntime, MISSING_ACCEPTANCE_REPORT_ERROR, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
 import { formatMidToolExitError, formatProcessSignalError, isOrdinaryToolForMidToolExit, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTrackedMutations } from "../shared/mutation-evidence.ts";
@@ -1450,7 +1450,7 @@ async function runSingleStepInner(
 	// instructions never leak into the display name.
 	const childSessionName = step.sessionName ?? deriveChildSessionName({ agent: step.agent, task, label: step.label });
 	if (step.effectiveAcceptance) {
-		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContractV1(step.agentContract), structuredOutput: Boolean(step.structuredOutput?.acceptanceReportPath) });
+		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContractV1(step.agentContract), structuredOutput: Boolean(step.structuredOutput?.acceptanceReportPath), reportRequired: Boolean(step.structuredOutput?.acceptanceReportRequired), reportOnly: Boolean(step.structuredOutput?.reportOnly) });
 		if (acceptancePrompt) task = `${task}\n${acceptancePrompt}`;
 	}
 	const sessionEnabled = Boolean(step.sessionFile) || ctx.sessionEnabled;
@@ -1863,6 +1863,15 @@ async function runSingleStepInner(
 		if (effectiveStructuredOutput && run.exitCode === 0 && !run.error && !toolAvailabilityError && !midToolExitError) {
 			if (!run.structuredOutputToolInvoked) {
 				structuredError = MISSING_STRUCTURED_OUTPUT_CALL_ERROR;
+			} else if (effectiveStructuredOutput.reportOnly) {
+				// Report-only runtime: the tool writes the report, not output.json.
+				const acceptanceReport = readStructuredOutputAcceptanceReport(effectiveStructuredOutput);
+				if (!acceptanceReport.value) structuredError = acceptanceReport.error ?? MISSING_ACCEPTANCE_REPORT_ERROR;
+				else {
+					structuredAcceptanceReport = acceptanceReport.value;
+					structuredAcceptanceReportError = acceptanceReport.error;
+					validatedStructuredOutput = true;
+				}
 			} else {
 				const structured = await readStructuredOutput({
 					schema: effectiveStructuredOutput.schema,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -73,7 +73,7 @@ import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledge
 import { assertAgentAllowedByCapabilityCeiling, decodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV } from "../shared/capability-ceiling.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
 import { assertThinkingWithinCeiling, decodeThinkingCeiling, intersectThinkingCeilings, SUBAGENT_THINKING_CEILING_ENV } from "../../shared/thinking-ceiling.ts";
-import { MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
+import { MISSING_ACCEPTANCE_REPORT_ERROR, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
 import { formatMidToolExitError, formatProcessSignalError, isOrdinaryToolForMidToolExit, isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import { readChildToolDiagnosticError } from "../shared/tool-availability.ts";
 import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTrackedMutations } from "../shared/mutation-evidence.ts";
@@ -1519,6 +1519,18 @@ async function runSingleAttempt(
 			result.exitCode = 1;
 			result.error = MISSING_STRUCTURED_OUTPUT_CALL_ERROR;
 			result.structuredOutputFailed = true;
+		} else if (options.structuredOutput.reportOnly) {
+			// Report-only runtime: the tool writes the report, not output.json.
+			const acceptanceReport = readStructuredOutputAcceptanceReport(options.structuredOutput);
+			if (!acceptanceReport.value) {
+				result.exitCode = 1;
+				result.error = acceptanceReport.error ?? MISSING_ACCEPTANCE_REPORT_ERROR;
+				result.structuredOutputFailed = true;
+			} else {
+				(result as SingleResult & { structuredAcceptanceReport?: unknown; structuredAcceptanceReportError?: string }).structuredAcceptanceReport = acceptanceReport.value;
+				(result as SingleResult & { structuredAcceptanceReport?: unknown; structuredAcceptanceReportError?: string }).structuredAcceptanceReportError = acceptanceReport.error;
+				validatedStructuredOutput = true;
+			}
 		} else {
 			const structured = await readStructuredOutput({
 				schema: options.structuredOutput.schema,
@@ -1827,7 +1839,7 @@ async function runSyncCompletionInner(
 		dynamicGroup: options.acceptanceContext?.dynamicGroup,
 		agentContract: options.agentContract,
 	});
-	const acceptancePrompt = formatAcceptancePrompt(effectiveAcceptance, { reportOptional: isAgentContractV1(options.agentContract), structuredOutput: Boolean(options.structuredOutput?.acceptanceReportPath) });
+	const acceptancePrompt = formatAcceptancePrompt(effectiveAcceptance, { reportOptional: isAgentContractV1(options.agentContract), structuredOutput: Boolean(options.structuredOutput?.acceptanceReportPath), reportRequired: Boolean(options.structuredOutput?.acceptanceReportRequired), reportOnly: Boolean(options.structuredOutput?.reportOnly) });
 	const taskWithAcceptance = acceptancePrompt ? `${task}\n${acceptancePrompt}` : task;
 	options.onEffectivePrompt?.(taskWithAcceptance);
 	const sessionEnabled = Boolean(options.sessionFile || options.sessionDir) || shareEnabled;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -50,7 +50,7 @@ import { acquireActiveAsyncCapacity, ActiveAsyncCapacityError, getActiveAsyncCap
 import { isScheduledRunAction } from "../background/scheduled-runs.ts";
 import { enqueueChainAppendRequest, readPendingChainAppendRequests, runnerStepOutputNames } from "../background/chain-append.ts";
 import { ChainOutputValidationError, validateChainOutputBindingsWithContext } from "../shared/chain-outputs.ts";
-import { normalizeGateAcceptance, validateExecutionAcceptance } from "../shared/acceptance.ts";
+import { normalizeGateAcceptance, resolveAcceptanceReportMode, validateExecutionAcceptance } from "../shared/acceptance.ts";
 import { canPreferFork, createForkContextResolver, forkedChildRequiresThinkingOff, resolveSubagentLaunchContext } from "../../shared/fork-context.ts";
 import { createPrunedForkSessionWriter } from "../../shared/pruned-fork.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
@@ -3689,9 +3689,12 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		if (worktreeSetup) cleanupWorktrees(worktreeSetup);
 		return { content: [{ type: "text", text: validationError }], isError: true, details: { mode: "single", results: [] } };
 	}
+	const acceptanceReportOn = resolveAcceptanceReportMode(params.acceptance) === "structured";
 	const structuredRuntime = params.outputSchema
-		? createStructuredOutputRuntime(params.outputSchema, artifactConfig.enabled ? path.join(artifactsDir, "structured-output", runId) : undefined, { captureAcceptanceReport: params.acceptance !== false })
-		: undefined;
+		? createStructuredOutputRuntime(params.outputSchema, artifactConfig.enabled ? path.join(artifactsDir, "structured-output", runId) : undefined, { captureAcceptanceReport: params.acceptance !== false, acceptanceReportRequired: acceptanceReportOn })
+		: acceptanceReportOn
+			? createStructuredOutputRuntime(undefined, artifactConfig.enabled ? path.join(artifactsDir, "structured-output", runId) : undefined, { captureAcceptanceReport: true, acceptanceReportRequired: true })
+			: undefined;
 	// Reads: caller override > agent defaultReads > none. `~`/`~/` expand to home;
 	// absolute paths pass through; relative paths resolve against the child cwd.
 	const reads = readsOverride !== undefined ? readsOverride : agentConfig.defaultReads ?? false;

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -23,7 +23,11 @@ import type {
 	SubagentRunMode,
 } from "../../shared/types.ts";
 import { isAgentContractV1 } from "./agent-contract.ts";
-import { classifyTaskMutationIntent, stripSeverityCompounds, taskMayMutate } from "./task-intent.ts";
+import {
+	classifyTaskMutationIntent,
+	stripSeverityCompounds,
+	taskMayMutate,
+} from "./task-intent.ts";
 
 const LEVEL_RANK: Record<Exclude<AcceptanceLevel, "auto">, number> = {
 	none: 0,
@@ -32,7 +36,13 @@ const LEVEL_RANK: Record<Exclude<AcceptanceLevel, "auto">, number> = {
 	verified: 3,
 };
 
-const VALID_LEVELS = new Set<AcceptanceLevel>(["auto", "none", "attested", "checked", "verified"]);
+const VALID_LEVELS = new Set<AcceptanceLevel>([
+	"auto",
+	"none",
+	"attested",
+	"checked",
+	"verified",
+]);
 const VALID_EVIDENCE_KINDS: AcceptanceEvidenceKind[] = [
 	"changed-files",
 	"tests-added",
@@ -46,14 +56,34 @@ const VALID_EVIDENCE_KINDS: AcceptanceEvidenceKind[] = [
 ];
 const VALID_EVIDENCE = new Set<AcceptanceEvidenceKind>(VALID_EVIDENCE_KINDS);
 const ACCEPTANCE_EVIDENCE_HELP = `Supported evidence kinds: ${VALID_EVIDENCE_KINDS.join(", ")}. Example: { level: "checked", evidence: ["commands-run", "changed-files"] }.`;
-const ACCEPTANCE_OBJECT_EXAMPLE = "Example: { level: \"checked\", evidence: [\"commands-run\", \"changed-files\"] }.";
-const ACCEPTANCE_CONFIG_KEYS = new Set(["level", "criteria", "evidence", "verify", "review", "stopRules", "reason"]);
+const ACCEPTANCE_OBJECT_EXAMPLE =
+	'Example: { level: "checked", evidence: ["commands-run", "changed-files"] }.';
+const ACCEPTANCE_CONFIG_KEYS = new Set([
+	"level",
+	"criteria",
+	"evidence",
+	"verify",
+	"review",
+	"stopRules",
+	"reason",
+	"report",
+]);
 const ACCEPTANCE_GATE_KEYS = new Set(["id", "must", "evidence", "severity"]);
-const ACCEPTANCE_VERIFY_KEYS = new Set(["id", "command", "timeoutMs", "cwd", "env", "allowFailure"]);
+const ACCEPTANCE_VERIFY_KEYS = new Set([
+	"id",
+	"command",
+	"timeoutMs",
+	"cwd",
+	"env",
+	"allowFailure",
+]);
 const ACCEPTANCE_REVIEW_KEYS = new Set(["agent", "focus", "required"]);
-const EXPLICIT_REVIEWED_UNAVAILABLE = "is an achieved status, not a requestable acceptance level. For a read-only reviewer call, omit acceptance. To require independent review of a writer result, use acceptance.review.required and orchestrate the reviewer separately.";
+const EXPLICIT_REVIEWED_UNAVAILABLE =
+	"is an achieved status, not a requestable acceptance level. For a read-only reviewer call, omit acceptance. To require independent review of a writer result, use acceptance.review.required and orchestrate the reviewer separately.";
 
-function normalizeLevel(level: AcceptanceLevel | undefined): Exclude<AcceptanceLevel, "auto"> | "auto" {
+function normalizeLevel(
+	level: AcceptanceLevel | undefined,
+): Exclude<AcceptanceLevel, "auto"> | "auto" {
 	return level ?? "auto";
 }
 
@@ -61,16 +91,31 @@ function unique<T>(items: T[]): T[] {
 	return [...new Set(items)];
 }
 
-function requiredEvidenceForLevel(level: Exclude<AcceptanceLevel, "auto">): AcceptanceEvidenceKind[] {
+function requiredEvidenceForLevel(
+	level: Exclude<AcceptanceLevel, "auto">,
+): AcceptanceEvidenceKind[] {
 	switch (level) {
 		case "none":
 			return [];
 		case "attested":
 			return ["manual-notes", "residual-risks"];
 		case "checked":
-			return ["changed-files", "tests-added", "commands-run", "residual-risks", "no-staged-files"];
+			return [
+				"changed-files",
+				"tests-added",
+				"commands-run",
+				"residual-risks",
+				"no-staged-files",
+			];
 		case "verified":
-			return ["changed-files", "tests-added", "commands-run", "validation-output", "residual-risks", "no-staged-files"];
+			return [
+				"changed-files",
+				"tests-added",
+				"commands-run",
+				"validation-output",
+				"residual-risks",
+				"no-staged-files",
+			];
 	}
 }
 
@@ -82,45 +127,89 @@ function inferLevel(input: {
 	async?: boolean;
 	dynamic?: boolean;
 	dynamicGroup?: boolean;
-}): { level: Exclude<AcceptanceLevel, "auto">; reasons: string[]; criteria: string[]; evidence: AcceptanceEvidenceKind[]; review?: { agent?: string; required?: boolean } } {
+}): {
+	level: Exclude<AcceptanceLevel, "auto">;
+	reasons: string[];
+	criteria: string[];
+	evidence: AcceptanceEvidenceKind[];
+	review?: { agent?: string; required?: boolean };
+} {
 	const agent = input.agentName.toLowerCase();
 	const task = input.task?.toLowerCase() ?? "";
 	const reasons: string[] = [];
 	// Declared roles replace name heuristics, so use the full writer grammar to detect explicit mutation independently of the actual agent name.
-	const intent = classifyTaskMutationIntent(input.acceptanceRole ? "worker" : input.agentName, input.task ?? "");
-	const readOnlyTask = intent.kind === "read-only"
-		|| (intent.kind === "unknown" && /\b(?:read[- ]only|review[- ]only|no edits|without edits|inspect|summari[sz]e)\b/.test(task));
-	const rolePatchTask = input.acceptanceRole !== undefined
-		&& intent.kind !== "read-only"
-		&& !/\b(?:do not|don't|must not)\s+patch\b/.test(task)
-		&& /\bpatch\s+(?:(?:\.{0,2}[\\/])?(?:[\w.-]+[\\/])+[\w.-]+|[\w.-]+\.[a-z0-9]+\b|(?:the\s+)?parser\b)/.test(stripSeverityCompounds(task));
-	const taskMayWrite = readOnlyTask ? false : taskMayMutate(input.task ?? "") || intent.kind === "implementation" || rolePatchTask;
-	const readOnlyAgent = input.acceptanceRole === "read-only"
-		|| (input.acceptanceRole === undefined && /\b(?:reviewer|oracle|scout|researcher|analyst)\b/.test(agent));
-	const writeTask = taskMayWrite
-		|| (input.acceptanceRole === "writer" && !readOnlyTask)
-		|| (input.acceptanceRole === undefined && /\bworker\b/.test(agent) && !readOnlyTask);
-	const inferredReadOnly = readOnlyTask || (input.acceptanceRole === "read-only" && !taskMayWrite);
-	const roleResolvesReadOnly = input.acceptanceRole !== undefined && inferredReadOnly;
-	const keywordRiskReadOnly = input.acceptanceRole === undefined ? intent.kind === "read-only" : inferredReadOnly;
-	const risky = Boolean(input.async && writeTask)
-		|| (Boolean(input.dynamic) && !roleResolvesReadOnly)
-		|| (Boolean(input.dynamicGroup) && !roleResolvesReadOnly)
-		|| (!keywordRiskReadOnly && /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/.test(task));
+	const intent = classifyTaskMutationIntent(
+		input.acceptanceRole ? "worker" : input.agentName,
+		input.task ?? "",
+	);
+	const readOnlyTask =
+		intent.kind === "read-only" ||
+		(intent.kind === "unknown" &&
+			/\b(?:read[- ]only|review[- ]only|no edits|without edits|inspect|summari[sz]e)\b/.test(
+				task,
+			));
+	const rolePatchTask =
+		input.acceptanceRole !== undefined &&
+		intent.kind !== "read-only" &&
+		!/\b(?:do not|don't|must not)\s+patch\b/.test(task) &&
+		/\bpatch\s+(?:(?:\.{0,2}[\\/])?(?:[\w.-]+[\\/])+[\w.-]+|[\w.-]+\.[a-z0-9]+\b|(?:the\s+)?parser\b)/.test(
+			stripSeverityCompounds(task),
+		);
+	const taskMayWrite = readOnlyTask
+		? false
+		: taskMayMutate(input.task ?? "") ||
+			intent.kind === "implementation" ||
+			rolePatchTask;
+	const readOnlyAgent =
+		input.acceptanceRole === "read-only" ||
+		(input.acceptanceRole === undefined &&
+			/\b(?:reviewer|oracle|scout|researcher|analyst)\b/.test(agent));
+	const writeTask =
+		taskMayWrite ||
+		(input.acceptanceRole === "writer" && !readOnlyTask) ||
+		(input.acceptanceRole === undefined &&
+			/\bworker\b/.test(agent) &&
+			!readOnlyTask);
+	const inferredReadOnly =
+		readOnlyTask || (input.acceptanceRole === "read-only" && !taskMayWrite);
+	const roleResolvesReadOnly =
+		input.acceptanceRole !== undefined && inferredReadOnly;
+	const keywordRiskReadOnly =
+		input.acceptanceRole === undefined
+			? intent.kind === "read-only"
+			: inferredReadOnly;
+	const risky =
+		Boolean(input.async && writeTask) ||
+		(Boolean(input.dynamic) && !roleResolvesReadOnly) ||
+		(Boolean(input.dynamicGroup) && !roleResolvesReadOnly) ||
+		(!keywordRiskReadOnly &&
+			/\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/.test(
+				task,
+			));
 
 	if (risky) {
-		reasons.push(input.async ? "async write-capable or risky run" : "risky write-capable run");
-		if (input.dynamic || input.dynamicGroup) reasons.push("dynamic fanout context");
+		reasons.push(
+			input.async ? "async write-capable or risky run" : "risky write-capable run",
+		);
+		if (input.dynamic || input.dynamicGroup)
+			reasons.push("dynamic fanout context");
 		return {
 			level: "checked",
 			reasons,
-			criteria: ["Implement the requested change without widening scope", "Return evidence sufficient for an independent acceptance review"],
+			criteria: [
+				"Implement the requested change without widening scope",
+				"Return evidence sufficient for an independent acceptance review",
+			],
 			evidence: requiredEvidenceForLevel("checked"),
 			review: { agent: "reviewer", required: true },
 		};
 	}
 	if (writeTask && !readOnlyTask) {
-		reasons.push(input.acceptanceRole === "writer" && !taskMayWrite ? "declared writer acceptance role" : "write-capable worker/task");
+		reasons.push(
+			input.acceptanceRole === "writer" && !taskMayWrite
+				? "declared writer acceptance role"
+				: "write-capable worker/task",
+		);
 		return {
 			level: "checked",
 			reasons,
@@ -129,11 +218,19 @@ function inferLevel(input: {
 		};
 	}
 	if (readOnlyAgent || readOnlyTask) {
-		reasons.push(input.acceptanceRole === "read-only" && !readOnlyTask ? "declared read-only acceptance role" : readOnlyAgent ? "read-only/reviewer-style agent" : "read-only task wording");
+		reasons.push(
+			input.acceptanceRole === "read-only" && !readOnlyTask
+				? "declared read-only acceptance role"
+				: readOnlyAgent
+					? "read-only/reviewer-style agent"
+					: "read-only task wording",
+		);
 		return {
 			level: "attested",
 			reasons,
-			criteria: ["Return concrete findings with file paths and severity when applicable"],
+			criteria: [
+				"Return concrete findings with file paths and severity when applicable",
+			],
 			evidence: ["review-findings", "residual-risks"],
 		};
 	}
@@ -146,9 +243,12 @@ function inferLevel(input: {
 	};
 }
 
-export function normalizeAcceptanceInput(input: AcceptanceInput | undefined): AcceptanceConfig {
+export function normalizeAcceptanceInput(
+	input: AcceptanceInput | undefined,
+): AcceptanceConfig {
 	if (input === undefined || input === "auto") return { level: "auto" };
-	if (input === false) return { level: "none", reason: "disabled by deprecated false shorthand" };
+	if (input === false)
+		return { level: "none", reason: "disabled by deprecated false shorthand" };
 	if (typeof input === "string") return { level: input };
 	return { ...input };
 }
@@ -157,96 +257,186 @@ type GateAcceptanceNormalizationResult =
 	| { ok: true; acceptance?: AcceptanceInput }
 	| { ok: false; error: string };
 
-export function normalizeGateAcceptance(gate: unknown, acceptance: AcceptanceInput | undefined): GateAcceptanceNormalizationResult {
-	if (gate === undefined) return acceptance === undefined ? { ok: true } : { ok: true, acceptance };
-	if (typeof gate !== "string" || !gate.trim()) return { ok: false, error: "gate must be a non-empty command string." };
-	if (acceptance !== undefined) return { ok: false, error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." };
-	return { ok: true, acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
+export function normalizeGateAcceptance(
+	gate: unknown,
+	acceptance: AcceptanceInput | undefined,
+): GateAcceptanceNormalizationResult {
+	if (gate === undefined)
+		return acceptance === undefined ? { ok: true } : { ok: true, acceptance };
+	if (typeof gate !== "string" || !gate.trim())
+		return { ok: false, error: "gate must be a non-empty command string." };
+	if (acceptance !== undefined)
+		return {
+			ok: false,
+			error:
+				"gate cannot be combined with acceptance; use one gate command or acceptance.verify.",
+		};
+	return {
+		ok: true,
+		acceptance: {
+			level: "verified",
+			verify: [{ id: "gate", command: gate.trim() }],
+		},
+	};
 }
 
 function explicitAcceptanceCanDisable(explicit: AcceptanceConfig): boolean {
-	return explicit.level === "none" && typeof explicit.reason === "string" && explicit.reason.trim().length > 0;
+	return (
+		explicit.level === "none" &&
+		typeof explicit.reason === "string" &&
+		explicit.reason.trim().length > 0
+	);
 }
 
-function unsupportedEvidenceKindMessage(pathLabel: string, item: unknown): string {
+function unsupportedEvidenceKindMessage(
+	pathLabel: string,
+	item: unknown,
+): string {
 	const value = typeof item === "string" ? ` "${item}"` : "";
 	return `${pathLabel}${value} is not a supported evidence kind. ${ACCEPTANCE_EVIDENCE_HELP}`;
 }
 
-export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"): string[] {
+export function validateAcceptanceInput(
+	input: unknown,
+	pathLabel = "acceptance",
+): string[] {
 	const errors: string[] = [];
 	if (input === undefined) return errors;
 	if (input === false) return errors;
 	if (typeof input === "string") {
-		if (input === "reviewed") errors.push(`${pathLabel} ${EXPLICIT_REVIEWED_UNAVAILABLE}`);
-		else if (!VALID_LEVELS.has(input as AcceptanceLevel)) errors.push(`${pathLabel} has invalid level '${input}'.`);
-		else if (input === "none") errors.push(`${pathLabel} level "none" requires a reason; use { level: "none", reason: "..." }.`);
-		else if (input === "verified") errors.push(`${pathLabel} level "verified" requires object form with at least one runtime verify command. Use level "checked" or provide a non-empty acceptance.verify array.`);
+		if (input === "reviewed")
+			errors.push(`${pathLabel} ${EXPLICIT_REVIEWED_UNAVAILABLE}`);
+		else if (!VALID_LEVELS.has(input as AcceptanceLevel))
+			errors.push(`${pathLabel} has invalid level '${input}'.`);
+		else if (input === "none")
+			errors.push(
+				`${pathLabel} level "none" requires a reason; use { level: "none", reason: "..." }.`,
+			);
+		else if (input === "verified")
+			errors.push(
+				`${pathLabel} level "verified" requires object form with at least one runtime verify command. Use level "checked" or provide a non-empty acceptance.verify array.`,
+			);
 		return errors;
 	}
 	if (!input || typeof input !== "object" || Array.isArray(input)) {
-		errors.push(`${pathLabel} must be a string level, false, or an object. ${ACCEPTANCE_OBJECT_EXAMPLE}`);
+		errors.push(
+			`${pathLabel} must be a string level, false, or an object. ${ACCEPTANCE_OBJECT_EXAMPLE}`,
+		);
 		return errors;
 	}
 	const value = input as Record<string, unknown>;
 	for (const key of Object.keys(value)) {
-		if (!ACCEPTANCE_CONFIG_KEYS.has(key)) errors.push(`${pathLabel}.${key} is not supported.`);
+		if (!ACCEPTANCE_CONFIG_KEYS.has(key))
+			errors.push(`${pathLabel}.${key} is not supported.`);
 	}
 	if (value.level === "reviewed") {
 		errors.push(`${pathLabel}.level ${EXPLICIT_REVIEWED_UNAVAILABLE}`);
-	} else if (value.level !== undefined && (typeof value.level !== "string" || !VALID_LEVELS.has(value.level as AcceptanceLevel))) {
-		errors.push(`${pathLabel}.level must be one of auto, none, attested, checked, verified.`);
+	} else if (
+		value.level !== undefined &&
+		(typeof value.level !== "string" ||
+			!VALID_LEVELS.has(value.level as AcceptanceLevel))
+	) {
+		errors.push(
+			`${pathLabel}.level must be one of auto, none, attested, checked, verified.`,
+		);
 	}
-	if (value.level === "none" && (typeof value.reason !== "string" || !value.reason.trim())) {
+	if (
+		value.level === "none" &&
+		(typeof value.reason !== "string" || !value.reason.trim())
+	) {
 		errors.push(`${pathLabel}.reason is required when level is none.`);
 	}
-	if (value.reason !== undefined && typeof value.reason !== "string") errors.push(`${pathLabel}.reason must be a string.`);
-	if (value.criteria !== undefined && !Array.isArray(value.criteria)) errors.push(`${pathLabel}.criteria must be an array.`);
+	if (value.reason !== undefined && typeof value.reason !== "string")
+		errors.push(`${pathLabel}.reason must be a string.`);
+	if (
+		value.report !== undefined &&
+		value.report !== "on" &&
+		value.report !== "off"
+	)
+		errors.push(`${pathLabel}.report must be "on" or "off".`);
+	if (value.criteria !== undefined && !Array.isArray(value.criteria))
+		errors.push(`${pathLabel}.criteria must be an array.`);
 	if (Array.isArray(value.criteria)) {
 		const criterionIds = new Set<string>();
 		for (const [index, criterion] of value.criteria.entries()) {
 			if (typeof criterion === "string") continue;
 			const criterionPath = `${pathLabel}.criteria[${index}]`;
-			if (!criterion || typeof criterion !== "object" || Array.isArray(criterion)) {
+			if (
+				!criterion ||
+				typeof criterion !== "object" ||
+				Array.isArray(criterion)
+			) {
 				errors.push(`${criterionPath} must be a string or an object.`);
 				continue;
 			}
 			const gate = criterion as Record<string, unknown>;
 			for (const key of Object.keys(gate)) {
-				if (!ACCEPTANCE_GATE_KEYS.has(key)) errors.push(`${criterionPath}.${key} is not supported.`);
+				if (!ACCEPTANCE_GATE_KEYS.has(key))
+					errors.push(`${criterionPath}.${key} is not supported.`);
 			}
 			if (typeof gate.id !== "string" || !gate.id.trim()) {
 				errors.push(`${criterionPath}.id is required.`);
 			} else {
 				const normalizedId = normalizedToken(gate.id);
-				if (criterionIds.has(normalizedId)) errors.push(`${criterionPath}.id duplicates normalized criterion id '${normalizedId}'.`);
+				if (criterionIds.has(normalizedId))
+					errors.push(
+						`${criterionPath}.id duplicates normalized criterion id '${normalizedId}'.`,
+					);
 				criterionIds.add(normalizedId);
 			}
-			if (typeof gate.must !== "string" || !gate.must.trim()) errors.push(`${criterionPath}.must is required.`);
-			if (gate.evidence !== undefined && !Array.isArray(gate.evidence)) errors.push(`${criterionPath}.evidence must be an array. ${ACCEPTANCE_EVIDENCE_HELP}`);
+			if (typeof gate.must !== "string" || !gate.must.trim())
+				errors.push(`${criterionPath}.must is required.`);
+			if (gate.evidence !== undefined && !Array.isArray(gate.evidence))
+				errors.push(
+					`${criterionPath}.evidence must be an array. ${ACCEPTANCE_EVIDENCE_HELP}`,
+				);
 			if (Array.isArray(gate.evidence)) {
 				for (const [evidenceIndex, item] of gate.evidence.entries()) {
-					if (typeof item !== "string" || !VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)) {
-						errors.push(unsupportedEvidenceKindMessage(`${criterionPath}.evidence[${evidenceIndex}]`, item));
+					if (
+						typeof item !== "string" ||
+						!VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)
+					) {
+						errors.push(
+							unsupportedEvidenceKindMessage(
+								`${criterionPath}.evidence[${evidenceIndex}]`,
+								item,
+							),
+						);
 					}
 				}
 			}
-			if (gate.severity !== undefined && gate.severity !== "required" && gate.severity !== "recommended") {
+			if (
+				gate.severity !== undefined &&
+				gate.severity !== "required" &&
+				gate.severity !== "recommended"
+			) {
 				errors.push(`${criterionPath}.severity must be required or recommended.`);
 			}
 		}
 	}
 	if (Array.isArray(value.evidence)) {
 		for (const [index, item] of value.evidence.entries()) {
-			if (typeof item !== "string" || !VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)) {
-				errors.push(unsupportedEvidenceKindMessage(`${pathLabel}.evidence[${index}]`, item));
+			if (
+				typeof item !== "string" ||
+				!VALID_EVIDENCE.has(item as AcceptanceEvidenceKind)
+			) {
+				errors.push(
+					unsupportedEvidenceKindMessage(`${pathLabel}.evidence[${index}]`, item),
+				);
 			}
 		}
 	} else if (value.evidence !== undefined) {
-		errors.push(`${pathLabel}.evidence must be an array. ${ACCEPTANCE_EVIDENCE_HELP}`);
+		errors.push(
+			`${pathLabel}.evidence must be an array. ${ACCEPTANCE_EVIDENCE_HELP}`,
+		);
 	}
-	if (value.level === "verified" && (!Array.isArray(value.verify) || value.verify.length === 0)) {
-		errors.push(`${pathLabel}.verify must contain at least one runtime command when level is verified. Use level "checked" or provide a non-empty acceptance.verify array.`);
+	if (
+		value.level === "verified" &&
+		(!Array.isArray(value.verify) || value.verify.length === 0)
+	) {
+		errors.push(
+			`${pathLabel}.verify must contain at least one runtime command when level is verified. Use level "checked" or provide a non-empty acceptance.verify array.`,
+		);
 	} else if (value.verify !== undefined && !Array.isArray(value.verify)) {
 		errors.push(`${pathLabel}.verify must be an array.`);
 	}
@@ -258,45 +448,76 @@ export function validateAcceptanceInput(input: unknown, pathLabel = "acceptance"
 			}
 			const cmd = command as Record<string, unknown>;
 			for (const key of Object.keys(cmd)) {
-				if (!ACCEPTANCE_VERIFY_KEYS.has(key)) errors.push(`${pathLabel}.verify[${index}].${key} is not supported.`);
+				if (!ACCEPTANCE_VERIFY_KEYS.has(key))
+					errors.push(`${pathLabel}.verify[${index}].${key} is not supported.`);
 			}
-			if (typeof cmd.id !== "string" || !cmd.id.trim()) errors.push(`${pathLabel}.verify[${index}].id is required.`);
-			if (typeof cmd.command !== "string" || !cmd.command.trim()) errors.push(`${pathLabel}.verify[${index}].command is required.`);
-			if (cmd.timeoutMs !== undefined && (typeof cmd.timeoutMs !== "number" || !Number.isInteger(cmd.timeoutMs) || cmd.timeoutMs < 1)) {
-				errors.push(`${pathLabel}.verify[${index}].timeoutMs must be an integer >= 1.`);
+			if (typeof cmd.id !== "string" || !cmd.id.trim())
+				errors.push(`${pathLabel}.verify[${index}].id is required.`);
+			if (typeof cmd.command !== "string" || !cmd.command.trim())
+				errors.push(`${pathLabel}.verify[${index}].command is required.`);
+			if (
+				cmd.timeoutMs !== undefined &&
+				(typeof cmd.timeoutMs !== "number" ||
+					!Number.isInteger(cmd.timeoutMs) ||
+					cmd.timeoutMs < 1)
+			) {
+				errors.push(
+					`${pathLabel}.verify[${index}].timeoutMs must be an integer >= 1.`,
+				);
 			}
-			if (cmd.cwd !== undefined && typeof cmd.cwd !== "string") errors.push(`${pathLabel}.verify[${index}].cwd must be a string.`);
+			if (cmd.cwd !== undefined && typeof cmd.cwd !== "string")
+				errors.push(`${pathLabel}.verify[${index}].cwd must be a string.`);
 			if (cmd.env !== undefined) {
 				if (!cmd.env || typeof cmd.env !== "object" || Array.isArray(cmd.env)) {
 					errors.push(`${pathLabel}.verify[${index}].env must be an object.`);
 				} else {
-					for (const [envKey, envValue] of Object.entries(cmd.env as Record<string, unknown>)) {
-						if (typeof envValue !== "string") errors.push(`${pathLabel}.verify[${index}].env.${envKey} must be a string.`);
+					for (const [envKey, envValue] of Object.entries(
+						cmd.env as Record<string, unknown>,
+					)) {
+						if (typeof envValue !== "string")
+							errors.push(
+								`${pathLabel}.verify[${index}].env.${envKey} must be a string.`,
+							);
 					}
 				}
 			}
-			if (cmd.allowFailure !== undefined && typeof cmd.allowFailure !== "boolean") {
-				errors.push(`${pathLabel}.verify[${index}].allowFailure must be a boolean.`);
+			if (
+				cmd.allowFailure !== undefined &&
+				typeof cmd.allowFailure !== "boolean"
+			) {
+				errors.push(
+					`${pathLabel}.verify[${index}].allowFailure must be a boolean.`,
+				);
 			}
 		}
 	}
 	if (value.review !== undefined && value.review !== false) {
-		if (!value.review || typeof value.review !== "object" || Array.isArray(value.review)) {
+		if (
+			!value.review ||
+			typeof value.review !== "object" ||
+			Array.isArray(value.review)
+		) {
 			errors.push(`${pathLabel}.review must be false or an object.`);
 		} else {
 			const review = value.review as Record<string, unknown>;
 			for (const key of Object.keys(review)) {
-				if (!ACCEPTANCE_REVIEW_KEYS.has(key)) errors.push(`${pathLabel}.review.${key} is not supported.`);
+				if (!ACCEPTANCE_REVIEW_KEYS.has(key))
+					errors.push(`${pathLabel}.review.${key} is not supported.`);
 			}
-			if (review.agent !== undefined && typeof review.agent !== "string") errors.push(`${pathLabel}.review.agent must be a string.`);
-			if (review.focus !== undefined && typeof review.focus !== "string") errors.push(`${pathLabel}.review.focus must be a string.`);
-			if (review.required !== undefined && typeof review.required !== "boolean") errors.push(`${pathLabel}.review.required must be a boolean.`);
+			if (review.agent !== undefined && typeof review.agent !== "string")
+				errors.push(`${pathLabel}.review.agent must be a string.`);
+			if (review.focus !== undefined && typeof review.focus !== "string")
+				errors.push(`${pathLabel}.review.focus must be a string.`);
+			if (review.required !== undefined && typeof review.required !== "boolean")
+				errors.push(`${pathLabel}.review.required must be a boolean.`);
 		}
 	}
-	if (value.stopRules !== undefined && !Array.isArray(value.stopRules)) errors.push(`${pathLabel}.stopRules must be an array.`);
+	if (value.stopRules !== undefined && !Array.isArray(value.stopRules))
+		errors.push(`${pathLabel}.stopRules must be an array.`);
 	if (Array.isArray(value.stopRules)) {
 		for (const [index, item] of value.stopRules.entries()) {
-			if (typeof item !== "string") errors.push(`${pathLabel}.stopRules[${index}] must be a string.`);
+			if (typeof item !== "string")
+				errors.push(`${pathLabel}.stopRules[${index}] must be a string.`);
 		}
 	}
 	return errors;
@@ -312,33 +533,71 @@ export function validateExecutionAcceptance(input: {
 }): string[] {
 	const errors = validateAcceptanceInput(input.acceptance, "acceptance");
 	for (const [index, task] of (input.tasks ?? []).entries()) {
-		errors.push(...validateAcceptanceInput(task.acceptance, `tasks[${index}].acceptance`));
+		errors.push(
+			...validateAcceptanceInput(task.acceptance, `tasks[${index}].acceptance`),
+		);
 	}
 	for (const [stepIndex, step] of (input.chain ?? []).entries()) {
-		errors.push(...validateAcceptanceInput(step.acceptance, `chain[${stepIndex}].acceptance`));
+		errors.push(
+			...validateAcceptanceInput(
+				step.acceptance,
+				`chain[${stepIndex}].acceptance`,
+			),
+		);
 		if (Array.isArray(step.parallel)) {
 			for (const [taskIndex, task] of step.parallel.entries()) {
-				errors.push(...validateAcceptanceInput(task.acceptance, `chain[${stepIndex}].parallel[${taskIndex}].acceptance`));
+				errors.push(
+					...validateAcceptanceInput(
+						task.acceptance,
+						`chain[${stepIndex}].parallel[${taskIndex}].acceptance`,
+					),
+				);
 			}
 		} else if (step.parallel) {
-			errors.push(...validateAcceptanceInput(step.parallel.acceptance, `chain[${stepIndex}].parallel.acceptance`));
+			errors.push(
+				...validateAcceptanceInput(
+					step.parallel.acceptance,
+					`chain[${stepIndex}].parallel.acceptance`,
+				),
+			);
 		}
 	}
 	return errors;
 }
 
-function normalizeCriteria(criteria: Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }> | undefined, evidence: AcceptanceEvidenceKind[]): ResolvedAcceptanceGate[] {
-	return (criteria ?? []).map((criterion, index): ResolvedAcceptanceGate => {
-		if (typeof criterion === "string") {
-			return { id: `criterion-${index + 1}`, must: criterion, evidence, severity: "required" };
-		}
-		return {
-			id: criterion.id?.trim() || `criterion-${index + 1}`,
-			must: criterion.must ?? "",
-			evidence: criterion.evidence?.filter((item) => VALID_EVIDENCE.has(item)) ?? evidence,
-			severity: criterion.severity ?? "required",
-		};
-	}).filter((criterion) => criterion.must.trim());
+function normalizeCriteria(
+	criteria:
+		| Array<
+				| string
+				| {
+						id?: string;
+						must?: string;
+						evidence?: AcceptanceEvidenceKind[];
+						severity?: "required" | "recommended";
+				  }
+		  >
+		| undefined,
+	evidence: AcceptanceEvidenceKind[],
+): ResolvedAcceptanceGate[] {
+	return (criteria ?? [])
+		.map((criterion, index): ResolvedAcceptanceGate => {
+			if (typeof criterion === "string") {
+				return {
+					id: `criterion-${index + 1}`,
+					must: criterion,
+					evidence,
+					severity: "required",
+				};
+			}
+			return {
+				id: criterion.id?.trim() || `criterion-${index + 1}`,
+				must: criterion.must ?? "",
+				evidence:
+					criterion.evidence?.filter((item) => VALID_EVIDENCE.has(item)) ?? evidence,
+				severity: criterion.severity ?? "required",
+			};
+		})
+		.filter((criterion) => criterion.must.trim());
 }
 
 export function resolveEffectiveAcceptance(input: {
@@ -355,12 +614,23 @@ export function resolveEffectiveAcceptance(input: {
 	const explicit = normalizeAcceptanceInput(input.explicit);
 	const explicitLevel = normalizeLevel(explicit.level);
 	if (isAgentContractV1(input.agentContract)) {
-		const level = explicitAcceptanceCanDisable(explicit) || explicitLevel === "auto"
-			? "none"
-			: explicitLevel;
+		const level =
+			explicitAcceptanceCanDisable(explicit) || explicitLevel === "auto"
+				? "none"
+				: explicitLevel;
 		const evidence = unique(explicit.evidence ?? []);
 		const criteria = normalizeCriteria(
-			explicit.criteria as Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }> | undefined,
+			explicit.criteria as
+				| Array<
+						| string
+						| {
+								id?: string;
+								must?: string;
+								evidence?: AcceptanceEvidenceKind[];
+								severity?: "required" | "recommended";
+						  }
+				  >
+				| undefined,
 			evidence,
 		);
 		return {
@@ -380,13 +650,29 @@ export function resolveEffectiveAcceptance(input: {
 		? "none"
 		: explicitLevel === "auto"
 			? inferred.level
-			: (LEVEL_RANK[explicitLevel] >= LEVEL_RANK[inferred.level] ? explicitLevel : inferred.level);
-	const evidence = unique([...(level === inferred.level ? inferred.evidence : requiredEvidenceForLevel(level)), ...(explicit.evidence ?? [])]);
+			: LEVEL_RANK[explicitLevel] >= LEVEL_RANK[inferred.level]
+				? explicitLevel
+				: inferred.level;
+	const evidence = unique([
+		...(level === inferred.level
+			? inferred.evidence
+			: requiredEvidenceForLevel(level)),
+		...(explicit.evidence ?? []),
+	]);
 	const criteria = normalizeCriteria(
-		(explicit.criteria?.length ? explicit.criteria : inferred.criteria) as Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }>,
+		(explicit.criteria?.length ? explicit.criteria : inferred.criteria) as Array<
+			| string
+			| {
+					id?: string;
+					must?: string;
+					evidence?: AcceptanceEvidenceKind[];
+					severity?: "required" | "recommended";
+			  }
+		>,
 		evidence,
 	);
-	const review = explicit.review !== undefined ? explicit.review : inferred.review;
+	const review =
+		explicit.review !== undefined ? explicit.review : inferred.review;
 	return {
 		level,
 		explicit: input.explicit !== undefined,
@@ -400,61 +686,115 @@ export function resolveEffectiveAcceptance(input: {
 	};
 }
 
-function acceptanceRequiresChildReport(acceptance: ResolvedAcceptanceConfig): boolean {
+function acceptanceRequiresChildReport(
+	acceptance: ResolvedAcceptanceConfig,
+): boolean {
 	return acceptance.criteria.length > 0 || acceptance.evidence.length > 0;
 }
 
-export function formatAcceptancePrompt(acceptance: ResolvedAcceptanceConfig, options: { reportOptional?: boolean; structuredOutput?: boolean } = {}): string {
+/**
+ * Resolve the acceptance report delivery mode for a run.
+ * - `"structured"`: report must be delivered as validated structured output
+ *   (acceptance.report === "on").
+ * - `"optional"`: report piggybacks on outputSchema when present, or is
+ *   delivered as a fenced-JSON text block (legacy behavior, default).
+ * - `"off"`: no report delivery is requested from the child.
+ */
+export function resolveAcceptanceReportMode(explicit: AcceptanceInput | undefined): "structured" | "optional" | "off" {
+	if (explicit === undefined || explicit === false) return "optional";
+	if (typeof explicit === "string") return "optional";
+	if (explicit.report === "on") return "structured";
+	if (explicit.report === "off") return "off";
+	return "optional";
+}
+
+export function formatAcceptancePrompt(
+	acceptance: ResolvedAcceptanceConfig,
+	options: { reportOptional?: boolean; structuredOutput?: boolean; reportRequired?: boolean; reportOnly?: boolean } = {},
+): string {
 	if (acceptance.level === "none") return "";
-	if (options.reportOptional && !acceptanceRequiresChildReport(acceptance)) return "";
+	if (options.reportOptional && !acceptanceRequiresChildReport(acceptance))
+		return "";
+	const structuredDelivery = options.structuredOutput || options.reportRequired;
+	// Report-only runtime: the standalone structured_output tool carries the
+	// report as its `value` parameter, so the piggyback wording would be wrong.
+	const standaloneDelivery = options.reportRequired && options.reportOnly;
 	const lines = [
 		"",
 		"## Acceptance Contract",
 		`Acceptance level: ${acceptance.level}`,
 		"Completion is not accepted from prose alone. End with a structured acceptance report.",
+		...(standaloneDelivery
+			? ["Mandatory: deliver the acceptance report by calling the `structured_output` tool with the report as `value`. A valid report call terminates the step."]
+			: []),
 		"",
 		"Criteria:",
-		...(acceptance.criteria.length ? acceptance.criteria.map((criterion) => `- ${criterion.id}: ${criterion.must}`) : ["- Return the requested result."]),
+		...(acceptance.criteria.length
+			? acceptance.criteria.map(
+					(criterion) => `- ${criterion.id}: ${criterion.must}`,
+				)
+			: ["- Return the requested result."]),
 		"",
 		`Required evidence: ${acceptance.evidence.join(", ") || "none"}`,
 	];
 	if (acceptance.verify.length > 0) {
 		lines.push("", "Runtime verification commands configured by parent:");
-		for (const command of acceptance.verify) lines.push(`- ${command.id}: ${command.command}`);
+		for (const command of acceptance.verify)
+			lines.push(`- ${command.id}: ${command.command}`);
 	}
 	if (acceptance.review) {
-		lines.push("", `Review gate: ${acceptance.review.required === false ? "optional" : "required"}${acceptance.review.agent ? ` by ${acceptance.review.agent}` : ""}.`);
-		if (acceptance.review.focus) lines.push(`Review focus: ${acceptance.review.focus}`);
+		lines.push(
+			"",
+			`Review gate: ${acceptance.review.required === false ? "optional" : "required"}${acceptance.review.agent ? ` by ${acceptance.review.agent}` : ""}.`,
+		);
+		if (acceptance.review.focus)
+			lines.push(`Review focus: ${acceptance.review.focus}`);
 	}
 	if (acceptance.stopRules.length > 0) {
-		lines.push("", "Stop rules:", ...acceptance.stopRules.map((rule) => `- ${rule}`));
+		lines.push(
+			"",
+			"Stop rules:",
+			...acceptance.stopRules.map((rule) => `- ${rule}`),
+		);
 	}
 	lines.push(
 		"",
-		options.structuredOutput
-			? "Include an `acceptanceReport` object in your final `structured_output` tool call in this shape:"
+		structuredDelivery
+			? standaloneDelivery
+				? "The report must be submitted by calling the `structured_output` tool; its single `value` parameter is the report object in this shape:"
+				: "Include an `acceptanceReport` object in your final `structured_output` tool call in this shape:"
 			: "Finish with a fenced JSON block tagged `acceptance-report` in this shape:",
 		"Use empty arrays when no items apply; array fields contain strings unless object entries are shown.",
-		"Empty-string entries (`[\"\"]`) are ignored; use `[]` when nothing applies.",
+		'Empty-string entries (`[""]`) are ignored; use `[]` when nothing applies.',
 		"`criteriaSatisfied[].status` must be exactly one of: satisfied, not-satisfied, not-applicable.",
 		"`commandsRun[].result` must be exactly one of: passed, failed, not-run.",
 		"`manualNotes` and `notes` are optional strings; an empty string means no note and does not satisfy `manual-notes` evidence.",
-		...(options.structuredOutput ? [] : ["```acceptance-report"]),
-		JSON.stringify({
-			criteriaSatisfied: acceptance.criteria
-				.filter((criterion) => criterion.severity !== "recommended")
-				.map((criterion) => ({ id: criterion.id, status: "satisfied", evidence: "specific proof" })),
-			changedFiles: ["src/file.ts"],
-			testsAddedOrUpdated: ["test/file.test.ts"],
-			commandsRun: [{ command: "command", result: "passed", summary: "short result" }],
-			validationOutput: ["validation output or concise summary"],
-			residualRisks: ["none"],
-			noStagedFiles: true,
-			diffSummary: "short description of the diff",
-			reviewFindings: ["blocker: file.ts:12 - issue found, or no blockers"],
-			manualNotes: "anything else the parent should know",
-		}, null, 2),
-		...(options.structuredOutput ? [] : ["```"]),
+		...(structuredDelivery ? [] : ["```acceptance-report"]),
+		JSON.stringify(
+			{
+				criteriaSatisfied: acceptance.criteria
+					.filter((criterion) => criterion.severity !== "recommended")
+					.map((criterion) => ({
+						id: criterion.id,
+						status: "satisfied",
+						evidence: "specific proof",
+					})),
+				changedFiles: ["src/file.ts"],
+				testsAddedOrUpdated: ["test/file.test.ts"],
+				commandsRun: [
+					{ command: "command", result: "passed", summary: "short result" },
+				],
+				validationOutput: ["validation output or concise summary"],
+				residualRisks: ["none"],
+				noStagedFiles: true,
+				diffSummary: "short description of the diff",
+				reviewFindings: ["blocker: file.ts:12 - issue found, or no blockers"],
+				manualNotes: "anything else the parent should know",
+			},
+			null,
+			2,
+		),
+		...(structuredDelivery ? [] : ["```"]),
 	);
 	return lines.join("\n");
 }
@@ -468,10 +808,10 @@ function extractBalancedJson(text: string, start: number): string | undefined {
 		if (inString) {
 			if (escaped) escaped = false;
 			else if (char === "\\") escaped = true;
-			else if (char === "\"") inString = false;
+			else if (char === '"') inString = false;
 			continue;
 		}
-		if (char === "\"") {
+		if (char === '"') {
 			inString = true;
 			continue;
 		}
@@ -484,7 +824,12 @@ function extractBalancedJson(text: string, start: number): string | undefined {
 	return undefined;
 }
 
-const ACCEPTANCE_REPORT_WRAPPERS = new Set(["acceptance", "acceptance-report", "acceptance_report", "acceptanceReport"]);
+const ACCEPTANCE_REPORT_WRAPPERS = new Set([
+	"acceptance",
+	"acceptance-report",
+	"acceptance_report",
+	"acceptanceReport",
+]);
 
 const ACCEPTANCE_REPORT_FIELDS: Record<string, keyof AcceptanceReport> = {
 	criteriaSatisfied: "criteriaSatisfied",
@@ -514,100 +859,184 @@ const CRITERION_REPORT_FIELDS = new Set(["id", "status", "evidence"]);
 const COMMAND_REPORT_FIELDS = new Set(["command", "result", "summary"]);
 
 function normalizedToken(value: string): string {
-	return value.trim().toLowerCase().replace(/[\s_]+/g, "-").replace(/-+/g, "-");
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[\s_]+/g, "-")
+		.replace(/-+/g, "-");
 }
 
 function normalizeCriterionStatus(value: unknown): unknown {
 	if (typeof value !== "string") return value;
 	const token = normalizedToken(value);
-	if (["satisfied", "met", "complete", "completed", "done", "pass", "passed", "success", "succeeded"].includes(token)) return "satisfied";
-	if (["not-satisfied", "not-met", "unmet", "incomplete", "fail", "failed"].includes(token)) return "not-satisfied";
-	if (["not-applicable", "n-a", "na", "skip", "skipped"].includes(token)) return "not-applicable";
+	if (
+		[
+			"satisfied",
+			"met",
+			"complete",
+			"completed",
+			"done",
+			"pass",
+			"passed",
+			"success",
+			"succeeded",
+		].includes(token)
+	)
+		return "satisfied";
+	if (
+		[
+			"not-satisfied",
+			"not-met",
+			"unmet",
+			"incomplete",
+			"fail",
+			"failed",
+		].includes(token)
+	)
+		return "not-satisfied";
+	if (["not-applicable", "n-a", "na", "skip", "skipped"].includes(token))
+		return "not-applicable";
 	return value;
 }
 
 function normalizeCommandResult(value: unknown): unknown {
 	if (typeof value !== "string") return value;
 	const token = normalizedToken(value);
-	if (["passed", "pass", "success", "successful", "succeeded", "ok"].includes(token)) return "passed";
+	if (
+		["passed", "pass", "success", "successful", "succeeded", "ok"].includes(token)
+	)
+		return "passed";
 	if (["failed", "fail", "failure", "error"].includes(token)) return "failed";
-	if (["not-run", "not-executed", "skip", "skipped"].includes(token)) return "not-run";
+	if (["not-run", "not-executed", "skip", "skipped"].includes(token))
+		return "not-run";
 	return value;
 }
 
-function normalizeCriterionReport(value: unknown, pathLabel: string, errors: string[]): unknown {
+function normalizeCriterionReport(
+	value: unknown,
+	pathLabel: string,
+	errors: string[],
+): unknown {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
 	const normalized: Record<string, unknown> = {};
-	for (const [key, fieldValue] of Object.entries(value as Record<string, unknown>)) {
+	for (const [key, fieldValue] of Object.entries(
+		value as Record<string, unknown>,
+	)) {
 		if (!CRITERION_REPORT_FIELDS.has(key)) {
 			errors.push(`${pathLabel}.${key}: unsupported acceptance criterion field`);
 			continue;
 		}
-		normalized[key] = key === "id" && typeof fieldValue === "string"
-			? normalizedToken(fieldValue)
-			: key === "status"
-				? normalizeCriterionStatus(fieldValue)
-				: fieldValue;
+		normalized[key] =
+			key === "id" && typeof fieldValue === "string"
+				? normalizedToken(fieldValue)
+				: key === "status"
+					? normalizeCriterionStatus(fieldValue)
+					: fieldValue;
 	}
 	return normalized;
 }
 
-function normalizeCommandReport(value: unknown, pathLabel: string, errors: string[]): unknown {
+function normalizeCommandReport(
+	value: unknown,
+	pathLabel: string,
+	errors: string[],
+): unknown {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
 	const normalized: Record<string, unknown> = {};
-	for (const [key, fieldValue] of Object.entries(value as Record<string, unknown>)) {
+	for (const [key, fieldValue] of Object.entries(
+		value as Record<string, unknown>,
+	)) {
 		if (!COMMAND_REPORT_FIELDS.has(key)) {
 			errors.push(`${pathLabel}.${key}: unsupported acceptance command field`);
 			continue;
 		}
-		normalized[key] = key === "result" ? normalizeCommandResult(fieldValue) : fieldValue;
+		normalized[key] =
+			key === "result" ? normalizeCommandResult(fieldValue) : fieldValue;
 	}
 	return normalized;
 }
 
-function normalizeAcceptanceReportValue(value: unknown, pathLabel = ""): { value: unknown; pathLabel: string; errors: string[] } {
+function normalizeAcceptanceReportValue(
+	value: unknown,
+	pathLabel = "",
+): { value: unknown; pathLabel: string; errors: string[] } {
 	const errors: string[] = [];
 	let reportValue = value;
 	let reportPath = pathLabel;
-	if (reportValue && typeof reportValue === "object" && !Array.isArray(reportValue)) {
+	if (
+		reportValue &&
+		typeof reportValue === "object" &&
+		!Array.isArray(reportValue)
+	) {
 		const record = reportValue as Record<string, unknown>;
-		const wrapperKeys = Object.keys(record).filter((key) => ACCEPTANCE_REPORT_WRAPPERS.has(key));
+		const wrapperKeys = Object.keys(record).filter((key) =>
+			ACCEPTANCE_REPORT_WRAPPERS.has(key),
+		);
 		if (wrapperKeys.length > 0) {
 			const wrapperKey = wrapperKeys[0]!;
-			if (wrapperKeys.length > 1) errors.push(`${pathLabel || "acceptance-report"}: multiple acceptance report wrappers are ambiguous`);
+			if (wrapperKeys.length > 1)
+				errors.push(
+					`${pathLabel || "acceptance-report"}: multiple acceptance report wrappers are ambiguous`,
+				);
 			for (const key of Object.keys(record)) {
-				if (key !== wrapperKey) errors.push(`${pathFor(pathLabel, key)}: unsupported alongside acceptance report wrapper '${wrapperKey}'`);
+				if (key !== wrapperKey)
+					errors.push(
+						`${pathFor(pathLabel, key)}: unsupported alongside acceptance report wrapper '${wrapperKey}'`,
+					);
 			}
 			reportValue = record[wrapperKey];
 			reportPath = pathFor(pathLabel, wrapperKey);
 		}
 	}
-	if (!reportValue || typeof reportValue !== "object" || Array.isArray(reportValue)) return { value: reportValue, pathLabel: reportPath, errors };
+	if (
+		!reportValue ||
+		typeof reportValue !== "object" ||
+		Array.isArray(reportValue)
+	)
+		return { value: reportValue, pathLabel: reportPath, errors };
 
 	const normalized: Record<string, unknown> = {};
-	for (const [key, fieldValue] of Object.entries(reportValue as Record<string, unknown>)) {
+	for (const [key, fieldValue] of Object.entries(
+		reportValue as Record<string, unknown>,
+	)) {
 		const canonical = ACCEPTANCE_REPORT_FIELDS[key];
 		if (!canonical) {
-			errors.push(`${pathFor(reportPath, key)}: unsupported acceptance report field`);
+			errors.push(
+				`${pathFor(reportPath, key)}: unsupported acceptance report field`,
+			);
 			continue;
 		}
 		if (Object.hasOwn(normalized, canonical)) {
-			errors.push(`${pathFor(reportPath, key)}: duplicates normalized field '${canonical}'`);
+			errors.push(
+				`${pathFor(reportPath, key)}: duplicates normalized field '${canonical}'`,
+			);
 			continue;
 		}
 		const fieldPath = pathFor(reportPath, canonical);
 		switch (canonical) {
 			case "criteriaSatisfied": {
-				const items = Array.isArray(fieldValue) ? fieldValue : fieldValue && typeof fieldValue === "object" ? [fieldValue] : fieldValue;
+				const items = Array.isArray(fieldValue)
+					? fieldValue
+					: fieldValue && typeof fieldValue === "object"
+						? [fieldValue]
+						: fieldValue;
 				normalized[canonical] = Array.isArray(items)
-					? items.map((item, index) => normalizeCriterionReport(item, `${fieldPath}[${index}]`, errors))
+					? items.map((item, index) =>
+							normalizeCriterionReport(item, `${fieldPath}[${index}]`, errors),
+						)
 					: items;
 				break;
 			}
 			case "commandsRun": {
-				const items = Array.isArray(fieldValue) ? fieldValue : fieldValue && typeof fieldValue === "object" ? [fieldValue] : fieldValue;
+				const items = Array.isArray(fieldValue)
+					? fieldValue
+					: fieldValue && typeof fieldValue === "object"
+						? [fieldValue]
+						: fieldValue;
 				normalized[canonical] = Array.isArray(items)
-					? items.map((item, index) => normalizeCommandReport(item, `${fieldPath}[${index}]`, errors))
+					? items.map((item, index) =>
+							normalizeCommandReport(item, `${fieldPath}[${index}]`, errors),
+						)
 					: items;
 				break;
 			}
@@ -622,13 +1051,19 @@ function normalizeAcceptanceReportValue(value: unknown, pathLabel = ""): { value
 				// flags structural garbage.
 				const items = typeof fieldValue === "string" ? [fieldValue] : fieldValue;
 				normalized[canonical] = Array.isArray(items)
-					? items.filter((item) => typeof item !== "string" || item.trim().length > 0)
+					? items.filter(
+							(item) => typeof item !== "string" || item.trim().length > 0,
+						)
 					: items;
 				break;
 			}
 			case "noStagedFiles": {
-				const token = typeof fieldValue === "string" ? fieldValue.trim().toLowerCase() : undefined;
-				normalized[canonical] = token === "true" ? true : token === "false" ? false : fieldValue;
+				const token =
+					typeof fieldValue === "string"
+						? fieldValue.trim().toLowerCase()
+						: undefined;
+				normalized[canonical] =
+					token === "true" ? true : token === "false" ? false : fieldValue;
 				break;
 			}
 			default:
@@ -641,17 +1076,20 @@ function normalizeAcceptanceReportValue(value: unknown, pathLabel = ""): { value
 function hasGenericAcceptanceReportSignal(value: unknown): boolean {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
 	const record = value as Record<string, unknown>;
-	return "criteriaSatisfied" in record && [
-		"changedFiles",
-		"testsAddedOrUpdated",
-		"commandsRun",
-		"validationOutput",
-		"residualRisks",
-		"noStagedFiles",
-		"diffSummary",
-		"reviewFindings",
-		"manualNotes",
-	].some((key) => key in record);
+	return (
+		"criteriaSatisfied" in record &&
+		[
+			"changedFiles",
+			"testsAddedOrUpdated",
+			"commandsRun",
+			"validationOutput",
+			"residualRisks",
+			"noStagedFiles",
+			"diffSummary",
+			"reviewFindings",
+			"manualNotes",
+		].some((key) => key in record)
+	);
 }
 
 function parseReportJson(body: string): unknown {
@@ -669,12 +1107,17 @@ function parseReportJson(body: string): unknown {
 }
 
 function fencedBlocks(output: string, tag: string): string[] {
-	return [...output.matchAll(new RegExp(`\`\`\`${tag}\\s*\\n([\\s\\S]*?)\`\`\``, "gi"))]
+	return [
+		...output.matchAll(new RegExp(`\`\`\`${tag}\\s*\\n([\\s\\S]*?)\`\`\``, "gi")),
+	]
 		.map((match) => match[1]?.trim())
 		.filter((value): value is string => Boolean(value));
 }
 
-function parseAcceptanceReportBody(body: string): { report?: AcceptanceReport; errors: string[] } {
+function parseAcceptanceReportBody(body: string): {
+	report?: AcceptanceReport;
+	errors: string[];
+} {
 	return validateAcceptanceReport(parseReportJson(body));
 }
 
@@ -686,38 +1129,61 @@ interface AcceptanceReportParseResult {
 	sourcePath?: string;
 }
 
-function parseUnterminatedAcceptanceReportFence(output: string): AcceptanceReportParseResult {
+function parseUnterminatedAcceptanceReportFence(
+	output: string,
+): AcceptanceReportParseResult {
 	const opener = /```acceptance[-_]report\b[^\n]*\n/gi.exec(output);
 	if (!opener) return {};
 	const bodyStart = opener.index + opener[0].length;
 	if (output.indexOf("```", bodyStart) !== -1) return {};
 	try {
-		const validation = validateAcceptanceReport(JSON.parse(output.slice(bodyStart).trim()) as unknown);
+		const validation = validateAcceptanceReport(
+			JSON.parse(output.slice(bodyStart).trim()) as unknown,
+		);
 		return validation.report
 			? { report: validation.report }
-			: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
+			: {
+					error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`,
+					malformed: true,
+				};
 	} catch (error) {
-		return { error: `Failed to parse acceptance-report: ${error instanceof Error ? error.message : String(error)}`, malformed: true };
+		return {
+			error: `Failed to parse acceptance-report: ${error instanceof Error ? error.message : String(error)}`,
+			malformed: true,
+		};
 	}
 }
 
-function parseGenericJsonAcceptanceReportBody(body: string): AcceptanceReportParseResult {
+function parseGenericJsonAcceptanceReportBody(
+	body: string,
+): AcceptanceReportParseResult {
 	const parsed = parseReportJson(body);
 	const normalized = normalizeAcceptanceReportValue(parsed);
-	const hasCriteriaMarker = normalized.value !== null
-		&& typeof normalized.value === "object"
-		&& !Array.isArray(normalized.value)
-		&& "criteriaSatisfied" in normalized.value;
-	if (!hasGenericAcceptanceReportSignal(normalized.value) && !(hasCriteriaMarker && normalized.errors.length > 0)) return {};
+	const hasCriteriaMarker =
+		normalized.value !== null &&
+		typeof normalized.value === "object" &&
+		!Array.isArray(normalized.value) &&
+		"criteriaSatisfied" in normalized.value;
+	if (
+		!hasGenericAcceptanceReportSignal(normalized.value) &&
+		!(hasCriteriaMarker && normalized.errors.length > 0)
+	)
+		return {};
 	const validation = validateAcceptanceReport(parsed);
 	return validation.report
 		? { report: validation.report }
-		: { error: `Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
+		: {
+				error: `Invalid acceptance-report: ${validation.errors.join("; ")}`,
+				malformed: true,
+			};
 }
 
-export const ACCEPTANCE_REPORT_NOT_FOUND = "Structured acceptance report not found.";
+export const ACCEPTANCE_REPORT_NOT_FOUND =
+	"Structured acceptance report not found.";
 
-export function parseAcceptanceReport(output: string): AcceptanceReportParseResult {
+export function parseAcceptanceReport(
+	output: string,
+): AcceptanceReportParseResult {
 	const explicitFencePresent = /```acceptance[-_]report\b/i.test(output);
 	const fenced = fencedBlocks(output, "acceptance[-_]report");
 	const parseErrors: string[] = [];
@@ -725,22 +1191,36 @@ export function parseAcceptanceReport(output: string): AcceptanceReportParseResu
 		try {
 			const validation = parseAcceptanceReportBody(body);
 			if (validation.report) return { report: validation.report };
-			parseErrors.push(`Invalid acceptance-report: ${validation.errors.join("; ")}`);
+			parseErrors.push(
+				`Invalid acceptance-report: ${validation.errors.join("; ")}`,
+			);
 		} catch (error) {
 			parseErrors.push(error instanceof Error ? error.message : String(error));
 		}
 	}
-	if (parseErrors.length > 0) return { error: `Failed to parse acceptance-report: ${parseErrors.join("; ")}`, malformed: true };
+	if (parseErrors.length > 0)
+		return {
+			error: `Failed to parse acceptance-report: ${parseErrors.join("; ")}`,
+			malformed: true,
+		};
 	if (explicitFencePresent) {
 		const recovered = parseUnterminatedAcceptanceReportFence(output);
 		if (recovered.report || recovered.error) return recovered;
-		return { error: "Failed to parse acceptance-report: Empty or unterminated acceptance-report fence.", malformed: true };
+		return {
+			error:
+				"Failed to parse acceptance-report: Empty or unterminated acceptance-report fence.",
+			malformed: true,
+		};
 	}
 	for (const body of fencedBlocks(output, "(?:json|jsonc|json5)")) {
 		try {
 			const parsed = parseGenericJsonAcceptanceReportBody(body);
 			if (parsed.report) return { report: parsed.report };
-			if (parsed.error) return { error: `Failed to parse acceptance-report: ${parsed.error}`, malformed: parsed.malformed };
+			if (parsed.error)
+				return {
+					error: `Failed to parse acceptance-report: ${parsed.error}`,
+					malformed: parsed.malformed,
+				};
 		} catch {
 			// Ignore unrelated malformed generic JSON. A recognizable report shape
 			// returns exact validation errors above instead of being mistaken for prose.
@@ -750,20 +1230,34 @@ export function parseAcceptanceReport(output: string): AcceptanceReportParseResu
 	if (markerIndex !== -1) {
 		const jsonStart = output.indexOf("{", markerIndex);
 		if (jsonStart === -1) {
-			return { error: "Failed to parse acceptance-report: Expected a JSON object after ACCEPTANCE_REPORT:.", malformed: true };
+			return {
+				error:
+					"Failed to parse acceptance-report: Expected a JSON object after ACCEPTANCE_REPORT:.",
+				malformed: true,
+			};
 		}
 		const json = extractBalancedJson(output, jsonStart);
 		if (!json) {
-			return { error: "Failed to parse acceptance-report: Unterminated JSON object after ACCEPTANCE_REPORT:.", malformed: true };
+			return {
+				error:
+					"Failed to parse acceptance-report: Unterminated JSON object after ACCEPTANCE_REPORT:.",
+				malformed: true,
+			};
 		}
 		try {
 			const parsed = JSON.parse(json) as unknown;
 			const validation = validateAcceptanceReport(parsed);
 			if (validation.report) return { report: validation.report };
-			return { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
+			return {
+				error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`,
+				malformed: true,
+			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			return { error: `Failed to parse acceptance-report: ${message}`, malformed: true };
+			return {
+				error: `Failed to parse acceptance-report: ${message}`,
+				malformed: true,
+			};
 		}
 	}
 	return { error: ACCEPTANCE_REPORT_NOT_FOUND };
@@ -771,7 +1265,9 @@ export function parseAcceptanceReport(output: string): AcceptanceReportParseResu
 
 function parseAcceptanceReportSources(
 	output: string,
-	fileOutput: { content: string; path: string; authoritative?: boolean } | undefined,
+	fileOutput:
+		| { content: string; path: string; authoritative?: boolean }
+		| undefined,
 ): AcceptanceReportParseResult {
 	const fromText = () => parseAcceptanceReport(output);
 	const fromFile = () => {
@@ -780,12 +1276,14 @@ function parseAcceptanceReportSources(
 		return parsed.report || parsed.error === ACCEPTANCE_REPORT_NOT_FOUND
 			? parsed
 			: {
-				...parsed,
-				error: `${parsed.error} (in configured output ${fileOutput.path})`,
-				sourcePath: fileOutput.path,
-			};
+					...parsed,
+					error: `${parsed.error} (in configured output ${fileOutput.path})`,
+					sourcePath: fileOutput.path,
+				};
 	};
-	const [primary, secondary] = fileOutput?.authoritative ? [fromFile, fromText] : [fromText, fromFile];
+	const [primary, secondary] = fileOutput?.authoritative
+		? [fromFile, fromText]
+		: [fromText, fromFile];
 	const first = primary();
 	// A malformed report in the primary source is a defect to surface, not a
 	// miss to paper over with the secondary source; only a genuinely absent
@@ -795,18 +1293,28 @@ function parseAcceptanceReportSources(
 }
 
 export function stripAcceptanceReport(output: string): string {
-	const trailingFencePattern = /\n?```(acceptance[-_]report|json|jsonc|json5)\s*\n([\s\S]*?)```\s*/gi;
+	const trailingFencePattern =
+		/\n?```(acceptance[-_]report|json|jsonc|json5)\s*\n([\s\S]*?)```\s*/gi;
 	let trailingFence: { index: number; tag: string; body: string } | undefined;
 	for (const match of output.matchAll(trailingFencePattern)) {
 		const end = (match.index ?? 0) + match[0].length;
 		if (output.slice(end).trim().length === 0 && match[1] && match[2]) {
-			trailingFence = { index: match.index ?? 0, tag: match[1].toLowerCase(), body: match[2] };
+			trailingFence = {
+				index: match.index ?? 0,
+				tag: match[1].toLowerCase(),
+				body: match[2],
+			};
 		}
 	}
 	if (trailingFence) {
-		if (trailingFence.tag === "acceptance-report" || trailingFence.tag === "acceptance_report") return output.slice(0, trailingFence.index).trimEnd();
+		if (
+			trailingFence.tag === "acceptance-report" ||
+			trailingFence.tag === "acceptance_report"
+		)
+			return output.slice(0, trailingFence.index).trimEnd();
 		try {
-			if (parseGenericJsonAcceptanceReportBody(trailingFence.body).report) return output.slice(0, trailingFence.index).trimEnd();
+			if (parseGenericJsonAcceptanceReportBody(trailingFence.body).report)
+				return output.slice(0, trailingFence.index).trimEnd();
 		} catch {
 			// Leave unrelated or malformed generic JSON fences visible.
 		}
@@ -837,21 +1345,36 @@ function describeValidationValue(value: unknown): string {
 	return `${typeof value} ${String(value)}`;
 }
 
-function pushTypeError(errors: string[], pathLabel: string, expected: string, value: unknown): void {
-	errors.push(`${pathLabel}: expected ${expected}; got ${describeValidationValue(value)}`);
+function pushTypeError(
+	errors: string[],
+	pathLabel: string,
+	expected: string,
+	value: unknown,
+): void {
+	errors.push(
+		`${pathLabel}: expected ${expected}; got ${describeValidationValue(value)}`,
+	);
 }
 
-function validateStringArrayField(errors: string[], value: unknown, pathLabel: string): void {
+function validateStringArrayField(
+	errors: string[],
+	value: unknown,
+	pathLabel: string,
+): void {
 	if (!Array.isArray(value)) {
 		pushTypeError(errors, pathLabel, "string[]", value);
 		return;
 	}
 	for (const [index, item] of value.entries()) {
-		if (typeof item !== "string" || !item.trim()) pushTypeError(errors, `${pathLabel}[${index}]`, "non-empty string", item);
+		if (typeof item !== "string" || !item.trim())
+			pushTypeError(errors, `${pathLabel}[${index}]`, "non-empty string", item);
 	}
 }
 
-function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: AcceptanceReport; errors: string[] } {
+function validateAcceptanceReport(
+	value: unknown,
+	pathLabel = "",
+): { report?: AcceptanceReport; errors: string[] } {
 	const normalized = normalizeAcceptanceReportValue(value, pathLabel);
 	value = normalized.value;
 	pathLabel = normalized.pathLabel;
@@ -863,7 +1386,12 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 	const report = value as AcceptanceReport;
 	if (report.criteriaSatisfied !== undefined) {
 		if (!Array.isArray(report.criteriaSatisfied)) {
-			pushTypeError(errors, pathFor(pathLabel, "criteriaSatisfied"), "array", report.criteriaSatisfied);
+			pushTypeError(
+				errors,
+				pathFor(pathLabel, "criteriaSatisfied"),
+				"array",
+				report.criteriaSatisfied,
+			);
 		} else {
 			const criterionIds = new Set<string>();
 			for (const [index, item] of report.criteriaSatisfied.entries()) {
@@ -872,25 +1400,62 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 					pushTypeError(errors, itemPath, "object", item);
 					continue;
 				}
-				const criterion = item as { id?: unknown; status?: unknown; evidence?: unknown };
+				const criterion = item as {
+					id?: unknown;
+					status?: unknown;
+					evidence?: unknown;
+				};
 				if (criterion.id !== undefined && typeof criterion.id !== "string") {
 					pushTypeError(errors, `${itemPath}.id`, "string", criterion.id);
 				} else if (typeof criterion.id === "string" && criterion.id) {
-					if (criterionIds.has(criterion.id)) errors.push(`${itemPath}.id: duplicate normalized criterion id '${criterion.id}'`);
+					if (criterionIds.has(criterion.id))
+						errors.push(
+							`${itemPath}.id: duplicate normalized criterion id '${criterion.id}'`,
+						);
 					criterionIds.add(criterion.id);
 				}
-				if (criterion.status !== "satisfied" && criterion.status !== "not-satisfied" && criterion.status !== "not-applicable") {
-					pushTypeError(errors, `${itemPath}.status`, "one of \"satisfied\", \"not-satisfied\", \"not-applicable\"", criterion.status);
+				if (
+					criterion.status !== "satisfied" &&
+					criterion.status !== "not-satisfied" &&
+					criterion.status !== "not-applicable"
+				) {
+					pushTypeError(
+						errors,
+						`${itemPath}.status`,
+						'one of "satisfied", "not-satisfied", "not-applicable"',
+						criterion.status,
+					);
 				}
-				if (typeof criterion.evidence !== "string" || !criterion.evidence.trim()) pushTypeError(errors, `${itemPath}.evidence`, "non-empty string", criterion.evidence);
+				if (typeof criterion.evidence !== "string" || !criterion.evidence.trim())
+					pushTypeError(
+						errors,
+						`${itemPath}.evidence`,
+						"non-empty string",
+						criterion.evidence,
+					);
 			}
 		}
 	}
-	if (report.changedFiles !== undefined) validateStringArrayField(errors, report.changedFiles, pathFor(pathLabel, "changedFiles"));
-	if (report.testsAddedOrUpdated !== undefined) validateStringArrayField(errors, report.testsAddedOrUpdated, pathFor(pathLabel, "testsAddedOrUpdated"));
+	if (report.changedFiles !== undefined)
+		validateStringArrayField(
+			errors,
+			report.changedFiles,
+			pathFor(pathLabel, "changedFiles"),
+		);
+	if (report.testsAddedOrUpdated !== undefined)
+		validateStringArrayField(
+			errors,
+			report.testsAddedOrUpdated,
+			pathFor(pathLabel, "testsAddedOrUpdated"),
+		);
 	if (report.commandsRun !== undefined) {
 		if (!Array.isArray(report.commandsRun)) {
-			pushTypeError(errors, pathFor(pathLabel, "commandsRun"), "array", report.commandsRun);
+			pushTypeError(
+				errors,
+				pathFor(pathLabel, "commandsRun"),
+				"array",
+				report.commandsRun,
+			);
 		} else {
 			for (const [index, item] of report.commandsRun.entries()) {
 				const itemPath = `${pathFor(pathLabel, "commandsRun")}[${index}]`;
@@ -898,50 +1463,146 @@ function validateAcceptanceReport(value: unknown, pathLabel = ""): { report?: Ac
 					pushTypeError(errors, itemPath, "object", item);
 					continue;
 				}
-				const command = item as { command?: unknown; result?: unknown; summary?: unknown };
-				if (typeof command.command !== "string" || !command.command.trim()) pushTypeError(errors, `${itemPath}.command`, "non-empty string", command.command);
-				if (command.result !== "passed" && command.result !== "failed" && command.result !== "not-run") {
-					pushTypeError(errors, `${itemPath}.result`, "one of \"passed\", \"failed\", \"not-run\"", command.result);
+				const command = item as {
+					command?: unknown;
+					result?: unknown;
+					summary?: unknown;
+				};
+				if (typeof command.command !== "string" || !command.command.trim())
+					pushTypeError(
+						errors,
+						`${itemPath}.command`,
+						"non-empty string",
+						command.command,
+					);
+				if (
+					command.result !== "passed" &&
+					command.result !== "failed" &&
+					command.result !== "not-run"
+				) {
+					pushTypeError(
+						errors,
+						`${itemPath}.result`,
+						'one of "passed", "failed", "not-run"',
+						command.result,
+					);
 				}
-				if (typeof command.summary !== "string" || !command.summary.trim()) pushTypeError(errors, `${itemPath}.summary`, "non-empty string", command.summary);
+				if (typeof command.summary !== "string" || !command.summary.trim())
+					pushTypeError(
+						errors,
+						`${itemPath}.summary`,
+						"non-empty string",
+						command.summary,
+					);
 			}
 		}
 	}
-	if (report.validationOutput !== undefined) validateStringArrayField(errors, report.validationOutput, pathFor(pathLabel, "validationOutput"));
-	if (report.residualRisks !== undefined) validateStringArrayField(errors, report.residualRisks, pathFor(pathLabel, "residualRisks"));
-	if (report.noStagedFiles !== undefined && typeof report.noStagedFiles !== "boolean") pushTypeError(errors, pathFor(pathLabel, "noStagedFiles"), "boolean", report.noStagedFiles);
-	if (report.diffSummary !== undefined && (typeof report.diffSummary !== "string" || !report.diffSummary.trim())) pushTypeError(errors, pathFor(pathLabel, "diffSummary"), "non-empty string", report.diffSummary);
-	if (report.reviewFindings !== undefined) validateStringArrayField(errors, report.reviewFindings, pathFor(pathLabel, "reviewFindings"));
-	if (report.manualNotes !== undefined && typeof report.manualNotes !== "string") pushTypeError(errors, pathFor(pathLabel, "manualNotes"), "string", report.manualNotes);
-	if (report.notes !== undefined && typeof report.notes !== "string") pushTypeError(errors, pathFor(pathLabel, "notes"), "string", report.notes);
+	if (report.validationOutput !== undefined)
+		validateStringArrayField(
+			errors,
+			report.validationOutput,
+			pathFor(pathLabel, "validationOutput"),
+		);
+	if (report.residualRisks !== undefined)
+		validateStringArrayField(
+			errors,
+			report.residualRisks,
+			pathFor(pathLabel, "residualRisks"),
+		);
+	if (
+		report.noStagedFiles !== undefined &&
+		typeof report.noStagedFiles !== "boolean"
+	)
+		pushTypeError(
+			errors,
+			pathFor(pathLabel, "noStagedFiles"),
+			"boolean",
+			report.noStagedFiles,
+		);
+	if (
+		report.diffSummary !== undefined &&
+		(typeof report.diffSummary !== "string" || !report.diffSummary.trim())
+	)
+		pushTypeError(
+			errors,
+			pathFor(pathLabel, "diffSummary"),
+			"non-empty string",
+			report.diffSummary,
+		);
+	if (report.reviewFindings !== undefined)
+		validateStringArrayField(
+			errors,
+			report.reviewFindings,
+			pathFor(pathLabel, "reviewFindings"),
+		);
+	if (report.manualNotes !== undefined && typeof report.manualNotes !== "string")
+		pushTypeError(
+			errors,
+			pathFor(pathLabel, "manualNotes"),
+			"string",
+			report.manualNotes,
+		);
+	if (report.notes !== undefined && typeof report.notes !== "string")
+		pushTypeError(errors, pathFor(pathLabel, "notes"), "string", report.notes);
 	if (errors.length > 0) return { errors };
-	const hasReportField = report.criteriaSatisfied !== undefined
-		|| report.changedFiles !== undefined
-		|| report.testsAddedOrUpdated !== undefined
-		|| report.commandsRun !== undefined
-		|| report.validationOutput !== undefined
-		|| report.residualRisks !== undefined
-		|| report.noStagedFiles !== undefined
-		|| report.diffSummary !== undefined
-		|| report.manualNotes !== undefined
-		|| report.notes !== undefined
-		|| report.reviewFindings !== undefined;
+	const hasReportField =
+		report.criteriaSatisfied !== undefined ||
+		report.changedFiles !== undefined ||
+		report.testsAddedOrUpdated !== undefined ||
+		report.commandsRun !== undefined ||
+		report.validationOutput !== undefined ||
+		report.residualRisks !== undefined ||
+		report.noStagedFiles !== undefined ||
+		report.diffSummary !== undefined ||
+		report.manualNotes !== undefined ||
+		report.notes !== undefined ||
+		report.reviewFindings !== undefined;
 	return hasReportField
 		? { report, errors }
-		: { errors: [`${pathLabel || "acceptance-report"}: expected at least one acceptance report field`] };
+		: {
+				errors: [
+					`${pathLabel || "acceptance-report"}: expected at least one acceptance report field`,
+				],
+			};
 }
 
-function checkCriteriaSatisfied(criteria: ResolvedAcceptanceGate[], report: AcceptanceReport): AcceptanceRuntimeCheck[] {
-	const reports = new Map((report.criteriaSatisfied ?? []).filter((item) => item.id).map((item) => [normalizedToken(item.id!), item]));
-	return criteria.filter((criterion) => criterion.severity !== "recommended").map((criterion) => {
-		const item = reports.get(normalizedToken(criterion.id));
-		if (!item) return { id: `criterion:${criterion.id}`, status: "failed", message: `Required criterion '${criterion.id}' was not reported.` };
-		if (item.status !== "satisfied") return { id: `criterion:${criterion.id}`, status: "failed", message: `Required criterion '${criterion.id}' was reported as ${item.status}.` };
-		return { id: `criterion:${criterion.id}`, status: "passed", message: `Required criterion '${criterion.id}' satisfied.` };
-	});
+function checkCriteriaSatisfied(
+	criteria: ResolvedAcceptanceGate[],
+	report: AcceptanceReport,
+): AcceptanceRuntimeCheck[] {
+	const reports = new Map(
+		(report.criteriaSatisfied ?? [])
+			.filter((item) => item.id)
+			.map((item) => [normalizedToken(item.id!), item]),
+	);
+	return criteria
+		.filter((criterion) => criterion.severity !== "recommended")
+		.map((criterion) => {
+			const item = reports.get(normalizedToken(criterion.id));
+			if (!item)
+				return {
+					id: `criterion:${criterion.id}`,
+					status: "failed",
+					message: `Required criterion '${criterion.id}' was not reported.`,
+				};
+			if (item.status !== "satisfied")
+				return {
+					id: `criterion:${criterion.id}`,
+					status: "failed",
+					message: `Required criterion '${criterion.id}' was reported as ${item.status}.`,
+				};
+			return {
+				id: `criterion:${criterion.id}`,
+				status: "passed",
+				message: `Required criterion '${criterion.id}' satisfied.`,
+			};
+		});
 }
 
-function reportEvidenceStatus(report: AcceptanceReport, kind: AcceptanceEvidenceKind): AcceptanceRuntimeCheckStatus {
+function reportEvidenceStatus(
+	report: AcceptanceReport,
+	kind: AcceptanceEvidenceKind,
+): AcceptanceRuntimeCheckStatus {
 	switch (kind) {
 		case "changed-files":
 			if (!isStringArray(report.changedFiles)) return "failed";
@@ -949,106 +1610,214 @@ function reportEvidenceStatus(report: AcceptanceReport, kind: AcceptanceEvidence
 		case "tests-added":
 			if (!isStringArray(report.testsAddedOrUpdated)) return "failed";
 			return report.testsAddedOrUpdated.length === 0 ? "not-applicable" : "passed";
-		case "commands-run": return Array.isArray(report.commandsRun) && report.commandsRun.length > 0 ? "passed" : "failed";
-		case "validation-output": return isStringArray(report.validationOutput) && report.validationOutput.length > 0 ? "passed" : "failed";
-		case "residual-risks": return isStringArray(report.residualRisks) ? "passed" : "failed";
-		case "no-staged-files": return report.noStagedFiles === true ? "passed" : "failed";
-		case "diff-summary": return typeof report.diffSummary === "string" && report.diffSummary.trim().length > 0 ? "passed" : "failed";
-		case "review-findings": return isStringArray(report.reviewFindings) ? "passed" : "failed";
-		case "manual-notes": return Boolean((report.manualNotes ?? report.notes)?.trim()) ? "passed" : "failed";
+		case "commands-run":
+			return Array.isArray(report.commandsRun) && report.commandsRun.length > 0
+				? "passed"
+				: "failed";
+		case "validation-output":
+			return isStringArray(report.validationOutput) &&
+				report.validationOutput.length > 0
+				? "passed"
+				: "failed";
+		case "residual-risks":
+			return isStringArray(report.residualRisks) ? "passed" : "failed";
+		case "no-staged-files":
+			return report.noStagedFiles === true ? "passed" : "failed";
+		case "diff-summary":
+			return typeof report.diffSummary === "string" &&
+				report.diffSummary.trim().length > 0
+				? "passed"
+				: "failed";
+		case "review-findings":
+			return isStringArray(report.reviewFindings) ? "passed" : "failed";
+		case "manual-notes":
+			return (report.manualNotes ?? report.notes)?.trim() ? "passed" : "failed";
 	}
 }
 
 function checkNoStagedFiles(cwd: string): AcceptanceRuntimeCheck {
-	const result = spawnSync("git", ["status", "--short"], { cwd, encoding: "utf-8", windowsHide: true });
+	const result = spawnSync("git", ["status", "--short"], {
+		cwd,
+		encoding: "utf-8",
+		windowsHide: true,
+	});
 	if (result.status !== 0) {
-		return { id: "no-staged-files", status: "not-applicable", message: "git status unavailable; no staged-files check skipped" };
+		return {
+			id: "no-staged-files",
+			status: "not-applicable",
+			message: "git status unavailable; no staged-files check skipped",
+		};
 	}
-	const staged = result.stdout.split(/\r?\n/).filter((line) => line.length >= 2 && line[0] !== " " && line[0] !== "?");
+	const staged = result.stdout
+		.split(/\r?\n/)
+		.filter((line) => line.length >= 2 && line[0] !== " " && line[0] !== "?");
 	return staged.length === 0
-		? { id: "no-staged-files", status: "passed", message: "No staged files detected." }
-		: { id: "no-staged-files", status: "failed", message: `Staged files present: ${staged.join(", ")}` };
+		? {
+				id: "no-staged-files",
+				status: "passed",
+				message: "No staged files detected.",
+			}
+		: {
+				id: "no-staged-files",
+				status: "failed",
+				message: `Staged files present: ${staged.join(", ")}`,
+			};
 }
 
-function runStructuralChecks(acceptance: ResolvedAcceptanceConfig, report: AcceptanceReport, cwd: string): AcceptanceRuntimeCheck[] {
+function runStructuralChecks(
+	acceptance: ResolvedAcceptanceConfig,
+	report: AcceptanceReport,
+	cwd: string,
+): AcceptanceRuntimeCheck[] {
 	const checks: AcceptanceRuntimeCheck[] = [];
 	for (const kind of acceptance.evidence) {
-		if (kind === "no-staged-files" && report.noStagedFiles === undefined) continue;
+		if (kind === "no-staged-files" && report.noStagedFiles === undefined)
+			continue;
 		const status = reportEvidenceStatus(report, kind);
 		checks.push({
 			id: `evidence:${kind}`,
 			status,
-			message: status === "passed"
-				? `${kind} evidence present.`
-				: status === "not-applicable"
-					? `${kind} evidence explicitly reported as not applicable.`
-					: `${kind} evidence missing from child report.`,
+			message:
+				status === "passed"
+					? `${kind} evidence present.`
+					: status === "not-applicable"
+						? `${kind} evidence explicitly reported as not applicable.`
+						: `${kind} evidence missing from child report.`,
 		});
 	}
-	if (acceptance.evidence.includes("no-staged-files")) checks.push(checkNoStagedFiles(cwd));
+	if (acceptance.evidence.includes("no-staged-files"))
+		checks.push(checkNoStagedFiles(cwd));
 	return checks;
 }
 
 function trimOutput(value: string): string | undefined {
 	const trimmed = value.trim();
 	if (!trimmed) return undefined;
-	return trimmed.length > 12_000 ? `${trimmed.slice(0, 12_000)}\n...[truncated]` : trimmed;
+	return trimmed.length > 12_000
+		? `${trimmed.slice(0, 12_000)}\n...[truncated]`
+		: trimmed;
 }
 
-const SENSITIVE_ENV_KEY_PATTERN = /(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASS|AUTH|CREDENTIAL|COOKIE|SESSION|PRIVATE|API_KEY|ACCESS_KEY)(?:_|$)/i;
+const SENSITIVE_ENV_KEY_PATTERN =
+	/(?:^|_)(?:TOKEN|SECRET|PASSWORD|PASS|AUTH|CREDENTIAL|COOKIE|SESSION|PRIVATE|API_KEY|ACCESS_KEY)(?:_|$)/i;
 
-function effectiveVerifyEnv(env: Record<string, string> | undefined): Record<string, string> {
-	const inherited = Object.fromEntries(Object.entries(process.env).flatMap(([key, value]) => {
-		return typeof value === "string" ? [[key, value]] : [];
-	}));
-	return { ...inherited, ...(env ?? {}) };
+function effectiveVerifyEnv(
+	env: Record<string, string> | undefined,
+): Record<string, string> {
+	const inherited = Object.fromEntries(
+		Object.entries(process.env).flatMap(([key, value]) => {
+			return typeof value === "string" ? [[key, value]] : [];
+		}),
+	);
+	return { ...inherited, ...env };
 }
 
-function verifyRedactionEnv(env: Record<string, string> | undefined): Record<string, string> {
-	return Object.fromEntries(Object.entries(effectiveVerifyEnv(env)).filter(([key, value]) => {
-		return value.length >= 4 && SENSITIVE_ENV_KEY_PATTERN.test(key);
-	}));
+function verifyRedactionEnv(
+	env: Record<string, string> | undefined,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(effectiveVerifyEnv(env)).filter(([key, value]) => {
+			return value.length >= 4 && SENSITIVE_ENV_KEY_PATTERN.test(key);
+		}),
+	);
 }
 
-function redactVerifyEnv(value: string, env: Record<string, string> | undefined): string {
+function redactVerifyEnv(
+	value: string,
+	env: Record<string, string> | undefined,
+): string {
 	let redacted = value;
-	const secrets = [...new Set(Object.values(verifyRedactionEnv(env)).filter(Boolean))].sort((left, right) => right.length - left.length);
-	for (const secret of secrets) redacted = redacted.replaceAll(secret, "[REDACTED]");
+	const secrets = [
+		...new Set(Object.values(verifyRedactionEnv(env)).filter(Boolean)),
+	].sort((left, right) => right.length - left.length);
+	for (const secret of secrets)
+		redacted = redacted.replaceAll(secret, "[REDACTED]");
 	return redacted;
 }
 
 function uniqueStrings(items: Array<string | undefined>): string[] {
-	return unique(items.map((item) => item?.trim()).filter((item): item is string => Boolean(item)));
+	return unique(
+		items
+			.map((item) => item?.trim())
+			.filter((item): item is string => Boolean(item)),
+	);
 }
 
 export function aggregateAcceptanceReport(input: {
-	results: Array<Pick<SingleResult, "agent" | "acceptance" | "error"> & { exitCode: number | null }>;
+	results: Array<
+		Pick<SingleResult, "agent" | "acceptance" | "error"> & {
+			exitCode: number | null;
+		}
+	>;
 	notes?: string;
 }): AcceptanceReport {
-	const childReports = input.results.map((result) => result.acceptance?.childReport).filter((report): report is AcceptanceReport => Boolean(report));
-	const blockers = input.results.filter((result) => result.exitCode !== 0 || result.acceptance?.status === "rejected");
+	const childReports = input.results
+		.map((result) => result.acceptance?.childReport)
+		.filter((report): report is AcceptanceReport => Boolean(report));
+	const blockers = input.results.filter(
+		(result) => result.exitCode !== 0 || result.acceptance?.status === "rejected",
+	);
 	const successfulChildren = input.results.length > 0 && blockers.length === 0;
 	return {
 		criteriaSatisfied: [
-			{ id: "criterion-1", status: successfulChildren ? "satisfied" : "not-satisfied", evidence: successfulChildren ? `All ${input.results.length} dynamic child run(s) completed without child or acceptance blockers.` : "Dynamic fanout produced no accepted child evidence." },
-			{ id: "criterion-2", status: successfulChildren ? "satisfied" : "not-satisfied", evidence: successfulChildren ? "Collected child acceptance evidence for aggregate review." : "Dynamic fanout produced no aggregate review evidence." },
-			...input.results.map((result, index): { id?: string; status: "satisfied" | "not-satisfied" | "not-applicable"; evidence: string } => ({
-				id: `child-${index + 1}`,
-				status: result.exitCode === 0 && result.acceptance?.status !== "rejected" ? "satisfied" : "not-satisfied",
-				evidence: `${result.agent}: acceptance ${result.acceptance?.status ?? "unreported"}${result.error ? ` (${result.error})` : ""}`,
-			})),
+			{
+				id: "criterion-1",
+				status: successfulChildren ? "satisfied" : "not-satisfied",
+				evidence: successfulChildren
+					? `All ${input.results.length} dynamic child run(s) completed without child or acceptance blockers.`
+					: "Dynamic fanout produced no accepted child evidence.",
+			},
+			{
+				id: "criterion-2",
+				status: successfulChildren ? "satisfied" : "not-satisfied",
+				evidence: successfulChildren
+					? "Collected child acceptance evidence for aggregate review."
+					: "Dynamic fanout produced no aggregate review evidence.",
+			},
+			...input.results.map(
+				(
+					result,
+					index,
+				): {
+					id?: string;
+					status: "satisfied" | "not-satisfied" | "not-applicable";
+					evidence: string;
+				} => ({
+					id: `child-${index + 1}`,
+					status:
+						result.exitCode === 0 && result.acceptance?.status !== "rejected"
+							? "satisfied"
+							: "not-satisfied",
+					evidence: `${result.agent}: acceptance ${result.acceptance?.status ?? "unreported"}${result.error ? ` (${result.error})` : ""}`,
+				}),
+			),
 		],
-		changedFiles: uniqueStrings(childReports.flatMap((report) => report.changedFiles ?? [])),
-		testsAddedOrUpdated: uniqueStrings(childReports.flatMap((report) => report.testsAddedOrUpdated ?? [])),
+		changedFiles: uniqueStrings(
+			childReports.flatMap((report) => report.changedFiles ?? []),
+		),
+		testsAddedOrUpdated: uniqueStrings(
+			childReports.flatMap((report) => report.testsAddedOrUpdated ?? []),
+		),
 		commandsRun: childReports.flatMap((report) => report.commandsRun ?? []),
-		validationOutput: uniqueStrings(childReports.flatMap((report) => report.validationOutput ?? [])),
+		validationOutput: uniqueStrings(
+			childReports.flatMap((report) => report.validationOutput ?? []),
+		),
 		residualRisks: uniqueStrings([
 			...childReports.flatMap((report) => report.residualRisks ?? []),
-			...blockers.map((result) => `${result.agent}: ${result.error ?? "child or acceptance gate failed"}`),
+			...blockers.map(
+				(result) =>
+					`${result.agent}: ${result.error ?? "child or acceptance gate failed"}`,
+			),
 		]),
-		noStagedFiles: childReports.length > 0 && childReports.every((report) => report.noStagedFiles === true),
-		reviewFindings: uniqueStrings(childReports.flatMap((report) => report.reviewFindings ?? [])),
-		manualNotes: input.notes ?? `Aggregated acceptance evidence from ${input.results.length} dynamic fanout child run(s).`,
+		noStagedFiles:
+			childReports.length > 0 &&
+			childReports.every((report) => report.noStagedFiles === true),
+		reviewFindings: uniqueStrings(
+			childReports.flatMap((report) => report.reviewFindings ?? []),
+		),
+		manualNotes:
+			input.notes ??
+			`Aggregated acceptance evidence from ${input.results.length} dynamic fanout child run(s).`,
 		notes: input.notes,
 	};
 }
@@ -1067,13 +1836,33 @@ interface VerifyWorkspaceState {
 	diffHash: string;
 }
 
-function readVerifyWorkspaceState(cwd: string): VerifyWorkspaceState | undefined {
-	const repo = spawnSync("git", ["rev-parse", "--show-toplevel"], { cwd, encoding: "utf-8", windowsHide: true });
+function readVerifyWorkspaceState(
+	cwd: string,
+): VerifyWorkspaceState | undefined {
+	const repo = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+		cwd,
+		encoding: "utf-8",
+		windowsHide: true,
+	});
 	if (repo.status !== 0 || !repo.stdout.trim()) return undefined;
 	const repoRoot = fs.realpathSync(repo.stdout.trim());
-	const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf-8", windowsHide: true });
-	const diff = spawnSync("git", ["diff", "--binary", "--full-index", "HEAD", "--"], { cwd: repoRoot, encoding: "utf-8", maxBuffer: 50 * 1024 * 1024, windowsHide: true });
-	if (head.status !== 0 || diff.status !== 0 || !head.stdout.trim()) return undefined;
+	const head = spawnSync("git", ["rev-parse", "HEAD"], {
+		cwd: repoRoot,
+		encoding: "utf-8",
+		windowsHide: true,
+	});
+	const diff = spawnSync(
+		"git",
+		["diff", "--binary", "--full-index", "HEAD", "--"],
+		{
+			cwd: repoRoot,
+			encoding: "utf-8",
+			maxBuffer: 50 * 1024 * 1024,
+			windowsHide: true,
+		},
+	);
+	if (head.status !== 0 || diff.status !== 0 || !head.stdout.trim())
+		return undefined;
 	return {
 		kind: "git-tracked",
 		repoRoot,
@@ -1086,19 +1875,28 @@ function readVerifyWorkspaceState(cwd: string): VerifyWorkspaceState | undefined
 function isCachedVerifyResult(value: unknown): value is AcceptanceVerifyResult {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
 	const result = value as Partial<AcceptanceVerifyResult>;
-	return typeof result.id === "string"
-		&& typeof result.command === "string"
-		&& (typeof result.exitCode === "number" || result.exitCode === null)
-		&& (result.status === "passed" || result.status === "failed" || result.status === "timed-out" || result.status === "allowed-failure")
-		&& typeof result.durationMs === "number";
+	return (
+		typeof result.id === "string" &&
+		typeof result.command === "string" &&
+		(typeof result.exitCode === "number" || result.exitCode === null) &&
+		(result.status === "passed" ||
+			result.status === "failed" ||
+			result.status === "timed-out" ||
+			result.status === "allowed-failure") &&
+		typeof result.durationMs === "number"
+	);
 }
 
-async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, options: {
-	signal?: AbortSignal;
-	abortMessage?: string;
-	artifactsDir?: string;
-	runId?: string;
-} = {}): Promise<AcceptanceVerifyResult> {
+async function runMemoizedVerifyCommand(
+	command: AcceptanceVerifyCommand,
+	defaultCwd: string,
+	options: {
+		signal?: AbortSignal;
+		abortMessage?: string;
+		artifactsDir?: string;
+		runId?: string;
+	} = {},
+): Promise<AcceptanceVerifyResult> {
 	const cwd = command.cwd ? path.resolve(defaultCwd, command.cwd) : defaultCwd;
 	let workspaceState: VerifyWorkspaceState | undefined;
 	try {
@@ -1110,46 +1908,93 @@ async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaul
 		return runVerifyCommand(command, defaultCwd, options);
 	}
 	const envKeys = Object.keys(command.env ?? {}).sort();
-	const envHash = hash(JSON.stringify(Object.fromEntries(Object.entries(effectiveVerifyEnv(command.env)).sort(([left], [right]) => left.localeCompare(right)))));
+	const envHash = hash(
+		JSON.stringify(
+			Object.fromEntries(
+				Object.entries(effectiveVerifyEnv(command.env)).sort(([left], [right]) =>
+					left.localeCompare(right),
+				),
+			),
+		),
+	);
 	const timeoutMs = command.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS;
-	const cacheKey = hash(JSON.stringify({
-		version: 1,
-		command: command.command,
-		cwdRelative: workspaceState.cwdRelative,
-		envKeys,
-		envHash,
-		timeoutMs,
-		allowFailure: command.allowFailure === true,
-		head: workspaceState.head,
-		diffHash: workspaceState.diffHash,
-	}));
-	const artifactPath = path.join(options.artifactsDir, "acceptance", "verify", options.runId, `${cacheKey}.json`);
-	try {
-		const cached = JSON.parse(fs.readFileSync(artifactPath, "utf-8")) as { cacheKey?: unknown; result?: unknown };
-		if (cached.cacheKey === cacheKey && isCachedVerifyResult(cached.result)) {
-			return { ...cached.result, id: command.id, command: command.command, cwd, artifactPath, cacheKey, memoized: true, envKeys, envHash, workspaceState };
-		}
-	} catch {
-		// A cache miss or unreadable artifact must not prevent host verification.
-	}
-	const result = await runVerifyCommand(command, defaultCwd, options);
-	const evidenced: AcceptanceVerifyResult = { ...result, artifactPath, cacheKey, memoized: false, envKeys, envHash, workspaceState };
-	try {
-		fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
-		fs.writeFileSync(artifactPath, JSON.stringify({
+	const cacheKey = hash(
+		JSON.stringify({
 			version: 1,
-			cacheKey,
 			command: command.command,
 			cwdRelative: workspaceState.cwdRelative,
 			envKeys,
 			envHash,
 			timeoutMs,
 			allowFailure: command.allowFailure === true,
-			workspaceState,
-			result: evidenced,
-		}, null, 2), "utf-8");
+			head: workspaceState.head,
+			diffHash: workspaceState.diffHash,
+		}),
+	);
+	const artifactPath = path.join(
+		options.artifactsDir,
+		"acceptance",
+		"verify",
+		options.runId,
+		`${cacheKey}.json`,
+	);
+	try {
+		const cached = JSON.parse(fs.readFileSync(artifactPath, "utf-8")) as {
+			cacheKey?: unknown;
+			result?: unknown;
+		};
+		if (cached.cacheKey === cacheKey && isCachedVerifyResult(cached.result)) {
+			return {
+				...cached.result,
+				id: command.id,
+				command: command.command,
+				cwd,
+				artifactPath,
+				cacheKey,
+				memoized: true,
+				envKeys,
+				envHash,
+				workspaceState,
+			};
+		}
+	} catch {
+		// A cache miss or unreadable artifact must not prevent host verification.
+	}
+	const result = await runVerifyCommand(command, defaultCwd, options);
+	const evidenced: AcceptanceVerifyResult = {
+		...result,
+		artifactPath,
+		cacheKey,
+		memoized: false,
+		envKeys,
+		envHash,
+		workspaceState,
+	};
+	try {
+		fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+		fs.writeFileSync(
+			artifactPath,
+			JSON.stringify(
+				{
+					version: 1,
+					cacheKey,
+					command: command.command,
+					cwdRelative: workspaceState.cwdRelative,
+					envKeys,
+					envHash,
+					timeoutMs,
+					allowFailure: command.allowFailure === true,
+					workspaceState,
+					result: evidenced,
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
 	} catch (error) {
-		evidenced.artifactError = error instanceof Error ? error.message : String(error);
+		evidenced.artifactError =
+			error instanceof Error ? error.message : String(error);
 		delete evidenced.artifactPath;
 	}
 	return evidenced;
@@ -1168,29 +2013,58 @@ async function runMemoizedVerifyCommand(command: AcceptanceVerifyCommand, defaul
  * whose first token already ends in an executable extension are returned
  * unchanged. Non-Windows platforms pass the command through untouched.
  */
-export function quoteExecutableForShell(command: string, platform: string = process.platform): string {
+export function quoteExecutableForShell(
+	command: string,
+	platform: string = process.platform,
+): string {
 	if (platform !== "win32") return command;
 	const trimmed = command.trimStart();
-	if (trimmed.startsWith("\"")) return command;
+	if (trimmed.startsWith('"')) return command;
 	const firstToken = trimmed.match(/^\S+/)?.[0];
 	if (/\.(?:exe|bat|cmd|com|ps1)$/i.test(firstToken ?? "")) return command;
-	const match = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i);
+	const match = trimmed.match(
+		/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\r\n]*?\.(?:exe|bat|cmd|com|ps1))(?=\s|$)/i,
+	);
 	const executable = match?.[1];
-	if (executable && /\s/.test(executable) && !/[A-Za-z]:\\/.test(executable.slice(3))) {
+	if (
+		executable &&
+		/\s/.test(executable) &&
+		!/[A-Za-z]:\\/.test(executable.slice(3))
+	) {
 		const rest = trimmed.slice(executable.length);
 		const leading = command.slice(0, command.length - trimmed.length);
 		return `${leading}"${executable}"${rest}`;
 	}
-	const extensionlessSpacedFilenameMatch = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?)(?=\s+--|$)/i);
+	const extensionlessSpacedFilenameMatch = trimmed.match(
+		/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?)(?=\s+--|$)/i,
+	);
 	const extensionlessSpacedFilename = extensionlessSpacedFilenameMatch?.[1];
-	if (extensionlessSpacedFilename && /\s/.test(extensionlessSpacedFilename.slice(0, extensionlessSpacedFilename.lastIndexOf("\\"))) && !/[A-Za-z]:\\/.test(extensionlessSpacedFilename.slice(3))) {
+	if (
+		extensionlessSpacedFilename &&
+		/\s/.test(
+			extensionlessSpacedFilename.slice(
+				0,
+				extensionlessSpacedFilename.lastIndexOf("\\"),
+			),
+		) &&
+		!/[A-Za-z]:\\/.test(extensionlessSpacedFilename.slice(3))
+	) {
 		const rest = trimmed.slice(extensionlessSpacedFilename.length);
 		const leading = command.slice(0, command.length - trimmed.length);
 		return `${leading}"${extensionlessSpacedFilename}"${rest}`;
 	}
-	const extensionlessMatch = trimmed.match(/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\s\r\n]+)(?=\s|$)/i);
+	const extensionlessMatch = trimmed.match(
+		/^([A-Za-z]:\\[^"<>|&*?\r\n]*?\s[^"<>|&*?\r\n]*?\\[^"<>|&*?\s\r\n]+)(?=\s|$)/i,
+	);
 	const extensionlessExecutable = extensionlessMatch?.[1];
-	if (extensionlessExecutable && /\s/.test(extensionlessExecutable) && !/[A-Za-z]:\\/.test(extensionlessExecutable.slice(3)) && !/\s/.test(extensionlessExecutable.slice(extensionlessExecutable.lastIndexOf("\\") + 1))) {
+	if (
+		extensionlessExecutable &&
+		/\s/.test(extensionlessExecutable) &&
+		!/[A-Za-z]:\\/.test(extensionlessExecutable.slice(3)) &&
+		!/\s/.test(
+			extensionlessExecutable.slice(extensionlessExecutable.lastIndexOf("\\") + 1),
+		)
+	) {
 		const rest = trimmed.slice(extensionlessExecutable.length);
 		const leading = command.slice(0, command.length - trimmed.length);
 		return `${leading}"${extensionlessExecutable}"${rest}`;
@@ -1198,7 +2072,11 @@ export function quoteExecutableForShell(command: string, platform: string = proc
 	return command;
 }
 
-function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, options: { signal?: AbortSignal; abortMessage?: string } = {}): Promise<AcceptanceVerifyResult> {
+function runVerifyCommand(
+	command: AcceptanceVerifyCommand,
+	defaultCwd: string,
+	options: { signal?: AbortSignal; abortMessage?: string } = {},
+): Promise<AcceptanceVerifyResult> {
 	return new Promise((resolve) => {
 		const startedAt = Date.now();
 		const cwd = command.cwd ? path.resolve(defaultCwd, command.cwd) : defaultCwd;
@@ -1214,7 +2092,12 @@ function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, 
 			stdio: ["ignore", "pipe", "pipe"],
 			windowsHide: true,
 		});
-		const finish = (result: Omit<AcceptanceVerifyResult, "id" | "command" | "cwd" | "durationMs">) => {
+		const finish = (
+			result: Omit<
+				AcceptanceVerifyResult,
+				"id" | "command" | "cwd" | "durationMs"
+			>,
+		) => {
 			if (settled) return;
 			settled = true;
 			clearTimeout(timeout);
@@ -1238,15 +2121,24 @@ function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, 
 					exitCode: null,
 					status: "timed-out",
 					stdout: trimOutput(redactVerifyEnv(stdout, command.env)),
-					stderr: trimOutput(redactVerifyEnv(stderr || options.abortMessage || "Acceptance verification timed out.", command.env)),
+					stderr: trimOutput(
+						redactVerifyEnv(
+							stderr || options.abortMessage || "Acceptance verification timed out.",
+							command.env,
+						),
+					),
 				});
 			}, 1000);
 			hardKill.unref?.();
 		};
-		const timeout = setTimeout(abortVerification, command.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS);
+		const timeout = setTimeout(
+			abortVerification,
+			command.timeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS,
+		);
 		timeout.unref?.();
 		if (options.signal?.aborted) abortVerification();
-		else options.signal?.addEventListener("abort", abortVerification, { once: true });
+		else
+			options.signal?.addEventListener("abort", abortVerification, { once: true });
 		child.stdout.on("data", (chunk: Buffer) => {
 			stdout += chunk.toString();
 		});
@@ -1257,18 +2149,41 @@ function runVerifyCommand(command: AcceptanceVerifyCommand, defaultCwd: string, 
 			const passed = exitCode === 0 && !timedOut;
 			finish({
 				exitCode,
-				status: timedOut ? "timed-out" : passed ? "passed" : command.allowFailure ? "allowed-failure" : "failed",
+				status: timedOut
+					? "timed-out"
+					: passed
+						? "passed"
+						: command.allowFailure
+							? "allowed-failure"
+							: "failed",
 				stdout: trimOutput(redactVerifyEnv(stdout, command.env)),
-				stderr: trimOutput(redactVerifyEnv(stderr || (timedOut ? options.abortMessage ?? "" : ""), command.env)),
+				stderr: trimOutput(
+					redactVerifyEnv(
+						stderr || (timedOut ? (options.abortMessage ?? "") : ""),
+						command.env,
+					),
+				),
 			});
 		});
 		child.on("error", (error) => {
 			finish({
 				exitCode: timedOut ? null : 1,
-				status: timedOut ? "timed-out" : command.allowFailure ? "allowed-failure" : "failed",
+				status: timedOut
+					? "timed-out"
+					: command.allowFailure
+						? "allowed-failure"
+						: "failed",
 				stderr: timedOut
-					? trimOutput(redactVerifyEnv(stderr || options.abortMessage || "Acceptance verification timed out.", command.env))
-					: redactVerifyEnv(error instanceof Error ? error.message : String(error), command.env),
+					? trimOutput(
+							redactVerifyEnv(
+								stderr || options.abortMessage || "Acceptance verification timed out.",
+								command.env,
+							),
+						)
+					: redactVerifyEnv(
+							error instanceof Error ? error.message : String(error),
+							command.env,
+						),
 			});
 		});
 	});
@@ -1284,7 +2199,12 @@ export async function evaluateAcceptance(input: {
 	 * be misattributed). Searched for the acceptance report; searched before
 	 * the assistant output when `authoritative` (outputMode "file-only").
 	 */
-	fileOutput?: { content: string; path: string; authoritative?: boolean; durable?: boolean };
+	fileOutput?: {
+		content: string;
+		path: string;
+		authoritative?: boolean;
+		durable?: boolean;
+	};
 	report?: AcceptanceReport;
 	reportError?: string;
 	reviewResult?: AcceptanceReviewResult;
@@ -1311,14 +2231,20 @@ export async function evaluateAcceptance(input: {
 	const parsed: AcceptanceReportParseResult = input.reportError
 		? { error: input.reportError }
 		: input.report
-		? (() => {
-			const validation = validateAcceptanceReport(input.report);
-			return validation.report
-				? { report: validation.report }
-				: { error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`, malformed: true };
-		})()
-		: parseAcceptanceReportSources(input.output, input.fileOutput);
-	const durableFileOutput = input.fileOutput?.authoritative && input.fileOutput.durable ? input.fileOutput : undefined;
+			? (() => {
+					const validation = validateAcceptanceReport(input.report);
+					return validation.report
+						? { report: validation.report }
+						: {
+								error: `Failed to parse acceptance-report: Invalid acceptance-report: ${validation.errors.join("; ")}`,
+								malformed: true,
+							};
+				})()
+			: parseAcceptanceReportSources(input.output, input.fileOutput);
+	const durableFileOutput =
+		input.fileOutput?.authoritative && input.fileOutput.durable
+			? input.fileOutput
+			: undefined;
 	if (parsed.malformed && parsed.sourcePath && durableFileOutput) {
 		ledger.recovery = {
 			status: "available-for-review",
@@ -1332,9 +2258,17 @@ export async function evaluateAcceptance(input: {
 		ledger.childReport = parsed.report;
 		ledger.status = "attested";
 		ledger.evidenceStatus = "attested";
-	} else if (!input.reportOptional || needsReport || parsed.error !== ACCEPTANCE_REPORT_NOT_FOUND) {
+	} else if (
+		!input.reportOptional ||
+		needsReport ||
+		parsed.error !== ACCEPTANCE_REPORT_NOT_FOUND
+	) {
 		ledger.childReportParseError = parsed.error;
-		ledger.runtimeChecks.push({ id: "attestation", status: "failed", message: parsed.error ?? "Structured acceptance report missing." });
+		ledger.runtimeChecks.push({
+			id: "attestation",
+			status: "failed",
+			message: parsed.error ?? "Structured acceptance report missing.",
+		});
 		if (ledger.recovery) {
 			ledger.status = "rejected";
 			ledger.evidenceStatus = "rejected";
@@ -1360,24 +2294,37 @@ export async function evaluateAcceptance(input: {
 		}
 	}
 
-	if (LEVEL_RANK[acceptance.level] >= LEVEL_RANK.verified && (acceptance.level === "verified" || acceptance.verify.length > 0)) {
+	if (
+		LEVEL_RANK[acceptance.level] >= LEVEL_RANK.verified &&
+		(acceptance.level === "verified" || acceptance.verify.length > 0)
+	) {
 		if (acceptance.level === "verified" && acceptance.verify.length === 0) {
-			ledger.runtimeChecks.push({ id: "verification-config", status: "failed", message: "verified acceptance requires runtime verify commands." });
+			ledger.runtimeChecks.push({
+				id: "verification-config",
+				status: "failed",
+				message: "verified acceptance requires runtime verify commands.",
+			});
 			ledger.status = "rejected";
 			ledger.evidenceStatus = "rejected";
 			return ledger;
 		}
 		ledger.verifyRuns = [];
 		for (const command of acceptance.verify) {
-			ledger.verifyRuns.push(await runMemoizedVerifyCommand(command, input.cwd, {
-				signal: input.signal,
-				abortMessage: input.abortMessage,
-				artifactsDir: input.artifactsDir,
-				runId: input.runId,
-			}));
+			ledger.verifyRuns.push(
+				await runMemoizedVerifyCommand(command, input.cwd, {
+					signal: input.signal,
+					abortMessage: input.abortMessage,
+					artifactsDir: input.artifactsDir,
+					runId: input.runId,
+				}),
+			);
 			if (input.signal?.aborted) break;
 		}
-		if (ledger.verifyRuns.some((run) => run.status === "failed" || run.status === "timed-out")) {
+		if (
+			ledger.verifyRuns.some(
+				(run) => run.status === "failed" || run.status === "timed-out",
+			)
+		) {
 			ledger.status = "rejected";
 			ledger.evidenceStatus = "rejected";
 			return ledger;
@@ -1394,7 +2341,8 @@ export async function evaluateAcceptance(input: {
 		return ledger;
 	}
 	if (ledger.status === "claimed") {
-		ledger.status = acceptance.level === "verified" ? "verified" : acceptance.level;
+		ledger.status =
+			acceptance.level === "verified" ? "verified" : acceptance.level;
 		ledger.evidenceStatus = ledger.status;
 	}
 
@@ -1408,11 +2356,13 @@ export async function evaluateAcceptance(input: {
 		} else if (acceptance.review.required !== false) {
 			ledger.reviewResult = input.reviewResult ?? {
 				status: "review-required",
-				findings: [{
-					severity: "non-blocking",
-					issue: "Independent review has not been supplied.",
-					rationale: "The run cannot be marked reviewed from child evidence alone.",
-				}],
+				findings: [
+					{
+						severity: "non-blocking",
+						issue: "Independent review has not been supplied.",
+						rationale: "The run cannot be marked reviewed from child evidence alone.",
+					},
+				],
 			};
 			ledger.status = "review-required";
 		}
@@ -1421,7 +2371,10 @@ export async function evaluateAcceptance(input: {
 	return ledger;
 }
 
-export function buildSkippedAcceptanceLedger(acceptance: ResolvedAcceptanceConfig, input: { id: string; message: string }): AcceptanceLedger {
+export function buildSkippedAcceptanceLedger(
+	acceptance: ResolvedAcceptanceConfig,
+	input: { id: string; message: string },
+): AcceptanceLedger {
 	const status = acceptance.level === "none" ? "not-required" : "rejected";
 	return {
 		status,
@@ -1430,19 +2383,28 @@ export function buildSkippedAcceptanceLedger(acceptance: ResolvedAcceptanceConfi
 		effectiveAcceptance: acceptance,
 		inferredReason: acceptance.inferredReason,
 		criteria: acceptance.criteria,
-		runtimeChecks: acceptance.level === "none"
-			? []
-			: [{ id: input.id, status: "failed", message: input.message }],
+		runtimeChecks:
+			acceptance.level === "none"
+				? []
+				: [{ id: input.id, status: "failed", message: input.message }],
 		verifyRuns: [],
 	};
 }
 
-export function acceptanceFailureMessage(ledger: AcceptanceLedger): string | undefined {
+export function acceptanceFailureMessage(
+	ledger: AcceptanceLedger,
+): string | undefined {
 	if (ledger.status !== "rejected") return undefined;
-	const failedCheck = ledger.runtimeChecks.find((check) => check.status === "failed");
+	const failedCheck = ledger.runtimeChecks.find(
+		(check) => check.status === "failed",
+	);
 	if (failedCheck) return `Acceptance rejected: ${failedCheck.message}`;
-	const failedVerify = ledger.verifyRuns.find((run) => run.status === "failed" || run.status === "timed-out");
-	if (failedVerify) return `Acceptance verification '${failedVerify.id}' ${failedVerify.status}.`;
-	if (ledger.reviewResult?.status === "blockers") return "Acceptance review found blockers.";
+	const failedVerify = ledger.verifyRuns.find(
+		(run) => run.status === "failed" || run.status === "timed-out",
+	);
+	if (failedVerify)
+		return `Acceptance verification '${failedVerify.id}' ${failedVerify.status}.`;
+	if (ledger.reviewResult?.status === "blockers")
+		return "Acceptance review found blockers.";
 	return "Acceptance rejected.";
 }

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -73,6 +73,8 @@ export interface RunnerSubagentStep {
 		schemaPath: string;
 		outputPath: string;
 		acceptanceReportPath?: string;
+		acceptanceReportRequired?: boolean;
+		reportOnly?: boolean;
 	};
 	structuredOutputSchema?: import("../../shared/types.ts").JsonSchemaObject;
 	agentContract?: import("../../shared/types.ts").AgentContract;

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -19,6 +19,7 @@ import { resolvePiPackageRoot } from "./pi-spawn.ts";
 import { encodeExtensionBindings, PI_SUBAGENT_EXTENSION_BINDINGS_ENV, type ExtensionBindings } from "./extension-bindings.ts";
 import { RUNTIME_EXTENSION_ACK_PATH_ENV } from "./runtime-acknowledged-extensions.ts";
 import {
+	ACCEPTANCE_REPORT_REQUIRED_ENV,
 	STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV,
 	STRUCTURED_OUTPUT_CAPTURE_ENV,
 	STRUCTURED_OUTPUT_SCHEMA_ENV,
@@ -206,6 +207,8 @@ export interface BuildPiArgsInput {
 		schemaPath: string;
 		outputPath: string;
 		acceptanceReportPath?: string;
+		acceptanceReportRequired?: boolean;
+		reportOnly?: boolean;
 	};
 	fast?: boolean;
 	modelCandidates?: readonly string[];
@@ -1000,9 +1003,12 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	if (encodedPermissionRules)
 		env[PERMISSION_POLICY_ENV] = encodedPermissionRules;
 	if (input.structuredOutput) {
-		env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
-		env[STRUCTURED_OUTPUT_SCHEMA_ENV] = input.structuredOutput.schemaPath;
+		if (!input.structuredOutput.reportOnly) {
+			env[STRUCTURED_OUTPUT_CAPTURE_ENV] = input.structuredOutput.outputPath;
+			env[STRUCTURED_OUTPUT_SCHEMA_ENV] = input.structuredOutput.schemaPath;
+		}
 		if (input.structuredOutput.acceptanceReportPath) env[STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV] = input.structuredOutput.acceptanceReportPath;
+		if (input.structuredOutput.acceptanceReportRequired) env[ACCEPTANCE_REPORT_REQUIRED_ENV] = "1";
 	}
 	if (input.steerInboxDir) {
 		env[SUBAGENT_STEER_INBOX_ENV] = input.steerInboxDir;

--- a/src/runs/shared/structured-output.ts
+++ b/src/runs/shared/structured-output.ts
@@ -9,13 +9,19 @@ import type { JsonSchemaObject } from "../../shared/types.ts";
 export const STRUCTURED_OUTPUT_SCHEMA_ENV = "PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA";
 export const STRUCTURED_OUTPUT_CAPTURE_ENV = "PI_SUBAGENT_STRUCTURED_OUTPUT_CAPTURE";
 export const STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV = "PI_SUBAGENT_STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE";
+export const ACCEPTANCE_REPORT_REQUIRED_ENV = "PI_SUBAGENT_ACCEPTANCE_REPORT_REQUIRED";
 export const MISSING_STRUCTURED_OUTPUT_CALL_ERROR = "Missing structured_output call; this step has outputSchema and must finish by calling structured_output.";
+export const MISSING_ACCEPTANCE_REPORT_ERROR = "Missing acceptance report; this step requires a valid structured_output delivery of the acceptance report (acceptance.report: \"on\").";
 
 export interface StructuredOutputRuntime {
 	schema: JsonSchemaObject;
 	schemaPath: string;
 	outputPath: string;
 	acceptanceReportPath?: string;
+	/** When true, the child must deliver an acceptance report (standalone structured_output call when there is no outputSchema, or the acceptanceReport parameter otherwise). */
+	acceptanceReportRequired?: boolean;
+	/** True when there is no outputSchema and the structured_output tool carries only the acceptance report. */
+	reportOnly?: boolean;
 }
 
 const SCHEMA_MAP_KEYWORDS = ["properties", "patternProperties", "$defs", "definitions", "dependentSchemas"] as const;
@@ -61,16 +67,65 @@ function rewriteLocalJsonPointerRefs(schema: unknown, pointerPrefix: string, inh
 	return rewritten;
 }
 
-export function createStructuredOutputToolParameters(schema: JsonSchemaObject, options: { acceptanceReport?: boolean } = {}): JsonSchemaObject {
+export function createStructuredOutputToolParameters(schema: JsonSchemaObject, options: { acceptanceReport?: boolean; acceptanceReportSchema?: JsonSchemaObject } = {}): JsonSchemaObject {
+	const reportProperty = options.acceptanceReportSchema
+		? options.acceptanceReportSchema
+		: { type: "object" };
 	return {
 		type: "object",
 		properties: {
 			value: rewriteLocalJsonPointerRefs(schema, "#/properties/value"),
-			...(options.acceptanceReport ? { acceptanceReport: { type: "object" } } : {}),
+			...(options.acceptanceReport ? { acceptanceReport: reportProperty } : {}),
 		},
 		required: ["value"],
 		additionalProperties: false,
 	};
+}
+
+const ACCEPTANCE_REPORT_JSON_SCHEMA: JsonSchemaObject = {
+	type: "object",
+	properties: {
+		criteriaSatisfied: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					id: { type: "string" },
+					status: { type: "string", enum: ["satisfied", "not-satisfied", "not-applicable"] },
+					evidence: { type: "string" },
+				},
+				required: ["status", "evidence"],
+				additionalProperties: false,
+			},
+		},
+		changedFiles: { type: "array", items: { type: "string" } },
+		testsAddedOrUpdated: { type: "array", items: { type: "string" } },
+		commandsRun: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					command: { type: "string" },
+					result: { type: "string", enum: ["passed", "failed", "not-run"] },
+					summary: { type: "string" },
+				},
+				required: ["command", "result", "summary"],
+				additionalProperties: false,
+			},
+		},
+		validationOutput: { type: "array", items: { type: "string" } },
+		residualRisks: { type: "array", items: { type: "string" } },
+		noStagedFiles: { type: "boolean" },
+		diffSummary: { type: "string" },
+		reviewFindings: { type: "array", items: { type: "string" } },
+		manualNotes: { type: "string" },
+		notes: { type: "string" },
+	},
+	additionalProperties: false,
+};
+
+export function acceptanceReportJsonSchema(): JsonSchemaObject {
+	return JSON.parse(JSON.stringify(ACCEPTANCE_REPORT_JSON_SCHEMA)) as JsonSchemaObject;
 }
 
 interface CompiledJsonSchema {
@@ -129,7 +184,23 @@ export function assertJsonSchemaObject(schema: unknown, label = "outputSchema"):
 	}
 }
 
-export function createStructuredOutputRuntime(schema: JsonSchemaObject, baseDir?: string, options: { captureAcceptanceReport?: boolean } = {}): StructuredOutputRuntime {
+export function createStructuredOutputRuntime(schema: JsonSchemaObject | undefined, baseDir?: string, options: { captureAcceptanceReport?: boolean; acceptanceReportRequired?: boolean } = {}): StructuredOutputRuntime {
+	if (schema === undefined) {
+		// Report-only runtime: no outputSchema, just a delivery target for the
+		// acceptance report. The child registers a standalone structured_output
+		// tool whose only parameter is the report.
+		const rootDir = baseDir ?? os.tmpdir();
+		fs.mkdirSync(rootDir, { recursive: true });
+		const dir = fs.mkdtempSync(path.join(rootDir, "pi-subagent-structured-"));
+		return {
+			schema: { type: "object", additionalProperties: true },
+			schemaPath: path.join(dir, "schema.json"),
+			outputPath: path.join(dir, "output.json"),
+			...(options.captureAcceptanceReport ? { acceptanceReportPath: path.join(dir, "acceptance-report.json") } : {}),
+			...(options.acceptanceReportRequired ? { acceptanceReportRequired: true } : {}),
+			reportOnly: true,
+		};
+	}
 	assertJsonSchemaObject(schema);
 	const rootDir = baseDir ?? os.tmpdir();
 	fs.mkdirSync(rootDir, { recursive: true });
@@ -137,7 +208,7 @@ export function createStructuredOutputRuntime(schema: JsonSchemaObject, baseDir?
 	const schemaPath = path.join(dir, "schema.json");
 	const outputPath = path.join(dir, "output.json");
 	fs.writeFileSync(schemaPath, JSON.stringify(schema), { mode: 0o600 });
-	return { schema, schemaPath, outputPath, ...(options.captureAcceptanceReport ? { acceptanceReportPath: path.join(dir, "acceptance-report.json") } : {}) };
+	return { schema, schemaPath, outputPath, ...(options.captureAcceptanceReport ? { acceptanceReportPath: path.join(dir, "acceptance-report.json") } : {}), ...(options.acceptanceReportRequired ? { acceptanceReportRequired: true } : {}) };
 }
 
 export async function validateStructuredOutputValue(schema: JsonSchemaObject, value: unknown): Promise<{ status: "valid" } | { status: "invalid"; message: string }> {

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -8,7 +8,7 @@ import { decodePermissionRules, permissionDecision, PERMISSION_AUDIT_PATH_ENV, P
 import { consumeSteerRequestsFromDir, MAX_STEER_QUEUE_SIZE, steerAckPathFromDir, writeSteerAckAt, writeSteerCapabilityAt, writeSteerRequestToDir, type SteerDeliveryStatus, type SteerRequest } from "../background/control-channel.ts";
 import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_FORK_CACHE_KEY_ENV, SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV, SUBAGENT_STEER_ACK_DIR_ENV, SUBAGENT_STEER_CAPABILITY_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
 import { RUNTIME_EXTENSION_ACK_EVENT, RUNTIME_EXTENSION_ACK_PATH_ENV, isRuntimeAcknowledgedExtensionId, writeRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
-import { createStructuredOutputToolParameters, STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
+import { acceptanceReportJsonSchema, createStructuredOutputToolParameters, ACCEPTANCE_REPORT_REQUIRED_ENV, STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
 import {
 	CHILD_TOOL_DIAGNOSTIC_PATH_ENV,
 	formatChildToolDiagnostic,
@@ -730,9 +730,46 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	const structuredOutputPath = process.env[STRUCTURED_OUTPUT_CAPTURE_ENV];
 	const structuredAcceptanceReportPath = process.env[STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV];
 	const structuredSchemaPath = process.env[STRUCTURED_OUTPUT_SCHEMA_ENV];
-	if (structuredOutputPath && structuredSchemaPath) {
+	const acceptanceReportRequired = process.env[ACCEPTANCE_REPORT_REQUIRED_ENV] === "1" && Boolean(structuredAcceptanceReportPath);
+	const reportJsonSchema = acceptanceReportRequired ? acceptanceReportJsonSchema() : undefined;
+	const reportOnly = !structuredOutputPath && !structuredSchemaPath && acceptanceReportRequired;
+	if (reportOnly) {
+		// Standalone report delivery: no outputSchema, only the acceptance report.
+		// The tool's `value` IS the report; valid submission terminates the step.
+		const registerTool = pi.registerTool as unknown as (tool: {
+			name: string;
+			label: string;
+			description: string;
+			parameters: unknown;
+			execute: (_id: string, params: { value: unknown }) => Promise<unknown>;
+		}) => void;
+		registerTool({
+			name: "structured_output",
+			label: "Structured Output",
+			description: "Submit the required acceptance report for this subagent step. This terminates the step.",
+			parameters: {
+				type: "object",
+				properties: { value: reportJsonSchema },
+				required: ["value"],
+				additionalProperties: false,
+			},
+			async execute(_id: string, params: { value: unknown }) {
+				const validation = await validateStructuredOutputValue(reportJsonSchema!, params.value);
+				if (validation.status === "invalid") {
+					throw new Error(`Acceptance report validation failed: ${validation.message}`);
+				}
+				fs.mkdirSync(path.dirname(structuredAcceptanceReportPath!), { recursive: true });
+				fs.writeFileSync(structuredAcceptanceReportPath!, JSON.stringify(params.value), { mode: 0o600 });
+				return {
+					content: [{ type: "text", text: "Acceptance report captured." }],
+					details: { path: structuredAcceptanceReportPath },
+					terminate: true,
+				};
+			},
+		});
+	} else if (structuredOutputPath && structuredSchemaPath) {
 		const schema = JSON.parse(fs.readFileSync(structuredSchemaPath, "utf-8")) as JsonSchemaObject;
-		const parameters = createStructuredOutputToolParameters(schema, { acceptanceReport: Boolean(structuredAcceptanceReportPath) });
+		const parameters = createStructuredOutputToolParameters(schema, { acceptanceReport: Boolean(structuredAcceptanceReportPath), acceptanceReportSchema: reportJsonSchema });
 		const registerTool = pi.registerTool as unknown as (tool: {
 			name: string;
 			label: string;
@@ -750,9 +787,18 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 				if (validation.status === "invalid") {
 					throw new Error(`Structured output validation failed: ${validation.message}`);
 				}
+				if (acceptanceReportRequired && params.acceptanceReport === undefined) {
+					throw new Error("Acceptance report required: include an `acceptanceReport` object matching the acceptance contract in this structured_output call.");
+				}
 				fs.mkdirSync(path.dirname(structuredOutputPath), { recursive: true });
 				fs.writeFileSync(structuredOutputPath, JSON.stringify(params.value), { mode: 0o600 });
 				if (structuredAcceptanceReportPath && params.acceptanceReport !== undefined) {
+					if (reportJsonSchema) {
+						const reportValidation = await validateStructuredOutputValue(reportJsonSchema, params.acceptanceReport);
+						if (reportValidation.status === "invalid") {
+							throw new Error(`Acceptance report validation failed: ${reportValidation.message}`);
+						}
+					}
 					fs.writeFileSync(structuredAcceptanceReportPath, JSON.stringify(params.acceptanceReport), { mode: 0o600 });
 				}
 				return {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,10 +9,17 @@ import type { AgentConfig } from "../agents/agents.ts";
 import type { FSWatcher } from "node:fs";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ModelScopeRule } from "../runs/shared/model-scope.ts";
-import type { ResolvedSubagentCapabilityCeiling, SubagentCapabilityAudit } from "../runs/shared/capability-ceiling.ts";
+import type {
+	ResolvedSubagentCapabilityCeiling,
+	SubagentCapabilityAudit,
+} from "../runs/shared/capability-ceiling.ts";
 import type { AuthorityPolicyConfig } from "../policy/authority.ts";
 import type { ThinkingLevel } from "./model-info.ts";
-import type { GlobalMissionIndexRecord, MissionRecord, MissionStoreConfig } from "../missions/types.ts";
+import type {
+	GlobalMissionIndexRecord,
+	MissionRecord,
+	MissionStoreConfig,
+} from "../missions/types.ts";
 import type { ExtensionBindings } from "../runs/shared/extension-bindings.ts";
 import type { WorkflowChildPermitContext } from "./workflow-child-permit.ts";
 
@@ -40,10 +47,24 @@ export interface ChainOutputMapEntry {
 
 export type ChainOutputMap = Record<string, ChainOutputMapEntry>;
 
-export type WorkflowNodeStatus = "pending" | "running" | "completed" | "failed" | "partial" | "paused" | "stopped" | "detached" | "rejected";
+export type WorkflowNodeStatus =
+	| "pending"
+	| "running"
+	| "completed"
+	| "failed"
+	| "partial"
+	| "paused"
+	| "stopped"
+	| "detached"
+	| "rejected";
 
 export type HostStepMonitorKind = "command" | "ci" | "gate";
-export type HostStepState = "pending" | "running" | "done" | "cancelled" | "error";
+export type HostStepState =
+	| "pending"
+	| "running"
+	| "done"
+	| "cancelled"
+	| "error";
 export type HostStepVerdict = "pass" | "fail" | "inconclusive";
 
 export interface HostStepFreshnessV1 {
@@ -76,7 +97,12 @@ export interface HostStepNodeV1 {
 
 export interface WorkflowGraphNode {
 	id: string;
-	kind: "step" | "parallel-group" | "dynamic-parallel-group" | "agent" | "host-step";
+	kind:
+		| "step"
+		| "parallel-group"
+		| "dynamic-parallel-group"
+		| "agent"
+		| "host-step";
 	agent?: string;
 	phase?: string;
 	label: string;
@@ -129,7 +155,10 @@ export interface WorkflowPreflightV1 {
 
 export type WorkflowReceiptState = "complete" | "failed" | "paused" | "stopped";
 
-export type WorkflowTerminalResolution = "settled-awaiting-resume" | "failed-child" | "interrupted-child";
+export type WorkflowTerminalResolution =
+	| "settled-awaiting-resume"
+	| "failed-child"
+	| "interrupted-child";
 
 export interface WorkflowTerminalOutcome {
 	state: "partial";
@@ -178,7 +207,13 @@ export interface WorkflowChildSummaryV1 {
 	parentToolCallId: string;
 	workflowRunId: string;
 	inventoryComplete: boolean;
-	workflowState: "queued" | "running" | "completed" | "failed" | "paused" | "stopped";
+	workflowState:
+		| "queued"
+		| "running"
+		| "completed"
+		| "failed"
+		| "paused"
+		| "stopped";
 	children: Array<{
 		childId: string;
 		runId?: string;
@@ -187,13 +222,24 @@ export interface WorkflowChildSummaryV1 {
 		sessionName?: string;
 		model?: string;
 		thinking?: string;
-		state: "pending" | "running" | "completed" | "failed" | "paused" | "stopped" | "rejected" | "detached";
+		state:
+			| "pending"
+			| "running"
+			| "completed"
+			| "failed"
+			| "paused"
+			| "stopped"
+			| "rejected"
+			| "detached";
 	}>;
 }
 
 type WorkflowReceiptEntryResumability =
 	| { latestRunId: string; resumability: { state: "resumable" } }
-	| { latestRunId?: string; resumability: { state: "not-resumable"; reason: string } };
+	| {
+			latestRunId?: string;
+			resumability: { state: "not-resumable"; reason: string };
+	  };
 
 export type WorkflowReceiptEntry = WorkflowReceiptEntryResumability & {
 	key: string;
@@ -258,7 +304,10 @@ export interface ResolvedToolBudget {
 	block: string[] | "*";
 }
 
-export type ToolBudgetOutcome = "within-budget" | "soft-reached" | "hard-blocked";
+export type ToolBudgetOutcome =
+	| "within-budget"
+	| "soft-reached"
+	| "hard-blocked";
 
 export interface ToolBudgetState extends ResolvedToolBudget {
 	outcome: ToolBudgetOutcome;
@@ -272,7 +321,11 @@ export interface ToolBudgetState extends ResolvedToolBudget {
  * @deprecated Turn budgets are no longer accepted as launch configuration or
  * enforced. Retained only to decode historical persisted status and result data.
  */
-export type TurnBudgetOutcome = "within-budget" | "wrap-up-requested" | "termination-deferred" | "exceeded";
+export type TurnBudgetOutcome =
+	| "within-budget"
+	| "wrap-up-requested"
+	| "termination-deferred"
+	| "exceeded";
 
 /**
  * @deprecated Historical persisted turn-budget state. New runs do not produce
@@ -363,7 +416,16 @@ export interface ControlEvent {
 	nestedRunId?: string;
 	nestingPath?: NestedRunAddress["path"];
 	message: string;
-	reason?: "idle" | "completion_guard" | "active_long_running" | "tool_failures" | "supervisor_request" | "time_threshold" | "turn_threshold" | "token_threshold" | "tool_open_threshold";
+	reason?:
+		| "idle"
+		| "completion_guard"
+		| "active_long_running"
+		| "tool_failures"
+		| "supervisor_request"
+		| "time_threshold"
+		| "turn_threshold"
+		| "token_threshold"
+		| "tool_open_threshold";
 	turns?: number;
 	tokens?: number;
 	toolCount?: number;
@@ -378,7 +440,12 @@ export interface ControlEvent {
 	taskPreview?: string;
 }
 
-export type SubagentResultStatus = "completed" | "failed" | "paused" | "stopped" | "detached";
+export type SubagentResultStatus =
+	| "completed"
+	| "failed"
+	| "paused"
+	| "stopped"
+	| "detached";
 export type SubagentOutputState = "present" | "absent" | "unknown";
 export type SubagentRunMode = "single" | "parallel" | "chain" | "workflow";
 export type SubagentResultMode = SubagentRunMode;
@@ -502,7 +569,13 @@ export interface AgentContract {
 
 export type ChainGateLayer = "execution" | "acceptance";
 
-export type ExecutionProjectionStatus = "completed" | "failed" | "partial" | "paused" | "stopped" | "detached";
+export type ExecutionProjectionStatus =
+	| "completed"
+	| "failed"
+	| "partial"
+	| "paused"
+	| "stopped"
+	| "detached";
 
 export interface ExecutionProjection {
 	status: ExecutionProjectionStatus;
@@ -521,7 +594,12 @@ export interface ReviewProjection {
 }
 
 export interface FileMutationEffect {
-	status: "not-requested" | "not-applicable" | "observed" | "missing" | "blocked";
+	status:
+		| "not-requested"
+		| "not-applicable"
+		| "observed"
+		| "missing"
+		| "blocked";
 	expected: boolean;
 	attempted: boolean;
 	message?: string;
@@ -590,12 +668,25 @@ export interface TimeoutRecoverySummary {
 }
 
 /** Safe parent-facing subset of a timeout recovery summary. */
-export type TimeoutRecoveryProjection = Pick<TimeoutRecoverySummary, "termination" | "changedFiles" | "truncated" | "recoveryNeeded" | "reason" | "reportStatus">;
+export type TimeoutRecoveryProjection = Pick<
+	TimeoutRecoverySummary,
+	| "termination"
+	| "changedFiles"
+	| "truncated"
+	| "recoveryNeeded"
+	| "reason"
+	| "reportStatus"
+>;
 
 export const SUBAGENT_LIFECYCLE_ARTIFACT_VERSION = 3;
-export type SubagentLifecycleArtifactVersion = typeof SUBAGENT_LIFECYCLE_ARTIFACT_VERSION;
+export type SubagentLifecycleArtifactVersion =
+	typeof SUBAGENT_LIFECYCLE_ARTIFACT_VERSION;
 
-export type ProcessTerminalState = "pending" | "observed" | "unknown" | "not-started";
+export type ProcessTerminalState =
+	| "pending"
+	| "observed"
+	| "unknown"
+	| "not-started";
 export type ProcessTerminalReason =
 	| "observer-unavailable"
 	| "runner-candidate-missing"
@@ -618,16 +709,16 @@ export interface RunnerProcessInstanceExitV1 {
 
 export type ProcessTreeTerminalV1 =
 	| {
-		state: "observed";
-		mechanism: "posix-process-group";
-		processGroupId: number;
-		verifiedAt: number;
-	}
+			state: "observed";
+			mechanism: "posix-process-group";
+			processGroupId: number;
+			verifiedAt: number;
+	  }
 	| {
-		state: "unknown";
-		reason: "unsupported-platform" | "signal-failed" | "verification-failed";
-		diagnostic?: string;
-	};
+			state: "unknown";
+			reason: "unsupported-platform" | "signal-failed" | "verification-failed";
+			diagnostic?: string;
+	  };
 
 export interface PiWriterProcessInstanceExitV1 {
 	processInstanceId: string;
@@ -639,7 +730,9 @@ export interface PiWriterProcessInstanceExitV1 {
 	processTree: ProcessTreeTerminalV1;
 }
 
-export type ProcessInstanceExitV1 = RunnerProcessInstanceExitV1 | PiWriterProcessInstanceExitV1;
+export type ProcessInstanceExitV1 =
+	| RunnerProcessInstanceExitV1
+	| PiWriterProcessInstanceExitV1;
 
 export interface CanonicalSessionTerminalV1 {
 	canonicalSessionId: string;
@@ -661,16 +754,16 @@ interface ProcessTerminalBaseV1 {
 export type ProcessTerminalV1 =
 	| (ProcessTerminalBaseV1 & { state: "pending" | "not-started" })
 	| (ProcessTerminalBaseV1 & {
-		state: "observed";
-		observedAt: number;
-		instances: ProcessInstanceExitV1[];
-		canonicalSession?: CanonicalSessionTerminalV1;
-	})
+			state: "observed";
+			observedAt: number;
+			instances: ProcessInstanceExitV1[];
+			canonicalSession?: CanonicalSessionTerminalV1;
+	  })
 	| (ProcessTerminalBaseV1 & {
-		state: "unknown";
-		reason: ProcessTerminalReason;
-		diagnostic?: string;
-	});
+			state: "unknown";
+			reason: ProcessTerminalReason;
+			diagnostic?: string;
+	  });
 
 /** Identifies the durable schedule that launched a run, so its completion is attributable. */
 export interface ScheduleOrigin {
@@ -678,8 +771,22 @@ export interface ScheduleOrigin {
 	name?: string;
 }
 
-export type SteeringActionState = "delivered" | "scheduled" | "pending" | "partial" | "recovered" | "failed";
-export type SteeringTargetState = "scheduled" | "pending" | "routed" | "queued" | "delivered" | "late" | "failed" | "recovered";
+export type SteeringActionState =
+	| "delivered"
+	| "scheduled"
+	| "pending"
+	| "partial"
+	| "recovered"
+	| "failed";
+export type SteeringTargetState =
+	| "scheduled"
+	| "pending"
+	| "routed"
+	| "queued"
+	| "delivered"
+	| "late"
+	| "failed"
+	| "recovered";
 
 export interface SteeringTargetStatus {
 	index: number;
@@ -819,7 +926,28 @@ export interface SteeringRecoveryDescriptor {
 
 export type PublicNestedStepSummary = Pick<
 	NestedStepSummary,
-	"agent" | "sessionName" | "status" | "model" | "thinking" | "sessionFile" | "transcriptPath" | "transcriptError" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "startedAt" | "endedAt" | "error" | "timedOut" | "stopped"
+	| "agent"
+	| "sessionName"
+	| "status"
+	| "model"
+	| "thinking"
+	| "sessionFile"
+	| "transcriptPath"
+	| "transcriptError"
+	| "activityState"
+	| "lastActivityAt"
+	| "currentTool"
+	| "currentToolStartedAt"
+	| "currentPath"
+	| "turnCount"
+	| "toolCount"
+	| "toolBudget"
+	| "toolBudgetBlocked"
+	| "startedAt"
+	| "endedAt"
+	| "error"
+	| "timedOut"
+	| "stopped"
 > & {
 	children?: PublicNestedRunSummary[];
 };
@@ -832,7 +960,51 @@ export type CostSummary = {
 
 export type PublicNestedRunSummary = Pick<
 	NestedRunSummary,
-	"id" | "parentRunId" | "parentStepIndex" | "parentAgent" | "depth" | "path" | "asyncDir" | "sessionId" | "sessionFile" | "intercomTarget" | "ownerIntercomTarget" | "leafIntercomTarget" | "ownerState" | "mode" | "state" | "agent" | "sessionName" | "agents" | "model" | "thinking" | "currentStep" | "chainStepCount" | "parallelGroups" | "activityState" | "lastActivityAt" | "currentTool" | "currentToolStartedAt" | "currentPath" | "turnCount" | "toolCount" | "toolBudget" | "toolBudgetBlocked" | "totalTokens" | "totalCost" | "startedAt" | "endedAt" | "lastUpdate" | "error" | "timeoutMs" | "deadlineAt" | "timedOut" | "stopped" | "turnBudget" | "turnBudgetExceeded" | "wrapUpRequested"
+	| "id"
+	| "parentRunId"
+	| "parentStepIndex"
+	| "parentAgent"
+	| "depth"
+	| "path"
+	| "asyncDir"
+	| "sessionId"
+	| "sessionFile"
+	| "intercomTarget"
+	| "ownerIntercomTarget"
+	| "leafIntercomTarget"
+	| "ownerState"
+	| "mode"
+	| "state"
+	| "agent"
+	| "sessionName"
+	| "agents"
+	| "model"
+	| "thinking"
+	| "currentStep"
+	| "chainStepCount"
+	| "parallelGroups"
+	| "activityState"
+	| "lastActivityAt"
+	| "currentTool"
+	| "currentToolStartedAt"
+	| "currentPath"
+	| "turnCount"
+	| "toolCount"
+	| "toolBudget"
+	| "toolBudgetBlocked"
+	| "totalTokens"
+	| "totalCost"
+	| "startedAt"
+	| "endedAt"
+	| "lastUpdate"
+	| "error"
+	| "timeoutMs"
+	| "deadlineAt"
+	| "timedOut"
+	| "stopped"
+	| "turnBudget"
+	| "turnBudgetExceeded"
+	| "wrapUpRequested"
 > & {
 	steps?: PublicNestedStepSummary[];
 	children?: PublicNestedRunSummary[];
@@ -957,7 +1129,12 @@ export interface ModelAttempt {
 	usage?: Usage;
 }
 
-export type AcceptanceLevel = "auto" | "none" | "attested" | "checked" | "verified";
+export type AcceptanceLevel =
+	| "auto"
+	| "none"
+	| "attested"
+	| "checked"
+	| "verified";
 
 export type AcceptanceEvidenceKind =
 	| "changed-files"
@@ -1000,10 +1177,21 @@ export interface AcceptanceConfig {
 	review?: AcceptanceReviewGate | false;
 	stopRules?: string[];
 	reason?: string;
+	/**
+	 * Require the child to deliver its acceptance report through the structured
+	 * output channel (a schema-validated `acceptanceReport` parameter on the
+	 * `structured_output` tool) in addition to the prompt contract. "off" keeps
+	 * the text fence channel. Omitted preserves the current behavior: the
+	 * structured channel is only used when the task already has an outputSchema.
+	 */
+	report?: "on" | "off";
 }
 
 /** Bare "none" and "verified" are not accepted; verified policies require object form with runtime commands. */
-export type AcceptanceInput = Exclude<AcceptanceLevel, "none" | "verified"> | false | AcceptanceConfig;
+export type AcceptanceInput =
+	| Exclude<AcceptanceLevel, "none" | "verified">
+	| false
+	| AcceptanceConfig;
 
 export interface ResolvedAcceptanceGate extends AcceptanceGate {
 	id: string;
@@ -1046,7 +1234,10 @@ export interface AcceptanceReport {
 	notes?: string;
 }
 
-export type AcceptanceRuntimeCheckStatus = "passed" | "failed" | "not-applicable";
+export type AcceptanceRuntimeCheckStatus =
+	| "passed"
+	| "failed"
+	| "not-applicable";
 
 export interface AcceptanceRuntimeCheck {
 	id: string;
@@ -1341,9 +1532,30 @@ export interface AgentCapabilityRow {
 	executable: boolean;
 	restrictionSources?: string[];
 	aliases?: string[];
-	runner: { type: "pi" } | { type: "external-cli"; adapter?: string; capabilities: ExternalCliCapabilities } | { type: "external-job"; provider: string; available?: boolean; capabilities: ExternalJobRunnerStatus["capabilities"] };
-	tools: { ambient: boolean; names: string[]; mcpDirectTools: string[]; mutationTools?: string[] };
-	model?: { value?: string; fallbackModels?: string[]; thinking?: string | false };
+	runner:
+		| { type: "pi" }
+		| {
+				type: "external-cli";
+				adapter?: string;
+				capabilities: ExternalCliCapabilities;
+		  }
+		| {
+				type: "external-job";
+				provider: string;
+				available?: boolean;
+				capabilities: ExternalJobRunnerStatus["capabilities"];
+		  };
+	tools: {
+		ambient: boolean;
+		names: string[];
+		mcpDirectTools: string[];
+		mutationTools?: string[];
+	};
+	model?: {
+		value?: string;
+		fallbackModels?: string[];
+		thinking?: string | false;
+	};
 	execution?: { defaultAsync?: boolean; timeoutMs?: number };
 	output?: { path?: string; mode?: OutputMode };
 	extensions?: { names?: string[]; subagentOnly?: string[]; skills?: string[] };
@@ -1395,9 +1607,9 @@ export interface Details {
 		artifactPath?: string;
 	};
 	// Chain metadata for observability
-	chainAgents?: string[];      // Agent names in order, e.g., ["scout", "planner"]
-	totalSteps?: number;         // Total steps in chain
-	currentStepIndex?: number;   // 0-indexed current step (for running chains)
+	chainAgents?: string[]; // Agent names in order, e.g., ["scout", "planner"]
+	totalSteps?: number; // Total steps in chain
+	currentStepIndex?: number; // 0-indexed current step (for running chains)
 	workflowGraph?: WorkflowGraphSnapshot;
 	/** Validated, display-only fanout plan supplied with a workflow launch. */
 	preflight?: WorkflowPreflightV1;
@@ -1436,7 +1648,16 @@ export interface Details {
 		trace: Array<{
 			operation: "run" | "status" | "steer" | "host";
 			key: string;
-			state: "started" | "completed" | "failed" | "detached" | "stopped" | "reused" | "queued" | "delivered" | "missed";
+			state:
+				| "started"
+				| "completed"
+				| "failed"
+				| "detached"
+				| "stopped"
+				| "reused"
+				| "queued"
+				| "delivered"
+				| "missed";
 			agent?: string;
 			runId?: string;
 			phase?: string;
@@ -1504,7 +1725,15 @@ export interface AsyncParallelGroupStatus {
 	stepIndex: number;
 }
 
-export type NestedRunState = "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
+export type NestedRunState =
+	| "queued"
+	| "running"
+	| "complete"
+	| "failed"
+	| "partial"
+	| "paused"
+	| "stopped"
+	| "rejected";
 export type NestedOwnerState = "live" | "gone" | "unknown";
 
 export interface NestedRunAddress {
@@ -1520,7 +1749,16 @@ export interface NestedStepSummary {
 	agent: string;
 	/** Human-readable display name for the child session, when derived at launch. */
 	sessionName?: string;
-	status: "pending" | "running" | "complete" | "completed" | "failed" | "partial" | "paused" | "stopped" | "rejected";
+	status:
+		| "pending"
+		| "running"
+		| "complete"
+		| "completed"
+		| "failed"
+		| "partial"
+		| "paused"
+		| "stopped"
+		| "rejected";
 	model?: string;
 	thinking?: string;
 	sessionFile?: string;
@@ -1651,20 +1889,37 @@ export interface AsyncStartedEvent {
 export type AgentRunnerConfig =
 	| { type: "pi" }
 	| {
-		type: "external-cli";
-		adapter?: "codex-exec" | "codex-exec-writer" | "claude-code" | "claude-code-writer" | "cursor-agent" | "cursor-agent-writer";
-		command: string;
-		args?: string[];
-		promptDelivery?: "stdin";
-		capabilities?: ExternalCliCapabilityNarrowing;
-	}
+			type: "external-cli";
+			adapter?:
+				| "codex-exec"
+				| "codex-exec-writer"
+				| "claude-code"
+				| "claude-code-writer"
+				| "cursor-agent"
+				| "cursor-agent-writer";
+			command: string;
+			args?: string[];
+			promptDelivery?: "stdin";
+			capabilities?: ExternalCliCapabilityNarrowing;
+	  }
 	| {
-		type: "external-job";
-		provider: string;
-		options?: Record<string, unknown>;
-	};
+			type: "external-job";
+			provider: string;
+			options?: Record<string, unknown>;
+	  };
 
-export type ExternalCliCapabilityNarrowing = Partial<Record<"steer" | "resume" | "structuredOutput" | "toolEvents" | "supervisor" | "forkContext" | "extensionBindings", false>>;
+export type ExternalCliCapabilityNarrowing = Partial<
+	Record<
+		| "steer"
+		| "resume"
+		| "structuredOutput"
+		| "toolEvents"
+		| "supervisor"
+		| "forkContext"
+		| "extensionBindings",
+		false
+	>
+>;
 
 export interface ExternalCliCapabilities {
 	stop: true;
@@ -1678,17 +1933,76 @@ export interface ExternalCliCapabilities {
 }
 
 export interface ExternalCliReceiptMetadata {
-	adapter: { id: "external-cli" | "codex-exec" | "codex-exec-writer" | "claude-code" | "claude-code-writer" | "cursor-agent" | "cursor-agent-writer" | "grok-build"; version: 1; executionMode: "one-shot-stdin" | "one-shot-prompt-file" };
+	adapter: {
+		id:
+			| "external-cli"
+			| "codex-exec"
+			| "codex-exec-writer"
+			| "claude-code"
+			| "claude-code-writer"
+			| "cursor-agent"
+			| "cursor-agent-writer"
+			| "grok-build";
+		version: 1;
+		executionMode: "one-shot-stdin" | "one-shot-prompt-file";
+	};
 	capabilities: ExternalCliCapabilities;
 	safety?:
 		| { sandbox: "read-only"; approvalPolicy: "never"; ephemeral: true }
-		| { access: "workspace-write"; sandbox: "workspace-write"; approvalPolicy: "never"; ephemeral: true }
-		| { permissionMode: "plan"; tools: "none"; mcp: "empty-strict"; settingSources: "none"; sessionPersistence: false }
-		| { access: "read-only"; authentication: "existing-cli-required"; permissionMode: "plan"; tools: "none"; mcp: "empty-strict"; settingSources: "user"; userSettingsTrust: "required"; sessionPersistence: false }
-		| { access: "workspace-write"; authentication: "existing-cli-required"; permissionMode: "acceptEdits"; tools: "Read,Write,Edit,Glob,Grep"; mcp: "empty-strict"; settingSources: "user"; userSettingsTrust: "required"; sessionPersistence: false }
-		| { access: "read-only"; authentication: "cursor-api-key-or-existing-login"; mode: "ask"; sandbox: "enabled"; workspaceTrust: "existing-required"; sessionReuse: false }
-		| { access: "workspace-write"; authentication: "cursor-api-key-or-existing-login"; mode: "print"; sandbox: "enabled"; workspaceTrust: "existing-required"; sessionReuse: false };
-	outputArtifacts?: { stdoutPath?: string; stderrPath?: string; finalOutputPath?: string };
+		| {
+				access: "workspace-write";
+				sandbox: "workspace-write";
+				approvalPolicy: "never";
+				ephemeral: true;
+		  }
+		| {
+				permissionMode: "plan";
+				tools: "none";
+				mcp: "empty-strict";
+				settingSources: "none";
+				sessionPersistence: false;
+		  }
+		| {
+				access: "read-only";
+				authentication: "existing-cli-required";
+				permissionMode: "plan";
+				tools: "none";
+				mcp: "empty-strict";
+				settingSources: "user";
+				userSettingsTrust: "required";
+				sessionPersistence: false;
+		  }
+		| {
+				access: "workspace-write";
+				authentication: "existing-cli-required";
+				permissionMode: "acceptEdits";
+				tools: "Read,Write,Edit,Glob,Grep";
+				mcp: "empty-strict";
+				settingSources: "user";
+				userSettingsTrust: "required";
+				sessionPersistence: false;
+		  }
+		| {
+				access: "read-only";
+				authentication: "cursor-api-key-or-existing-login";
+				mode: "ask";
+				sandbox: "enabled";
+				workspaceTrust: "existing-required";
+				sessionReuse: false;
+		  }
+		| {
+				access: "workspace-write";
+				authentication: "cursor-api-key-or-existing-login";
+				mode: "print";
+				sandbox: "enabled";
+				workspaceTrust: "existing-required";
+				sessionReuse: false;
+		  };
+	outputArtifacts?: {
+		stdoutPath?: string;
+		stderrPath?: string;
+		finalOutputPath?: string;
+	};
 	handoff: { mode: "fresh" };
 	supervisor: { mode: "unsupported"; reason: string };
 	nonResumableReason: string;
@@ -1702,7 +2016,10 @@ export interface ExternalCliRunnerStatus {
 	adapter: ExternalCliReceiptMetadata["adapter"];
 	safety?: ExternalCliReceiptMetadata["safety"];
 	capabilities: ExternalCliCapabilities;
-	unsupportedReasons: Record<Exclude<keyof ExternalCliCapabilities, "stop">, string>;
+	unsupportedReasons: Record<
+		Exclude<keyof ExternalCliCapabilities, "stop">,
+		string
+	>;
 	nonResumableReason: string;
 }
 
@@ -1768,7 +2085,15 @@ export interface AsyncStatus {
 	mode: SubagentRunMode;
 	context?: "fresh" | "fork" | "mixed";
 	isNested?: boolean;
-	state: "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
+	state:
+		| "queued"
+		| "running"
+		| "complete"
+		| "failed"
+		| "partial"
+		| "paused"
+		| "stopped"
+		| "rejected";
 	/** Display-only dismissal marker for a reload-orphaned workflow. */
 	displayDismissedAt?: number;
 	error?: string;
@@ -1846,7 +2171,16 @@ export interface AsyncStatus {
 		parentWorkflowRunId?: string;
 		outputName?: string;
 		structured?: boolean;
-		status: "pending" | "running" | "complete" | "completed" | "failed" | "partial" | "paused" | "stopped" | "rejected";
+		status:
+			| "pending"
+			| "running"
+			| "complete"
+			| "completed"
+			| "failed"
+			| "partial"
+			| "paused"
+			| "stopped"
+			| "rejected";
 		stopRequested?: boolean;
 		stopRequestedAt?: number;
 		children?: NestedRunSummary[];
@@ -1913,7 +2247,10 @@ export interface AsyncStatus {
 	parallelHandoff?: ParallelHandoffReference;
 }
 
-export type AsyncJobStep = Omit<NonNullable<AsyncStatus["steps"]>[number], "timeoutRecovery"> & {
+export type AsyncJobStep = Omit<
+	NonNullable<AsyncStatus["steps"]>[number],
+	"timeoutRecovery"
+> & {
 	index?: number;
 	description?: string;
 	timeoutRecovery?: TimeoutRecoveryProjection;
@@ -1928,7 +2265,15 @@ export interface AsyncJobState {
 	cwd?: string;
 	/** Parent-resolved child session root retained for trusted live transcript lookup. */
 	sessionRoot?: string;
-	status: "queued" | "running" | "complete" | "failed" | "partial" | "paused" | "stopped" | "rejected";
+	status:
+		| "queued"
+		| "running"
+		| "complete"
+		| "failed"
+		| "partial"
+		| "paused"
+		| "stopped"
+		| "rejected";
 	/** Short caller-facing task/goal shown in fleet surfaces when available. */
 	description?: string;
 	pid?: number;
@@ -2115,7 +2460,10 @@ export interface ForegroundRunControl {
 	/** Independently tracked children for foreground parallel work and fleet inspection. */
 	activeChildren?: Map<number, ForegroundChildControl>;
 	/** Live Prompt Audit redo callback. It is current-session memory only. */
-	promptAuditRedo?: (index: number, guidance: string) => Promise<{ text: string; isError?: boolean }>;
+	promptAuditRedo?: (
+		index: number,
+		guidance: string,
+	) => Promise<{ text: string; isError?: boolean }>;
 	/** Memory-only source run for Prompt Audit redo. */
 	sourceRunId?: string;
 	/** Memory-only replacement run started by Prompt Audit redo. */
@@ -2206,7 +2554,10 @@ export interface SubagentState {
 	/** Live in-process workflow controllers. Durable status remains on disk after settlement. */
 	workflowControllers?: Map<string, AbortController>;
 	/** Live in-process workflow child stoppers keyed by parent workflow run id. */
-	workflowChildStops?: Map<string, (childId: string, message?: string) => boolean>;
+	workflowChildStops?: Map<
+		string,
+		(childId: string, message?: string) => boolean
+	>;
 }
 
 export interface HerdrProjectPaneSnapshot {
@@ -2231,8 +2582,8 @@ export interface HerdrProjectPaneSnapshot {
 // Display
 // ============================================================================
 
-export type DisplayItem = 
-	| { type: "text"; text: string } 
+export type DisplayItem =
+	| { type: "text"; text: string }
 	| { type: "tool"; name: string; args: Record<string, unknown> };
 
 // ============================================================================
@@ -2256,13 +2607,15 @@ export const INTERCOM_DETACH_RESPONSE_EVENT = "pi-intercom:detach-response";
 export const SUBAGENT_ASYNC_STARTED_EVENT = "subagent:async-started";
 export const SUBAGENT_ASYNC_COMPLETE_EVENT = "subagent:async-complete";
 export const SUBAGENT_PROCESS_TERMINAL_EVENT = "subagent:process-terminal";
-export const SUBAGENT_FOREGROUND_COMPLETE_EVENT = "subagent:foreground-complete";
+export const SUBAGENT_FOREGROUND_COMPLETE_EVENT =
+	"subagent:foreground-complete";
 export const SUBAGENT_CONTROL_EVENT = "subagent:control-event";
 export const SUBAGENT_CONTROL_INTERCOM_EVENT = "subagent:control-intercom";
 export const SUBAGENT_STEERING_NOTICE_EVENT = "subagent:steering-notice";
 export const SUBAGENT_CHILD_STATUS_EVENT = "subagent:child-status";
 export const SUBAGENT_RESULT_INTERCOM_EVENT = "subagent:result-intercom";
-export const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT = "subagent:result-intercom-delivery";
+export const SUBAGENT_RESULT_INTERCOM_DELIVERY_EVENT =
+	"subagent:result-intercom-delivery";
 
 export interface SubagentChildStatusEvent {
 	type: "subagent.child-status";
@@ -2364,7 +2717,12 @@ export interface RunSyncOptions {
 	/** Package-internal one-use authorization for one foreground workflow child. */
 	workflowChildPermitLaunch?: WorkflowChildPermitContext;
 	/** Registry models available for heuristic bare-model resolution */
-	availableModels?: Array<{ provider: string; id: string; fullId: string; contextWindow?: number }>;
+	availableModels?: Array<{
+		provider: string;
+		id: string;
+		fullId: string;
+		contextWindow?: number;
+	}>;
 	/** Current parent-session provider to prefer for ambiguous bare model ids */
 	preferredModelProvider?: string;
 	/** Parent Pi event host used to snapshot runtime-registered MCP servers before child launch. */
@@ -2378,6 +2736,8 @@ export interface RunSyncOptions {
 		schemaPath: string;
 		outputPath: string;
 		acceptanceReportPath?: string;
+		acceptanceReportRequired?: boolean;
+		reportOnly?: boolean;
 	};
 	agentContract?: AgentContract;
 	acceptance?: AcceptanceInput;
@@ -2390,7 +2750,9 @@ export interface RunSyncOptions {
 	/** Private live callback for the exact child prompt after runtime acceptance injection. */
 	onEffectivePrompt?: (prompt: string) => void;
 	/** Internal lifecycle hook for the observer shared across retries of one logical child. */
-	onOrcaProgressTabCreated?: (tab: import("../runs/shared/orca-progress-tabs.ts").OrcaProgressTab) => void;
+	onOrcaProgressTabCreated?: (
+		tab: import("../runs/shared/orca-progress-tabs.ts").OrcaProgressTab,
+	) => void;
 }
 
 export type IntercomBridgeMode = "off" | "fork-only" | "always";
@@ -2454,8 +2816,10 @@ export const FLEET_KEYBINDING_ACTIONS = [
 	"toggleTools",
 ] as const;
 
-export type FleetKeybindingAction = typeof FLEET_KEYBINDING_ACTIONS[number];
-export type FleetKeybindingsConfig = Partial<Record<FleetKeybindingAction, string[]>>;
+export type FleetKeybindingAction = (typeof FLEET_KEYBINDING_ACTIONS)[number];
+export type FleetKeybindingsConfig = Partial<
+	Record<FleetKeybindingAction, string[]>
+>;
 
 export interface OrcaProgressTabsConfig {
 	/** Create one Orca observer tab per top-level subagent call. Experimental and opt-in. */
@@ -2607,9 +2971,10 @@ export function resolveTempScopeId(options?: {
 	homedir?: (() => string) | undefined;
 }): string {
 	const env = options?.env ?? process.env;
-	const getuid = options && Object.hasOwn(options, "getuid")
-		? options.getuid
-		: process.getuid?.bind(process);
+	const getuid =
+		options && Object.hasOwn(options, "getuid")
+			? options.getuid
+			: process.getuid?.bind(process);
 	if (typeof getuid === "function") {
 		return `uid-${getuid()}`;
 	}
@@ -2619,9 +2984,10 @@ export function resolveTempScopeId(options?: {
 		if (value) return `user-${sanitizeTempScopeSegment(value)}`;
 	}
 
-	const userInfo = options && Object.hasOwn(options, "userInfo")
-		? options.userInfo
-		: os.userInfo;
+	const userInfo =
+		options && Object.hasOwn(options, "userInfo")
+			? options.userInfo
+			: os.userInfo;
 	try {
 		const username = userInfo?.().username;
 		if (username) return `user-${sanitizeTempScopeSegment(username)}`;
@@ -2632,12 +2998,12 @@ export function resolveTempScopeId(options?: {
 	const homedir = env.USERPROFILE ?? env.HOME;
 	if (homedir) return `home-${sanitizeTempScopeSegment(homedir)}`;
 
-	const resolveHomedir = options && Object.hasOwn(options, "homedir")
-		? options.homedir
-		: os.homedir;
+	const resolveHomedir =
+		options && Object.hasOwn(options, "homedir") ? options.homedir : os.homedir;
 	try {
 		const fallbackHomedir = resolveHomedir?.();
-		if (fallbackHomedir) return `home-${sanitizeTempScopeSegment(fallbackHomedir)}`;
+		if (fallbackHomedir)
+			return `home-${sanitizeTempScopeSegment(fallbackHomedir)}`;
 	} catch {
 		// Fall through to the last-resort shared scope.
 	}
@@ -2674,7 +3040,64 @@ export const POLL_INTERVAL_MS = 250;
 export const WIDGET_ANIMATION_INTERVAL_MS = 1000;
 export const MAX_WIDGET_JOBS = 4;
 export const DEFAULT_SUBAGENT_MAX_DEPTH = 2;
-export const SUBAGENT_ACTIONS = ["list", "get", "models", "children.list", "guide", "validate", "create", "update", "delete", "eject", "disable", "enable", "reset", "mission.create", "mission.list", "mission.show", "mission.update", "mission.resolve-decision", "mission.attach-run", "mission.close", "worktree.discard", "worktree.cleanup", "lane.status", "lane.recordMerge", "lane.recordSupersession", "refine", "refine.show", "refine.rollback", "inspector.open", "inspector.status", "inspector.close", "project.open", "project.status", "project.close", "status", "debug.run", "grant-spawn-budget", "interrupt", "resume", "steer", "stop", "dismiss", "doctor", "watchdog.status", "watchdog.check", "watchdog.configure", "watchdog.recommend-model", "schedule.create", "schedule.list", "schedule.show", "schedule.history", "schedule.pause", "schedule.resume", "schedule.run", "schedule.run-due", "schedule.delete"] as const;
+export const SUBAGENT_ACTIONS = [
+	"list",
+	"get",
+	"models",
+	"children.list",
+	"guide",
+	"validate",
+	"create",
+	"update",
+	"delete",
+	"eject",
+	"disable",
+	"enable",
+	"reset",
+	"mission.create",
+	"mission.list",
+	"mission.show",
+	"mission.update",
+	"mission.resolve-decision",
+	"mission.attach-run",
+	"mission.close",
+	"worktree.discard",
+	"worktree.cleanup",
+	"lane.status",
+	"lane.recordMerge",
+	"lane.recordSupersession",
+	"refine",
+	"refine.show",
+	"refine.rollback",
+	"inspector.open",
+	"inspector.status",
+	"inspector.close",
+	"project.open",
+	"project.status",
+	"project.close",
+	"status",
+	"debug.run",
+	"grant-spawn-budget",
+	"interrupt",
+	"resume",
+	"steer",
+	"stop",
+	"dismiss",
+	"doctor",
+	"watchdog.status",
+	"watchdog.check",
+	"watchdog.configure",
+	"watchdog.recommend-model",
+	"schedule.create",
+	"schedule.list",
+	"schedule.show",
+	"schedule.history",
+	"schedule.pause",
+	"schedule.resume",
+	"schedule.run",
+	"schedule.run-due",
+	"schedule.delete",
+] as const;
 
 export const DEFAULT_FORK_PREAMBLE =
 	"You are a delegated subagent running from a fork of the parent session. " +
@@ -2683,7 +3106,12 @@ export const DEFAULT_FORK_PREAMBLE =
 	"Your sole job is to execute the task below and return a focused result for that task using your tools.";
 
 function normalizeTopLevelParallelValue(value: unknown): number | undefined {
-	const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+	const parsed =
+		typeof value === "number"
+			? value
+			: typeof value === "string"
+				? Number(value)
+				: NaN;
 	if (!Number.isInteger(parsed) || parsed < 1) return undefined;
 	return parsed;
 }
@@ -2696,9 +3124,11 @@ export function resolveTopLevelParallelConcurrency(
 	override: unknown,
 	configValue: unknown,
 ): number {
-	return normalizeTopLevelParallelValue(override)
-		?? normalizeTopLevelParallelValue(configValue)
-		?? MAX_CONCURRENCY;
+	return (
+		normalizeTopLevelParallelValue(override) ??
+		normalizeTopLevelParallelValue(configValue) ??
+		MAX_CONCURRENCY
+	);
 }
 
 export function getAsyncConfigPath(suffix: string): string {
@@ -2718,7 +3148,12 @@ export function wrapForkTask(task: string, preamble?: string | false): string {
 // ============================================================================
 
 function normalizeNonNegativeInteger(value: unknown): number | undefined {
-	const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+	const parsed =
+		typeof value === "number"
+			? value
+			: typeof value === "string"
+				? Number(value)
+				: NaN;
 	if (!Number.isInteger(parsed) || parsed < 0) return undefined;
 	return parsed;
 }
@@ -2727,19 +3162,33 @@ export function normalizeMaxSubagentDepth(value: unknown): number | undefined {
 	return normalizeNonNegativeInteger(value);
 }
 
-export function resolveCurrentMaxSubagentDepth(configMaxDepth?: number): number {
-	return normalizeMaxSubagentDepth(process.env.PI_SUBAGENT_MAX_DEPTH)
-		?? normalizeMaxSubagentDepth(configMaxDepth)
-		?? DEFAULT_SUBAGENT_MAX_DEPTH;
+export function resolveCurrentMaxSubagentDepth(
+	configMaxDepth?: number,
+): number {
+	return (
+		normalizeMaxSubagentDepth(process.env.PI_SUBAGENT_MAX_DEPTH) ??
+		normalizeMaxSubagentDepth(configMaxDepth) ??
+		DEFAULT_SUBAGENT_MAX_DEPTH
+	);
 }
 
-export function resolveChildMaxSubagentDepth(parentMaxDepth: number, agentMaxDepth?: number): number {
-	const normalizedParent = normalizeMaxSubagentDepth(parentMaxDepth) ?? DEFAULT_SUBAGENT_MAX_DEPTH;
+export function resolveChildMaxSubagentDepth(
+	parentMaxDepth: number,
+	agentMaxDepth?: number,
+): number {
+	const normalizedParent =
+		normalizeMaxSubagentDepth(parentMaxDepth) ?? DEFAULT_SUBAGENT_MAX_DEPTH;
 	const normalizedAgent = normalizeMaxSubagentDepth(agentMaxDepth);
-	return normalizedAgent === undefined ? normalizedParent : Math.min(normalizedParent, normalizedAgent);
+	return normalizedAgent === undefined
+		? normalizedParent
+		: Math.min(normalizedParent, normalizedAgent);
 }
 
-export function checkSubagentDepth(configMaxDepth?: number): { blocked: boolean; depth: number; maxDepth: number } {
+export function checkSubagentDepth(configMaxDepth?: number): {
+	blocked: boolean;
+	depth: number;
+	maxDepth: number;
+} {
 	const depth = Number(process.env.PI_SUBAGENT_DEPTH ?? "0");
 	const maxDepth = resolveCurrentMaxSubagentDepth(configMaxDepth);
 	const blocked = Number.isFinite(depth) && depth >= maxDepth;
@@ -2751,32 +3200,50 @@ export function getSubagentDepthEnv(maxDepth?: number): Record<string, string> {
 	const nextDepth = Number.isFinite(parentDepth) ? parentDepth + 1 : 1;
 	return {
 		PI_SUBAGENT_DEPTH: String(nextDepth),
-		PI_SUBAGENT_MAX_DEPTH: String(normalizeMaxSubagentDepth(maxDepth) ?? resolveCurrentMaxSubagentDepth()),
+		PI_SUBAGENT_MAX_DEPTH: String(
+			normalizeMaxSubagentDepth(maxDepth) ?? resolveCurrentMaxSubagentDepth(),
+		),
 	};
 }
 
-export function normalizeMaxSubagentSpawnsPerSession(value: unknown): number | undefined {
+export function normalizeMaxSubagentSpawnsPerSession(
+	value: unknown,
+): number | undefined {
 	return normalizeNonNegativeInteger(value);
 }
 
-export function resolveMaxSubagentSpawnsPerSession(configMaxSpawns?: number): number | undefined {
-	const envMaxSpawns = normalizeMaxSubagentSpawnsPerSession(process.env.PI_SUBAGENT_MAX_SPAWNS_PER_SESSION);
-	if (envMaxSpawns !== undefined) return envMaxSpawns === 0 ? undefined : envMaxSpawns;
-	const configuredMaxSpawns = normalizeMaxSubagentSpawnsPerSession(configMaxSpawns);
+export function resolveMaxSubagentSpawnsPerSession(
+	configMaxSpawns?: number,
+): number | undefined {
+	const envMaxSpawns = normalizeMaxSubagentSpawnsPerSession(
+		process.env.PI_SUBAGENT_MAX_SPAWNS_PER_SESSION,
+	);
+	if (envMaxSpawns !== undefined)
+		return envMaxSpawns === 0 ? undefined : envMaxSpawns;
+	const configuredMaxSpawns =
+		normalizeMaxSubagentSpawnsPerSession(configMaxSpawns);
 	return configuredMaxSpawns === 0 ? undefined : configuredMaxSpawns;
 }
 
 export const DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN = 64;
 
-export function normalizeMaxSubagentSpawnsPerRun(value: unknown): number | undefined {
+export function normalizeMaxSubagentSpawnsPerRun(
+	value: unknown,
+): number | undefined {
 	const normalized = normalizeNonNegativeInteger(value);
 	return normalized !== undefined && normalized > 0 ? normalized : undefined;
 }
 
-export function resolveMaxSubagentSpawnsPerRun(configMaxSpawns?: number): number {
-	return normalizeMaxSubagentSpawnsPerRun(process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN)
-		?? normalizeMaxSubagentSpawnsPerRun(configMaxSpawns)
-		?? DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN;
+export function resolveMaxSubagentSpawnsPerRun(
+	configMaxSpawns?: number,
+): number {
+	return (
+		normalizeMaxSubagentSpawnsPerRun(
+			process.env.PI_SUBAGENT_MAX_SPAWNS_PER_RUN,
+		) ??
+		normalizeMaxSubagentSpawnsPerRun(configMaxSpawns) ??
+		DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN
+	);
 }
 
 // ============================================================================

--- a/test/unit/acceptance-report-mode.test.ts
+++ b/test/unit/acceptance-report-mode.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import {
+	formatAcceptancePrompt,
+	resolveAcceptanceReportMode,
+	resolveEffectiveAcceptance,
+	validateAcceptanceInput,
+} from "../../src/runs/shared/acceptance.ts";
+import {
+	acceptanceReportJsonSchema,
+	createStructuredOutputRuntime,
+	validateStructuredOutputValue,
+} from "../../src/runs/shared/structured-output.ts";
+
+describe("acceptance report mode", () => {
+	it("defaults to optional when report is omitted", () => {
+		assert.equal(resolveAcceptanceReportMode(undefined), "optional");
+		assert.equal(resolveAcceptanceReportMode("checked"), "optional");
+		assert.equal(resolveAcceptanceReportMode(false), "optional");
+		assert.equal(resolveAcceptanceReportMode({ level: "checked" }), "optional");
+	});
+
+	it("returns structured for report: on and off for report: off", () => {
+		assert.equal(resolveAcceptanceReportMode({ level: "checked", report: "on" }), "structured");
+		assert.equal(resolveAcceptanceReportMode({ level: "checked", report: "off" }), "off");
+	});
+
+	it("rejects invalid report values in validateAcceptanceInput", () => {
+		const errors = validateAcceptanceInput({ level: "checked", report: "maybe" } as never);
+		assert.ok(errors.some((error: string) => error.includes('report must be "on" or "off"')));
+		const valid = validateAcceptanceInput({ level: "checked", report: "on" } as never);
+		assert.ok(!valid.some((error: string) => error.includes("report")));
+	});
+});
+
+describe("acceptance report required runtime", () => {
+	it("creates a report-only runtime when there is no outputSchema", () => {
+		const base = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-report-mode-"));
+		const runtime = createStructuredOutputRuntime(undefined, base, { captureAcceptanceReport: true, acceptanceReportRequired: true });
+		assert.equal(runtime.reportOnly, true);
+		assert.equal(runtime.acceptanceReportRequired, true);
+		assert.ok(runtime.acceptanceReportPath);
+		// Report-only: no outputSchema exists, so no schema file is materialized.
+		assert.ok(!fs.existsSync(runtime.schemaPath));
+	});
+
+	it("keeps reportOnly false when an outputSchema is provided", () => {
+		const base = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-report-mode-"));
+		const runtime = createStructuredOutputRuntime({ type: "object", properties: { answer: { type: "string" } } }, base, { captureAcceptanceReport: true, acceptanceReportRequired: true });
+		assert.equal(runtime.reportOnly, undefined);
+		assert.equal(runtime.acceptanceReportRequired, true);
+		assert.ok(runtime.acceptanceReportPath);
+	});
+
+	it("does not set acceptanceReportRequired when the flag is absent", () => {
+		const base = fs.mkdtempSync(path.join(os.tmpdir(), "subagent-report-mode-"));
+		const runtime = createStructuredOutputRuntime({ type: "object" }, base);
+		assert.equal(runtime.acceptanceReportRequired, undefined);
+		assert.equal(runtime.reportOnly, undefined);
+	});
+});
+
+describe("acceptance report json schema", () => {
+	it("validates a well-formed report", async () => {
+		const schema = acceptanceReportJsonSchema();
+		const result = await validateStructuredOutputValue(schema, {
+			criteriaSatisfied: [{ id: "tests", status: "satisfied", evidence: "all green" }],
+			commandsRun: [{ command: "npm test", result: "passed", summary: "ok" }],
+			changedFiles: ["src/a.ts"],
+			noStagedFiles: true,
+		});
+		assert.equal(result.status, "valid");
+	});
+
+	it("rejects a report with an invalid criterion status", async () => {
+		const schema = acceptanceReportJsonSchema();
+		const result = await validateStructuredOutputValue(schema, {
+			criteriaSatisfied: [{ id: "tests", status: "done", evidence: "x" }],
+		});
+		assert.equal(result.status, "invalid");
+		assert.ok(result.status === "invalid" && result.message.includes("criteriaSatisfied"));
+	});
+
+	it("rejects a report with an invalid command result", async () => {
+		const schema = acceptanceReportJsonSchema();
+		const result = await validateStructuredOutputValue(schema, {
+			commandsRun: [{ command: "npm test", result: "green", summary: "ok" }],
+		});
+		assert.equal(result.status, "invalid");
+	});
+});
+
+describe("formatAcceptancePrompt report modes", () => {
+	const acceptance = resolveEffectiveAcceptance({ explicit: { level: "checked", criteria: ["npm test passes"] }, agentName: "worker" });
+
+	it("text mode keeps the fenced template when no structured delivery is configured", () => {
+		const prompt = formatAcceptancePrompt(acceptance);
+		assert.ok(prompt.includes("```acceptance-report"));
+		assert.ok(!prompt.includes("structured_output"));
+	});
+
+	it("piggyback mode asks for acceptanceReport inside structured_output without a fence", () => {
+		const prompt = formatAcceptancePrompt(acceptance, { structuredOutput: true });
+		assert.ok(prompt.includes("Include an `acceptanceReport` object in your final `structured_output` tool call"));
+		assert.ok(!prompt.includes("```acceptance-report"));
+	});
+
+	it("required report-only mode demands a structured_output report delivery", () => {
+		// Mirrors real callers: report-only runtime => reportRequired + reportOnly,
+		// and structuredOutput stays false because there is no outputSchema delivery.
+		const prompt = formatAcceptancePrompt(acceptance, { reportRequired: true, reportOnly: true });
+		assert.ok(prompt.includes("structured_output"));
+		assert.ok(prompt.includes("Mandatory"));
+		assert.ok(prompt.includes("its single `value` parameter"));
+		assert.ok(!prompt.includes("Include an `acceptanceReport` object"));
+		assert.ok(!prompt.includes("```acceptance-report"));
+	});
+
+	it("required piggyback mode keeps the acceptanceReport instruction", () => {
+		// Real caller combination: outputSchema + report on => structuredOutput true, reportOnly false.
+		const prompt = formatAcceptancePrompt(acceptance, { structuredOutput: true, reportRequired: true, reportOnly: false });
+		assert.ok(prompt.includes("Include an `acceptanceReport` object"));
+		assert.ok(!prompt.includes("Mandatory:"));
+		assert.ok(!prompt.includes("```acceptance-report"));
+	});
+
+	it("report with notes passes the report schema (alias for manualNotes)", async () => {
+		const schema = acceptanceReportJsonSchema();
+		const result = await validateStructuredOutputValue(schema, { notes: "extra context" });
+		assert.equal(result.status, "valid");
+	});
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `acceptance.report: "on" | "off"` switch to the acceptance config that changes **how** the child delivers its acceptance report: as schema-validated structured output instead of a fenced JSON text block parsed from prose.

Motivation: the fenced-JSON report channel is parsed from the child's final text with a tolerant regex pipeline (enum synonym folding, wrapper keys, underscore fence tags). A malformed or missing block fails late and ambiguously. `structured_output` delivery already exists for `outputSchema` deliverables — this change reuses that machine-validated channel for the acceptance report, with format failures surfaced in-session (cheap retry) instead of post-hoc parsing.

## Behavior

| `acceptance.report` | Delivery | Validation | Termination |
|---|---|---|---|
| omitted / `"off"` | fenced `acceptance-report` JSON block (legacy) | post-hoc regex parse (unchanged) | unchanged |
| `"on"` without `outputSchema` | standalone `structured_output` tool, `value` = report | real JSON Schema (enum-strict `criteriaSatisfied[].status`, `commandsRun[].result`) | only a valid delivery terminates the step |
| `"on"` with `outputSchema` | single `structured_output` with `value` + `acceptanceReport` | deliverable + report both schema-validated | missing/invalid report throws in-session; child corrects and re-calls |

## Implementation notes

- `resolveAcceptanceReportMode()` resolves the switch once; foreground (`subagent-executor.ts`) and async (`async-execution.ts`) orchestration create a **report-only runtime** when `"on"` and no `outputSchema` exists (no schema file materialized; report capture side file only).
- Child side (`subagent-prompt-runtime.ts`) registers the standalone tool when `PI_SUBAGENT_ACCEPTANCE_REPORT_REQUIRED=1` and the structured-output env vars are absent; the piggyback branch validates `acceptanceReport` against the real report schema and refuses delivery without it when required.
- Parent read sides (`execution.ts` foreground, `subagent-runner.ts` async) gain a `reportOnly` branch: skip `readStructuredOutput` (output.json is never written), read the report capture; missing required report fails the run with `MISSING_ACCEPTANCE_REPORT_ERROR`.
- `formatAcceptancePrompt` emits mode-correct instructions (standalone "value is the report" wording vs piggyback "include acceptanceReport" wording) and drops the fenced template for structured delivery.
- The report schema includes the `notes` field accepted by the legacy parser (`manualNotes` alias).
- Backward compatibility: omitted `report` leaves every default template and behavior byte-identical.

## Testing

- New `test/unit/acceptance-report-mode.test.ts` (15 tests): mode resolution matrix, report-only/piggyback runtime shapes, schema validation positive/negative, prompt templates for all four mode combinations, `notes` schema acceptance.
- `npm run typecheck` passes.
- Full unit suite: normalized failure-set diff vs clean HEAD shows zero new failures.