### PR TITLE
fix(windows): spawn Pi JavaScript overrides with Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 - Establish async lifecycle sidecars before external CLI workers can mutate a worktree, so a disappeared runner is reconciled to a failed run. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1764.
 - Preserve explicit read-only intent when escaped line separators surround no-edit wording, so workflow delegates do not trigger the completion mutation guard. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1765.
+- Launch child Pi processes through the resolved CLI JavaScript on Windows hosts and run JavaScript `PI_SUBAGENT_PI_BINARY` overrides with Node. Thanks [@caohuipeng](https://github.com/caohuipeng) for #1768.
 
 ## [0.61.0] - 2026-08-31
 

--- a/src/runs/shared/pi-spawn.ts
+++ b/src/runs/shared/pi-spawn.ts
@@ -58,12 +58,16 @@ interface PiSpawnCommand {
 	args: string[];
 }
 
+function isNodeScriptPath(filePath: string): boolean {
+	return /\.(?:mjs|cjs|js)$/i.test(filePath);
+}
+
 function isRunnableNodeScript(
 	filePath: string,
 	existsSync: (filePath: string) => boolean,
 ): boolean {
 	if (!existsSync(filePath)) return false;
-	return /\.(?:mjs|cjs|js)$/i.test(filePath);
+	return isNodeScriptPath(filePath);
 }
 
 function normalizePath(filePath: string): string {
@@ -140,9 +144,16 @@ export function getPiSpawnCommand(
 	args: string[],
 	deps: PiSpawnDeps = {},
 ): PiSpawnCommand {
+	const platform = deps.platform ?? process.platform;
 	const env = deps.env ?? process.env;
 	const piBinary = env[PI_SUBAGENT_PI_BINARY_ENV]?.trim();
 	if (piBinary) {
+		if (platform === "win32" && isNodeScriptPath(piBinary)) {
+			return {
+				command: deps.execPath ?? process.execPath,
+				args: [piBinary, ...args],
+			};
+		}
 		return { command: piBinary, args };
 	}
 

--- a/test/unit/pi-spawn.test.ts
+++ b/test/unit/pi-spawn.test.ts
@@ -59,6 +59,33 @@ describe("getPiSpawnCommand", () => {
 		});
 	});
 
+	for (const extension of ["js", "mjs", "cjs"] as const) {
+		it(`runs a Windows ${extension} PI_SUBAGENT_PI_BINARY override through Node`, () => {
+			const piBinary = `C:\\Program Files\\pi\\bin\\pi-cli.${extension}`;
+			const args = ["--mode", "json", "Task: check output"];
+			const result = getPiSpawnCommand(args, {
+				platform: "win32",
+				execPath: "C:\\Program Files\\nodejs\\node.exe",
+				env: { PI_SUBAGENT_PI_BINARY: piBinary },
+			});
+			assert.deepEqual(result, {
+				command: "C:\\Program Files\\nodejs\\node.exe",
+				args: [piBinary, ...args],
+			});
+		});
+	}
+
+	it("keeps a JavaScript PI_SUBAGENT_PI_BINARY override direct on POSIX", () => {
+		const piBinary = "/opt/pi/bin/pi-cli.mjs";
+		const args = ["--mode", "json", "Task: check output"];
+		const result = getPiSpawnCommand(args, {
+			platform: "darwin",
+			execPath: "/usr/local/bin/node",
+			env: { PI_SUBAGENT_PI_BINARY: piBinary },
+		});
+		assert.deepEqual(result, { command: piBinary, args });
+	});
+
 	it("ignores a blank PI_SUBAGENT_PI_BINARY override", () => {
 		const args = ["--mode", "json", "Task: check output"];
 		const result = getPiSpawnCommand(args, {
@@ -148,6 +175,33 @@ describe("getPiSpawnCommand", () => {
 		const result = getPiSpawnCommand(args, deps);
 		assert.deepEqual(result, {
 			command: "/usr/local/bin/node",
+			args: [cliPath, ...args],
+		});
+	});
+
+	it("switches from bare pi to the installed CLI script when Windows resolution becomes available", () => {
+		const packageJsonPath = "/opt/pi/package.json";
+		const cliPath = path.resolve(
+			path.dirname(packageJsonPath),
+			"dist/cli/index.js",
+		);
+		let cliAvailable = false;
+		const deps = makeDeps({
+			platform: "win32",
+			execPath: "C:\\Program Files\\nodejs\\node.exe",
+			argv1: "/opt/pi-web/dist/server.js",
+			packageJsonPath,
+			packageJsonContent: JSON.stringify({ bin: { pi: "dist/cli/index.js" } }),
+			existing: [packageJsonPath],
+		});
+		deps.existsSync = (filePath) =>
+			filePath === packageJsonPath || (cliAvailable && filePath === cliPath);
+		const args = ["-p", "Task: hello"];
+
+		assert.deepEqual(getPiSpawnCommand(args, deps), { command: "pi", args });
+		cliAvailable = true;
+		assert.deepEqual(getPiSpawnCommand(args, deps), {
+			command: "C:\\Program Files\\nodejs\\node.exe",
 			args: [cliPath, ...args],
 		});
 	});


### PR DESCRIPTION
## Summary
- run Windows JavaScript `PI_SUBAGENT_PI_BINARY` overrides through Node instead of spawning the script directly
- keep non-JavaScript overrides direct and preserve POSIX override behavior
- cover the Windows package-CLI resolution path so wrapper hosts use the resolved Pi CLI JavaScript instead of falling back to bare `pi`

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/pi-spawn.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- same-writer challenge: no further change needed; baseline-source check failed the three new JavaScript override cases before the production fix
- fresh exact-head review `ab8932c8-153e-4a40-9c5f-0fce94679cc9`: no issues found

Fixes #1768.

Thanks [@caohuipeng](https://github.com/caohuipeng) for the report.
