### PR TITLE
fix: clarify steering receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Separate steer and follow-up receipt statuses from their redacted message previews (#1773).
 - Establish async lifecycle sidecars before external CLI workers can mutate a worktree, so a disappeared runner is reconciled to a failed run. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1764.
 - Preserve explicit read-only intent when escaped line separators surround no-edit wording, so workflow delegates do not trigger the completion mutation guard. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1765.
 - Launch child Pi processes through the resolved CLI JavaScript on Windows hosts and run JavaScript `PI_SUBAGENT_PI_BINARY` overrides with Node. Thanks [@caohuipeng](https://github.com/caohuipeng) for #1768.

--- a/src/runs/background/steering.ts
+++ b/src/runs/background/steering.ts
@@ -23,7 +23,10 @@ export function steeringMessagePreview(message: string): string {
 }
 
 export function steeringReceipt(message: string, receipt: string): string {
-	return `${receipt} Message: ${JSON.stringify(steeringMessagePreview(message))}`;
+	const preview = steeringMessagePreview(message);
+	const longestFence = Math.max(2, ...[...preview.matchAll(/`{3,}/g)].map((match) => match[0]!.length));
+	const fence = "`".repeat(longestFence + 1);
+	return `${receipt}\n\nMessage sent:\n${fence}text\n${preview}\n${fence}`;
 }
 
 export function createSteeringStatus(): SteeringStatus {

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -216,7 +216,7 @@ describe("async interrupt action", () => {
 			assert.equal(result.details.steering?.state, "delivered");
 			assert.equal(result.details.steering?.sourceRunId, childRunId);
 			assert.equal(request.message, "Focus on the failing test.");
-			assert.match(text(result), /Message: "Focus on the failing test\."/);
+			assert.match(text(result), /Message sent:\n```text\nFocus on the failing test\.\n```/);
 		} finally {
 			cleanup(workflowRunId, asyncDir);
 		}

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -252,7 +252,7 @@ describe("Herdr inspector", () => {
 			assert.match(dashboard, /decision-1: Choose UX/);
 			assert.match(dashboard, /closing it does not stop the run/i);
 
-			assert.match(submitInspectorControl({ asyncDir, runId: "run-123", refreshMs: 1_500 }, "steer keep going"), /Steering queued for run run-123\. Message: "keep going"/);
+			assert.match(submitInspectorControl({ asyncDir, runId: "run-123", refreshMs: 1_500 }, "steer keep going"), /Steering queued for run run-123\.\n\nMessage sent:\n```text\nkeep going\n```/);
 			assert.deepEqual(consumeSteerRequests(asyncDir).map((request) => ({ message: request.message, targetIndex: request.targetIndex, source: request.source })), [
 				{ message: "keep going", targetIndex: 0, source: "herdr-inspector" },
 			]);

--- a/test/unit/steering-action.test.ts
+++ b/test/unit/steering-action.test.ts
@@ -139,7 +139,7 @@ describe("acknowledged steering action", () => {
 			assert.equal(result.isError, undefined);
 			assert.equal(result.details.steering?.state, "delivered");
 			assert.match(result.content[0]!.text, /Steering delivered/);
-			assert.match(result.content[0]!.text, /Message: "correct course"/);
+			assert.match(result.content[0]!.text, /Message sent:\n```text\ncorrect course\n```/);
 		} finally {
 			removeAsyncDir(asyncDir);
 		}
@@ -330,7 +330,7 @@ describe("acknowledged steering action", () => {
 			const result = await action;
 			assert.equal(result.isError, undefined);
 			assert.equal(result.details.steering?.state, "recovered");
-			assert.match(result.content[0]!.text, /Message: "correct course"/);
+			assert.match(result.content[0]!.text, /Message sent:\n```text\ncorrect course\n```/);
 			assert.equal(result.details.steering?.replacementRunId, "replacement");
 			assert.ok(result.details.steering?.targets[0]?.lateDeliveredAt);
 			const limits = receivedLimits as { timeoutMs: number; absoluteDeadlineAt: number; toolBudget: unknown };

--- a/test/unit/steering.test.ts
+++ b/test/unit/steering.test.ts
@@ -3,17 +3,23 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { actionResultFromSteeringStatus, claimSteeringRecovery, createSteeringStatus, recordSteeringRequest, remainingSteeringRecoveryLimits, steeringMessagePreview, terminalSteeringNoticeState, updateSteeringTarget } from "../../src/runs/background/steering.ts";
+import { actionResultFromSteeringStatus, claimSteeringRecovery, createSteeringStatus, recordSteeringRequest, remainingSteeringRecoveryLimits, steeringMessagePreview, steeringReceipt, terminalSteeringNoticeState, updateSteeringTarget } from "../../src/runs/background/steering.ts";
 import { applySteeringRecoveryAgentConfig } from "../../src/runs/background/async-resume.ts";
 import type { AgentConfig } from "../../src/agents/agents.ts";
 
 describe("steering lifecycle ledger", () => {
-	it("redacts and bounds steering message previews", () => {
+	it("redacts, bounds, and separates steering message previews", () => {
 		const secret = "ghp_1234567890abcdef";
-		const preview = steeringMessagePreview(`Use ${secret}\n${"x".repeat(200)}`);
+		const message = `Use ${secret}\n${"x".repeat(200)}`;
+		const preview = steeringMessagePreview(message);
+		const receipt = steeringReceipt(message, "Steering delivered.");
 		assert.ok(preview.length <= 160);
 		assert.match(preview, /\[redacted\]/);
 		assert.doesNotMatch(preview, new RegExp(secret));
+		assert.match(receipt, /\[redacted\]/);
+		assert.doesNotMatch(receipt, new RegExp(secret));
+		assert.match(receipt, /^Steering delivered\.\n\nMessage sent:\n```text\n[\s\S]+\n```$/);
+		assert.match(steeringReceipt("review this:\n```\ntext\n```", "Steering queued."), /^Steering queued\.\n\nMessage sent:\n````text\n[\s\S]+\n````$/);
 	});
 
 	it("retains 20 recent requests while aggregate totals remain monotonic", () => {


### PR DESCRIPTION
## Summary

- make steer and follow-up receipts show the sent message in a separate `Message sent:` fenced text block
- keep receipt message text redacted and bounded through the existing steering preview formatter
- update async, workflow-foreground, and Herdr receipt tests

Fixes #1773.

## Validation

- `node --experimental-strip-types --test test/unit/steering.test.ts test/unit/steering-action.test.ts test/unit/async-interrupt-action.test.ts test/unit/herdr-inspector.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Full unit was attempted by the writer and is blocked by this worktree's missing `node_modules/oxlint/bin/oxlint`; no steering tests failed.
