### PR TITLE
fix: verify Windows Pi CLI package roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Establish async lifecycle sidecars before external CLI workers can mutate a worktree, so a disappeared runner is reconciled to a failed run. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1764.
 - Preserve explicit read-only intent when escaped line separators surround no-edit wording, so workflow delegates do not trigger the completion mutation guard. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1765.
 - Launch child Pi processes through the resolved CLI JavaScript on Windows hosts and run JavaScript `PI_SUBAGENT_PI_BINARY` overrides with Node. Thanks [@caohuipeng](https://github.com/caohuipeng) for #1768.
+- Resolve the installed Pi CLI for Windows wrapper hosts from the forwarded package root, and report a clear error when no verified CLI can be found. Thanks [@lux032](https://github.com/lux032) for #1780.
 
 ## [0.61.0] - 2026-08-31
 

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -19,7 +19,7 @@ import { injectOutputPathSystemPrompt, injectSingleOutputInstruction, normalizeS
 import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveExistingReadPaths, writeInitialProgressFile, type ChainStep, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import type { ContextMode } from "../shared/context-mode.ts";
-import { resolvePiPackageRoot } from "../shared/pi-spawn.ts";
+import { resolveInstalledPiPackageRoot, resolvePiPackageRoot } from "../shared/pi-spawn.ts";
 import { preflightLaunchCwd } from "../shared/launch-cwd.ts";
 import { resolveNodeExecutable } from "../../shared/node-executable.ts";
 import { backgroundProcessOptions } from "../shared/background-process-options.ts";
@@ -81,7 +81,7 @@ import { normalizeExtensionBindings, omitExtensionBindingsEnv, type ExtensionBin
 import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "../shared/lane-metadata.ts";
 
 const require = createRequire(import.meta.url);
-const piPackageRoot = resolvePiPackageRoot();
+const piPackageRoot = resolvePiPackageRoot() ?? resolveInstalledPiPackageRoot();
 
 function resolveJitiCliFromPackageJson(packageJsonPath: string): string | undefined {
 	if (!fs.existsSync(packageJsonPath)) return undefined;

--- a/src/runs/shared/pi-spawn.ts
+++ b/src/runs/shared/pi-spawn.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../shared/utils.ts";
 
 export const PI_CODING_AGENT_PACKAGE = "@earendil-works/pi-coding-agent";
 export const PI_SUBAGENT_PI_BINARY_ENV = "PI_SUBAGENT_PI_BINARY";
@@ -23,9 +24,13 @@ export function findPiPackageRootFromEntry(
 }
 
 export function resolveInstalledPiPackageRoot(): string | undefined {
-	return findPiPackageRootFromEntry(
-		fileURLToPath(import.meta.resolve(PI_CODING_AGENT_PACKAGE)),
-	);
+	try {
+		return findPiPackageRootFromEntry(
+			fileURLToPath(import.meta.resolve(PI_CODING_AGENT_PACKAGE)),
+		);
+	} catch {
+		return undefined;
+	}
 }
 
 export function resolvePiPackageRoot(): string | undefined {
@@ -58,6 +63,11 @@ interface PiSpawnCommand {
 	args: string[];
 }
 
+interface PiPackageJson {
+	name?: unknown;
+	bin?: string | Record<string, string>;
+}
+
 function isNodeScriptPath(filePath: string): boolean {
 	return /\.(?:mjs|cjs|js)$/i.test(filePath);
 }
@@ -79,6 +89,23 @@ function isStandalonePiExecutable(execPath: string): boolean {
 	return /^pi(?:\.exe)?$/i.test(executableName ?? "");
 }
 
+function resolvePiCliScriptFromPackageJson(
+	packageJsonPath: string,
+	readFileSync: (filePath: string, encoding: "utf-8") => string,
+	existsSync: (filePath: string) => boolean,
+): string | undefined {
+	const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PiPackageJson;
+	if (packageJson.name !== PI_CODING_AGENT_PACKAGE) return undefined;
+	const binField = packageJson.bin;
+	const binPath =
+		typeof binField === "string"
+			? binField
+			: (binField?.pi ?? Object.values(binField ?? {})[0]);
+	if (!binPath) return undefined;
+	const candidate = path.resolve(path.dirname(packageJsonPath), binPath);
+	return isRunnableNodeScript(candidate, existsSync) ? candidate : undefined;
+}
+
 export function resolvePiCliScript(
 	deps: PiSpawnDeps = {},
 ): string | undefined {
@@ -88,6 +115,7 @@ export function resolvePiCliScript(
 		deps.readFileSync ??
 		((filePath, encoding) => fs.readFileSync(filePath, encoding));
 	const argv1 = deps.argv1 ?? process.argv[1];
+	const env = deps.env ?? process.env;
 
 	if (argv1) {
 		const argvPath = normalizePath(argv1);
@@ -103,38 +131,28 @@ export function resolvePiCliScript(
 		}
 	}
 
-	try {
-		const resolvePackageJson =
-			deps.resolvePackageJson ??
-			(() => {
-				const root = deps.piPackageRoot ?? resolvePiPackageRoot();
-				if (root) return path.join(root, "package.json");
-				const packageRoot = deps.resolvePackageEntry
-					? findPiPackageRootFromEntry(deps.resolvePackageEntry())
-					: resolveInstalledPiPackageRoot();
-				if (!packageRoot)
-					throw new Error(
-						`Could not resolve ${PI_CODING_AGENT_PACKAGE} package root`,
-					);
-				return path.join(packageRoot, "package.json");
-			});
-		const packageJsonPath = resolvePackageJson();
-		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
-			bin?: string | Record<string, string>;
-		};
-		const binField = packageJson.bin;
-		const binPath =
-			typeof binField === "string"
-				? binField
-				: (binField?.pi ?? Object.values(binField ?? {})[0]);
-		if (!binPath) return undefined;
-		const candidate = path.resolve(path.dirname(packageJsonPath), binPath);
-		if (isRunnableNodeScript(candidate, existsSync)) {
-			return candidate;
+	const packageJsonCandidates: Array<() => string | undefined> = [];
+	if (deps.resolvePackageJson) packageJsonCandidates.push(deps.resolvePackageJson);
+	for (const root of [deps.piPackageRoot, env[PI_CODING_AGENT_PACKAGE_ROOT_ENV], resolvePiPackageRoot()]) {
+		const trimmed = root?.trim();
+		if (trimmed) packageJsonCandidates.push(() => path.join(trimmed, "package.json"));
+	}
+	packageJsonCandidates.push(() => {
+		const packageRoot = deps.resolvePackageEntry
+			? findPiPackageRootFromEntry(deps.resolvePackageEntry())
+			: resolveInstalledPiPackageRoot();
+		return packageRoot ? path.join(packageRoot, "package.json") : undefined;
+	});
+
+	for (const candidatePackageJson of packageJsonCandidates) {
+		try {
+			const packageJsonPath = candidatePackageJson();
+			if (!packageJsonPath) continue;
+			const candidate = resolvePiCliScriptFromPackageJson(packageJsonPath, readFileSync, existsSync);
+			if (candidate) return candidate;
+		} catch {
+			// Keep resolving; callers decide whether a PATH fallback is safe.
 		}
-	} catch {
-		// Verified CLI resolution is optional; falling back to `pi` lets PATH handle execution.
-		return undefined;
 	}
 
 	return undefined;
@@ -168,6 +186,11 @@ export function getPiSpawnCommand(
 			command: execPath,
 			args: [piCliPath, ...args],
 		};
+	}
+	if (platform === "win32") {
+		throw new Error(
+			`Could not resolve the Pi CLI on Windows. Set ${PI_SUBAGENT_PI_BINARY_ENV} or ensure ${PI_CODING_AGENT_PACKAGE} is installed.`,
+		);
 	}
 
 	return { command: "pi", args };

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -29,6 +29,8 @@ import { discoverAgents } from "../../src/agents/agents.ts";
 import { runSync } from "../../src/runs/foreground/execution.ts";
 import { ACTIVE_ASYNC_CAPACITY_DIR, acquireActiveAsyncCapacity, activeAsyncCapacitySessionKey, getActiveAsyncCapacitySnapshot } from "../../src/runs/background/active-async-capacity.ts";
 import { deriveForkPromptCacheKey, SUBAGENT_FORK_CACHE_KEY_ENV } from "../../src/runs/shared/pi-args.ts";
+import { resolveInstalledPiPackageRoot } from "../../src/runs/shared/pi-spawn.ts";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
 import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 
 interface LaunchResolvedExtensions {
@@ -567,6 +569,29 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf-8")) as AsyncStatusPayload;
 		assert.equal(status.state, "complete");
 		assert.equal(status.endedAt !== undefined, true);
+	});
+
+	it("forwards the installed Pi package root through the async runner environment", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const packageRoot = resolveInstalledPiPackageRoot();
+		assert.ok(packageRoot, "expected the test Pi package to be installed");
+		mockPi.onCall({ echoEnv: [PI_CODING_AGENT_PACKAGE_ROOT_ENV] });
+		const id = `async-package-root-env-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker",
+			task: "Report the forwarded package root.",
+			agentConfig: makeAgent("worker", { completionGuard: false }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-package-root-env" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, true);
+		assert.deepEqual(JSON.parse(payload.results[0]?.output ?? "{}"), {
+			[PI_CODING_AGENT_PACKAGE_ROOT_ENV]: packageRoot,
+		});
 	});
 
 	it("persists the bounded usage projection in async results and metadata", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/unit/herdr-inspector.test.ts
+++ b/test/unit/herdr-inspector.test.ts
@@ -369,6 +369,8 @@ describe("Herdr inspector", () => {
 
 	it("fails closed when an idle-only project pane close sees active work", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-project-pane-busy-"));
+		const previousPiBinary = process.env[PI_SUBAGENT_PI_BINARY_ENV];
+		process.env[PI_SUBAGENT_PI_BINARY_ENV] = path.join(root, "pi-bin");
 		try {
 			const projectRoot = fs.realpathSync(root);
 			const calls: string[][] = [];
@@ -394,12 +396,16 @@ describe("Herdr inspector", () => {
 			assert.equal(calls.some((args) => args.join(" ") === "pane close w1:p11"), false);
 			assert.equal(readHerdrProjectPaneBinding(root)?.paneId, "w1:p11");
 		} finally {
+			if (previousPiBinary === undefined) delete process.env[PI_SUBAGENT_PI_BINARY_ENV];
+			else process.env[PI_SUBAGENT_PI_BINARY_ENV] = previousPiBinary;
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});
 
 	it("preserves legacy model-facing recovery for transient and opaque pane inspection results", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-herdr-project-pane-legacy-"));
+		const previousPiBinary = process.env[PI_SUBAGENT_PI_BINARY_ENV];
+		process.env[PI_SUBAGENT_PI_BINARY_ENV] = path.join(root, "pi-bin");
 		try {
 			let splitCount = 0;
 			let getMode: "valid" | "timeout" | "opaque" = "valid";
@@ -436,6 +442,8 @@ describe("Herdr inspector", () => {
 			assert.match(text(closed), /INVALID_PANE_RESPONSE/);
 			assert.equal(readHerdrProjectPaneBinding(root)?.paneId, "w1:p32");
 		} finally {
+			if (previousPiBinary === undefined) delete process.env[PI_SUBAGENT_PI_BINARY_ENV];
+			else process.env[PI_SUBAGENT_PI_BINARY_ENV] = previousPiBinary;
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/pi-spawn.test.ts
+++ b/test/unit/pi-spawn.test.ts
@@ -8,6 +8,7 @@ import {
 	resolvePiCliScript,
 	type PiSpawnDeps,
 } from "../../src/runs/shared/pi-spawn.ts";
+import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
 
 function makeDeps(input: {
 	platform?: NodeJS.Platform;
@@ -116,7 +117,7 @@ describe("getPiSpawnCommand", () => {
 				execPath,
 				argv1: "/missing/host.js",
 				packageJsonPath,
-				packageJsonContent: JSON.stringify({ bin: { pi: "dist/cli.js" } }),
+				packageJsonContent: JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/cli.js" } }),
 				existing: [packageJsonPath, cliPath],
 			});
 			const args = ["--mode", "json", "-p", "Task: review diff"];
@@ -168,7 +169,7 @@ describe("getPiSpawnCommand", () => {
 			execPath: "/usr/local/bin/node",
 			argv1: "/opt/pi/subagent-runner.ts",
 			packageJsonPath,
-			packageJsonContent: JSON.stringify({ bin: { pi: "dist/cli/index.js" } }),
+			packageJsonContent: JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/cli/index.js" } }),
 			existing: [packageJsonPath, cliPath],
 		});
 		const args = ["-p", "Task: hello"];
@@ -179,7 +180,7 @@ describe("getPiSpawnCommand", () => {
 		});
 	});
 
-	it("switches from bare pi to the installed CLI script when Windows resolution becomes available", () => {
+	it("fails closed until the Windows CLI script becomes available", () => {
 		const packageJsonPath = "/opt/pi/package.json";
 		const cliPath = path.resolve(
 			path.dirname(packageJsonPath),
@@ -191,19 +192,82 @@ describe("getPiSpawnCommand", () => {
 			execPath: "C:\\Program Files\\nodejs\\node.exe",
 			argv1: "/opt/pi-web/dist/server.js",
 			packageJsonPath,
-			packageJsonContent: JSON.stringify({ bin: { pi: "dist/cli/index.js" } }),
+			packageJsonContent: JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/cli/index.js" } }),
 			existing: [packageJsonPath],
 		});
 		deps.existsSync = (filePath) =>
 			filePath === packageJsonPath || (cliAvailable && filePath === cliPath);
 		const args = ["-p", "Task: hello"];
 
-		assert.deepEqual(getPiSpawnCommand(args, deps), { command: "pi", args });
+		assert.throws(
+			() => getPiSpawnCommand(args, deps),
+			/Could not resolve the Pi CLI on Windows/,
+		);
 		cliAvailable = true;
 		assert.deepEqual(getPiSpawnCommand(args, deps), {
 			command: "C:\\Program Files\\nodejs\\node.exe",
 			args: [cliPath, ...args],
 		});
+	});
+
+	it("resolves the Windows CLI from the forwarded package-root env for wrapper hosts", () => {
+		const packageJsonPath = "/opt/pi/package.json";
+		const cliPath = path.resolve(
+			path.dirname(packageJsonPath),
+			"dist/cli/index.js",
+		);
+		const args = ["-p", "Task: hello"];
+		const result = getPiSpawnCommand(args, {
+			platform: "win32",
+			execPath: "C:\\Program Files\\nodejs\\node.exe",
+			argv1: "/opt/pi-web/dist/server.js",
+			env: { [PI_CODING_AGENT_PACKAGE_ROOT_ENV]: "/opt/pi" },
+			existsSync: (filePath) => filePath === packageJsonPath || filePath === cliPath,
+			readFileSync: () => JSON.stringify({
+				name: "@earendil-works/pi-coding-agent",
+				bin: { pi: "dist/cli/index.js" },
+			}),
+		});
+
+		assert.deepEqual(result, {
+			command: "C:\\Program Files\\nodejs\\node.exe",
+			args: [cliPath, ...args],
+		});
+	});
+
+	it("skips an unverified forwarded package-root env before resolving a verified Pi package", () => {
+		const tempDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "pi-spawn-unverified-env-root-"),
+		);
+		try {
+			const wrongRoot = path.join(tempDir, "not-pi");
+			const wrongCli = path.join(wrongRoot, "bin", "evil.js");
+			const piRoot = path.join(tempDir, "node_modules", "@earendil-works", "pi-coding-agent");
+			const piEntry = path.join(piRoot, "dist", "index.js");
+			const piCli = path.join(piRoot, "dist", "cli.js");
+			fs.mkdirSync(path.dirname(wrongCli), { recursive: true });
+			fs.mkdirSync(path.dirname(piCli), { recursive: true });
+			fs.writeFileSync(wrongCli, "console.log('evil');\n");
+			fs.writeFileSync(path.join(wrongRoot, "package.json"), JSON.stringify({ name: "not-pi", bin: { pi: "bin/evil.js" } }));
+			fs.writeFileSync(piEntry, "export {};\n");
+			fs.writeFileSync(piCli, "#!/usr/bin/env node\n");
+			fs.writeFileSync(path.join(piRoot, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/cli.js" } }));
+
+			const result = getPiSpawnCommand(["-p", "Task: hello"], {
+				platform: "win32",
+				execPath: "C:\\Program Files\\nodejs\\node.exe",
+				argv1: "/opt/pi-web/dist/server.js",
+				env: { [PI_CODING_AGENT_PACKAGE_ROOT_ENV]: wrongRoot },
+				resolvePackageEntry: () => piEntry,
+			});
+
+			assert.deepEqual(result, {
+				command: "C:\\Program Files\\nodejs\\node.exe",
+				args: [piCli, "-p", "Task: hello"],
+			});
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("falls back to plain pi command on POSIX when CLI script cannot be resolved", () => {
@@ -335,23 +399,12 @@ describe("getPiSpawnCommand", () => {
 			execPath: "/usr/local/bin/node",
 			argv1: "/opt/pi/subagent-runner.ts",
 			packageJsonPath,
-			packageJsonContent: JSON.stringify({ bin: { pi: "dist/cli/index.js" } }),
+			packageJsonContent: JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/cli/index.js" } }),
 			existing: [packageJsonPath, cliPath],
 		});
 		const result = getPiSpawnCommand(["-p", "Task: hello"], deps);
 		assert.equal(result.command, "/usr/local/bin/node");
 		assert.equal(result.args[0], cliPath);
-	});
-
-	it("falls back to pi when Windows CLI script cannot be resolved", () => {
-		const deps = makeDeps({
-			platform: "win32",
-			argv1: "/opt/pi/subagent-runner.ts",
-			existing: [],
-		});
-		const args = ["-p", "Task: hello"];
-		const result = getPiSpawnCommand(args, deps);
-		assert.deepEqual(result, { command: "pi", args });
 	});
 
 	it("walks from package main entry to resolve package bin", () => {
@@ -405,7 +458,7 @@ describe("getPiSpawnCommand with piPackageRoot", () => {
 			execPath: "/usr/local/bin/node",
 			argv1: "/opt/pi/subagent-runner.ts",
 			packageJsonPath,
-			packageJsonContent: JSON.stringify({ bin: { pi: "dist/cli/index.js" } }),
+			packageJsonContent: JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: { pi: "dist/cli/index.js" } }),
 			existing: [packageJsonPath, cliPath],
 		});
 		deps.piPackageRoot = "/opt/pi";
@@ -426,7 +479,7 @@ describe("resolvePiCliScript", () => {
 			platform: "win32",
 			argv1: "/opt/pi/subagent-runner.ts",
 			packageJsonPath,
-			packageJsonContent: JSON.stringify({ bin: "dist/cli/index.mjs" }),
+			packageJsonContent: JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: "dist/cli/index.mjs" }),
 			existing: [packageJsonPath, cliPath],
 		});
 		assert.equal(resolvePiCliScript(deps), cliPath);

--- a/test/unit/profiles.test.ts
+++ b/test/unit/profiles.test.ts
@@ -37,6 +37,7 @@ describe("profiles helpers", () => {
 		homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subprofiles-home-"));
 		process.env.HOME = homeDir;
 		process.env.USERPROFILE = homeDir;
+		process.env[PI_SUBAGENT_PI_BINARY_ENV] = path.join(homeDir, "pi-test-bin");
 	});
 
 	afterEach(() => {

--- a/test/unit/project-panes-public-api.test.ts
+++ b/test/unit/project-panes-public-api.test.ts
@@ -30,6 +30,8 @@ describe("public project-panes package export", () => {
 
 	it("runs the structured lifecycle and verifies pane ownership before idle close", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-"));
+		const previousPiBinary = process.env.PI_SUBAGENT_PI_BINARY;
+		process.env.PI_SUBAGENT_PI_BINARY = path.join(root, "pi-bin");
 		try {
 			const projectRoot = fs.realpathSync(root);
 			const calls: string[][] = [];
@@ -76,6 +78,8 @@ describe("public project-panes package export", () => {
 			assert.ok(calls.some((args) => args.join(" ") === "tab focus tab-20"));
 			assert.ok(calls.some((args) => args.join(" ") === "pane close w1:p20"));
 		} finally {
+			if (previousPiBinary === undefined) delete process.env.PI_SUBAGENT_PI_BINARY;
+			else process.env.PI_SUBAGENT_PI_BINARY = previousPiBinary;
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});
@@ -131,6 +135,8 @@ describe("public project-panes package export", () => {
 
 	it("returns a structured error and closes the pane when binding persistence fails", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-public-project-pane-write-failure-"));
+		const previousPiBinary = process.env.PI_SUBAGENT_PI_BINARY;
+		process.env.PI_SUBAGENT_PI_BINARY = path.join(root, "pi-bin");
 		try {
 			fs.mkdirSync(path.join(root, ".pi"));
 			fs.writeFileSync(path.join(root, ".pi/subagents"), "directory collision");
@@ -152,6 +158,8 @@ describe("public project-panes package export", () => {
 			}
 			assert.ok(calls.some((args) => args.join(" ") === "pane close w1:p24"));
 		} finally {
+			if (previousPiBinary === undefined) delete process.env.PI_SUBAGENT_PI_BINARY;
+			else process.env.PI_SUBAGENT_PI_BINARY = previousPiBinary;
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});


### PR DESCRIPTION
## Summary
- verify automatic Pi package-root candidates before launching their `bin.pi` script
- forward the installed Pi package root through async runner startup for wrapper hosts
- fail closed on Windows when no verified runnable Pi CLI script can be found while preserving POSIX PATH fallback

Closes #1780.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/pi-spawn.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'forwards the installed Pi package root through the async runner environment' test/integration/async-execution.test.ts`\n- `npm run typecheck`\n- `git diff --check`\n\nThanks [@lux032](https://github.com/lux032) for the report in #1780.