### PR TITLE
fix: align async fork sessions with child cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add session-only durable schedules that execute only in their creating session. Thanks [@yangfeng20](https://github.com/yangfeng20) for #1777.
 
 ### Fixed
+- Align async forked session headers with an explicit child cwd before initial and resumed background launches. Thanks [@stekman08](https://github.com/stekman08) for #1785.
 - Tolerate JSON-encoded acceptance objects from model tool calls by normalizing them before validation, while preserving clear failures for malformed strings. Thanks [@mapleluvr](https://github.com/mapleluvr) for #1781.
 - Separate steer and follow-up receipt statuses from their redacted message previews (#1773).
 - Establish async lifecycle sidecars before external CLI workers can mutate a worktree, so a disappeared runner is reconciled to a failed run. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1764.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -77,6 +77,7 @@ import {
 } from "../shared/parallel-utils.ts";
 import { applyThinkingSuffix, buildPiArgs, cleanupTempDir, deriveForkPromptCacheKey, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan, type SubagentTaskDelivery } from "../shared/pi-args.ts";
 import { deriveChildSessionName } from "../../shared/child-session-name.ts";
+import { alignForkedSessionCwd } from "../../shared/fork-session-cwd.ts";
 import { readRuntimeAcknowledgedExtensions } from "../shared/runtime-acknowledged-extensions.ts";
 import { outputEntryFromAsyncResult, resolveOutputReferences } from "../shared/chain-outputs.ts";
 import { clearStructuredOutputCaptures, createStructuredOutputRuntime, MISSING_STRUCTURED_OUTPUT_CALL_ERROR, readStructuredOutput, readStructuredOutputAcceptanceReport } from "../shared/structured-output.ts";
@@ -1628,6 +1629,9 @@ async function runSingleStepInner(
 	const effectiveCwd = step.cwd ?? ctx.cwd;
 	const cwdError = preflightLaunchCwd(step.requestedCwd ?? effectiveCwd, effectiveCwd);
 	if (cwdError) return { agent: step.agent, output: cwdError, error: cwdError, exitCode: 1, context: step.context };
+	if (step.context === "fork" && step.sessionFile && fs.existsSync(step.sessionFile)) {
+		alignForkedSessionCwd(step.sessionFile, effectiveCwd);
+	}
 
 	const candidates = step.modelCandidates !== undefined
 		? step.modelCandidates.length > 0 ? step.modelCandidates : [undefined]

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
 import { discoverAgents, formatUnknownAgentError, unknownAgentDiagnosticContext, type AgentConfig } from "../../agents/agents.ts";
 import { appendAgentRefinementOverlay } from "../../agents/agent-refinements.ts";
-import { alignForkedSessionCwd } from "../../shared/fork-context.ts";
+import { alignForkedSessionCwd } from "../../shared/fork-session-cwd.ts";
 import {
 	ensureArtifactsDir,
 	formatOutputArtifactContent,

--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -174,18 +174,6 @@ function readSessionEntries(sessionFile: string): BranchSessionEntry[] {
 	});
 }
 
-/** Keep Pi from restoring a forked session into the parent's cwd instead of the child launch cwd. */
-export function alignForkedSessionCwd(sessionFile: string, cwd: string): void {
-	const entries = readSessionEntries(sessionFile);
-	const header = entries[0];
-	if (header?.type !== "session") throw new Error(`Forked session ${sessionFile} does not start with a session header.`);
-	const resolvedCwd = path.resolve(cwd);
-	const effectiveCwd = fs.realpathSync.native(resolvedCwd);
-	if (header.cwd === effectiveCwd) return;
-	header.cwd = effectiveCwd;
-	fs.writeFileSync(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf-8");
-}
-
 export function createForkContextResolver(
 	sessionManager: ForkableSessionManager,
 	requestedContext: unknown,

--- a/src/shared/fork-session-cwd.ts
+++ b/src/shared/fork-session-cwd.ts
@@ -1,0 +1,27 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+interface SessionEntry {
+	type?: string;
+	cwd?: string;
+	[key: string]: unknown;
+}
+
+/** Keep Pi from restoring a forked session into the parent's cwd instead of the child launch cwd. */
+export function alignForkedSessionCwd(sessionFile: string, cwd: string): void {
+	const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter((line) => line.trim().length > 0);
+	const entries = lines.map((line, index) => {
+		try {
+			return JSON.parse(line) as SessionEntry;
+		} catch (error) {
+			const cause = error instanceof Error ? error : new Error(String(error));
+			throw new Error(`Unable to inspect forked session ${sessionFile}: invalid JSONL on line ${index + 1}: ${cause.message}`, { cause });
+		}
+	});
+	const header = entries[0];
+	if (header?.type !== "session") throw new Error(`Forked session ${sessionFile} does not start with a session header.`);
+	const effectiveCwd = fs.realpathSync.native(path.resolve(cwd));
+	if (header.cwd === effectiveCwd) return;
+	header.cwd = effectiveCwd;
+	fs.writeFileSync(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf-8");
+}

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -4995,6 +4995,59 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(args[args.indexOf("--model") + 1], "mock/fallback");
 	});
 
+	it("aligns initial and resumed background forked sessions with an explicit child cwd", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		mockPi.onCall({ output: "Forked async work" });
+		const parentCwd = fs.realpathSync(tempDir);
+		const childCwd = path.join(tempDir, "child-cwd");
+		fs.mkdirSync(childCwd);
+		const parentSessionFile = path.join(tempDir, "parent-cross-cwd.jsonl");
+		const forkedSessionFile = path.join(tempDir, "forked-cross-cwd.jsonl");
+		const parentHeader = { type: "session", version: 1, id: "parent", cwd: parentCwd };
+		const childHeader = { type: "session", version: 1, id: "child", cwd: parentCwd, parentSession: parentSessionFile };
+		fs.writeFileSync(parentSessionFile, `${JSON.stringify(parentHeader)}\n`, "utf-8");
+		fs.writeFileSync(forkedSessionFile, `${JSON.stringify(childHeader)}\n`, "utf-8");
+		const ctx = {
+			...makeMinimalCtx(parentCwd),
+			sessionManager: {
+				getSessionId: () => "session-cross-cwd",
+				getSessionFile: () => parentSessionFile,
+				getLeafId: () => "leaf-current",
+				openSession: () => ({ createBranchedSession: () => forkedSessionFile }),
+			},
+		};
+
+		const executor = makeAsyncExecutor([makeAgent("worker")]);
+		const launch = await executor.execute(
+			"forked-cross-cwd",
+			{ agent: "worker", task: "Do work", async: true, context: "fork", cwd: childCwd },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		) as AsyncExecutionResult;
+		assert.ok(!launch.isError, launch.content[0]?.text);
+		assert.ok(launch.details.asyncId);
+		await readAsyncPayload(launch.details.asyncId);
+
+		const sessionHeader = JSON.parse(fs.readFileSync(forkedSessionFile, "utf-8").split("\n", 1)[0]!) as { cwd?: string };
+		assert.equal(sessionHeader.cwd, fs.realpathSync.native(childCwd));
+
+		fs.writeFileSync(forkedSessionFile, `${JSON.stringify(childHeader)}\n`, "utf-8");
+		mockPi.onCall({ output: "Resumed async work" });
+		const resumed = await executor.execute(
+			"resume-cross-cwd",
+			{ action: "resume", id: launch.details.asyncId, message: "Continue" },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		) as AsyncExecutionResult;
+		assert.ok(!resumed.isError, resumed.content[0]?.text);
+		assert.ok(resumed.details.asyncId);
+		await readAsyncPayload(resumed.details.asyncId);
+
+		const resumedHeader = JSON.parse(fs.readFileSync(forkedSessionFile, "utf-8").split("\n", 1)[0]!) as { cwd?: string };
+		assert.equal(resumedHeader.cwd, fs.realpathSync.native(childCwd));
+	});
+
 	it("background forked runs inherit a parent model outside the registry", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		mockPi.onCall({ output: "Forked async work" });
 		const parentSessionFile = path.join(tempDir, "parent.jsonl");


### PR DESCRIPTION
## Summary
- rewrite the forked session header cwd to the child effective cwd before launching background runs
- apply the same alignment when resuming retained async fork runs
- cover initial async fork launch and resume with explicit cwd regressions

## Verification
- `npm run typecheck`
- full unit and integration test suite
- targeted async execution regression tests
- detached runtime import tests

This fixes background `context: "fork"` runs retaining the parent session cwd even when the child was launched with an explicit cwd. No human approval is required for the downstream pin; it remains pinned to commit `1aa8305e` until an upstream release contains this change.