### PR TITLE
fix: preserve read-only async resume evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Preserve coordinated read-only intent when resuming direct async children and surface captured structured output in completion and status evidence. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1788.
+
 ## [0.62.0] - 2026-08-31
 
 ### Highlights

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -420,6 +420,18 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 	const handoffPath = typeof parallelHandoff?.path === "string" ? parallelHandoff.path : undefined;
 	const rawRunId = typeof result.runId === "string" ? result.runId : typeof result.id === "string" ? result.id : undefined;
 	const workflowRunId = (result.mode === "workflow" || agent === "workflow") && rawRunId ? rawRunId : undefined;
+	const directChild = !workflowRunId && result.results?.length === 1 ? result.results[0]! : undefined;
+	const directStructuredPreview = directChild
+		? childInlinePreview(directChild).preview
+		: undefined;
+	const directSummary = summary.trim();
+	const directAgent = typeof directChild?.agent === "string" ? directChild.agent : agent;
+	const directNoOutputSummary = directChild && (!directSummary
+		|| directSummary === "(no output)"
+		|| (directAgent && directSummary === `${directAgent}:\n(no output)`));
+	const resultPreview = directStructuredPreview && directNoOutputSummary
+		? `Structured output:\n${directStructuredPreview}`
+		: summary;
 	const childRuns = result.results?.flatMap((child) => {
 		const runId = typeof child.runId === "string" && child.runId.trim() ? child.runId.trim() : undefined;
 		const workflowKey = typeof child.workflowKey === "string" && child.workflowKey.trim() ? child.workflowKey.trim() : undefined;
@@ -468,7 +480,7 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 		...(scheduleOrigin ? { scheduleOrigin } : {}),
 		...(result.source ? { source: result.source } : {}),
 		...(taskInfo ? { taskInfo } : {}),
-		resultPreview: summary,
+		resultPreview,
 		...(typeof result.durationMs === "number" ? { durationMs: result.durationMs } : {}),
 		...(handoffPath ? { handoffPath } : {}),
 		...(workflowRunId ? { workflowRunId } : {}),

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -551,6 +551,9 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				const display = runStatusStepDisplayName(step);
 				const phase = step.phase ? `[${step.phase}] ` : "";
 				lines.push(`${stepLineLabel(status, index)}: ${phase}${display} ${step.status}${modelText}${stepActivityText ? `, ${stepActivityText}` : ""}${steeringSuffix}${acceptanceText}${budgetText}${errorText}`);
+				const structuredOutputPreview = step.structuredOutput === undefined ? undefined : formatWorkflowJsonPreview(step.structuredOutput, 4_000);
+				if (structuredOutputPreview !== undefined) lines.push(`  Structured output: ${structuredOutputPreview}`);
+				if (step.structuredOutputPath) lines.push(`  Structured output path: ${step.structuredOutputPath}`);
 				lines.push(...formatTimeoutRecoveryLines(step.timeoutRecovery, "  "));
 				if (step.runner?.type === "external-cli") {
 					const runner = normalizeExternalCliRunnerStatus(step.runner);
@@ -670,7 +673,14 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			if (data.parallelHandoff?.path) lines.push(`Parallel handoff: ${data.parallelHandoff.path}`);
 			const children = Array.isArray(data.results) ? data.results : data.agent ? [{ agent: data.agent, sessionFile: data.sessionFile }] : [];
 			lines.push(...formatTimeoutRecoveryLines(data.timeoutRecovery, "  "));
-			for (const child of children) lines.push(...formatTimeoutRecoveryLines(child.timeoutRecovery, "  "));
+			for (const [index, child] of children.entries()) {
+				const structuredOutput = (child as { structuredOutput?: unknown }).structuredOutput;
+				const structuredOutputPreview = structuredOutput === undefined ? undefined : formatWorkflowJsonPreview(structuredOutput, 4_000);
+				if (structuredOutputPreview !== undefined) lines.push(`  Structured output${children.length > 1 ? ` (${index + 1})` : ""}: ${structuredOutputPreview}`);
+				const structuredOutputPath = (child as { structuredOutputPath?: unknown }).structuredOutputPath;
+				if (typeof structuredOutputPath === "string" && structuredOutputPath.trim()) lines.push(`  Structured output path${children.length > 1 ? ` (${index + 1})` : ""}: ${structuredOutputPath}`);
+				lines.push(...formatTimeoutRecoveryLines(child.timeoutRecovery, "  "));
+			}
 			lines.push(formatResumeGuidance(runId, children, data.sessionFile, { stopped: status === "stopped" }));
 			if (data.summary) lines.push("", data.summary);
 			const workflowChildren = parseWorkflowChildSummary((data as unknown as Record<string, unknown>).workflowChildren);

--- a/src/runs/background/wait-completions.ts
+++ b/src/runs/background/wait-completions.ts
@@ -42,6 +42,15 @@ function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+const STRUCTURED_OUTPUT_INLINE_LIMIT_BYTES = 4 * 1024;
+
+export function projectStructuredOutput(value: unknown): unknown {
+	if (value === undefined) return undefined;
+	const serialized = JSON.stringify(value);
+	if (typeof serialized !== "string") throw new Error("Structured output must be JSON-serializable");
+	return Buffer.byteLength(serialized, "utf8") <= STRUCTURED_OUTPUT_INLINE_LIMIT_BYTES ? JSON.parse(serialized) : undefined;
+}
+
 /**
  * Project a terminal result payload into the slim shape that is safe to surface in
  * tool_result details: run identity, per-child outcome, and the artifact trail.
@@ -65,6 +74,8 @@ export function toWaitCompletion(data: Record<string, unknown>, runId: string): 
 			const sessionFile = asNonEmptyString(child.sessionFile);
 			const error = asNonEmptyString(child.error);
 			const model = asNonEmptyString(child.model);
+			const structuredOutput = projectStructuredOutput(child.structuredOutput);
+			const structuredOutputPath = asNonEmptyString(child.structuredOutputPath);
 			const contextOverflow = child.contextOverflow === true;
 			const timeoutRecovery = projectTimeoutRecovery(child.timeoutRecovery);
 			return [{
@@ -74,6 +85,8 @@ export function toWaitCompletion(data: Record<string, unknown>, runId: string): 
 				...(sessionFile ? { sessionFile } : {}),
 				...(typeof child.success === "boolean" ? { success: child.success } : {}),
 				...(outputState ? { outputState } : {}),
+				...(structuredOutput !== undefined ? { structuredOutput } : {}),
+				...(structuredOutputPath ? { structuredOutputPath } : {}),
 				...(error ? { error } : {}),
 				...(model ? { model } : {}),
 				...(contextOverflow ? { contextOverflow: true } : {}),

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -41,6 +41,7 @@ const REVIEWER_REQUIRED_EDIT_PATTERNS = [
 // Accept serialized line separators too: workflow prompts can carry literal
 // `\\n`/`\\r\\n` between clauses instead of decoded newlines.
 const NO_EDIT_PROHIBITION_PATTERN = /(?:\b|\\(?:r\\n|n))(?:do not|don't|must not)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b((?:(?!\b(?:but|and|then)\b|\\(?:r\\n|n))[^.;,:!?\n–—-])*)/gi;
+const COORDINATED_NO_EDIT_PROHIBITION_PATTERN = /(?:\b|\\(?:r\\n|n))(?:do not|don't|must not)\s+((?=(?:(?!\\(?:r\\n|n))[^.;:!?\n–—-])*\b(?:and|or)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b)(?:(?!\\(?:r\\n|n))[^.;:!?\n–—-])*?\b(?:and|or)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b(?:(?!\b(?:but|and|then)\b|\\(?:r\\n|n))[^.;,:!?\n–—-])*)/gi;
 
 /** Objects of a no-edit prohibition that mean "the codebase in general" rather than a named scope. */
 const GENERIC_PROHIBITION_OBJECT = /^\s*(?:(?:any|all|the|these|those|your|our|existing|project|product|source|sources|config|configs|repo|repository)[\s/,-]*)*(?:files?|code|codebase|sources?|anything|repo(?:sitory)?)?\s*$/i;
@@ -144,11 +145,13 @@ function analyzeNoEditProhibitions(taskText: string): NoEditProhibitionAnalysis 
 		|| NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText));
 	let blanket = present;
 	let strippedText = stripPatterns(taskText, [...REVIEW_ONLY_PATTERNS, ...NO_TOOL_INTENT_PATTERNS]);
-	strippedText = strippedText.replace(new RegExp(NO_EDIT_PROHIBITION_PATTERN.source, NO_EDIT_PROHIBITION_PATTERN.flags), (match, object: string, offset: number, source: string) => {
+	const stripNoEditProhibition = (match: string, object: string, offset: number, source: string): string => {
 		present = true;
 		if (GENERIC_PROHIBITION_OBJECT.test(object) && !hasScopedProhibitionContinuation(source.slice(offset + match.length))) blanket = true;
 		return " ";
-	});
+	};
+	strippedText = strippedText.replace(new RegExp(COORDINATED_NO_EDIT_PROHIBITION_PATTERN.source, COORDINATED_NO_EDIT_PROHIBITION_PATTERN.flags), stripNoEditProhibition);
+	strippedText = strippedText.replace(new RegExp(NO_EDIT_PROHIBITION_PATTERN.source, NO_EDIT_PROHIBITION_PATTERN.flags), stripNoEditProhibition);
 	// Restore boundaries after stripping a prohibition from serialized prompts.
 	strippedText = strippedText.replace(/\\(?:r\\n|n)/g, "\n");
 	return { present, blanket, strippedText };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1307,6 +1307,8 @@ export interface WaitCompletionChild {
 	sessionFile?: string;
 	success?: boolean;
 	outputState?: SubagentOutputState;
+	structuredOutput?: unknown;
+	structuredOutputPath?: string;
 	error?: string;
 	model?: string;
 	contextOverflow?: boolean;

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -709,6 +709,20 @@ describe("completion formatting helpers", () => {
 		assert.equal(details.agent, "unknown");
 		assert.equal(details.status, "completed");
 	});
+
+	it("surfaces direct structured output when the completion has no text output", () => {
+		const details = buildCompletionDetails({
+			id: "structured-run",
+			agent: "delegate",
+			success: true,
+			summary: "delegate:\n(no output)",
+			results: [{ agent: "delegate", output: "", structuredOutput: { payload: { ok: true } }, success: true }],
+		});
+
+		assert.match(details.resultPreview, /Structured output:/);
+		assert.match(details.resultPreview, /"ok": true/);
+		assert.match(formatSingleCompletion(details), /"ok": true/);
+	});
 });
 
 describe("scheduled completions", () => {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -1446,6 +1446,8 @@ describe("async run status inspection", () => {
 				results: [{
 					agent: "worker",
 					success: false,
+					structuredOutput: { payload: { ok: true } },
+					structuredOutputPath: "/runs/structured-output/output.json",
 					timeoutRecovery: {
 						termination: "timed-out",
 						changedFiles: ["input.md"],
@@ -1470,6 +1472,8 @@ describe("async run status inspection", () => {
 			assert.match(text, /Recovery needed: review the diff and artifacts before resuming or launching dependent stages\./);
 			assert.match(text, /requested report: missing/);
 			assert.match(text, /changed tracked files: input\.md/);
+			assert.match(text, /Structured output: \{"payload":\{"ok":true\}\}/);
+			assert.match(text, /Structured output path: \/runs\/structured-output\/output\.json/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -40,6 +40,22 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests and fixtures").kind, "read-only");
 	});
 
+	it("recognizes coordinated read-only prohibitions", () => {
+		for (const task of [
+			"Do not read more files, run commands, or edit anything.",
+			"Do not read more files, run commands, and edit anything.",
+			"Do not read files or modify anything.",
+		]) {
+			assert.notEqual(classifyTaskMutationIntent("worker", task).kind, "implementation", task);
+			assert.equal(expectsImplementationMutation("worker", task), false, task);
+			assert.equal(taskMayMutate(task), false, task);
+		}
+		assert.equal(classifyTaskMutationIntent("worker", "Do not read more files, run commands, or edit anything; implement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not read more files, run commands, or edit anything\\r\\nImplement the fix").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not read more files\\r\\nImplement or edit the fix").kind, "implementation");
+		assert.equal(taskMayMutate("Do not read more files\\r\\nImplement or edit the fix"), true);
+	});
+
 	it("lets blanket no-edit prohibitions win over write verbs", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Implement this. Do not edit files.").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("worker", "Do not edit files. Tell me how to fix the bug.").kind, "read-only");

--- a/test/unit/wait-completions.test.ts
+++ b/test/unit/wait-completions.test.ts
@@ -66,6 +66,40 @@ describe("workflow wait completion projection", () => {
 		assert.doesNotMatch(JSON.stringify(completion), /raw recovery message|settlementDiagnostic/);
 	});
 
+	it("retains captured structured output and its durable artifact path", () => {
+		const completion = toWaitCompletion({
+			success: true,
+			results: [{
+				agent: "delegate",
+				success: true,
+				output: "",
+				structuredOutput: { payload: { ok: true }, contract_checks: {} },
+				structuredOutputPath: "/runs/structured-output/output.json",
+			}],
+		}, "run-structured");
+
+		assert.deepEqual(completion.results?.[0]?.structuredOutput, { payload: { ok: true }, contract_checks: {} });
+		assert.equal(completion.results?.[0]?.structuredOutputPath, "/runs/structured-output/output.json");
+	});
+
+	it("omits oversized structured output while retaining its artifact path", () => {
+		const completion = toWaitCompletion({
+			success: true,
+			results: [{
+				agent: "delegate",
+				structuredOutput: { payload: "x".repeat(8_000) },
+				structuredOutputPath: "/runs/structured-output/output.json",
+			}],
+		}, "run-large-structured");
+
+		assert.equal(completion.results?.[0]?.structuredOutput, undefined);
+		assert.equal(completion.results?.[0]?.structuredOutputPath, "/runs/structured-output/output.json");
+	});
+
+	it("rejects non-JSON structured output", () => {
+		assert.throws(() => toWaitCompletion({ success: true, results: [{ structuredOutput: 1n }] }, "run-invalid-structured"), /JSON-serializable|serialize a BigInt/);
+	});
+
 	it("rejects unbounded or unknown summary fields at the replay boundary", () => {
 		assert.throws(() => toWaitCompletion({ workflowChildren: { version: 1, parentToolCallId: "tool", workflowRunId: "run", inventoryComplete: true, workflowState: "completed", children: [], output: "secret" } }, "run"), /unsupported fields/);
 	});


### PR DESCRIPTION
## Summary
- preserve coordinated read-only intent for direct async resume follow-ups
- surface captured structured output in completion, wait, intercom, and status evidence
- keep structured-output projections bounded while retaining durable artifact paths

Closes #1788.

Thanks to [@fkhawajagh](https://github.com/fkhawajagh) for reporting #1788.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/task-intent.test.ts test/unit/wait-completions.test.ts test/unit/notify.test.ts test/unit/run-status.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/result-watcher.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'structured output|acceptance|resume' test/integration/async-execution.test.ts test/integration/single-execution.test.ts test/integration/top-level-async.test.ts`
- `npm run typecheck`
- `git diff --check`
