### PR TITLE
Fix runtime timing footers in child output

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -237,6 +237,12 @@ export function findLatestSessionFile(sessionDir: string): string | null {
 	return latest ? latest.path : null;
 }
 
+const PI_TURN_TIMING_FOOTER = /(?:\r?\n)*\x1b\[38;2;136;136;136m✻ Turn took [^()\r\n]+ \(Total time [^·\r\n]+ · \d+ turns?\)\x1b\[0m[ \t]*$/u;
+
+function stripPiTurnTimingFooter(text: string): string {
+	return text.replace(PI_TURN_TIMING_FOOTER, "");
+}
+
 export function getFinalOutput(messages: Message[]): string {
 	const validTextParts: string[] = [];
 	for (let i = messages.length - 1; i >= 0; i--) {
@@ -246,21 +252,26 @@ export function getFinalOutput(messages: Message[]): string {
 			|| ("stopReason" in msg && msg.stopReason === "error");
 		if (hasAssistantError) continue;
 		const messageText = msg.content
-			.filter((part) => part.type === "text" && part.text.trim().length > 0)
-			.map((part) => part.type === "text" ? part.text : "")
+			.flatMap((part) => {
+				if (part.type !== "text") return [];
+				const text = stripPiTurnTimingFooter(part.text);
+				return text.trim().length > 0 ? [text] : [];
+			})
 			.join("\n");
 		for (let j = msg.content.length - 1; j >= 0; j--) {
 			const part = msg.content[j];
-			if (!part || part.type !== "text" || part.text.trim().length === 0) continue;
-			validTextParts.push(part.text);
-			if (/```acceptance[-_]report\s*\n[\s\S]*?```/i.test(part.text)) return messageText;
-			for (const match of part.text.matchAll(/```(?:json|jsonc|json5)\s*\n([\s\S]*?)```/gi)) {
+			if (!part || part.type !== "text") continue;
+			const text = stripPiTurnTimingFooter(part.text);
+			if (text.trim().length === 0) continue;
+			validTextParts.push(text);
+			if (/```acceptance[-_]report\s*\n[\s\S]*?```/i.test(text)) return messageText;
+			for (const match of text.matchAll(/```(?:json|jsonc|json5)\s*\n([\s\S]*?)```/gi)) {
 				const body = match[1] ?? "";
 				if (/"(?:criteriaSatisfied|criteria_satisfied)"/.test(body) && /"(?:changedFiles|changed_files|testsAddedOrUpdated|tests_added_or_updated|commandsRun|commands_run|validationOutput|validation_output|residualRisks|residual_risks|noStagedFiles|no_staged_files|diffSummary|diff_summary|reviewFindings|review_findings|manualNotes|manual_notes)"/.test(body)) {
 					return messageText;
 				}
 			}
-			if (/ACCEPTANCE_REPORT\s*:/i.test(part.text)) return messageText;
+			if (/ACCEPTANCE_REPORT\s*:/i.test(text)) return messageText;
 		}
 	}
 	return validTextParts[0] ?? "";

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -4153,6 +4153,40 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "async full output\nwith details");
 	});
 
+	it("removes Pi turn-timing telemetry from runtime-persisted background output", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const report = "## Review\n\nVERDICT: FINDINGS";
+		const timingFooter = "\x1b[38;2;136;136;136m✻ Turn took 5m 54s (Total time 5m 54s · 2 turns)\x1b[0m";
+		mockPi.onCall({ output: `${report}\n\n${timingFooter}` });
+		const id = `async-timing-footer-${Date.now().toString(36)}`;
+		const outputPath = path.join(tempDir, "async-review.md");
+		executeAsyncSingle(id, {
+			agent: "reviewer",
+			task: "Review without modifying files",
+			agentConfig: makeAgent("reviewer", { tools: ["read", "grep", "find", "ls"] }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: {
+				enabled: false,
+				includeInput: false,
+				includeOutput: false,
+				includeJsonl: false,
+				includeMetadata: false,
+				cleanupDays: 7,
+			},
+			shareEnabled: false,
+			sessionRoot: path.join(tempDir, "sessions"),
+			output: outputPath,
+			acceptance: false,
+			maxSubagentDepth: 2,
+		});
+
+		const resultPath = await waitForAsyncResultFile(id);
+		const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+		assert.equal(payload.success, true);
+		assert.equal(fs.readFileSync(outputPath, "utf-8"), report);
+		assert.doesNotMatch(payload.summary ?? "", /Turn took/);
+		assert.doesNotMatch(payload.results[0]?.output ?? "", /Turn took/);
+	});
+
 	it("background single runs route relative outputs to outputBaseDir", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: "async configured report" });
 		const id = `async-configured-output-base-${Date.now().toString(36)}`;

--- a/test/unit/get-final-output.test.ts
+++ b/test/unit/get-final-output.test.ts
@@ -17,6 +17,32 @@ describe("getFinalOutput", () => {
 		assert.equal(getFinalOutput(messages), "Summary");
 	});
 
+	it("removes a trailing Pi turn-timing footer from final output", () => {
+		const report = "## Review\n\nVERDICT: FINDINGS";
+		const timingFooter = "\x1b[38;2;136;136;136m✻ Turn took 5m 54s (Total time 5m 54s · 2 turns)\x1b[0m";
+		const messages = [assistantContent([
+			{ type: "text", text: `${report}\n\n${timingFooter}` },
+		])];
+
+		assert.equal(getFinalOutput(messages), report);
+	});
+
+	it("ignores a separate Pi turn-timing footer text part", () => {
+		const report = "## Review\n\nVERDICT: CLEAN";
+		const timingFooter = "\x1b[38;2;136;136;136m✻ Turn took 2m 19s (Total time 2m 18s · 1 turn)\x1b[0m";
+		const messages = [assistantContent([
+			{ type: "text", text: report },
+			{ type: "text", text: timingFooter },
+		])];
+
+		assert.equal(getFinalOutput(messages), report);
+	});
+
+	it("preserves ordinary timing prose", () => {
+		const text = "The benchmark turn took 5m 54s.";
+		assert.equal(getFinalOutput([assistantContent([{ type: "text", text }])]), text);
+	});
+
 	it("prefers final text over progress text in a multi-part assistant message", () => {
 		const messages = [assistantContent([
 			{ type: "text", text: "Working on the fix..." },


### PR DESCRIPTION
## Summary

- remove the exact trailing Pi turn-timing footer during final-output extraction
- preserve ordinary timing prose and unrelated ANSI content
- keep runtime-persisted read-only reports and completion summaries free of timing metadata

## Testing

- `npm run typecheck`
- `npm run test:all` (906 passed, 6 skipped, 0 failed)