### PR TITLE
fix: keep macOS subagent tasks out of argv

### DIFF
--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -16,6 +16,12 @@ import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../shared/utils.ts";
 import { SUBAGENT_CAPABILITY_CEILING_ENV, decodeSubagentCapabilityCeiling, encodeSubagentCapabilityCeiling, intersectSubagentCapabilityCeilings, type ResolvedSubagentCapabilityCeiling, type SubagentCapabilityAudit } from "./capability-ceiling.ts";
 
 const TASK_ARG_LIMIT = 8000;
+
+// Keep code-like task content out of macOS exec arguments, which endpoint-security
+// clients may inspect. Pi expands the @file argument to the same task content.
+export function shouldWriteTaskToFile(task: string, platform: NodeJS.Platform = process.platform): boolean {
+	return platform === "darwin" || task.length > TASK_ARG_LIMIT;
+}
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-prompt-runtime.ts");
 const FANOUT_CHILD_EXTENSION_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "extension", "fanout-child.ts");
 export const SUBAGENT_CHILD_ENV = "PI_SUBAGENT_CHILD";
@@ -271,7 +277,7 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 		args.push(input.systemPromptMode === "replace" ? "--system-prompt" : "--append-system-prompt", promptPath);
 	}
 
-	if (input.task.length > TASK_ARG_LIMIT) {
+	if (shouldWriteTaskToFile(input.task)) {
 		if (!tempDir) {
 			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));
 		}

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -27,6 +27,7 @@ import {
 	PI_INTERCOM_SESSION_ID_ENV,
 	applyThinkingSuffix,
 	buildPiArgs,
+	shouldWriteTaskToFile,
 } from "../../src/runs/shared/pi-args.ts";
 
 const originalEnv = {
@@ -1090,6 +1091,38 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env[SUBAGENT_FANOUT_CHILD_ENV], "1");
 		assert.ok(extensionArgs.some((arg) => arg.endsWith(path.join("src", "extension", "fanout-child.ts"))));
 		assert.ok(extensionArgs.includes("./agent-allowed-ext.ts"));
+	});
+
+	it("selects task files explicitly by platform and size", () => {
+		assert.equal(shouldWriteTaskToFile("", "darwin"), true);
+		assert.equal(shouldWriteTaskToFile("short", "darwin"), true);
+		assert.equal(shouldWriteTaskToFile("short", "linux"), false);
+		assert.equal(shouldWriteTaskToFile("short", "win32"), false);
+		assert.equal(shouldWriteTaskToFile("x".repeat(8001), "linux"), true);
+	});
+
+	it("keeps task content out of macOS exec arguments", () => {
+		const task = "shell-like `command` $(command) $VALUE";
+		const { args, tempDir } = buildPiArgs({
+			baseArgs: ["-p"],
+			task,
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+		});
+
+		try {
+			const taskArg = args.at(-1);
+			if (process.platform === "darwin") {
+				assert.ok(taskArg?.startsWith("@"));
+				assert.equal(fs.readFileSync(taskArg.slice(1), "utf-8"), `Task: ${task}`);
+				assert.ok(args.every((arg) => !arg.includes(task)));
+			} else {
+				assert.equal(taskArg, `Task: ${task}`);
+			}
+		} finally {
+			if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("emits an empty prompt file when replace mode is used with an empty prompt", () => {


### PR DESCRIPTION
## Summary

- keep subagent task content out of process arguments on macOS
- pass macOS tasks through Pi's existing `@file` path, regardless of size
- retain the existing 8 KB threshold on Linux and Windows
- add platform-explicit tests for Darwin, Linux, and Windows

## Motivation

On an enterprise-managed macOS host, child Pi processes were intermittently terminated before producing any model/tool activity. The correlated system log was:

```text
AppleSystemPolicy: ASP: Unable to apply provenance sandbox: ..., /opt/homebrew/Cellar/node/24.8.0/bin/node
```

The failures were reproducible when structured/code-like task content was present in the child argv and disappeared when the same task was delivered through the existing `@task.md` mechanism. Keeping prompt content out of argv also prevents shell metacharacters and potentially sensitive task text from being exposed to process-argument inspection.

This does not introduce a shell wrapper or disable endpoint security. Foreground and background launches continue to use argument-vector spawning with `shell: false` behavior.

## Validation

- `node --experimental-strip-types --test test/unit/pi-args.test.ts test/unit/subagent-startup-retry.test.ts`
  - 56 passed, 0 failed
- `npm test`
  - 1474 passed, 0 failed, 1 skipped
- live macOS subagent checks:
  - scout with inferred acceptance: completed
  - reviewer/high with inferred acceptance: completed

## Scope

The behavioral change is macOS-only. Linux and Windows continue to inline tasks up to the existing 8 KB threshold.
