### PR TITLE
fix: keep macOS subagent tasks out of argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Strip the trailing Pi turn-timing footer from child output. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1792.
 - Preserve coordinated read-only intent when resuming direct async children and surface captured structured output in completion and status evidence. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1788.
+- Keep macOS subagent tasks out of argv by delivering them through temporary files. Thanks [@josephkallas](https://github.com/josephkallas) for #1793.
 
 ## [0.62.0] - 2026-08-31
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,7 +356,7 @@ Overrides the command used to launch child Pi processes. Package wrappers can se
 export PI_SUBAGENT_TASK_DELIVERY=file   # auto | file (default: auto)
 ```
 
-Controls how the task text reaches the child Pi process. `auto` (default) passes short tasks as an inline argv token and writes tasks longer than 8000 characters to a temp `task.md` referenced as `@<path>`. `file` always uses a temp file, keeping the task out of argv entirely.
+Controls how the task text reaches the child Pi process. `auto` (default) passes short non-macOS tasks as an inline argv token, and writes macOS tasks plus tasks longer than 8000 characters to a temp `task.md` referenced as `@<path>`. `file` always uses a temp file, keeping the task out of argv entirely.
 
 Use `file` on hosts where endpoint protection (EDR) pre-execution scanning denies child processes whose command line embeds a long natural-language task — that denial surfaces as an immediate zero-activity `SIGKILL`. Independently of this setting, startup retries automatically escalate to file delivery after an unexplained zero-activity `SIGKILL`. Empty, whitespace-only, or unrecognized values fall back to `auto`.
 

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -93,11 +93,12 @@ export function resolveSubagentTaskDelivery(
 		: "auto";
 }
 
-function shouldDeliverTaskViaFile(
+export function shouldDeliverTaskViaFile(
 	task: string,
 	delivery: SubagentTaskDelivery,
+	platform: NodeJS.Platform = process.platform,
 ): boolean {
-	return delivery === "file" || task.length > TASK_ARG_LIMIT;
+	return delivery === "file" || platform === "darwin" || task.length > TASK_ARG_LIMIT;
 }
 const MAX_LAUNCH_RESOLVED_EXTENSION_IDS = 32;
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(

--- a/test/integration/fork-context-execution.test.ts
+++ b/test/integration/fork-context-execution.test.ts
@@ -202,6 +202,10 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		return args;
 	}
 
+	function isTaskFileArg(arg: string): boolean {
+		return arg.startsWith("@") && arg.endsWith("task.md");
+	}
+
 	function readSessionArg(args: string[]): string {
 		const sessionIndex = args.indexOf("--session");
 		assert.notEqual(sessionIndex, -1);
@@ -314,7 +318,12 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 
 		assert.equal(result.isError, undefined);
 		const args = readCallArgs();
-		assert.ok((args.at(-1) ?? "").startsWith("Task: \n\n## Acceptance Contract"));
+		const taskArg = args.at(-1) ?? "";
+		if (process.platform === "darwin") {
+			assert.ok(isTaskFileArg(taskArg));
+		} else {
+			assert.ok(taskArg.startsWith("Task: \n\n## Acceptance Contract"));
+		}
 	});
 
 	it("fails pruned fork model auth before child spawn", async () => {
@@ -1314,8 +1323,13 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		);
 
 		assert.equal(result.isError, undefined);
-		const args = readAllCallArgs().find((callArgs) => (callArgs.at(-1) ?? "").startsWith(`Task: ${task}\n\n## Acceptance Contract`));
-		assert.ok(args, "expected a recorded mock pi call for this test task");
+		const args = readCallArgs();
+		const taskArg = args.at(-1) ?? "";
+		if (process.platform === "darwin") {
+			assert.ok(isTaskFileArg(taskArg));
+		} else {
+			assert.ok(taskArg.startsWith(`Task: ${task}\n\n## Acceptance Contract`));
+		}
 		const modelIndex = args.indexOf("--model");
 		assert.notEqual(modelIndex, -1);
 		assert.equal(args[modelIndex + 1], "anthropic/claude-haiku-4-5");

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -5953,7 +5953,12 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.finalOutput, "Recovered via file delivery");
 		assert.equal(mockPi.callCount(), 2);
 		const [firstArgs, retryArgs] = readAllCallArgs();
-		assert.ok(firstArgs?.includes("Task: Do work"), "first attempt should deliver the task inline");
+		const firstTaskArg = firstArgs?.find((arg) => arg === "Task: Do work" || arg.endsWith("task.md"));
+		if (process.platform === "darwin") {
+			assert.ok(firstTaskArg?.startsWith("@"), "first attempt should deliver the task through a file on macOS");
+		} else {
+			assert.equal(firstTaskArg, "Task: Do work", "first attempt should deliver the task inline");
+		}
 		const retryTaskArg = retryArgs?.at(-1) ?? "";
 		assert.ok(
 			retryTaskArg.startsWith("@") && retryTaskArg.endsWith("task.md"),

--- a/test/unit/pi-args-permission-system.test.ts
+++ b/test/unit/pi-args-permission-system.test.ts
@@ -56,7 +56,7 @@ afterEach(() => {
 function readPromptFile(result: { tempDir?: string }): string {
 	assert.ok(result.tempDir, "expected a temp dir from buildPiArgs");
 	const files = fs.readdirSync(result.tempDir);
-	const promptFile = files.find((f: string) => f.endsWith(".md"));
+	const promptFile = files.find((f: string) => f.endsWith(".md") && f !== "task.md");
 	assert.ok(promptFile, "expected a prompt.md file");
 	return fs.readFileSync(path.join(result.tempDir, promptFile), "utf-8");
 }

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -47,6 +47,7 @@ import {
 	buildPiArgs,
 	projectLaunchResolvedChildExtensions,
 	resolvePiLaunchToolPlan,
+	shouldDeliverTaskViaFile,
 } from "../../src/runs/shared/pi-args.ts";
 
 const originalEnv = {
@@ -693,7 +694,7 @@ describe("buildPiArgs task delivery", () => {
 		return ref ? ref.slice(1) : undefined;
 	}
 
-	it("delivers short tasks inline by default", () => {
+	it("delivers short tasks through the platform default", () => {
 		const { args } = buildPiArgs({
 			baseArgs: ["-p"],
 			task: "hello",
@@ -702,8 +703,13 @@ describe("buildPiArgs task delivery", () => {
 			inheritSkills: false,
 		});
 
-		assert.ok(args.includes("Task: hello"));
-		assert.equal(taskFileFromArgs(args), undefined);
+		if (process.platform === "darwin") {
+			assert.ok(taskFileFromArgs(args), "expected an @task.md argv reference on macOS");
+			assert.ok(!args.includes("Task: hello"));
+		} else {
+			assert.ok(args.includes("Task: hello"));
+			assert.equal(taskFileFromArgs(args), undefined);
+		}
 	});
 
 	it("delivers tasks over the argv limit via a temp file by default", () => {
@@ -737,7 +743,6 @@ describe("buildPiArgs task delivery", () => {
 		assert.ok(!args.includes("Task: hello"));
 	});
 
-
 	it("falls back to auto when PI_SUBAGENT_TASK_DELIVERY is invalid", () => {
 		process.env.PI_SUBAGENT_TASK_DELIVERY = "carrier-pigeon";
 		const { args } = buildPiArgs({
@@ -764,6 +769,13 @@ describe("buildPiArgs task delivery", () => {
 
 		assert.ok(taskFileFromArgs(args), "expected an @task.md argv reference");
 		assert.ok(!args.includes("Task: hello"));
+	});
+
+	it("selects file delivery for macOS or over-limit tasks", () => {
+		assert.equal(shouldDeliverTaskViaFile("short", "auto", "darwin"), true);
+		assert.equal(shouldDeliverTaskViaFile("short", "auto", "linux"), false);
+		assert.equal(shouldDeliverTaskViaFile("short", "auto", "win32"), false);
+		assert.equal(shouldDeliverTaskViaFile("x".repeat(8001), "auto", "linux"), true);
 	});
 });
 
@@ -1340,7 +1352,8 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.deepEqual(requestedNames, [serverName, serverName]);
 		assert.equal(serverLaunch.args[serverLaunch.args.indexOf("--tools") + 1], "read,runtime-github_search_repositories,runtime-github_create_issue");
 		assert.equal(toolLaunch.args[toolLaunch.args.indexOf("--tools") + 1], "read,runtime-github_search_repositories");
-		assert.ok(serverLaunch.args.indexOf("--mcp-config") < serverLaunch.args.indexOf("Task: hello"));
+		const serverTaskArgIndex = serverLaunch.args.findIndex((arg) => arg === "Task: hello" || arg.endsWith("task.md"));
+		assert.ok(serverLaunch.args.indexOf("--mcp-config") < serverTaskArgIndex);
 		for (const launch of [serverLaunch, toolLaunch]) {
 			const configPath = launch.args[launch.args.indexOf("--mcp-config") + 1];
 			assert.ok(configPath);


### PR DESCRIPTION
## Summary
- Deliver macOS subagent task text through Pi's existing `@task.md` path by default.
- Preserve Linux/Windows short-task inline behavior, the 8 KB threshold, and explicit `file` overrides.
- Update focused task-delivery, permission-system, and startup-retry coverage.

Supersedes #1793 by integrating the accepted behavior into the current `PI_SUBAGENT_TASK_DELIVERY` seam.

Credit: thanks to [@josephkallas](https://github.com/josephkallas) for #1793.

## Validation
- `node --experimental-strip-types --test test/unit/pi-args.test.ts test/unit/pi-args-permission-system.test.ts test/unit/subagent-startup-retry.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'retries a zero-activity startup exit on the same model|escalates to file task delivery after a zero-activity SIGKILL startup exit|does not retry a non-zero exit after tool activity' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check origin/main`

## Backlog evidence
- Fresh review: `lane-reports/backlog-20260901/pr-1793-rework-review.md`
- Deletion-first challenge: `lane-reports/backlog-20260901/pr-1793-rework-challenge.md`
