### PR TITLE
fix: apply custom agent overrides consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Let Fleet open selected async children in their child-specific Herdr inspector with plain-input guidance. Thanks to [@stekman08](https://github.com/stekman08) for #1790.
 
 ### Fixed
+- Make `subagents.agentOverrides.<name>` replace matching custom-agent frontmatter fields, consistently with builtin agents. Thanks to [@expoli](https://github.com/expoli) for #1796.
 - Strip the trailing Pi turn-timing footer from child output. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1792.
 - Avoid injecting inferred acceptance reports into reviewer/read-only child prompts. Thanks [@expoli](https://github.com/expoli) for #1797.
 - Preserve coordinated read-only intent when resuming direct async children and surface captured structured output in completion and status evidence. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1788.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -189,9 +189,9 @@ The `researcher` builtin uses `web_search`, `fetch_content`, and `get_search_con
 pi install npm:pi-web-access
 ```
 
-## Overriding builtins
+## Overriding builtins and custom agents
 
-You can override selected builtin fields without copying the whole agent. Overrides live in settings:
+You can override selected agent fields without copying the whole agent. Overrides live in settings:
 
 - User: `~/.pi/agent/settings.json`
 - Project: project config settings file (`.pi/settings.json` in standard Pi)
@@ -213,9 +213,9 @@ Supported override fields: `description`, `output`, `outputMode`, `defaultReads`
 
 - `description` replaces the discovered description for builtin and custom agents, which lets list output show deployment-specific routing or model metadata.
 - Use `output: false`, `defaultReads: false`, `defaultContext: false`, or `acceptanceRole: false` to clear an inherited value.
-- Use `tools: "inherit"` on a builtin when that one role should omit its bundled tool allowlist and receive Pi's normal builtins and ambient extensions. This keeps strict tools as the default for other builtins.
+- Use `tools: "inherit"` when that one role should omit its bundled or frontmatter tool allowlist and receive Pi's normal builtins and ambient extensions.
 - Project overrides beat user overrides.
-- Matching user and project agents also receive override fields that their frontmatter leaves unset, so a shared project config agent can keep the persona while local settings choose the model.
+- Matching package, user, and project agents also receive override fields, which replace the same fields declared in their frontmatter. This lets a shared agent keep its persona while local settings choose the effective model, context, tools, or other supported options.
 
 Disable and restore:
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -11,7 +11,7 @@ Builtin agents inherit your current Pi default model. This keeps new installs fr
 - `subagents.agentOverridesByProvider.<provider>.<name>` — layer role fields for the active parent provider.
 - Per-run overrides — for one launch only.
 
-Precedence, strongest first: per-run override → agent frontmatter `model` → provider-scoped role override → `agentOverrides.<name>.model` → `subagents.defaultModel` → the parent session model. A provider preference does not replace this order; it only resolves bare model ids when the active registry has more than one match. Fully qualified `provider/model` strings still win exactly.
+Precedence, strongest first: per-run override → provider-scoped role override → `agentOverrides.<name>.model` → agent frontmatter `model` → `subagents.defaultModel` → the parent session model. A provider preference does not replace this order; it only resolves bare model ids when the active registry has more than one match. Fully qualified `provider/model` strings still win exactly.
 
 Use `model: "inherit"` in agent frontmatter or `agentOverrides.<name>.model` to select the current parent session model explicitly.
 
@@ -81,7 +81,7 @@ For a persistent role override with a backup model for provider failures:
 }
 ```
 
-`subagents.defaultModel` and `subagents.defaultProvider` apply to builtin, package, user, and project agents. `defaultModel` fills only agents that do not set `model` in frontmatter. `defaultProvider` is also applied to frontmatter and override models so bare ids resolve against the intended provider. Per-run model overrides and `agentOverrides.<name>.model` still win, and explicit agent frontmatter still wins over the global default. The same `agentOverrides` block can change `tools`, `skills`, inherited context, prompt text, or disable a builtin (see [agents.md](agents.md)). Matching user and project agents also receive override fields that their frontmatter leaves unset, so a shared project config agent can keep the persona while local settings choose the model or provider.
+`subagents.defaultModel` and `subagents.defaultProvider` apply to builtin, package, user, and project agents. `defaultModel` fills only agents that do not set `model` in frontmatter. `defaultProvider` is also applied to frontmatter and override models so bare ids resolve against the intended provider. Per-run model overrides and `agentOverrides.<name>.model` win over frontmatter and the global default. The same `agentOverrides` block can change `tools`, `skills`, inherited context, prompt text, or disable an agent (see [agents.md](agents.md)); matching custom-agent frontmatter is replaced for any field set by the override.
 
 ## Fast mode
 
@@ -116,7 +116,7 @@ One interaction worth knowing for tier 4: forked context over an Anthropic paren
 
 ## Thinking level defaults
 
-Set `subagents.defaultThinking` to give builtin, package, user, and project agents without a `thinking` value a shared thinking level, independent of the parent session's default. Project settings win over user settings. Explicit frontmatter, `agentOverrides.<name>.thinking`, and per-run thinking overrides still win. `thinking: false` remains an explicit opt-out:
+Set `subagents.defaultThinking` to give builtin, package, user, and project agents without a `thinking` value a shared thinking level, independent of the parent session's default. Project settings win over user settings. Matching `agentOverrides.<name>.thinking` and per-run thinking overrides replace frontmatter; otherwise explicit frontmatter remains in effect. `thinking: false` remains an explicit opt-out:
 
 ```json
 {
@@ -129,7 +129,7 @@ Set `subagents.defaultThinking` to give builtin, package, user, and project agen
 }
 ```
 
-If your provider rejects model IDs with thinking suffixes, set `subagents.disableThinking: true` in user or project settings. That clears bundled builtin thinking defaults in one place. An explicit higher-precedence `agentOverrides.<name>.thinking` value can opt a role back in. Existing custom-agent frontmatter remains authoritative.
+If your provider rejects model IDs with thinking suffixes, set `subagents.disableThinking: true` in user or project settings. That clears bundled builtin thinking defaults in one place. An explicit higher-precedence `agentOverrides.<name>.thinking` value can opt a role back in or replace custom-agent frontmatter thinking.
 
 ### Thinking ceiling
 
@@ -154,7 +154,7 @@ Set `subagents.defaultExtensions` to give builtin, package, user, and project ag
 - Empty array: sets `extensions: []` for agents that do not explicitly define it, disabling ambient extension loading.
 - Non-empty array: supplies that allowlist to agents that do not explicitly define one.
 
-Project settings win over user settings. Use `agentOverrides.<name>.extensions` for per-agent settings; explicit custom-agent frontmatter remains authoritative.
+Project settings win over user settings. Use `agentOverrides.<name>.extensions` for per-agent settings; a matching override replaces custom-agent frontmatter for that field.
 
 ```json
 {

--- a/skills/pi-subagents/references/management-authoring-rpc.md
+++ b/skills/pi-subagents/references/management-authoring-rpc.md
@@ -85,7 +85,7 @@ subagent({ action: "reset", agent: "reviewer" })
 Use management actions when the system needs to create or edit subagents on
 demand without dropping into raw file editing.
 
-Management actions create or update user/project agent files. `config.name` is the local frontmatter name; optional `config.package` registers and looks up the runtime name as `{package}.{name}`. Use the dotted runtime name for `get`, `update`, `delete`, slash commands, and scripted workflow steps. For small builtin changes such as a model swap, prefer `subagents.agentOverrides` in settings. Durable `.chain.md` definitions are legacy records, not a current authoring target; use `workflowScript` or `/prompt-workflow` for repeatable orchestration.
+Management actions create or update user/project agent files. `config.name` is the local frontmatter name; optional `config.package` registers and looks up the runtime name as `{package}.{name}`. Use the dotted runtime name for `get`, `update`, `delete`, slash commands, and scripted workflow steps. For small agent changes such as a model swap, prefer `subagents.agentOverrides` in settings. Durable `.chain.md` definitions are legacy records, not a current authoring target; use `workflowScript` or `/prompt-workflow` for repeatable orchestration.
 
 ## Creating and Editing Agents by File
 

--- a/skills/pi-subagents/references/prompting-and-roles.md
+++ b/skills/pi-subagents/references/prompting-and-roles.md
@@ -185,7 +185,7 @@ Builtin `worker` and `delegate` use strict tool allowlists and do not inherit am
 
 Builtin agents inherit the current Pi default model unless a run, user setting, project setting, or `subagents.defaultModel` overrides `model`. The table records recommended tier routing, not shipped hard defaults; explicit run, user, or project settings still win. Keep the parent/orchestrator on the ordinary strong default model unless parent/user policy says otherwise. Override builtin defaults before copying full agent files when a small tweak is enough.
 
-Set `subagents.defaultThinking` to apply a shared thinking level to builtin, package, user, and project agents whose frontmatter leaves `thinking` unset. Project settings win over user settings; explicit frontmatter (including `thinking: false`), `agentOverrides.<name>.thinking`, and per-run overrides remain more specific. This setting affects child agents only and does not change the parent session's default thinking level.
+Set `subagents.defaultThinking` to apply a shared thinking level to builtin, package, user, and project agents whose frontmatter leaves `thinking` unset. Project settings win over user settings; matching `agentOverrides.<name>.thinking` and per-run overrides replace frontmatter, while an explicit frontmatter value remains in effect when no matching override is set. This setting affects child agents only and does not change the parent session's default thinking level.
 
 ```json
 {
@@ -288,8 +288,8 @@ Use `fallbackModels` when a tier has provider quota or availability risk. Prefer
 If a provider rejects model IDs with thinking suffixes, use
 `subagents.disableThinking: true` in user or project settings to clear bundled
 builtin thinking defaults globally. A higher-precedence per-agent `thinking`
-override can opt one builtin back in. Existing custom-agent frontmatter remains authoritative.
+override can opt one builtin back in or replace custom-agent frontmatter thinking.
 
-Set `subagents.defaultExtensions` to give agents without an `extensions` field a shared child extension allowlist. Omit it to preserve ambient extension discovery, set it to `[]` to disable ambient extensions by default, or use `agentOverrides.<name>.extensions` for one agent. Explicit custom-agent frontmatter still wins.
+Set `subagents.defaultExtensions` to give agents without an `extensions` field a shared child extension allowlist. Omit it to preserve ambient extension discovery, set it to `[]` to disable ambient extensions by default, or use `agentOverrides.<name>.extensions` for one agent. A matching override replaces custom-agent frontmatter for that field.
 
 Tool description modes live in `~/.pi/agent/extensions/subagent/config.json`, not `subagents` settings. The default uses split prompt metadata: a short tool description plus active `promptSnippet` and `promptGuidelines`. Set `toolDescriptionMode` to `full` or `compact` to force one description string, or `custom` to read `subagent-tool-description.md` from the project config dir or agent dir; invalid custom files fall back to full mode and the safety guidance is still appended.

--- a/src/agents/agent-management.ts
+++ b/src/agents/agent-management.ts
@@ -250,13 +250,25 @@ function withDeclaredExtensionPaths(config: AgentConfig, filePath: string): Agen
 export function editableAgentConfig(agent: AgentConfig): AgentConfig {
 	const { extensions: _extensions, ...withoutExtensions } = agent;
 	const base = agent.override?.base;
+	const description = base?.description ?? agent.description;
+	const frontmatterFields = agent.source === "builtin" || agent.source === "runtime" ? undefined : readAgentFrontmatterFields(agent.filePath);
+	const hasDeclaredField = (...fields: string[]) => frontmatterFields === undefined || fields.some((field) => frontmatterFields.has(field));
+	const withoutSettingsDefaults = (config: AgentConfig): AgentConfig => {
+		if (!frontmatterFields) return config;
+		const next = { ...config };
+		if (!hasDeclaredField("model")) delete next.model;
+		if (!hasDeclaredField("thinking")) delete next.thinking;
+		return next;
+	};
 	const {
 		override: _override,
+		description: _description,
 		output: _output,
 		outputMode: _outputMode,
 		defaultReads: _defaultReads,
 		model: _model,
 		fallbackModels: _fallbackModels,
+		fast: _fast,
 		thinking: _thinking,
 		systemPromptMode: _systemPromptMode,
 		inheritProjectContext: _inheritProjectContext,
@@ -271,26 +283,30 @@ export function editableAgentConfig(agent: AgentConfig): AgentConfig {
 		tools: _tools,
 		excludeTools: _excludeTools,
 		mcpDirectTools: _mcpDirectTools,
+		allowNestedSubagents: _allowNestedSubagents,
 		subagentOnlyExtensions: _subagentOnlyExtensions,
 		mutationTools: _mutationTools,
 		completionGuard: _completionGuard,
+		toolBudget: _toolBudget,
 		...editable
 	} = withoutExtensions;
 	if (!base) {
-		return withDeclaredExtensionPaths({
+		return withDeclaredExtensionPaths(withoutSettingsDefaults({
 			...withoutExtensions,
 			...(agent.extensionsFromDefault ? {} : agent.extensions !== undefined ? { extensions: [...agent.extensions] } : {}),
-		}, agent.filePath);
+		}), agent.filePath);
 	}
 
 	return withDeclaredExtensionPaths({
 		...editable,
+		description,
 		...(base.output !== undefined ? { output: base.output } : {}),
 		...(base.outputMode !== undefined ? { outputMode: base.outputMode } : {}),
 		...(base.defaultReads !== undefined ? { defaultReads: [...base.defaultReads] } : {}),
-		...(base.model !== undefined ? { model: base.model } : {}),
+		...(base.model !== undefined && hasDeclaredField("model") ? { model: base.model } : {}),
 		...(base.fallbackModels !== undefined ? { fallbackModels: [...base.fallbackModels] } : {}),
-		...(base.thinking !== undefined ? { thinking: base.thinking } : {}),
+		...(base.fast !== undefined ? { fast: base.fast } : {}),
+		...(base.thinking !== undefined && hasDeclaredField("thinking") ? { thinking: base.thinking } : {}),
 		systemPromptMode: base.systemPromptMode,
 		inheritProjectContext: base.inheritProjectContext,
 		inheritGlobalContext: base.inheritGlobalContext,
@@ -304,10 +320,12 @@ export function editableAgentConfig(agent: AgentConfig): AgentConfig {
 		...(base.tools !== undefined ? { tools: [...base.tools] } : {}),
 		...(base.excludeTools !== undefined ? { excludeTools: [...base.excludeTools] } : {}),
 		...(base.mcpDirectTools !== undefined ? { mcpDirectTools: [...base.mcpDirectTools] } : {}),
+		...(base.allowNestedSubagents !== undefined ? { allowNestedSubagents: base.allowNestedSubagents } : {}),
 		...(base.extensions !== undefined ? { extensions: [...base.extensions] } : {}),
 		...(base.subagentOnlyExtensions !== undefined ? { subagentOnlyExtensions: [...base.subagentOnlyExtensions] } : {}),
 		...(base.mutationTools !== undefined ? { mutationTools: [...base.mutationTools] } : {}),
 		...(base.completionGuard !== undefined ? { completionGuard: base.completionGuard } : {}),
+		...(base.toolBudget !== undefined ? { toolBudget: base.toolBudget } : {}),
 	}, agent.filePath);
 }
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -113,6 +113,8 @@ interface BuiltinAgentOverrideInfo {
 	scope: "user" | "project";
 	path: string;
 	base: BuiltinAgentOverrideBase;
+	fields?: string[];
+	fieldScopes?: Record<string, Array<"user" | "project">>;
 }
 
 export interface AgentModelSourceInfo {
@@ -1348,9 +1350,19 @@ function applyBuiltinOverride(
 	override: BuiltinAgentOverrideConfig,
 	meta: { scope: "user" | "project"; path: string },
 ): AgentConfig {
+	const overrideInfo: BuiltinAgentOverrideInfo = {
+		...meta,
+		base: agent.override?.base ?? cloneOverrideBase(agent),
+		fields: [...new Set([...(agent.override?.fields ?? []), ...Object.keys(override)])].sort(),
+		fieldScopes: Object.fromEntries(Object.entries({ ...(agent.override?.fieldScopes ?? {}) }).map(([field, scopes]) => [field, [...scopes]])),
+	};
+	for (const field of Object.keys(override)) {
+		const scopes = overrideInfo.fieldScopes![field] ?? [];
+		overrideInfo.fieldScopes![field] = [...new Set([...scopes, meta.scope])].sort();
+	}
 	const next: AgentConfig = {
 		...agent,
-		override: { ...meta, base: cloneOverrideBase(agent) },
+		override: overrideInfo,
 	};
 
 	if (override.description !== undefined) next.description = override.description;
@@ -1450,128 +1462,12 @@ function applyBuiltinOverrides(
 	});
 }
 
-export function agentHasFrontmatterField(agent: AgentConfig, ...fields: string[]): boolean {
-	const frontmatterFields = agentFrontmatterFields.get(agent);
-	return frontmatterFields ? fields.some((field) => frontmatterFields.has(field)) : false;
-}
-
 function applyCustomAgentOverride(
 	agent: AgentConfig,
 	override: BuiltinAgentOverrideConfig,
 	meta: { scope: "user" | "project"; path: string },
 ): AgentConfig {
-	let next: AgentConfig | undefined;
-	let anyFilled = false;
-
-	const mutable = (): AgentConfig => {
-		next ??= { ...agent };
-		return next;
-	};
-
-	const fill = <K extends keyof AgentConfig>(
-		field: K,
-		frontmatterFields: string[],
-		value: AgentConfig[K],
-	): void => {
-		if (agentHasFrontmatterField(agent, ...frontmatterFields)) return;
-		const target = mutable();
-		if (value === undefined) delete target[field]; else target[field] = value;
-		anyFilled = true;
-	};
-
-	if (override.description !== undefined) {
-		mutable().description = override.description;
-		anyFilled = true;
-	}
-	if (override.output !== undefined) {
-		fill("output", ["output"], override.output === false ? undefined : override.output);
-	}
-	if (override.outputMode !== undefined) {
-		fill("outputMode", ["outputMode"], override.outputMode);
-	}
-	if (override.defaultReads !== undefined) {
-		fill("defaultReads", ["defaultReads"], override.defaultReads === false ? undefined : [...override.defaultReads]);
-	}
-	if (override.model !== undefined && !agentHasFrontmatterField(agent, "model")) {
-		const target = mutable();
-		if (override.model === false) delete target.model; else target.model = override.model;
-		delete target.modelSource;
-		anyFilled = true;
-	}
-	if (override.defaultProvider !== undefined) {
-		fill("modelProvider", ["modelProvider", "defaultProvider"], override.defaultProvider === false ? undefined : override.defaultProvider);
-	}
-	if (override.fallbackModels !== undefined) {
-		fill(
-			"fallbackModels",
-			["fallbackModels"],
-			override.fallbackModels === false ? undefined : [...override.fallbackModels],
-		);
-	}
-	if (override.fast !== undefined) {
-		fill("fast", ["fast"], override.fast);
-	}
-	if (override.thinking !== undefined) {
-		fill("thinking", ["thinking"], override.thinking === false ? undefined : override.thinking);
-	}
-	if (override.systemPromptMode !== undefined) {
-		fill("systemPromptMode", ["systemPromptMode"], override.systemPromptMode);
-	}
-	if (override.inheritProjectContext !== undefined) {
-		fill("inheritProjectContext", ["inheritProjectContext"], override.inheritProjectContext);
-	}
-	if (override.inheritGlobalContext !== undefined) {
-		fill("inheritGlobalContext", ["inheritGlobalContext"], override.inheritGlobalContext);
-	}
-	if (override.inheritSkills !== undefined) {
-		fill("inheritSkills", ["inheritSkills"], override.inheritSkills);
-	}
-	if (override.defaultContext !== undefined) {
-		fill("defaultContext", ["defaultContext"], override.defaultContext === false ? undefined : override.defaultContext);
-	}
-	if (override.acceptanceRole !== undefined) {
-		fill("acceptanceRole", ["acceptanceRole"], override.acceptanceRole === false ? undefined : override.acceptanceRole);
-	}
-	if (override.disabled !== undefined) {
-		// Custom agent files cannot set `disabled`, so project overrides replace user overrides.
-		mutable().disabled = override.disabled;
-		anyFilled = true;
-	}
-	if (override.skills !== undefined) {
-		fill("skills", ["skill", "skills"], override.skills === false ? undefined : [...override.skills]);
-	}
-	if (override.tools !== undefined && !agentHasFrontmatterField(agent, "tools")) {
-		applyToolsOverride(mutable(), override.tools);
-		anyFilled = true;
-	}
-	if (override.excludeTools !== undefined) {
-		fill("excludeTools", ["excludeTools"], override.excludeTools === false ? undefined : [...override.excludeTools]);
-	}
-	if (override.allowNestedSubagents !== undefined) {
-		fill("allowNestedSubagents", ["allowNestedSubagents"], override.allowNestedSubagents);
-	}
-	if (override.extensions !== undefined) {
-		fill("extensions", ["extensions"], override.extensions === false ? undefined : [...override.extensions]);
-	}
-	if (override.subagentOnlyExtensions !== undefined) {
-		fill(
-			"subagentOnlyExtensions",
-			["subagentOnlyExtensions"],
-			override.subagentOnlyExtensions === false ? undefined : [...override.subagentOnlyExtensions],
-		);
-	}
-	if (override.mutationTools !== undefined) {
-		fill("mutationTools", ["mutationTools"], override.mutationTools === false ? undefined : [...override.mutationTools]);
-	}
-	if (override.completionGuard !== undefined) {
-		fill("completionGuard", ["completionGuard"], override.completionGuard);
-	}
-	if (override.toolBudget !== undefined) {
-		fill("toolBudget", ["toolBudget"], override.toolBudget === false ? undefined : override.toolBudget);
-	}
-
-	if (!anyFilled || !next) return agent;
-	next.override = { ...meta, base: agent.override?.base ?? cloneOverrideBase(agent) };
+	const next = applyBuiltinOverride(agent, override, meta);
 	const frontmatterFields = agentFrontmatterFields.get(agent);
 	if (frontmatterFields) agentFrontmatterFields.set(next, frontmatterFields);
 	return next;

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
-	agentHasFrontmatterField,
 	discoverAgentsAll,
 	EXTRA_AGENT_DIRS_ENV,
 	frontmatterNameForConfig,
@@ -116,18 +115,15 @@ type AgentSelection =
 
 function savesThroughSettings(agent: AgentConfig, field: EditableOverrideField): boolean {
 	if (agent.source === "builtin") return true;
-	if (agent.source === "package") {
-		if (field === "systemPrompt") return false;
-		return !agentHasFrontmatterField(agent, field);
-	}
+	if (agent.source === "package") return true;
 	if (!agent.override) return false;
+	if (agent.override.fields?.includes(field) === true) return true;
 	// A lower-scope override can flow into a higher-scope custom agent with the
 	// same name. Persist that agent's edits in its own frontmatter instead of
 	// rewriting the shared lower-scope override used by another agent.
 	if (agent.source !== agent.override.scope) return false;
-	// Custom-agent overrides fill only fields absent from frontmatter. Compare the
-	// effective value with the pre-override base so an override on one field does
-	// not redirect edits to an unrelated frontmatter-owned field.
+	// Compare the effective value with the pre-override base so an override on one
+	// field does not redirect edits to an unrelated frontmatter-owned field.
 	return agent[field] !== agent.override.base[field];
 }
 
@@ -256,10 +252,12 @@ async function chooseThinking(ctx: ExtensionContext, agent: AgentConfig): Promis
 }
 
 async function chooseOverrideScope(ctx: ExtensionContext, agent: AgentConfig): Promise<"user" | "project" | undefined> {
-	if (agent.override?.scope) return agent.override.scope;
 	const d = discoverAgentsAll(ctx.cwd);
+	if (agent.override?.scope) {
+		return agent.source === "project" && agent.override.scope === "user" && d.projectSettingsPath ? "project" : agent.override.scope;
+	}
 	if (!d.projectSettingsPath || !ctx.hasUI) return "user";
-	const choice = await ctx.ui.select(`Save builtin override for ${agent.name}`, ["user", "project"]);
+	const choice = await ctx.ui.select(`Save subagent override for ${agent.name}`, ["user", "project"]);
 	return choice === "user" || choice === "project" ? choice : undefined;
 }
 
@@ -271,6 +269,18 @@ function persistSettingsField(
 	value: string | undefined,
 ): { filePath: string; overridden: boolean } {
 	const base = agent.override?.base ?? buildBuiltinBase(agent);
+	const shadowsLowerScope = scope === "project" && agent.override?.fieldScopes?.[field]?.includes("user") === true;
+	if (shadowsLowerScope && (value === undefined || value === base[field])) {
+		const filePath = field === "model"
+			? mergeBuiltinAgentOverride(ctx.cwd, agent.name, scope, { model: value ?? base.model ?? false })
+			: field === "thinking"
+				? mergeBuiltinAgentOverride(ctx.cwd, agent.name, scope, { thinking: value ?? (base.thinking === false ? "off" : base.thinking) ?? false })
+				: mergeBuiltinAgentOverride(ctx.cwd, agent.name, scope, { systemPrompt: value ?? base.systemPrompt });
+		return {
+			filePath,
+			overridden: true,
+		};
+	}
 	if (value === undefined || value === base[field]) {
 		return {
 			filePath: removeBuiltinAgentOverrideFields(ctx.cwd, agent.name, scope, [field]).path,
@@ -358,13 +368,15 @@ async function saveAgentSystemPrompt(ctx: ExtensionContext, agent: AgentConfig, 
 }
 
 async function editSystemPrompt(ctx: ExtensionContext, agent: AgentConfig): Promise<string | null> {
-	if (!savesThroughSettings(agent, "systemPrompt")) {
+	const saveThroughSettings = savesThroughSettings(agent, "systemPrompt");
+	if (!saveThroughSettings) {
 		const readOnlyMessage = readOnlyAgentMessage(agent, "systemPrompt");
 		if (readOnlyMessage) return readOnlyMessage;
 	}
 	const edited = await ctx.ui.editor(`Edit '${agent.name}' system prompt`, agent.systemPrompt ?? "");
 	if (edited === undefined) return null;
-	if (edited.replace(/\s+$/, "") === (agent.systemPrompt ?? "").replace(/\s+$/, "")) {
+	const projectOwnsLowerScopeOverride = agent.source === "project" && agent.override?.scope === "user" && discoverAgentsAll(ctx.cwd).projectSettingsPath;
+	if (edited.replace(/\s+$/, "") === (agent.systemPrompt ?? "").replace(/\s+$/, "") && !(saveThroughSettings && projectOwnsLowerScopeOverride)) {
 		return `System prompt for '${agent.name}' left unchanged.`;
 	}
 	return saveAgentSystemPrompt(ctx, agent, edited);

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -8,6 +8,7 @@ import { EXTRA_AGENT_DIRS_ENV } from "../../src/agents/agents.ts";
 import { EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
 import { clearSkillCache } from "../../src/agents/skills.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
+import { openSubagentsAdmin } from "../../src/slash/subagents-admin.ts";
 
 let tempDir = "";
 let oldAgentDir: string | undefined;
@@ -940,7 +941,219 @@ Drive the failing test first.
 		assert.match(afterText, /Inherit skills: true/);
 	});
 
-	it("preserves blank output and defaultReads frontmatter that blocks settings overrides during updates", () => {
+	it("does not serialize settings descriptions, fast, or defaults into custom agent frontmatter during updates", () => {
+		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
+		const settingsPath = path.join(tempDir, ".pi", "settings.json");
+		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(settingsPath, JSON.stringify({
+			subagents: {
+				defaultModel: "openai/gpt-default",
+				defaultThinking: "high",
+				agentOverrides: {
+					implementer: { description: "Settings description", output: "settings.md", fast: true },
+				},
+			},
+		}, null, 2), "utf-8");
+		fs.writeFileSync(agentPath, `---
+name: implementer
+description: Frontmatter description
+---
+
+Drive the failing test first.
+`, "utf-8");
+
+		const beforeText = readText(handleManagementAction("get", { agent: "implementer" }, ctx));
+		assert.match(beforeText, /Description: Settings description/);
+		assert.match(beforeText, /Model: openai\/gpt-default/);
+		assert.match(beforeText, /Thinking: high/);
+
+		const updated = handleUpdate({ agent: "implementer", config: { output: "local.md" } }, ctx);
+		assert.equal(updated.isError, false);
+
+		const content = fs.readFileSync(agentPath, "utf-8");
+		assert.match(content, /^description: Frontmatter description$/m);
+		assert.match(content, /^output: local\.md$/m);
+		assert.doesNotMatch(content, /^fast:/m);
+		assert.doesNotMatch(content, /^model:/m);
+		assert.doesNotMatch(content, /^thinking:/m);
+	});
+
+	it("keeps same-value custom override ownership for interactive admin edits", async () => {
+		const settingsPath = path.join(tempDir, ".pi", "settings.json");
+		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(settingsPath, JSON.stringify({
+			subagents: {
+				agentOverrides: { implementer: { model: "anthropic/claude-old" } },
+			},
+		}, null, 2), "utf-8");
+		fs.writeFileSync(agentPath, `---
+name: implementer
+description: Frontmatter description
+model: anthropic/claude-old
+---
+
+Drive the failing test first.
+`, "utf-8");
+		const sent: unknown[] = [];
+		const notified: string[] = [];
+
+		await openSubagentsAdmin(
+			{ sendMessage: (message: unknown) => sent.push(message) } as never,
+			{
+				cwd: tempDir,
+				hasUI: true,
+				modelRegistry: {
+					getAvailable: () => [
+						{ provider: "anthropic", id: "claude-old" },
+						{ provider: "anthropic", id: "claude-new" },
+					],
+				},
+				ui: {
+					select: async () => "anthropic/claude-new",
+					notify: (message: string) => notified.push(message),
+				},
+			} as never,
+			"implementer model",
+		);
+
+		assert.match(notified[0] ?? "", /Saved project settings override/);
+		assert.match(JSON.stringify(sent), /Saved project settings override/);
+		assert.match(fs.readFileSync(agentPath, "utf-8"), /^model: anthropic\/claude-old$/m);
+		assert.equal(JSON.parse(fs.readFileSync(settingsPath, "utf-8")).subagents.agentOverrides.implementer.model, "anthropic/claude-new");
+		const after = readText(handleManagementAction("get", { agent: "implementer" }, { cwd: tempDir, modelRegistry: { getAvailable: () => [] } }));
+		assert.match(after, /Model: anthropic\/claude-new/);
+	});
+
+	it("promotes cross-scope custom override edits to project settings", async () => {
+		const userSettingsPath = path.join(tempDir, "agent-home", "settings.json");
+		const projectSettingsPath = path.join(tempDir, ".pi", "settings.json");
+		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");
+		fs.mkdirSync(path.dirname(userSettingsPath), { recursive: true });
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(userSettingsPath, JSON.stringify({
+			subagents: {
+				agentOverrides: {
+					implementer: { model: "anthropic/claude-old" },
+					critic: { thinking: "high" },
+					speaker: { systemPrompt: "Shared prompt" },
+				},
+			},
+		}, null, 2), "utf-8");
+		fs.writeFileSync(projectSettingsPath, JSON.stringify({
+			subagents: { defaultModel: "openai/gpt-default" },
+		}, null, 2), "utf-8");
+		fs.writeFileSync(agentPath, `---
+name: implementer
+description: Frontmatter description
+---
+
+Drive the failing test first.
+`, "utf-8");
+		fs.writeFileSync(path.join(path.dirname(agentPath), "critic.md"), `---
+name: critic
+description: Thinking critic
+thinking: false
+---
+
+Keep thinking off.
+`, "utf-8");
+		fs.writeFileSync(path.join(path.dirname(agentPath), "speaker.md"), `---
+name: speaker
+description: Prompt speaker
+---
+
+Base prompt.
+`, "utf-8");
+		const sent: unknown[] = [];
+		const notified: string[] = [];
+
+		await openSubagentsAdmin(
+			{ sendMessage: (message: unknown) => sent.push(message) } as never,
+			{
+				cwd: tempDir,
+				hasUI: true,
+				modelRegistry: {
+					getAvailable: () => [
+						{ provider: "anthropic", id: "claude-old" },
+						{ provider: "anthropic", id: "claude-new" },
+					],
+				},
+				ui: {
+					select: async () => "anthropic/claude-new",
+					notify: (message: string) => notified.push(message),
+				},
+			} as never,
+			"implementer model",
+		);
+
+		assert.match(notified[0] ?? "", /Saved project settings override/);
+		assert.match(JSON.stringify(sent), /Saved project settings override/);
+		assert.doesNotMatch(fs.readFileSync(agentPath, "utf-8"), /^model:/m);
+		assert.equal(JSON.parse(fs.readFileSync(userSettingsPath, "utf-8")).subagents.agentOverrides.implementer.model, "anthropic/claude-old");
+		assert.equal(JSON.parse(fs.readFileSync(projectSettingsPath, "utf-8")).subagents.agentOverrides.implementer.model, "anthropic/claude-new");
+		const after = readText(handleManagementAction("get", { agent: "implementer" }, { cwd: tempDir, modelRegistry: { getAvailable: () => [] } }));
+		assert.match(after, /Model: anthropic\/claude-new/);
+
+		await openSubagentsAdmin(
+			{ sendMessage: (message: unknown) => sent.push(message) } as never,
+			{
+				cwd: tempDir,
+				hasUI: true,
+				modelRegistry: { getAvailable: () => [{ provider: "anthropic", id: "claude-new" }] },
+				ui: {
+					select: async () => "Default / inherit session model",
+					notify: (message: string) => notified.push(message),
+				},
+			} as never,
+			"implementer model",
+		);
+
+		assert.equal(JSON.parse(fs.readFileSync(userSettingsPath, "utf-8")).subagents.agentOverrides.implementer.model, "anthropic/claude-old");
+		assert.equal(JSON.parse(fs.readFileSync(projectSettingsPath, "utf-8")).subagents.agentOverrides.implementer.model, "openai/gpt-default");
+		const cleared = readText(handleManagementAction("get", { agent: "implementer" }, { cwd: tempDir, modelRegistry: { getAvailable: () => [] } }));
+		assert.match(cleared, /Model: openai\/gpt-default/);
+		assert.doesNotMatch(cleared, /Model: anthropic\/claude-old|Model: anthropic\/claude-new/);
+
+		await openSubagentsAdmin(
+			{ sendMessage: (message: unknown) => sent.push(message) } as never,
+			{
+				cwd: tempDir,
+				hasUI: true,
+				modelRegistry: { getAvailable: () => [] },
+				ui: {
+					select: async () => "Default / inherit session thinking",
+					notify: (message: string) => notified.push(message),
+				},
+			} as never,
+			"critic thinking",
+		);
+
+		assert.equal(JSON.parse(fs.readFileSync(userSettingsPath, "utf-8")).subagents.agentOverrides.critic.thinking, "high");
+		assert.equal(JSON.parse(fs.readFileSync(projectSettingsPath, "utf-8")).subagents.agentOverrides.critic.thinking, "off");
+		const thinkingCleared = readText(handleManagementAction("get", { agent: "critic" }, { cwd: tempDir, modelRegistry: { getAvailable: () => [] } }));
+		assert.match(thinkingCleared, /Thinking: off/);
+
+		await openSubagentsAdmin(
+			{ sendMessage: (message: unknown) => sent.push(message) } as never,
+			{
+				cwd: tempDir,
+				hasUI: true,
+				modelRegistry: { getAvailable: () => [] },
+				ui: {
+					editor: async () => "Shared prompt",
+					notify: (message: string) => notified.push(message),
+				},
+			} as never,
+			"speaker system-prompt",
+		);
+
+		assert.equal(JSON.parse(fs.readFileSync(userSettingsPath, "utf-8")).subagents.agentOverrides.speaker.systemPrompt, "Shared prompt");
+		assert.equal(JSON.parse(fs.readFileSync(projectSettingsPath, "utf-8")).subagents.agentOverrides.speaker.systemPrompt, "Shared prompt");
+	});
+
+	it("preserves blank output and defaultReads frontmatter while settings overrides replace them", () => {
 		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
 		const settingsPath = path.join(tempDir, ".pi", "settings.json");
 		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");
@@ -965,11 +1178,11 @@ Drive the failing test first.
 		assert.match(content, /^output: ?$/m);
 		assert.match(content, /^defaultReads: ?$/m);
 		const after = readText(handleManagementAction("get", { agent: "implementer" }, ctx));
-		assert.doesNotMatch(after, /Output: settings\.md/);
-		assert.doesNotMatch(after, /Reads: settings\.md/);
+		assert.match(after, /Output: settings\.md/);
+		assert.match(after, /Reads: settings\.md/);
 	});
 
-	it("preserves explicit default-like frontmatter that blocks settings overrides during updates", () => {
+	it("preserves explicit default-like frontmatter while settings overrides replace it", () => {
 		const ctx = { cwd: tempDir, modelRegistry: { getAvailable: () => [] } };
 		const settingsPath = path.join(tempDir, ".pi", "settings.json");
 		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");
@@ -1007,8 +1220,8 @@ Drive the failing test first.
 		const got = handleManagementAction("get", { agent: "implementer" }, ctx);
 		assert.equal(got.isError, false);
 		const beforeText = readText(got);
-		assert.match(beforeText, /Thinking: off/);
-		assert.doesNotMatch(beforeText, /Thinking: high/);
+		assert.match(beforeText, /Thinking: high/);
+		assert.doesNotMatch(beforeText, /Thinking: off/);
 
 		const updated = handleUpdate(
 			{ agent: "implementer", config: { description: "Updated implementer" } },
@@ -1029,8 +1242,8 @@ Drive the failing test first.
 		const gotAfter = handleManagementAction("get", { agent: "implementer" }, ctx);
 		assert.equal(gotAfter.isError, false);
 		const afterText = readText(gotAfter);
-		assert.match(afterText, /Thinking: off/);
-		assert.doesNotMatch(afterText, /Thinking: high/);
+		assert.match(afterText, /Thinking: high/);
+		assert.doesNotMatch(afterText, /Thinking: off/);
 	});
 
 	it("reports builtin runtime-loaded model mappings from current session state", () => {

--- a/test/unit/agent-overrides.test.ts
+++ b/test/unit/agent-overrides.test.ts
@@ -716,7 +716,7 @@ describe("builtin agent overrides", () => {
 		assert.equal(reviewer.override?.scope, "project");
 	});
 
-	it("frontmatter wins per-field over agentOverrides for a shadowing project agent", () => {
+	it("agentOverrides replace frontmatter for a shadowing project agent", () => {
 		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
 			subagents: { agentOverrides: { reviewer: { model: "openai/gpt-5.4" } } },
@@ -726,11 +726,11 @@ describe("builtin agent overrides", () => {
 		const reviewer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "reviewer");
 		assert.ok(reviewer);
 		assert.equal(reviewer.source, "project");
-		assert.equal(reviewer.model, "google/gemini-3-pro");
-		assert.equal(reviewer.override, undefined);
+		assert.equal(reviewer.model, "openai/gpt-5.4");
+		assert.equal(reviewer.override?.scope, "project");
 	});
 
-	it("fills in unset fields on a custom project agent from project agentOverrides", () => {
+	it("applies project agentOverrides to a custom project agent", () => {
 		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
 			subagents: {
@@ -782,7 +782,7 @@ describe("builtin agent overrides", () => {
 		assert.equal(implementer.override?.path, path.join(tempProject, ".pi", "settings.json"));
 	});
 
-	it("fills in unset fields on a custom user agent from user agentOverrides", () => {
+	it("applies user agentOverrides to a custom user agent", () => {
 		writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), {
 			subagents: { agentOverrides: { implementer: { model: "anthropic/claude-sonnet-4-6" } } },
 		});
@@ -826,7 +826,7 @@ describe("builtin agent overrides", () => {
 		assert.equal(implementer.override?.scope, "project");
 	});
 
-	it("keeps explicit custom frontmatter fields over matching agentOverrides", () => {
+	it("agentOverrides replace explicit custom frontmatter fields", () => {
 		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
 			subagents: {
@@ -843,6 +843,7 @@ describe("builtin agent overrides", () => {
 						inheritProjectContext: true,
 						defaultContext: "fork",
 						acceptanceRole: "writer",
+						systemPrompt: "Override prompt",
 						completionGuard: true,
 					},
 				},
@@ -852,23 +853,24 @@ describe("builtin agent overrides", () => {
 
 		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
 		assert.ok(implementer);
-		assert.equal(implementer.output, "artifacts/explicit.md");
-		assert.equal(implementer.outputMode, "inline");
-		assert.deepEqual(implementer.defaultReads, ["explicit.md"]);
-		assert.equal(implementer.model, "google/gemini-3-pro");
-		assert.equal(implementer.fast, false);
-		assert.equal(implementer.thinking, "medium");
-		assert.deepEqual(implementer.tools, ["read"]);
-		assert.deepEqual(implementer.mcpDirectTools, ["local_tool"]);
-		assert.deepEqual(implementer.skills, ["agent-skill"]);
-		assert.equal(implementer.inheritProjectContext, false);
-		assert.equal(implementer.defaultContext, "fresh");
-		assert.equal(implementer.acceptanceRole, "read-only");
-		assert.equal(implementer.completionGuard, false);
-		assert.equal(implementer.override, undefined);
+		assert.equal(implementer.output, "artifacts/override.md");
+		assert.equal(implementer.outputMode, "file-only");
+		assert.deepEqual(implementer.defaultReads, ["override.md"]);
+		assert.equal(implementer.model, "anthropic/claude-sonnet-4-6");
+		assert.equal(implementer.fast, true);
+		assert.equal(implementer.thinking, "high");
+		assert.deepEqual(implementer.tools, ["bash"]);
+		assert.equal(implementer.mcpDirectTools, undefined);
+		assert.deepEqual(implementer.skills, ["override-skill"]);
+		assert.equal(implementer.inheritProjectContext, true);
+		assert.equal(implementer.defaultContext, "fork");
+		assert.equal(implementer.acceptanceRole, "writer");
+		assert.equal(implementer.systemPrompt, "Override prompt");
+		assert.equal(implementer.completionGuard, true);
+		assert.equal(implementer.override?.scope, "project");
 	});
 
-	it("keeps explicit output and defaultReads frontmatter when overrides clear them", () => {
+	it("lets false overrides clear explicit output and defaultReads frontmatter", () => {
 		fs.mkdirSync(path.join(tempProject, ".pi"), { recursive: true });
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
 			subagents: { agentOverrides: { implementer: { output: false, defaultReads: false } } },
@@ -876,8 +878,8 @@ describe("builtin agent overrides", () => {
 		writeProjectAgent(tempProject, "implementer", `---\nname: implementer\ndescription: TDD implementer\noutput: explicit.md\ndefaultReads: explicit.md\n---\n\nDrive the failing test first.\n`);
 
 		const implementer = discoverAgents(tempProject, "both").agents.find((agent) => agent.name === "implementer");
-		assert.equal(implementer?.output, "explicit.md");
-		assert.deepEqual(implementer?.defaultReads, ["explicit.md"]);
+		assert.equal(implementer?.output, undefined);
+		assert.deepEqual(implementer?.defaultReads, undefined);
 	});
 
 	it("keeps an explicit empty defaultReads override distinct from false", () => {
@@ -1049,7 +1051,7 @@ describe("builtin agent overrides", () => {
 		const packageRoot = path.join(tempProject, "package-agents");
 		fs.mkdirSync(path.join(packageRoot, "agents"), { recursive: true });
 		writeJson(path.join(packageRoot, "package.json"), { "pi-subagents": { agents: ["agents"] } });
-		fs.writeFileSync(path.join(packageRoot, "agents", "package-scout.md"), `---\nname: package-scout\ndescription: Package scout\n---\n\nScout the package.\n`, "utf-8");
+		fs.writeFileSync(path.join(packageRoot, "agents", "package-scout.md"), `---\nname: package-scout\ndescription: Package scout\noutput: package-frontmatter.md\ndefaultReads: PACKAGE-FRONTMATTER.md\n---\n\nScout the package.\n`, "utf-8");
 		writeJson(path.join(tempProject, ".pi", "settings.json"), {
 			packages: [packageRoot],
 			subagents: { agentOverrides: { "package-scout": { output: "package.md", defaultReads: ["PACKAGE.md"] } } },

--- a/test/unit/default-extensions.test.ts
+++ b/test/unit/default-extensions.test.ts
@@ -117,7 +117,7 @@ describe("subagents.defaultExtensions", () => {
 		);
 		assert.deepEqual(
 			agents.find((agent) => agent.name === "explicit")?.extensions,
-			[path.join(tempProject, ".pi", "agents", "frontmatter.ts")],
+			["./ignored.ts"],
 		);
 	});
 


### PR DESCRIPTION
## Summary
- make `subagents.agentOverrides.<name>` replace matching custom and package agent fields the same way builtin overrides do
- keep management edits from writing settings/default-derived values back into custom-agent frontmatter
- update docs and changelog with credit to [@expoli](https://github.com/expoli)

Closes #1796.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/default-extensions.test.ts test/unit/agent-overrides.test.ts test/unit/agent-management.test.ts` — 109 passed
- `npm run typecheck`
- `git diff --check`
- `git diff --cached --name-only` — empty before commit

Full unit sweep had only the unrelated missing local Oxlint binary failure in `test/unit/anti-slop-oxlint.test.ts`.
