### PR TITLE
fix: omit inferred acceptance for read-only reviewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Strip the trailing Pi turn-timing footer from child output. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1792.
+- Avoid injecting inferred acceptance reports into reviewer/read-only child prompts. Thanks [@expoli](https://github.com/expoli) for #1797.
 - Preserve coordinated read-only intent when resuming direct async children and surface captured structured output in completion and status evidence. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1788.
 - Keep macOS subagent tasks out of argv by delivering them through temporary files. Thanks [@josephkallas](https://github.com/josephkallas) for #1793.
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -393,7 +393,7 @@ Acceptance evidence levels are `auto`, `none`, `attested`, `checked`, and `verif
 Review is a separate gate configured with `acceptance.review`:
 
 - Async, risky, and dynamic writer contexts infer checked evidence plus `review: { agent: "reviewer", required: true }`.
-- Read-only tasks infer lightweight attestation.
+- Reviewer/read-only calls infer no acceptance by default; explicit acceptance requests still apply.
 - Normal writer tasks infer checked evidence without review.
 
 Agent frontmatter or `subagents.agentOverrides` may set `acceptanceRole: "read-only" | "writer"` for ambiguous tasks. Explicit task mutation or no-edit intent wins over that role, while omitted metadata preserves the existing reviewer/scout/worker name heuristics. The role affects acceptance inference only and does not change tool access.
@@ -420,7 +420,7 @@ Acceptance provenance is stored separately from child prose. `evidenceStatus` pr
 
 ### The acceptance report
 
-For `attested` or stricter levels, the child prompt includes a standardized acceptance section and asks for a fenced `acceptance-report` JSON block. With `outputSchema`, set `acceptance.report: "on"` to require the same report in the final `structured_output` call, or `"off"` to keep the fenced-report path. Omitting `report` preserves the default behavior. Runs without `outputSchema` never gain a standalone structured-output tool from this option.
+For `attested` or stricter levels, the child prompt includes a standardized acceptance section and asks for a fenced `acceptance-report` JSON block. Reviewer/read-only inference resolves to `none`, so it does not add this section; explicit acceptance still does. With `outputSchema`, set `acceptance.report: "on"` to require the same report in the final `structured_output` call, or `"off"` to keep the fenced-report path. Omitting `report` preserves the default behavior. Runs without `outputSchema` never gain a standalone structured-output tool from this option.
 
 The parser canonicalizes known enum synonyms, snake_case report keys and wrappers, underscore fence tags, unambiguous scalar arrays, string booleans, and criterion-id separators. Unknown or ambiguous keys and enum values fail with field-level diagnostics. Explicit empty `changedFiles` and `testsAddedOrUpdated` arrays are recorded as not applicable; missing fields and empty required command or validation evidence still fail.
 

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -100,12 +100,13 @@ function inferLevel(input: {
 	const writeTask = taskMayWrite
 		|| (input.acceptanceRole === "writer" && !readOnlyTask)
 		|| (input.acceptanceRole === undefined && /\bworker\b/.test(agent) && !readOnlyTask);
-	const inferredReadOnly = readOnlyTask || (input.acceptanceRole === "read-only" && !taskMayWrite);
+	const inferredReadOnly = readOnlyTask || ((readOnlyAgent || input.acceptanceRole === "read-only") && !taskMayWrite);
 	const roleResolvesReadOnly = input.acceptanceRole !== undefined && inferredReadOnly;
+	const dynamicResolvesReadOnly = inferredReadOnly && !writeTask;
 	const keywordRiskReadOnly = input.acceptanceRole === undefined ? intent.kind === "read-only" : inferredReadOnly;
 	const risky = Boolean(input.async && writeTask)
-		|| (Boolean(input.dynamic) && !roleResolvesReadOnly)
-		|| (Boolean(input.dynamicGroup) && !roleResolvesReadOnly)
+		|| (Boolean(input.dynamic) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
+		|| (Boolean(input.dynamicGroup) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
 		|| (!keywordRiskReadOnly && /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/.test(task));
 
 	if (risky) {
@@ -131,7 +132,7 @@ function inferLevel(input: {
 	if (readOnlyAgent || readOnlyTask) {
 		reasons.push(input.acceptanceRole === "read-only" && !readOnlyTask ? "declared read-only acceptance role" : readOnlyAgent ? "read-only/reviewer-style agent" : "read-only task wording");
 		return {
-			level: "attested",
+			level: "none",
 			reasons,
 			criteria: ["Return concrete findings with file paths and severity when applicable"],
 			evidence: ["review-findings", "residual-risks"],
@@ -205,6 +206,10 @@ export function normalizeGateAcceptance(gate: unknown, acceptance: AcceptanceInp
 
 function explicitAcceptanceCanDisable(explicit: AcceptanceConfig): boolean {
 	return explicit.level === "none" && typeof explicit.reason === "string" && explicit.reason.trim().length > 0;
+}
+
+function explicitAcceptanceRequestsPolicy(explicit: AcceptanceConfig): boolean {
+	return (explicit.level !== undefined && explicit.level !== "auto") || Object.keys(explicit).some((key) => key !== "level");
 }
 
 function unsupportedEvidenceKindMessage(pathLabel: string, item: unknown): string {
@@ -437,12 +442,13 @@ export function resolveEffectiveAcceptance(input: {
 		};
 	}
 	const inferred = inferLevel(input);
+	const inferredLevel = inferred.level === "none" && explicitAcceptanceRequestsPolicy(explicit) ? "attested" : inferred.level;
 	const level = explicitAcceptanceCanDisable(explicit)
 		? "none"
 		: explicitLevel === "auto"
-			? inferred.level
-			: (LEVEL_RANK[explicitLevel] >= LEVEL_RANK[inferred.level] ? explicitLevel : inferred.level);
-	const evidence = unique([...(level === inferred.level ? inferred.evidence : requiredEvidenceForLevel(level)), ...(explicit.evidence ?? [])]);
+			? inferredLevel
+			: (LEVEL_RANK[explicitLevel] >= LEVEL_RANK[inferredLevel] ? explicitLevel : inferredLevel);
+	const evidence = unique([...(level === inferredLevel ? inferred.evidence : requiredEvidenceForLevel(level)), ...(explicit.evidence ?? [])]);
 	const criteria = normalizeCriteria(
 		(explicit.criteria?.length ? explicit.criteria : inferred.criteria) as Array<string | { id?: string; must?: string; evidence?: AcceptanceEvidenceKind[]; severity?: "required" | "recommended" }>,
 		evidence,
@@ -452,8 +458,8 @@ export function resolveEffectiveAcceptance(input: {
 		level,
 		explicit: input.explicit !== undefined,
 		inferredReason: inferred.reasons,
-		criteria,
-		evidence,
+		criteria: level === "none" ? [] : criteria,
+		evidence: level === "none" ? [] : evidence,
 		verify: explicit.verify ?? [],
 		review,
 		stopRules: explicit.stopRules ?? [],

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -2403,7 +2403,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const asyncId = result.details?.asyncId;
 		assert.ok(asyncId, "expected asyncId");
 		const payload = await readAsyncPayload(asyncId);
-		assert.equal(payload.results[0]?.acceptance?.effectiveAcceptance.level, "attested");
+		assert.equal(payload.results[0]?.acceptance?.effectiveAcceptance.level, "none");
 	});
 
 
@@ -2436,7 +2436,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			maxSubagentDepth: 2,
 		});
 		const reviewPayload = await readAsyncPayload(reviewId);
-		assert.equal(reviewPayload.results[0]?.acceptance?.effectiveAcceptance?.level, "attested");
+		assert.equal(reviewPayload.results[0]?.acceptance?.effectiveAcceptance?.level, "none");
 	});
 
 
@@ -2916,10 +2916,10 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.ok(!result.isError);
 		const payload = await readAsyncPayload(id);
 		const explorerResults = payload.results.filter((child) => child.agent === "explorer");
-		assert.deepEqual(explorerResults.map((child) => child.acceptance?.effectiveAcceptance?.level), ["attested", "attested"]);
+		assert.deepEqual(explorerResults.map((child) => child.acceptance?.effectiveAcceptance?.level), ["none", "none"]);
 		const dynamicNode = payload.workflowGraph?.nodes?.[1];
-		assert.equal(dynamicNode?.acceptanceStatus, "attested");
-		assert.deepEqual(dynamicNode?.children?.map((child) => child.acceptanceStatus), ["attested", "attested"]);
+		assert.equal(dynamicNode?.acceptanceStatus, "not-required");
+		assert.deepEqual(dynamicNode?.children?.map((child) => child.acceptanceStatus), ["not-required", "not-required"]);
 	});
 
 	it("infers async dynamic acceptance after materializing item templates", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
@@ -5980,6 +5980,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			agent: "scout",
 			task: "Inspect something",
 			agentConfig: makeAgent("scout"),
+			acceptance: { level: "attested", criteria: ["Finish cleanly"] },
 			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
 			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
 			shareEnabled: false,

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -5118,6 +5118,16 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.doesNotMatch(call.args.join("\n"), /## Acceptance Contract/);
 	});
 
+	it("does not inject inferred acceptance into reviewer prompts", async () => {
+		mockPi.onCall({ output: "VERDICT: PASS" });
+		const result = await runSync(tempDir, [makeAgent("reviewer", { tools: ["read"], completionGuard: false })], "reviewer", "Review the diff and return findings only.", {
+			runId: "reviewer-inferred-acceptance",
+		});
+
+		assert.equal(result.exitCode, 0);
+		assert.doesNotMatch(readCall().args.join("\n"), /## Acceptance Contract/);
+	});
+
 	it("agent contract v1 keeps acceptance rejection out of execution status", async () => {
 		mockPi.onCall({ output: "Done\n```acceptance-report\n{\"criteriaSatisfied\":[{\"id\":\"criterion-1\",\"status\":\"not-satisfied\",\"evidence\":\"no proof\"}]}\n```" });
 		const agents = [makeAgent("worker", { tools: ["read"], completionGuard: false })];
@@ -8172,7 +8182,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		});
 
 		const result = await runSync(tempDir, makeAgentConfigs(["slow"]), "slow", "Slow task", {
-			timeoutMs: 150,
+			timeoutMs: 1000,
 			outputPath: reportPath,
 			outputMode: "file-only",
 			acceptance: false,

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -64,7 +64,7 @@ function tempGitRepo(): string {
 
 describe("acceptance gates", () => {
 	it("infers evidence levels and review requirements independently", () => {
-		assert.equal(resolveEffectiveAcceptance({ agentName: "reviewer", task: "Review-only. Do not edit.", mode: "single" }).level, "attested");
+		assert.equal(resolveEffectiveAcceptance({ agentName: "reviewer", task: "Review-only. Do not edit.", mode: "single" }).level, "none");
 		assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task: "Implement the fix", mode: "single" }).level, "checked");
 		for (const resolved of [
 			resolveEffectiveAcceptance({ agentName: "worker", task: "Implement the fix", mode: "single", async: true }),
@@ -75,7 +75,7 @@ describe("acceptance gates", () => {
 		}
 	});
 
-	it("keeps async oracle review tasks on read-only acceptance despite implementation vocabulary", () => {
+	it("omits inferred acceptance for async oracle review tasks despite implementation vocabulary", () => {
 		const resolved = resolveEffectiveAcceptance({
 			agentName: "oracle",
 			task: "Review prep findings and determine what to implement with playbooks instead of before.",
@@ -83,9 +83,9 @@ describe("acceptance gates", () => {
 			async: true,
 		});
 
-		assert.equal(resolved.level, "attested");
+		assert.equal(resolved.level, "none");
 		assert.deepEqual(resolved.inferredReason, ["read-only/reviewer-style agent"]);
-		assert.deepEqual(resolved.criteria.map((criterion) => criterion.must), ["Return concrete findings with file paths and severity when applicable"]);
+		assert.deepEqual(resolved.criteria, []);
 	});
 
 	it("uses explicit agent roles for ambiguous tasks while preserving task-intent precedence", () => {
@@ -94,7 +94,7 @@ describe("acceptance gates", () => {
 			acceptanceRole: "read-only",
 			task: "Explore the authentication flow",
 			mode: "single",
-		}).level, "attested");
+		}).level, "none");
 		assert.equal(resolveEffectiveAcceptance({
 			agentName: "reviewer",
 			acceptanceRole: "writer",
@@ -121,13 +121,13 @@ describe("acceptance gates", () => {
 			acceptanceRole: "read-only",
 			task: "Create a report",
 			mode: "single",
-		}).level, "attested");
+		}).level, "none");
 		assert.equal(resolveEffectiveAcceptance({
 			agentName: "worker",
 			acceptanceRole: "writer",
 			task: "Review only; do not edit files",
 			mode: "single",
-		}).level, "attested");
+		}).level, "none");
 		assert.equal(resolveEffectiveAcceptance({
 			agentName: "reviewer",
 			acceptanceRole: "writer",
@@ -140,35 +140,35 @@ describe("acceptance gates", () => {
 			acceptanceRole: "read-only",
 			task: "Explore the authentication flow",
 			mode: "single",
-		}).level, "attested");
+		}).level, "none");
 		assert.equal(resolveEffectiveAcceptance({
 			agentName: "explorer",
 			acceptanceRole: "read-only",
 			task: "Audit the security posture",
 			mode: "single",
-		}).level, "attested");
+		}).level, "none");
 		assert.equal(resolveEffectiveAcceptance({
 			agentName: "explorer",
 			acceptanceRole: "read-only",
 			task: "Explore each target",
 			mode: "chain",
 			dynamic: true,
-		}).level, "attested");
+		}).level, "none");
 		assert.equal(resolveEffectiveAcceptance({
 			agentName: "worker",
 			acceptanceRole: "writer",
 			task: "Review only; do not edit files",
 			mode: "chain",
 			dynamicGroup: true,
-		}).level, "attested");
+		}).level, "none");
 		const dynamicReviewer = resolveEffectiveAcceptance({
 			agentName: "reviewer",
 			task: "Review each target",
 			mode: "chain",
 			dynamic: true,
 		});
-		assert.equal(dynamicReviewer.level, "checked");
-		assert.equal(dynamicReviewer.review && dynamicReviewer.review !== false ? dynamicReviewer.review.required : undefined, true);
+		assert.equal(dynamicReviewer.level, "none");
+		assert.equal(formatAcceptancePrompt(dynamicReviewer), "");
 	});
 
 	it("preserves risky keyword review inference when acceptance role metadata is omitted", () => {
@@ -254,6 +254,30 @@ describe("acceptance gates", () => {
 		assert.match(prompt, /commandsRun\[\]\.result.*passed, failed, not-run/);
 		assert.match(prompt, /manualNotes.*optional strings.*empty string.*does not satisfy.*manual-notes/);
 		assert.match(prompt, /"reviewFindings": \[\n    "blocker:/);
+	});
+
+	it("omits inferred read-only prompts while preserving explicit acceptance", () => {
+		const inferred = resolveEffectiveAcceptance({
+			agentName: "reviewer",
+			task: "Review the diff and return findings only.",
+		});
+		assert.equal(inferred.level, "none");
+		assert.equal(formatAcceptancePrompt(inferred), "");
+
+		const explicit = resolveEffectiveAcceptance({
+			agentName: "reviewer",
+			task: "Review the diff and return findings only.",
+			explicit: { level: "checked", criteria: ["Return the review findings"] },
+		});
+		assert.match(formatAcceptancePrompt(explicit), /```acceptance-report/);
+
+		const explicitCriteria = resolveEffectiveAcceptance({
+			agentName: "reviewer",
+			task: "Review the diff and return findings only.",
+			explicit: { criteria: ["Return the review findings"] },
+		});
+		assert.equal(explicitCriteria.level, "attested");
+		assert.match(formatAcceptancePrompt(explicitCriteria), /```acceptance-report/);
 	});
 
 	it("includes every required resolved criterion in report examples", () => {
@@ -1227,14 +1251,14 @@ describe("acceptance gates", () => {
 			task: "Report on the extraction pipeline. Do not modify project/source files.",
 			async: true,
 		});
-		assert.equal(readOnlyWorker.level, "attested");
+		assert.equal(readOnlyWorker.level, "none");
 		for (const task of [
 			"Inspect the extraction pipeline",
 			"Summarize the extraction pipeline",
 			"Review only: return findings",
 			"Analyze the extraction pipeline without edits",
 		]) {
-			assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task, async: true }).level, "attested", task);
+			assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task, async: true }).level, "none", task);
 		}
 
 		assert.equal(resolveEffectiveAcceptance({ agentName: "worker", task: "Inspect the failure and implement the fix" }).level, "checked");


### PR DESCRIPTION
## Summary
- resolve inferred reviewer/read-only acceptance to `none` so child prompts do not receive an inferred fenced acceptance report
- preserve explicit acceptance levels and criteria-only acceptance prompts
- update docs and changelog with credit to [@expoli](https://github.com/expoli)

Closes #1797.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/acceptance.test.ts` — 72 passed
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'does not inject inferred acceptance into reviewer prompts|agent contract v1 reports omitted acceptance separately without injecting a prompt' test/integration/single-execution.test.ts` — 2 passed
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'applies agent acceptance roles to inferred async acceptance|infers async chain acceptance after expanding top-level task templates|applies read-only acceptance roles to async dynamic children and their aggregate group' test/integration/async-execution.test.ts` — 3 passed
- `npm run typecheck`
- `git diff --check`
- `git diff --cached --name-only` — empty before commit

Full unit sweep had only the unrelated missing local Oxlint binary failure in `test/unit/anti-slop-oxlint.test.ts`; the full integration aggregate has existing mock/concurrency instability in this checkout.
