### PR TITLE
feat: add settings-driven agent scan directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Added
+- Add settings-driven extra agent scan directories with one-segment wildcard expansion. Thanks to [@mystery4f](https://github.com/mystery4f) for #1801.
 - Make Worktrunk a first-class managed worktree provider with automatic selection when available and native Git fallback when not (#1800).
 - Let Fleet open selected async children in their child-specific Herdr inspector with plain-input guidance. Thanks to [@stekman08](https://github.com/stekman08) for #1790.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -27,6 +27,7 @@ Discovery notes:
 
 - Project discovery also reads legacy `.agents/**/*.md` files. If both `.agents/` and the project config agents directory define the same parsed runtime agent name, the project config directory wins.
 - Nested subdirectories are discovered recursively. `.chain.md` files do not define agents.
+- User and project settings can add extra recursive scan roots with `subagents.agentScanDirs`; fixed user/project agent directories keep higher priority than same-name agents from scan roots.
 - Installed Pi packages can expose agent directories from either `{"pi-subagents":{"agents":["./agents"]}}` or `{"pi":{"subagents":{"agents":["./agents"]}}}` in their package manifest. Package agents load above builtins and below user/project agents.
 - Use `agentScope: "user" | "project" | "both"` to control discovery. `both` is the default, and project definitions win runtime-name collisions.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 `pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`. This page lists every key, plus the environment variables and the settings-file keys that affect config resolution.
 
-Settings-level keys (`subagents.defaultModel`, `defaultProvider`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. `modelScope.agents.<name>` adds per-agent restrictions, and `allow: ["inherit"]` permits the current parent model. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
+Settings-level keys (`subagents.defaultModel`, `defaultProvider`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `agentScanDirs`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. `modelScope.agents.<name>` adds per-agent restrictions, and `allow: ["inherit"]` permits the current parent model. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
 
 ## Project root resolution (settings)
 
@@ -17,6 +17,20 @@ By default, project settings resolve from the nearest parent directory that cont
 ```
 
 `"git-root"` keeps package discovery, project agents, chains, and `agentOverrides` anchored to the git worktree root when that root also has Pi project config. A nested project can still opt back into nearest-root behavior by setting `"projectRootResolution": "nearest"` in its own `.pi/settings.json`.
+
+## Extra agent scan directories (settings)
+
+Add recursive user or project agent roots with `subagents.agentScanDirs` in Pi settings:
+
+```json
+{
+  "subagents": {
+    "agentScanDirs": ["~/.pi/flows/*/agents"]
+  }
+}
+```
+
+Entries support `~` expansion. A single `*` path segment expands one directory level, so package-like folders can each expose an `agents/` directory. Missing directories are ignored. Fixed user/project agent directories still win over same-name agents from scan roots.
 
 ## `modelExclusions`
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import type { AcceptanceInput, AcceptanceRole, AgentRunnerConfig, OutputMode, ToolBudgetConfig } from "../shared/types.ts";
 import { CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL, isCodeOwnedExternalCliAdapterId, parseExternalCliCapabilityNarrowing, validateCodeOwnedProfileRunner } from "../runs/shared/external-cli-contract.ts";
 import { getAgentDir, getProjectConfigDir } from "../shared/utils.ts";
+import { expandHomePath } from "../shared/settings.ts";
 import { KNOWN_FIELDS } from "./agent-serializer.ts";
 import { parseChain, parseJsonChain } from "./chain-serializer.ts";
 import { mergeAgentsForScope } from "./agent-selection.ts";
@@ -186,6 +187,7 @@ type ProjectRootResolution = "nearest" | "git-root";
 interface SubagentSettings {
 	overrides: Record<string, BuiltinAgentOverrideConfig>;
 	providerOverrides: Record<string, Record<string, BuiltinAgentOverrideConfig>>;
+	agentScanDirs?: string[];
 	defaultModel?: string;
 	defaultProvider?: string;
 	defaultThinking?: string;
@@ -1174,6 +1176,14 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		}
 		defaultExtensions = subagentsObject.defaultExtensions.map((item) => item.trim());
 	}
+	let agentScanDirs: string[] | undefined;
+	if ("agentScanDirs" in subagentsObject) {
+		if (!Array.isArray(subagentsObject.agentScanDirs)
+			|| subagentsObject.agentScanDirs.some((item) => typeof item !== "string" || !item.trim())) {
+			throw new Error(`Subagent settings in '${filePath}' have invalid 'agentScanDirs'; expected an array of non-empty strings.`);
+		}
+		agentScanDirs = subagentsObject.agentScanDirs.map((item) => item.trim());
+	}
 	const modelScope = parseModelScopeConfig(subagentsObject.modelScope, { filePath });
 
 	const parsed: Record<string, BuiltinAgentOverrideConfig> = {};
@@ -1188,6 +1198,7 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		...(defaultThinking !== undefined ? { defaultThinking } : {}),
 		...(maxThinking !== undefined ? { maxThinking } : {}),
 		...(defaultExtensions !== undefined ? { defaultExtensions } : {}),
+		...(agentScanDirs !== undefined ? { agentScanDirs } : {}),
 		...(disableBuiltins !== undefined ? { disableBuiltins } : {}),
 		...(disableThinking !== undefined ? { disableThinking } : {}),
 		...(modelScope !== undefined ? { modelScope } : {}),
@@ -2238,6 +2249,61 @@ function extraUserAgentDirs(): string[] {
 		.filter((dir) => dir.length > 0);
 }
 
+interface AgentScanDirs {
+	dirs: string[];
+	watchPaths: string[];
+}
+
+function readConfiguredAgentScanDirs(filePath: string | null): string[] {
+	if (!filePath) return [];
+	try {
+		const settings = readSettingsFileStrict(filePath);
+		const subagents = settings.subagents;
+		if (!subagents || typeof subagents !== "object" || Array.isArray(subagents)) return [];
+		const dirs = (subagents as { agentScanDirs?: unknown }).agentScanDirs;
+		return Array.isArray(dirs) ? dirs.filter((dir): dir is string => typeof dir === "string" && dir.trim().length > 0) : [];
+	} catch {
+		return [];
+	}
+}
+
+function expandAgentScanDirPattern(pattern: string): AgentScanDirs {
+	const expanded = expandHomePath(pattern.trim()).replace(/[\\/]+/g, path.sep);
+	if (!expanded) return { dirs: [], watchPaths: [] };
+	const wildcardMatches = [...expanded.matchAll(/\*/g)];
+	if (wildcardMatches.length === 0) {
+		const dir = path.resolve(expanded);
+		return { dirs: fs.existsSync(dir) ? [dir] : [], watchPaths: [dir] };
+	}
+	const parts = expanded.split(path.sep);
+	const wildcardIndex = parts.findIndex((part) => part.includes("*"));
+	if (wildcardMatches.length !== 1 || wildcardIndex === -1 || parts[wildcardIndex] !== "*") return { dirs: [], watchPaths: [] };
+	const base = path.resolve(parts.slice(0, wildcardIndex).join(path.sep) || path.sep);
+	const rest = parts.slice(wildcardIndex + 1);
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(base, { withFileTypes: true });
+	} catch {
+		return { dirs: [], watchPaths: [base] };
+	}
+	const candidateDirs = entries.filter((entry) => entry.isDirectory()).map((entry) => path.join(base, entry.name, ...rest));
+	return {
+		dirs: candidateDirs.filter((dir) => fs.existsSync(dir)),
+		watchPaths: [base, ...candidateDirs],
+	};
+}
+
+function settingsAgentScanDirs(entries: string[]): AgentScanDirs {
+	const dirs = new Set<string>();
+	const watchPaths = new Set<string>();
+	for (const entry of entries) {
+		const expanded = expandAgentScanDirPattern(entry);
+		for (const dir of expanded.dirs) dirs.add(dir);
+		for (const watchPath of expanded.watchPaths) watchPaths.add(watchPath);
+	}
+	return { dirs: [...dirs], watchPaths: [...watchPaths] };
+}
+
 export interface AgentDiscoveryAllResult {
 	builtin: AgentConfig[];
 	package: AgentConfig[];
@@ -2398,16 +2464,18 @@ function buildAgentDiscoverySources(cwd: string, preferredModelProvider?: string
 	const userSettingsPath = getUserAgentSettingsPath();
 	const projectSettingsPath = getProjectAgentSettingsPath(effectiveCwd);
 	const packageSubagentPaths = collectPackageSubagentPaths(effectiveCwd);
+	const userScanDirs = settingsAgentScanDirs(readConfiguredAgentScanDirs(userSettingsPath));
+	const projectScanDirs = settingsAgentScanDirs(readConfiguredAgentScanDirs(projectSettingsPath));
 
 	const builtinLoaded = loadAgentsFromDefinitionFiles(BUILTIN_AGENT_DEFINITION_FILES, "builtin");
-	const userLoaded = [...extraUserAgentDirs(), userDirOld, userDirNew].map((dir, discoveryPriority): LoadedAgentDirectory => {
+	const userLoaded = [...extraUserAgentDirs(), ...userScanDirs.dirs, userDirOld, userDirNew].map((dir, discoveryPriority): LoadedAgentDirectory => {
 		const inspection = inspectAgentDefinitionDirectory(dir);
 		return { dir, inspection, loaded: loadAgentsFromDir(dir, "user", discoveryPriority, undefined, inspection) };
 	});
 	const projectInspections = new Map(projectCandidateDirs.map((dir) => [dir, inspectAgentDefinitionDirectory(dir)]));
-	const projectLoaded = projectAgentDirs.map((dir): LoadedAgentDirectory => {
-		const inspection = projectInspections.get(dir)!;
-		return { dir, inspection, loaded: loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : 0, undefined, inspection) };
+	const projectLoaded = [...projectScanDirs.dirs, ...projectAgentDirs].map((dir, discoveryPriority): LoadedAgentDirectory => {
+		const inspection = projectInspections.get(dir) ?? inspectAgentDefinitionDirectory(dir);
+		return { dir, inspection, loaded: loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : discoveryPriority, undefined, inspection) };
 	});
 	const packageLoaded = packageSubagentPaths.agents.map((entry, index): LoadedAgentDirectory => {
 		const inspection = inspectAgentDefinitionDirectory(entry.dir);
@@ -2419,6 +2487,8 @@ function buildAgentDiscoverySources(cwd: string, preferredModelProvider?: string
 		...(projectSettingsPath ? [projectSettingsPath] : []),
 		...projectDiscoveryWatchPaths(effectiveCwd),
 		...findProjectRootCandidates(effectiveCwd).map((root) => path.join(getProjectConfigDir(root), "settings.json")),
+		...userScanDirs.watchPaths,
+		...projectScanDirs.watchPaths,
 		...packageSubagentPaths.watchPaths,
 	]);
 	for (const directory of userLoaded) addDirectoryWatchPaths(watchPaths, directory.dir, directory.inspection.files, inspectedAgentDefinitionDirectories(directory.inspection, directory.dir));
@@ -2426,6 +2496,7 @@ function buildAgentDiscoverySources(cwd: string, preferredModelProvider?: string
 		const inspection = projectInspections.get(dir);
 		addDirectoryWatchPaths(watchPaths, dir, inspection?.files ?? [], inspection ? inspectedAgentDefinitionDirectories(inspection, dir) : []);
 	}
+	for (const directory of projectLoaded) addDirectoryWatchPaths(watchPaths, directory.dir, directory.inspection.files, inspectedAgentDefinitionDirectories(directory.inspection, directory.dir));
 	for (const directory of packageLoaded) addDirectoryWatchPaths(watchPaths, directory.dir, directory.inspection.files, inspectedAgentDefinitionDirectories(directory.inspection, directory.dir));
 
 	const userDir = process.env.PI_CODING_AGENT_DIR ? userDirOld : fs.existsSync(userDirNew) ? userDirNew : userDirOld;
@@ -2561,7 +2632,16 @@ function configuredAgentsForScope(sources: AgentDiscoverySources, scope: AgentSc
 function discoveryDirectories(sources: AgentDiscoverySources, scope: AgentScope): AgentDefinitionDirectoryReport[] {
 	const directories: AgentDefinitionDirectoryReport[] = [reportAgentDefinitionDirectory("builtin", BUILTIN_AGENTS_DIR, BUILTIN_AGENT_DEFINITION_INSPECTION)];
 	if (scope !== "project") for (const directory of sources.userLoaded) directories.push(reportAgentDefinitionDirectory("user", directory.dir, directory.inspection));
-	if (scope !== "user") for (const dir of sources.projectCandidateDirs) directories.push(reportAgentDefinitionDirectory("project", dir, sources.projectInspections.get(dir)!));
+	if (scope !== "user") {
+		const reported = new Set<string>();
+		for (const dir of sources.projectCandidateDirs) {
+			reported.add(path.resolve(dir));
+			directories.push(reportAgentDefinitionDirectory("project", dir, sources.projectInspections.get(dir)!));
+		}
+		for (const directory of sources.projectLoaded) {
+			if (!reported.has(path.resolve(directory.dir))) directories.push(reportAgentDefinitionDirectory("project", directory.dir, directory.inspection));
+		}
+	}
 	for (const directory of sources.packageLoaded) {
 		if (directory.packageEntry && packageEntryIncluded(scope, directory.packageEntry.scope)) directories.push(reportAgentDefinitionDirectory("package", directory.dir, directory.inspection));
 	}
@@ -2670,7 +2750,9 @@ function discoverAgentsUncached(cwd: string, scope: AgentScope, preferredModelPr
 	const directories: AgentDefinitionDirectoryReport[] = [reportAgentDefinitionDirectory("builtin", BUILTIN_AGENTS_DIR, BUILTIN_AGENT_DEFINITION_INSPECTION)];
 	const builtinLoaded = loadAgentsFromDefinitionFiles(BUILTIN_AGENT_DEFINITION_FILES, "builtin");
 	const builtinAgents = applyBuiltinOverrides(applySubagentDefaults(builtinLoaded.agents, defaultModel, defaultProvider, defaultThinking, defaultExtensions), userSettings, projectSettings, userSettingsPath, projectSettingsPath);
-	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), userDirOld, userDirNew].map((dir, discoveryPriority) => {
+	const userScanDirs = settingsAgentScanDirs(userSettings.agentScanDirs ?? []);
+	const projectScanDirs = settingsAgentScanDirs(projectSettings.agentScanDirs ?? []);
+	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), ...userScanDirs.dirs, userDirOld, userDirNew].map((dir, discoveryPriority) => {
 		const inspection = inspectAgentDefinitionDirectory(dir);
 		directories.push(reportAgentDefinitionDirectory("user", dir, inspection));
 		return loadAgentsFromDir(dir, "user", discoveryPriority, undefined, inspection);
@@ -2678,7 +2760,11 @@ function discoverAgentsUncached(cwd: string, scope: AgentScope, preferredModelPr
 	const userAgents = applyCustomAgentOverrides(applySubagentDefaults(userLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions), userSettings, projectSettings, userSettingsPath, projectSettingsPath);
 	const projectInspections = scope === "user" ? new Map<string, AgentDefinitionInspection>() : new Map(projectCandidateDirs.map((dir) => [dir, inspectAgentDefinitionDirectory(dir)]));
 	if (scope !== "user") for (const dir of projectCandidateDirs) directories.push(reportAgentDefinitionDirectory("project", dir, projectInspections.get(dir)!));
-	const projectLoaded = scope === "user" ? [] : projectAgentDirs.map((dir) => loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : 0, undefined, projectInspections.get(dir)!));
+	const projectLoaded = scope === "user" ? [] : [...projectScanDirs.dirs, ...projectAgentDirs].map((dir, discoveryPriority) => {
+		const inspection = projectInspections.get(dir) ?? inspectAgentDefinitionDirectory(dir);
+		if (!projectInspections.has(dir)) directories.push(reportAgentDefinitionDirectory("project", dir, inspection));
+		return loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : discoveryPriority, undefined, inspection);
+	});
 	const projectAgents = applyCustomAgentOverrides(applySubagentDefaults(projectLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions), userSettings, projectSettings, userSettingsPath, projectSettingsPath);
 	const packageLoaded = packageSubagentPaths.agents.map((entry, index) => {
 		const inspection = inspectAgentDefinitionDirectory(entry.dir);

--- a/test/unit/agent-scan-dirs.test.ts
+++ b/test/unit/agent-scan-dirs.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearAgentDiscoveryCache, discoverAgents } from "../../src/agents/agents.ts";
+
+function tempDir(prefix: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), `agent-scan-${prefix}-`));
+}
+
+function writeAgent(dir: string, name: string, description = "scan dirs test"): void {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, `${name}.md`), `---\nname: ${name}\ndescription: ${description}\n---\nbody\n`, "utf-8");
+}
+
+describe("settings subagents.agentScanDirs", () => {
+	let agentDir: string;
+	let projectDir: string;
+	let scanRoot: string;
+	let previousAgentDir: string | undefined;
+
+	beforeEach(() => {
+		agentDir = tempDir("agent");
+		projectDir = tempDir("project");
+		scanRoot = tempDir("scan");
+		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = agentDir;
+		fs.mkdirSync(path.join(agentDir, "agents"), { recursive: true });
+		fs.mkdirSync(path.join(projectDir, ".pi"), { recursive: true });
+		clearAgentDiscoveryCache();
+	});
+
+	afterEach(() => {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		for (const dir of [agentDir, projectDir, scanRoot]) fs.rmSync(dir, { recursive: true, force: true });
+		clearAgentDiscoveryCache();
+	});
+
+	function writeUserSettings(value: unknown): void {
+		fs.writeFileSync(path.join(agentDir, "settings.json"), JSON.stringify(value), "utf-8");
+	}
+
+	function writeProjectSettings(value: unknown): void {
+		fs.writeFileSync(path.join(projectDir, ".pi", "settings.json"), JSON.stringify(value), "utf-8");
+	}
+
+	it("discovers agents from configured user scan directories", () => {
+		writeAgent(scanRoot, "scan-writer");
+		writeUserSettings({ subagents: { agentScanDirs: [scanRoot] } });
+
+		const result = discoverAgents(projectDir, "user");
+
+		const agent = result.agents.find((candidate) => candidate.name === "scan-writer");
+		assert.equal(agent?.source, "user");
+		assert.equal(agent?.filePath, path.join(scanRoot, "scan-writer.md"));
+	});
+
+	it("expands one wildcard directory segment and invalidates when children are added", () => {
+		writeUserSettings({ subagents: { agentScanDirs: [path.join(scanRoot, "*", "agents")] } });
+		assert.equal(discoverAgents(projectDir, "user").agents.some((agent) => agent.name === "late-writer"), false);
+
+		writeAgent(path.join(scanRoot, "template-a", "agents"), "late-writer");
+		const result = discoverAgents(projectDir, "user");
+
+		assert.equal(result.agents.some((agent) => agent.name === "late-writer"), true);
+	});
+
+	it("invalidates when an existing wildcard child receives its agents directory", () => {
+		fs.mkdirSync(path.join(scanRoot, "template-a"));
+		writeUserSettings({ subagents: { agentScanDirs: [path.join(scanRoot, "*", "agents")] } });
+		assert.equal(discoverAgents(projectDir, "user").agents.some((agent) => agent.name === "late-nested-writer"), false);
+
+		writeAgent(path.join(scanRoot, "template-a", "agents"), "late-nested-writer");
+		const result = discoverAgents(projectDir, "user");
+
+		assert.equal(result.agents.some((agent) => agent.name === "late-nested-writer"), true);
+	});
+
+	it("keeps user and project scan directories scoped", () => {
+		const userScanDir = path.join(scanRoot, "user-agents");
+		const projectScanDir = path.join(scanRoot, "project-agents");
+		writeAgent(userScanDir, "user-scan");
+		writeAgent(projectScanDir, "project-scan");
+		writeUserSettings({ subagents: { agentScanDirs: [userScanDir] } });
+		writeProjectSettings({ subagents: { agentScanDirs: [projectScanDir] } });
+
+		assert.equal(discoverAgents(projectDir, "user").agents.some((agent) => agent.name === "project-scan"), false);
+		assert.equal(discoverAgents(projectDir, "project").agents.some((agent) => agent.name === "user-scan"), false);
+		assert.equal(discoverAgents(projectDir, "both").agents.some((agent) => agent.name === "user-scan"), true);
+		assert.equal(discoverAgents(projectDir, "both").agents.some((agent) => agent.name === "project-scan"), true);
+	});
+
+	it("lets fixed user agents override same-name scan-dir agents", () => {
+		writeAgent(path.join(scanRoot, "template", "agents"), "writer", "from scan dir");
+		writeAgent(path.join(agentDir, "agents"), "writer", "from fixed user dir");
+		writeUserSettings({ subagents: { agentScanDirs: [path.join(scanRoot, "*", "agents")] } });
+
+		const agent = discoverAgents(projectDir, "both").agents.find((candidate) => candidate.name === "writer");
+
+		assert.equal(agent?.filePath, path.join(agentDir, "agents", "writer.md"));
+	});
+
+	it("accepts backslash-separated wildcard patterns", () => {
+		writeAgent(path.join(scanRoot, "template", "agents"), "backslash-scan");
+		writeUserSettings({ subagents: { agentScanDirs: [`${scanRoot}\\*\\agents`] } });
+
+		const result = discoverAgents(projectDir, "user");
+
+		assert.equal(result.agents.some((agent) => agent.name === "backslash-scan"), true);
+	});
+
+	it("does not treat constrained wildcard segments as broad directory scans", () => {
+		writeAgent(path.join(scanRoot, "flow-a", "agents"), "flow-scan");
+		writeAgent(path.join(scanRoot, "other", "agents"), "other-scan");
+		writeUserSettings({ subagents: { agentScanDirs: [path.join(scanRoot, "flow-*", "agents")] } });
+
+		const result = discoverAgents(projectDir, "user");
+
+		assert.equal(result.agents.some((agent) => agent.name === "flow-scan"), false);
+		assert.equal(result.agents.some((agent) => agent.name === "other-scan"), false);
+	});
+
+	it("rejects malformed scan directory settings", () => {
+		writeUserSettings({ subagents: { agentScanDirs: [path.join(scanRoot, "agents"), 42] } });
+
+		assert.throws(
+			() => discoverAgents(projectDir, "user"),
+			/Subagent settings .* invalid 'agentScanDirs'/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Add a settings-driven way to register additional subagent scan directories, so third-party templates/plugins can ship agents in their own folders instead of requiring users to copy agent files into the fixed scan roots (`~/.pi/agent/agents/` or `.pi/agents/`).

## Motivation

`pi-subagents` currently discovers agents from three hardcoded roots:
- user-level `~/.pi/agent/agents/`
- project-level `.pi/agents/`
- package-declared `agents/` (`pi-subagents.agents` manifest)

ECOSYSTEM packages (orchestrators, workflow templates, flow plugins) that want to distribute role agents together with their templates currently have no supported path: users must either `eject`/copy each agent into a fixed root, or the package must cast its agents through the manifest, which only works for install-time registration.

This change lets any directory be registered as an additional agent scan root purely through settings.

## What changed

- New settings key `subagents.agentScanDirs` (user-level `~/.pi/agent/settings.json` and/or project-level `.pi/settings.json`):
  - Each entry is a directory to scan for agent definitions, mirroring the existing agent discovery rules (frontmatter `name`, subdirectory traversal).
  - Paths support `~` expansion.
  - The **last path segment** may be a `*` wildcard (one level), e.g. `~/.pi/flow/*/agents/` — for multi-template installs under the same parent.
- Discovery merges these extra roots with the standard ones, preserving the existing resolution priority (user > project > package).
- Scope isolation is preserved: agents discovered via scan dirs behave exactly like agents in the fixed roots (name resolution, overrides, ejection).

## Tests

- `test/unit/agent-scan-dirs.test.ts` — 7 cases covering: string entries, `~` expansion, single-level `*` wildcard, mixed standard + custom roots, missing/unresolvable dirs ignored, and scope/basename collision behavior.
- Existing discovery tests remain green.

## Docs

- `docs/configuration.md` — new `agentScanDirs` section under subagents.
- `docs/agents.md` — custom scan directories explained.

## Notes

- No behavior change when the key is absent (standard roots only).
- This is the minimal, settings-only mechanism: no manifest changes, no runtime renames, no build steps.
