### PR TITLE
fix: isolate nested tool diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Let Fleet open selected async children in their child-specific Herdr inspector with plain-input guidance. Thanks to [@stekman08](https://github.com/stekman08) for #1790.
 
 ### Fixed
+- Clear parent required-tool diagnostics when launching nested zero-tool children so a grandchild cannot overwrite and fail its parent's otherwise valid result. Thanks to [@robertvangor](https://github.com/robertvangor) for #1802.
 - Make `subagents.agentOverrides.<name>` replace matching custom-agent frontmatter fields, consistently with builtin agents. Thanks to [@expoli](https://github.com/expoli) for #1796.
 - Strip the trailing Pi turn-timing footer from child output. Thanks [@fkhawajagh](https://github.com/fkhawajagh) for #1792.
 - Avoid injecting inferred acceptance reports into reviewer/read-only child prompts. Thanks [@expoli](https://github.com/expoli) for #1797.

--- a/src/runs/shared/pi-args.ts
+++ b/src/runs/shared/pi-args.ts
@@ -846,6 +846,11 @@ export function buildPiArgs(input: BuildPiArgsInput): BuildPiArgsResult {
 	);
 	env[RUNTIME_EXTENSION_ACK_PATH_ENV] = runtimeAcknowledgedExtensionsPath;
 	let toolDiagnosticPath: string | undefined;
+	// Child launch environments are merged over process.env. Explicitly clear
+	// parent-scoped diagnostics so a nested zero-tool child cannot validate
+	// against, or overwrite, its parent's required-tool report.
+	env[REQUIRED_CHILD_TOOLS_ENV] = undefined;
+	env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV] = undefined;
 	if (toolPlan.requiredChildTools.length > 0) {
 		if (!tempDir)
 			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagent-"));

--- a/test/unit/pi-args.test.ts
+++ b/test/unit/pi-args.test.ts
@@ -1045,6 +1045,27 @@ describe("buildPiArgs system prompt mode wiring", () => {
 		assert.equal(env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV], toolDiagnosticPath);
 	});
 
+	it("clears inherited tool diagnostics for nested zero-tool children", () => {
+		const inheritedDiagnosticPath = "/tmp/parent-tool-diagnostic.json";
+		const { env, toolDiagnosticPath } = buildPiArgs({
+			baseArgs: ["-p"],
+			task: "repair retained output",
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritSkills: false,
+			tools: [],
+		});
+		const spawnEnv = {
+			[REQUIRED_CHILD_TOOLS_ENV]: JSON.stringify(["read", "bash"]),
+			[CHILD_TOOL_DIAGNOSTIC_PATH_ENV]: inheritedDiagnosticPath,
+			...env,
+		};
+
+		assert.equal(toolDiagnosticPath, undefined);
+		assert.equal(spawnEnv[REQUIRED_CHILD_TOOLS_ENV], undefined);
+		assert.equal(spawnEnv[CHILD_TOOL_DIAGNOSTIC_PATH_ENV], undefined);
+	});
+
 	it("strips the legacy supervisor pairing from requirements", () => {
 		const { args, env } = buildPiArgs({
 			baseArgs: ["-p"],


### PR DESCRIPTION
## Summary
- clear inherited required-tool diagnostic variables for nested children without required tools
- prevent zero-tool grandchildren from validating against or overwriting a parent diagnostic
- add regression coverage for the nested launch environment

## Validation
- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/pi-args.test.ts` (87 passed)
- `npm audit --omit=dev`

## Note
The full local unit suite is affected by the operator's ambient Pi agent configuration; the focused `pi-args` suite and typecheck pass in this checkout.