### PR TITLE
fix: preserve exact external run session identities

### DIFF
--- a/src/api/external-runs.ts
+++ b/src/api/external-runs.ts
@@ -113,6 +113,12 @@ function identity(value: unknown, field: string, maxLength: number = EXTERNAL_RU
 	return value;
 }
 
+function sessionIdentity(value: unknown, field: string): string {
+	if (typeof value !== "string" || value.trim().length === 0 || value.includes("\0")) throw new Error(`${field} must be a non-empty string without NUL characters.`);
+	if (value.length > EXTERNAL_RUN_LIMITS.maxSessionIdLength) throw new Error(`${field} must be at most ${EXTERNAL_RUN_LIMITS.maxSessionIdLength} characters.`);
+	return value;
+}
+
 function displayText(value: unknown, field: string, maxLength: number): string | undefined;
 function displayText(value: unknown, field: string, maxLength: number, required: true): string;
 function displayText(value: unknown, field: string, maxLength: number, required = false): string | undefined {
@@ -146,7 +152,7 @@ function validateRun(value: unknown): ExternalRun {
 	const transcriptPath = displayText(run.transcriptPath, "External run transcriptPath", EXTERNAL_RUN_LIMITS.maxPathLength);
 	return {
 		id: identity(run.id, "External run id"),
-		sessionId: identity(run.sessionId, "External run sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength),
+		sessionId: sessionIdentity(run.sessionId, "External run sessionId"),
 		source: displayText(run.source, "External run source", EXTERNAL_RUN_LIMITS.maxTextLength, true),
 		label: displayText(run.label, "External run label", EXTERNAL_RUN_LIMITS.maxTextLength, true),
 		state: state(run.state, "External run state"),
@@ -217,7 +223,7 @@ export function registerExternalRun(input: ExternalRun): ExternalRun {
 
 /** Update display fields for a registered external job without changing its identity or owner. */
 export function updateExternalRun(sessionId: string, id: string, update: ExternalRunUpdate): ExternalRun {
-	const safeSessionId = identity(sessionId, "External run sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength);
+	const safeSessionId = sessionIdentity(sessionId, "External run sessionId");
 	const safeId = identity(id, "External run id");
 	const patch = inputObject(update, "External run update", UPDATE_FIELDS);
 	const current = registry();
@@ -233,7 +239,7 @@ export function updateExternalRun(sessionId: string, id: string, update: Externa
 /** Remove a cached external job. The caller remains responsible for its process and artifacts. */
 export function unregisterExternalRun(sessionId: string, id: string): boolean {
 	const current = registry();
-	const runKey = key(identity(sessionId, "External run sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength), identity(id, "External run id"));
+	const runKey = key(sessionIdentity(sessionId, "External run sessionId"), identity(id, "External run id"));
 	const deleted = current.runs.delete(runKey);
 	if (deleted) trustedRecords(current).delete(runKey);
 	return deleted;
@@ -249,7 +255,7 @@ function getErrorMessage(error: unknown): string {
 
 /** Read a bounded cached snapshot for one Pi session. This never invokes third-party code. */
 export function snapshotExternalRuns(sessionId: string, options: ExternalRunSnapshotOptions = {}): readonly ExternalRun[] {
-	const safeSessionId = identity(sessionId, "External-run snapshot sessionId", EXTERNAL_RUN_LIMITS.maxSessionIdLength);
+	const safeSessionId = sessionIdentity(sessionId, "External-run snapshot sessionId");
 	const current = registry();
 	const trusted = trustedRecords(current);
 	const sessionPrefix = `${safeSessionId}\0`;

--- a/test/unit/external-runs.test.ts
+++ b/test/unit/external-runs.test.ts
@@ -63,6 +63,37 @@ test("external runs register, update, list, and unregister cached display record
 	clearRegistry();
 });
 
+test("external run session identities preserve exact session file paths", () => {
+	clearRegistry();
+	try {
+		const sessionId = "/tmp/pi sessions/session-name\n/session.jsonl\n";
+		const registered = registerExternalRun({
+			id: "newline-session",
+			sessionId,
+			source: "tool",
+			label: "Newline session",
+			state: "running",
+			startedAt: 1,
+		});
+
+		assert.equal(registered.sessionId, sessionId);
+		assert.deepEqual(snapshotExternalRuns(sessionId), [registered]);
+		assert.equal(updateExternalRun(sessionId, registered.id, { state: "completed" }).state, "completed");
+		assert.equal(unregisterExternalRun(sessionId, registered.id), true);
+		assert.deepEqual(snapshotExternalRuns(sessionId), []);
+		assert.throws(
+			() => registerExternalRun({ ...registered, id: "nul-session", sessionId: "/tmp/session\0.jsonl" }),
+			/without NUL characters/,
+		);
+		assert.throws(
+			() => registerExternalRun({ ...registered, id: "blank-session", sessionId: " \n\t" }),
+			/non-empty string/,
+		);
+	} finally {
+		clearRegistry();
+	}
+});
+
 test("external snapshots reuse validated records, detect direct mutations, and clone reads", () => {
 	clearRegistry();
 	try {


### PR DESCRIPTION
## Summary

- treat `sessionId` as an exact internal session-file identity instead of display text
- preserve whitespace and literal newlines while retaining length, non-empty, and NUL guards
- keep external run IDs on the existing display-safe validation path
- cover register, update, snapshot, and unregister with a newline-bearing session path

Pi session IDs are session file paths. A valid filename can contain a literal newline, but the shared display sanitizer rejects it. That prevented external runs from registering even though the path itself was valid.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/external-runs.test.ts` - 9 passed
- `npm run typecheck`
- `git diff --check`

The full unit sweep reached 2,831 passes. Four unrelated assertions failed in agent refinement and capability allowlist tests, and the Herdr inspector suite canceled after a pending promise.
