### PR TITLE
Show workflow lanes as checklist progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [Unreleased]
 
 ### Added
+- Show workflow lanes as stacked checklist progress across subagent status, Fleet, and live widget surfaces (#1806).
 - Add settings-driven extra agent scan directories with one-segment wildcard expansion. Thanks to [@mystery4f](https://github.com/mystery4f) for #1801.
 - Make Worktrunk a first-class managed worktree provider with automatic selection when available and native Git fallback when not (#1800).
 - Let Fleet open selected async children in their child-specific Herdr inspector with plain-input guidance. Thanks to [@stekman08](https://github.com/stekman08) for #1790.

--- a/src/runs/background/async-status.ts
+++ b/src/runs/background/async-status.ts
@@ -24,6 +24,7 @@ import { validateAsyncStatusLaneMetadata } from "../shared/lane-metadata.ts";
 import { formatWorkflowPreflightPlanSummary, formatWorkflowPreflightWarningSummary } from "../../workflows/workflow-preflight.ts";
 import { workflowGraphStageNodes } from "../shared/workflow-graph.ts";
 import { formatTimeoutRecoveryLines, projectTimeoutRecovery } from "../shared/mutation-evidence.ts";
+import { formatWorkflowChecklistText, projectWorkflowChecklist } from "../../workflows/workflow-checklist.ts";
 
 interface AsyncRunStepSummary {
 	index: number;
@@ -711,6 +712,17 @@ export function formatAsyncRunList(runs: AsyncRunSummary[], heading = "Active as
 		if (run.preflight) lines.push(formatWorkflowPreflightPlanSummary(run.preflight, { indent: "  " }));
 		const preflightWarning = formatWorkflowPreflightWarningSummary(run.workflow?.preflightWarnings, { indent: "  " });
 		if (preflightWarning) lines.push(preflightWarning);
+		if (run.mode === "workflow") {
+			const checklist = projectWorkflowChecklist({
+				graph: run.workflowGraph,
+				steps: run.steps,
+				hostSteps: run.hostSteps,
+				preflight: run.preflight,
+				trace: run.workflow?.trace,
+				now: run.lastUpdate ?? run.endedAt ?? Date.now(),
+			});
+			lines.push(...formatWorkflowChecklistText(checklist, "  ", { includeItems: false }));
+		}
 		for (const step of run.steps) {
 			lines.push(`  ${formatStepLine(step)}`);
 			lines.push(...formatTimeoutRecoveryLines(step.timeoutRecovery, "    "));

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -28,6 +28,8 @@ import { formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetD
 import { workflowGraphStageNodes } from "../shared/workflow-graph.ts";
 import { getExternalJobProvider } from "../../api/external-job-provider.ts";
 import { formatTimeoutRecoveryLines } from "../shared/mutation-evidence.ts";
+import { formatWorkflowChecklistText, projectWorkflowChecklist } from "../../workflows/workflow-checklist.ts";
+import { validHostStepNodes } from "../shared/host-step-status.ts";
 
 interface RunStatusParams {
 	action?: string;
@@ -522,6 +524,14 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				status.mode === "workflow" && workflowReturnPreview !== undefined ? `Return: ${workflowReturnPreview}` : undefined,
 				status.mode === "workflow" && workflowEmitPreview !== undefined ? `Latest emit: ${workflowEmitPreview}` : undefined,
 				`Progress: ${progressLabel}`,
+				...(status.mode === "workflow" ? formatWorkflowChecklistText(projectWorkflowChecklist({
+					graph: status.workflowGraph,
+					steps: status.steps,
+					hostSteps: validHostStepNodes(status.workflowGraph),
+					preflight: status.preflight,
+					trace: status.workflow?.trace,
+					now: status.lastUpdate ?? status.endedAt ?? Date.now(),
+				}), "", { includeItems: false }) : []),
 				status.pendingAppends ? `Pending appends: ${status.pendingAppends}` : undefined,
 				`Started: ${started}`,
 				`Updated: ${updated}`,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4189,6 +4189,10 @@ function workflowOutputPathMappingSummary(children: WorkflowScriptChildResult[])
 	return mappings.length > 0 ? ` Output path mappings: ${mappings.join("; ")}.` : "";
 }
 
+function workflowDetailsResults(children: WorkflowScriptChildResult[]): SingleResult[] {
+	return children.flatMap((child) => (child.results ?? []).map((result) => result.workflowKey ? result : { ...result, workflowKey: child.key }));
+}
+
 function workflowSteerReceipt(key: string, result: AgentToolResult<Details>): WorkflowSteerResult {
 	const steering = result.details.steering;
 	const error = result.content.map((part) => part.type === "text" ? part.text : "").filter(Boolean).join("\n") || undefined;
@@ -5544,7 +5548,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				const displayText = appendWorkflowOutputWarning(workflowText, outputWarning);
 				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: displayText }],
-					details: compactOptional<Details>({ mode: "workflow", runId: _id, results: workflow.children.flatMap((child) => (child.results ?? []) as SingleResult[]), ...(workflowPreflight ? { preflight: workflowPreflight } : {}), workflowChildren, totalChildUsage: sumResultsUsage(workflowResults), totalCost: sumResultsCost(workflowResults), usageBudget: usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)), workflow: { value: workflow.value, trace: finalPreflightTrace, emits: workflow.emits, console: workflow.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}), receipt }, chatProgress }),
+					details: compactOptional<Details>({ mode: "workflow", runId: _id, results: workflowDetailsResults(workflow.children), ...(workflowPreflight ? { preflight: workflowPreflight } : {}), workflowChildren, totalChildUsage: sumResultsUsage(workflowResults), totalCost: sumResultsCost(workflowResults), usageBudget: usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)), workflow: { value: workflow.value, trace: finalPreflightTrace, emits: workflow.emits, console: workflow.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}), receipt }, chatProgress }),
 				}, workflowFanoutBudget));
 			} catch (error) {
 				const partial = error instanceof WorkflowScriptError ? error.partial : { trace: [], emits: [], console: [], children: [] };
@@ -5571,7 +5575,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				return attachWorkflowMission(withRunFanoutBudget({
 					content: [{ type: "text", text: displayText }],
 					isError: true,
-					details: compactOptional<Details>({ mode: "workflow", runId: _id, results: partial.children.flatMap((child) => (child.results ?? []) as SingleResult[]), ...(workflowPreflight ? { preflight: workflowPreflight } : {}), workflowChildren, totalChildUsage: sumResultsUsage(workflowResults), totalCost: sumResultsCost(workflowResults), usageBudget: usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)), workflow: { trace: finalPreflightTrace, emits: partial.emits, console: partial.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}), receipt }, chatProgress }),
+					details: compactOptional<Details>({ mode: "workflow", runId: _id, results: workflowDetailsResults(partial.children), ...(workflowPreflight ? { preflight: workflowPreflight } : {}), workflowChildren, totalChildUsage: sumResultsUsage(workflowResults), totalCost: sumResultsCost(workflowResults), usageBudget: usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)), workflow: { trace: finalPreflightTrace, emits: partial.emits, console: partial.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}), receipt }, chatProgress }),
 				}, workflowFanoutBudget));
 			}
 		}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1217,6 +1217,8 @@ export interface SingleResult {
 	 * result row's array position.
 	 */
 	index: number;
+	/** Workflow child key that owns this result when returned from workflow details. */
+	workflowKey?: string;
 	agent: string;
 	task: string;
 	/** Human-readable display name for the child's own session (agent + task

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -8,6 +8,7 @@ import { contextModeLabel } from "../runs/shared/context-mode.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
 import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
 import { isStaleExtensionContextError } from "../shared/extension-context.ts";
+import { formatWorkflowChecklistBottleneck, formatWorkflowChecklistPhase, formatWorkflowChecklistSummary, projectWorkflowChecklist, type WorkflowChecklistPhase, type WorkflowChecklistProjection } from "../workflows/workflow-checklist.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
 
@@ -35,6 +36,7 @@ type FleetStatusEntry = {
 	projectPane?: HerdrProjectPaneSnapshot;
 	nestedChildren?: NestedRunSummary[];
 	workflowRows?: AsyncStatusWorkflowRow[];
+	workflowChecklist?: WorkflowChecklistProjection;
 };
 
 type FleetNestedRow = {
@@ -50,6 +52,7 @@ type FleetNestedRow = {
 type FleetTreeRow =
 	| { kind: "owner"; entry: FleetStatusEntry }
 	| { kind: "child"; entry: FleetStatusEntry; last: boolean }
+	| { kind: "workflow-phase"; ownerKey: string; phase: WorkflowChecklistPhase; last: boolean }
 	| { kind: "workflow"; ownerKey: string; row: AsyncStatusWorkflowRow; last: boolean }
 	| { kind: "nested"; ownerKey: string; row: FleetNestedRow; last: boolean };
 
@@ -115,6 +118,18 @@ function visibleWorkflowRows(rows: AsyncStatusWorkflowRow[] | undefined, visible
 	for (let index = rows.length - 1; index >= 0 && selected.size < visibleLimit; index--) selected.add(index);
 	const visible = [...selected].sort((left, right) => left - right).map((index) => rows[index]!);
 	return [{ name: `… +${rows.length - visible.length} hidden workflow steps`, state: "complete", overflow: rows.length - visible.length }, ...visible];
+}
+
+function visibleWorkflowPhases(checklist: WorkflowChecklistProjection | undefined, visibleLimit: number): WorkflowChecklistPhase[] {
+	const phases = checklist?.phases ?? [];
+	if (phases.length <= visibleLimit) return phases;
+	const selected = new Set<number>();
+	for (const [index, phase] of phases.entries()) {
+		if (phase.state !== "complete") selected.add(index);
+		if (selected.size >= visibleLimit) break;
+	}
+	for (let index = phases.length - 1; index >= 0 && selected.size < visibleLimit; index--) selected.add(index);
+	return [...selected].sort((left, right) => left - right).map((index) => phases[index]!);
 }
 
 function isWorkflowRowTerminal(row: AsyncStatusWorkflowRow): boolean {
@@ -224,10 +239,11 @@ function fleetTreeRows(entries: FleetStatusEntry[]): FleetTreeRow[] {
 		if (entry.parentKey && entryKeys.has(entry.parentKey)) continue;
 		rows.push({ kind: "owner", entry });
 		const attached = childrenByParent.get(entry.key) ?? [];
+		const workflowPhases = visibleWorkflowPhases(entry.workflowChecklist, attached.length > 0 ? 2 : 4);
 		const workflowRows = visibleWorkflowRows(entry.workflowRows, attached.length > 0 ? 2 : 4);
 		for (const [index, child] of attached.entries()) {
 			const nested = nestedFleetRows(child.nestedChildren, 3);
-			const laterRows = index < attached.length - 1 || workflowRows.length > 0 || Boolean(entry.nestedChildren?.length);
+			const laterRows = index < attached.length - 1 || workflowPhases.length > 0 || workflowRows.length > 0 || Boolean(entry.nestedChildren?.length);
 			rows.push({ kind: "child", entry: child, last: !laterRows && nested.length === 0 });
 			for (const [nestedIndex, row] of nested.entries()) rows.push({
 				kind: "nested",
@@ -236,6 +252,12 @@ function fleetTreeRows(entries: FleetStatusEntry[]): FleetTreeRow[] {
 				last: nestedIndex === nested.length - 1 && !laterRows,
 			});
 		}
+		for (const [index, phase] of workflowPhases.entries()) rows.push({
+			kind: "workflow-phase",
+			ownerKey: entry.key,
+			phase,
+			last: index === workflowPhases.length - 1 && workflowRows.length === 0 && !entry.nestedChildren?.length,
+		});
 		for (const [index, row] of workflowRows.entries()) rows.push({ kind: "workflow", ownerKey: entry.key, row, last: index === workflowRows.length - 1 && !entry.nestedChildren?.length });
 		const nested = nestedFleetRows(entry.nestedChildren, attached.length > 0 ? 3 : 4);
 		for (const [index, row] of nested.entries()) rows.push({ kind: "nested", ownerKey: entry.key, row, last: index === nested.length - 1 });
@@ -364,6 +386,14 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			const latestEmit = job.workflow?.emits?.length ? formatWorkflowJsonPreview(job.workflow.emits.at(-1), 120) : undefined;
 			const workflowSteps = workflowStepsWithoutMaterializedChildren(job.steps, materializedChildrenByWorkflow.get(`async:${job.asyncId}`));
 			const workflowRows = projectAsyncWorkflowRows(workflowSteps, job.workflowGraph ?? job.hostSteps, job.preflight);
+			const workflowChecklist = projectWorkflowChecklist({
+				graph: job.workflowGraph,
+				steps: job.steps,
+				hostSteps: job.hostSteps,
+				preflight: job.preflight,
+				trace: job.workflow?.trace,
+				now: job.updatedAt ?? Date.now(),
+			});
 			entries.push({
 				key: `async:${job.asyncId}`,
 				...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
@@ -375,6 +405,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				...(job.totalTokens?.window !== undefined ? { window: job.totalTokens.window } : {}),
 				state: job.status,
 				...(workflowRows.length ? { workflowRows } : {}),
+				...(workflowChecklist.total ? { workflowChecklist } : {}),
 				...(job.nestedChildren?.length ? { nestedChildren: job.nestedChildren } : {}),
 			});
 			continue;
@@ -668,6 +699,8 @@ export class SubagentFleetStatus {
 				lines.push(this.renderEntry(rosterIndex, selectedIndex, row.entry, width, theme, row.kind === "child" ? (row.last ? "└─" : "├─") : undefined));
 			} else if (row.kind === "workflow") {
 				lines.push(this.renderWorkflowRow(row.row, row.last, width, theme));
+			} else if (row.kind === "workflow-phase") {
+				lines.push(this.renderWorkflowPhaseRow(row.phase, row.last, width, theme));
 			} else {
 				lines.push(this.renderNestedRow(row.row, row.last, width, theme));
 			}
@@ -691,7 +724,10 @@ export class SubagentFleetStatus {
 	private renderEntry(rosterIndex: number, selectedIndex: number, entry: FleetStatusEntry, width: number, theme: Theme, branch?: string): string {
 		const agent = entry.modelThinking ? `${entry.agent} (${entry.modelThinking})` : entry.agent;
 		const prefix = branch ? `    ${branch}` : " ";
-		const left = `${prefix} ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", agent)} · ${entry.state}`;
+		const checklist = entry.workflowWrapper && entry.workflowChecklist
+			? ` · checklist ${formatWorkflowChecklistSummary(entry.workflowChecklist)}${entry.workflowChecklist.bottleneck ? ` · bottleneck ${formatWorkflowChecklistBottleneck(entry.workflowChecklist.bottleneck)}` : ""}`
+			: "";
+		const left = `${prefix} ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", agent)} · ${entry.state}${checklist}`;
 		const elapsed = Date.now() - entry.startedAt;
 		const rightText = entry.projectPane
 			? `${entry.projectPane.summary ?? "—"} · ${formatFleetElapsed(Date.now() - entry.projectPane.refreshedAt)} ago`
@@ -728,6 +764,20 @@ export class SubagentFleetStatus {
 		if (state === "pass" || state === "complete" || state === "completed") return theme.fg("success", state === "pass" ? "pass" : "complete");
 		if (state === "fail" || state === "failed" || state === "error") return theme.fg("error", state === "fail" ? "fail" : state);
 		return theme.fg("warning", state);
+	}
+
+	private renderWorkflowPhaseRow(phase: WorkflowChecklistPhase, last: boolean, width: number, theme: Theme): string {
+		const marker = last ? "└─" : "├─";
+		const glyph = phase.state === "complete"
+			? theme.fg("success", "✓")
+			: phase.state === "running"
+				? theme.fg("accent", "●")
+				: phase.state === "blocked" || phase.state === "failed"
+					? theme.fg("error", phase.state === "blocked" ? "!" : "✗")
+					: phase.state === "queued"
+						? theme.fg("muted", "◦")
+						: theme.fg("warning", "■");
+		return truncateToWidth(`    ${marker} ${glyph} ${theme.fg("muted", formatWorkflowChecklistPhase(phase))}`, width);
 	}
 
 	private renderWorkflowRow(row: AsyncStatusWorkflowRow, last: boolean, width: number, theme: Theme): string {
@@ -809,6 +859,15 @@ export class SubagentFleetStatus {
 					entry.external,
 					Math.round((now - entry.startedAt) / 1000),
 					entry.tokens,
+					entry.workflowChecklist ? [
+						entry.workflowChecklist.total,
+						entry.workflowChecklist.done,
+						entry.workflowChecklist.running,
+						entry.workflowChecklist.queued,
+						entry.workflowChecklist.blocked,
+						entry.workflowChecklist.failed,
+						entry.workflowChecklist.phases.map((phase) => [phase.key, phase.state, phase.done, phase.total, phase.running, phase.queued, phase.blocked, phase.failed, phase.items.map((item) => [item.key, item.state, item.currentTool, item.currentPath, item.durationMs, item.toolCount, item.error])]),
+					] : undefined,
 					visibleWorkflowRows(entry.workflowRows, entry.parentKey ? 2 : 4).map((row) => [
 						row.kind,
 						row.name,

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -39,6 +39,7 @@ import { encodeAsyncStatusSnapshotWidget } from "../runs/background/async-status
 import { projectAsyncWorkflowRows, type AsyncStatusWorkflowRow } from "../runs/shared/async-status-projection.ts";
 import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
 import { workflowGraphStageNodes } from "../runs/shared/workflow-graph.ts";
+import { formatWorkflowChecklistBottleneck, formatWorkflowChecklistPhase, formatWorkflowChecklistSummary, projectWorkflowChecklist, type WorkflowChecklistItem, type WorkflowChecklistProjection, type WorkflowChecklistState, type WorkflowChecklistStep } from "../workflows/workflow-checklist.ts";
 
 type Theme = ExtensionContext["ui"]["theme"];
 
@@ -47,6 +48,7 @@ interface WorkflowWidgetProjection {
 	steps: AsyncJobStep[];
 	stageProgress?: { total: number; current?: number };
 	plannedKeys?: Set<string>;
+	checklist?: WorkflowChecklistProjection;
 }
 
 type WorkflowWidgetProjectionLookup = (job: AsyncJobState) => WorkflowWidgetProjection;
@@ -442,6 +444,17 @@ function buildWorkflowWidgetProjection(job: AsyncJobState): WorkflowWidgetProjec
 	const projection: WorkflowWidgetProjection = { stages, steps };
 	if (stageProgress) projection.stageProgress = stageProgress;
 	if (stages.length) projection.plannedKeys = new Set(stages.map((node) => node.id));
+	if (job.mode === "workflow") {
+		const checklist = projectWorkflowChecklist({
+			graph: job.workflowGraph,
+			steps: job.steps,
+			hostSteps: job.hostSteps,
+			preflight: job.preflight,
+			trace: job.workflow?.trace,
+			now: job.updatedAt ?? Date.now(),
+		});
+		if (checklist.total > 0) projection.checklist = checklist;
+	}
 	return projection;
 }
 
@@ -1059,6 +1072,15 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 		} : undefined,
 		preflight: expanded ? job.preflight : job.preflight ? formatWorkflowPreflightPlanSummary(job.preflight) : undefined,
 		preflightWarnings: expanded ? job.workflow?.preflightWarnings : job.workflow?.preflightWarnings?.length || undefined,
+		checklist: projection.checklist ? {
+			total: projection.checklist.total,
+			done: projection.checklist.done,
+			running: projection.checklist.running,
+			queued: projection.checklist.queued,
+			blocked: projection.checklist.blocked,
+			failed: projection.checklist.failed,
+			phases: projection.checklist.phases.map((phase) => [phase.key, phase.state, phase.done, phase.total, phase.running, phase.queued, phase.blocked, phase.failed, phase.paused, phase.stopped, phase.items.map((item) => [item.key, item.state, item.currentTool, item.currentPath, item.durationMs, item.toolCount, item.error])]),
+		} : undefined,
 		steps: job.steps?.map((step, index) => widgetStepRenderKey(step, index, expanded)),
 		nestedChildren: nestedRenderKey(job.nestedChildren, expanded),
 		lane: laneRenderKey(job, projection),
@@ -1232,6 +1254,73 @@ function widgetStepStatus(status: AsyncJobStep["status"], theme: Theme): string 
 	if (status === "paused") return theme.fg("warning", "paused");
 	if (status === "stopped") return theme.fg("warning", "stopped");
 	return theme.fg("dim", status);
+}
+
+function workflowChecklistStateLabel(state: WorkflowChecklistState): string {
+	if (state === "running") return "running";
+	if (state === "complete") return "complete";
+	return state;
+}
+
+function workflowChecklistGlyph(item: { state: WorkflowChecklistState; startedAt?: number; durationMs?: number; toolCount?: number; currentToolStartedAt?: number }, theme: Theme, frame?: number): string {
+	if (item.state === "running") return theme.fg("accent", runningGlyph(animatedSeed(runningSeed(item.startedAt, item.durationMs, item.toolCount, item.currentToolStartedAt), frame)));
+	if (item.state === "complete") return theme.fg("success", "✓");
+	if (item.state === "blocked") return theme.fg("error", "!");
+	if (item.state === "failed") return theme.fg("error", "✗");
+	if (item.state === "paused" || item.state === "stopped") return theme.fg("warning", "■");
+	return theme.fg("muted", "◦");
+}
+
+function workflowChecklistItemPriority(state: WorkflowChecklistState): number {
+	if (state === "blocked") return 0;
+	if (state === "failed") return 1;
+	if (state === "running") return 2;
+	if (state === "paused") return 3;
+	if (state === "stopped") return 4;
+	if (state === "queued") return 5;
+	return 6;
+}
+
+function workflowChecklistItemLine(item: WorkflowChecklistItem, theme: Theme, indent: string, frame?: number): string {
+	const identity = [item.label, item.agent && item.agent !== item.label ? item.agent : undefined].filter(Boolean).join(" · ");
+	const context = contextModeBadge(theme, item.context);
+	const state = item.state === "complete" ? "" : ` ${theme.fg("dim", `· ${workflowChecklistStateLabel(item.state)}`)}`;
+	const details = [
+		item.currentTool ? `${item.currentTool}${item.durationMs !== undefined ? ` ${formatDuration(item.durationMs)}` : ""}` : undefined,
+		!item.currentTool && item.currentPath ? shortenPath(item.currentPath) : undefined,
+		!item.currentTool && item.durationMs !== undefined ? formatDuration(item.durationMs) : undefined,
+		item.toolCount !== undefined ? `${item.toolCount} tools` : undefined,
+		item.outputName ? `out:${item.outputName}` : undefined,
+		item.error ? `error:${oneLine(item.error)}` : undefined,
+	].filter(Boolean).join(" · ");
+	return `${indent}${workflowChecklistGlyph(item, theme, frame)} ${theme.bold(identity || item.key)}${context}${state}${details ? ` ${theme.fg("dim", `· ${details}`)}` : ""}`;
+}
+
+function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | undefined, theme: Theme, indent: string, expanded: boolean, frame?: number): string[] {
+	if (!checklist?.total) return [];
+	const lines = [`${indent}${theme.fg("dim", `Checklist ${formatWorkflowChecklistSummary(checklist)}`)}`];
+	for (const phase of checklist.phases) {
+		const phaseItem = phase.items.find((item) => item.state === "running") ?? phase.items[0];
+		const glyph = workflowChecklistGlyph({
+			state: phase.state,
+			startedAt: phaseItem?.startedAt,
+			durationMs: phaseItem?.durationMs,
+			toolCount: phaseItem?.toolCount,
+			currentToolStartedAt: phaseItem?.currentToolStartedAt,
+		}, theme, frame);
+		lines.push(`${indent}${glyph} ${theme.bold(formatWorkflowChecklistPhase(phase))}`);
+		if (expanded) {
+			for (const item of [...phase.items].sort((left, right) => workflowChecklistItemPriority(left.state) - workflowChecklistItemPriority(right.state))) {
+				lines.push(workflowChecklistItemLine(item, theme, `${indent}  `, frame));
+			}
+		}
+	}
+	const bottleneck = formatWorkflowChecklistBottleneck(checklist.bottleneck);
+	if (bottleneck) {
+		const tone = checklist.bottleneck?.state === "blocked" || checklist.bottleneck?.state === "failed" ? "error" : checklist.bottleneck?.state === "running" ? "accent" : "warning";
+		lines.push(`${indent}${theme.fg(tone, `bottleneck · ${bottleneck}`)}`);
+	}
+	return lines;
 }
 
 function widgetStepActivity(step: NonNullable<AsyncJobState["steps"]>[number], snapshotNow?: number): string {
@@ -1762,6 +1851,7 @@ function widgetStats(job: AsyncJobState, theme: Theme, projection = buildWorkflo
 	} else if (stepsTotal > 1) {
 		parts.push(`steps ${stepsTotal}`);
 	}
+	if (projection.checklist) parts.push(formatWorkflowChecklistSummary(projection.checklist));
 	if (job.toolCount !== undefined) parts.push(formatToolUseStat(job.toolCount));
 	if (job.totalTokens?.total) parts.push(formatTokenUsage(job.totalTokens, "token"));
 	if (job.startedAt !== undefined && job.updatedAt !== undefined) parts.push(formatDuration(Math.max(0, job.updatedAt - job.startedAt)));
@@ -2048,6 +2138,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 		const lane = projectAsyncLane(job, laneStepForJob(job, steps));
 		return [
 			...workflowPreflightLines(job, expanded),
+			...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
 			...(lane ? formatLaneProjectionLines(lane, theme, "  ") : []),
 			...hostStepWidgetLines(job, theme, "  "),
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
@@ -2055,7 +2146,10 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 		];
 	}
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
-	const lines: string[] = workflowPreflightLines(job, expanded);
+	const lines: string[] = [
+		...workflowPreflightLines(job, expanded),
+		...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
+	];
 	const group = activeParallelWidgetGroup(job);
 	if (group) {
 		lines.push(...parallelWidgetGroupDetails(job, theme, group, expanded, width, frame, Boolean(job.activeParallelGroup)));
@@ -2088,7 +2182,9 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 
 function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, frame?: number, projection = buildWorkflowWidgetProjection(job)): string[] {
 	const stats = widgetStats(job, theme, projection);
-	const count = job.mode === "chain" ? job.chainStepCount : projection.stageProgress?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length;
+	const count = job.mode === "workflow"
+		? projection.checklist?.total ?? projection.stageProgress?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length
+		: job.mode === "chain" ? job.chainStepCount : projection.stageProgress?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length;
 	const mode = widgetJobName(job);
 	const title = isSingleChildAsyncJob(job)
 		? "async subagent"
@@ -2435,6 +2531,7 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
 			...widgetLaneDetailLines(job, theme, projection),
+			...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
 			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 		]);
 	};
@@ -2580,6 +2677,62 @@ function workflowOverallState(rows: WorkflowChatProgressRow[], hasTerminalValue:
 	return "running";
 }
 
+function foregroundWorkflowChecklist(details: Details): WorkflowChecklistProjection | undefined {
+	if (details.mode !== "workflow") return undefined;
+	const stageNodes = details.workflowGraph ? workflowGraphStageNodes(details.workflowGraph) : [];
+	const steps: WorkflowChecklistStep[] = details.results.flatMap((result, resultIndex) => {
+		const stableIndex = foregroundResultIndex(details, resultIndex);
+		const workflowKey = (result as { workflowKey?: unknown }).workflowKey;
+		if (details.workflowGraph && typeof workflowKey !== "string") return [];
+		const node = typeof workflowKey === "string"
+			? stageNodes.find((candidate) => candidate.id === workflowKey)
+			: undefined;
+		const progress = foregroundProgressForResult(details, resultIndex);
+		const status = isResultRunning(result) || progress?.status === "running"
+			? "running"
+			: result.detached
+				? "paused"
+				: result.stopped
+					? "stopped"
+					: result.exitCode === 0
+						? "complete"
+						: "failed";
+		return [{
+			key: node?.id ?? (typeof workflowKey === "string" ? workflowKey : `result-${resultIndex + 1}`),
+			label: node?.label ?? workflowLabelForResult(details, resultIndex) ?? result.task ?? result.agent,
+			phase: node?.phase,
+			agent: result.agent,
+			status,
+			context: result.context,
+			activityState: progress?.activityState,
+			startedAt: progress?.lastActivityAt !== undefined && progress.durationMs !== undefined ? progress.lastActivityAt - progress.durationMs : undefined,
+			durationMs: progress?.durationMs,
+			currentTool: progress?.currentTool,
+			currentToolStartedAt: progress?.currentToolStartedAt,
+			currentPath: progress?.currentPath,
+			turnCount: progress?.turnCount,
+			toolCount: progress?.toolCount ?? result.progressSummary?.toolCount,
+			error: result.error,
+			toolBudgetBlocked: result.toolBudgetBlocked,
+			turnBudgetExceeded: result.turnBudgetExceeded,
+			timedOut: result.timedOut,
+			stopped: result.stopped,
+			acceptance: result.acceptance ? { status: result.acceptance.status, reviewResult: result.acceptance.reviewResult ? { status: result.acceptance.reviewResult.status } : undefined } : undefined,
+			review: result.review ? { status: result.review.status } : undefined,
+			watchdog: result.watchdog,
+		}];
+	});
+	const checklist = projectWorkflowChecklist({
+		graph: details.workflowGraph,
+		steps,
+		hostSteps: details.workflow?.receipt?.hostSteps,
+		preflight: details.preflight,
+		trace: details.workflow?.trace,
+		now: Date.now(),
+	});
+	return checklist.total > 0 ? checklist : undefined;
+}
+
 function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>, theme: Theme, layout: MainWindowRenderLayout, frame?: number, expanded = false): Component {
 	const workflow = d.workflow;
 	const rows = workflow ? buildWorkflowChatProgressRows(workflow.trace, d.preflight) : d.preflight ? buildWorkflowChatProgressRows([], d.preflight) : [];
@@ -2595,6 +2748,10 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 	c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}Repo   ${repoLabel}`), width), 0, 0));
 	if (d.preflight) c.addChild(new Text(truncLine(theme.fg("dim", formatWorkflowPreflightPlanSummary(d.preflight, { indent: rowIndent })), width), 0, 0));
 	if (phase) c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}Phase  ${phase}`), width), 0, 0));
+	const checklist = projectWorkflowChecklist({ hostSteps: workflow?.receipt?.hostSteps, preflight: d.preflight, trace: workflow?.trace, now: Date.now() });
+	for (const line of workflowChecklistWidgetLines(checklist, theme, rowIndent, false, frame)) {
+		c.addChild(new Text(truncLine(line, width), 0, 0));
+	}
 	if (rows.length === 0) {
 		c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}◦ waiting for workflow child launches`), width), 0, 0));
 		return c;
@@ -2671,6 +2828,10 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 	const rowIndent = mainWindowIndent(layout, 1);
 	const detailIndent = mainWindowIndent(layout, 2);
 	c.addChild(new Text(truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
+	const workflowChecklist = foregroundWorkflowChecklist(d);
+	for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, rowIndent, false, frame)) {
+		c.addChild(new Text(truncLine(line, width), 0, 0));
+	}
 
 	const useResultsDirectly = multiLabel.hasParallelInChain || !d.chainAgents?.length;
 	const displayStart = multiLabel.showActiveGroupOnly ? multiLabel.groupStartIndex : 0;
@@ -3011,6 +3172,10 @@ export function renderSubagentResult(
 	);
 	if (chainVis) {
 		c.addChild(new Text(fit(`  ${chainVis}`), 0, 0));
+	}
+	const workflowChecklist = foregroundWorkflowChecklist(d);
+	for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, "  ", true, frame)) {
+		c.addChild(new Text(fit(line), 0, 0));
 	}
 
 	const useResultsDirectly = multiLabel.hasParallelInChain || !d.chainAgents?.length;

--- a/src/workflows/workflow-checklist.ts
+++ b/src/workflows/workflow-checklist.ts
@@ -1,0 +1,440 @@
+import type { AsyncJobStep, HostStepNodeV1, WorkflowGraphNode, WorkflowGraphSnapshot, WorkflowPreflightLaneV1, WorkflowPreflightV1 } from "../shared/types.ts";
+import { sanitizeDisplayText } from "../shared/display-text.ts";
+
+export type WorkflowChecklistState = "complete" | "running" | "queued" | "blocked" | "failed" | "paused" | "stopped";
+
+export interface WorkflowChecklistStep {
+	key?: string;
+	workflowKey?: string;
+	runId?: string;
+	label?: string;
+	description?: string;
+	phase?: string;
+	agent?: string;
+	status: string;
+	context?: "fresh" | "fork";
+	activityState?: string;
+	startedAt?: number;
+	endedAt?: number;
+	durationMs?: number;
+	currentTool?: string;
+	currentToolStartedAt?: number;
+	currentPath?: string;
+	turnCount?: number;
+	toolCount?: number;
+	outputName?: string;
+	error?: string;
+	toolBudgetBlocked?: boolean;
+	turnBudgetExceeded?: boolean;
+	timedOut?: boolean;
+	stopped?: boolean;
+	acceptance?: { status?: string; reviewResult?: { status?: string } };
+	review?: { status?: string };
+	watchdog?: { phase?: string };
+}
+
+export interface WorkflowChecklistTraceEntry {
+	operation?: string;
+	key: string;
+	state: string;
+	agent?: string;
+	runId?: string;
+	phase?: string;
+	label?: string;
+	generatedLaneKey?: string;
+	durationMs?: number;
+	error?: string;
+}
+
+export interface WorkflowChecklistItem {
+	key: string;
+	label: string;
+	phase: string;
+	state: WorkflowChecklistState;
+	agent?: string;
+	context?: "fresh" | "fork";
+	startedAt?: number;
+	durationMs?: number;
+	currentTool?: string;
+	currentToolStartedAt?: number;
+	currentPath?: string;
+	toolCount?: number;
+	outputName?: string;
+	error?: string;
+	preflight?: WorkflowPreflightLaneV1;
+	kind?: "child" | "host";
+	monitorKind?: HostStepNodeV1["monitorKind"];
+	provider?: string;
+	role?: string;
+	verdict?: HostStepNodeV1["verdict"];
+	target?: string;
+	reasonCode?: string;
+	stale?: boolean;
+	reportPath?: string;
+}
+
+export interface WorkflowChecklistPhase {
+	key: string;
+	label: string;
+	state: WorkflowChecklistState;
+	items: WorkflowChecklistItem[];
+	total: number;
+	done: number;
+	running: number;
+	queued: number;
+	blocked: number;
+	failed: number;
+	paused: number;
+	stopped: number;
+	parallel: boolean;
+}
+
+export interface WorkflowChecklistProjection {
+	phases: WorkflowChecklistPhase[];
+	total: number;
+	done: number;
+	running: number;
+	queued: number;
+	blocked: number;
+	failed: number;
+	paused: number;
+	stopped: number;
+	bottleneck?: WorkflowChecklistItem;
+}
+
+export interface WorkflowChecklistInput {
+	graph?: WorkflowGraphSnapshot;
+	steps?: readonly WorkflowChecklistStep[] | readonly AsyncJobStep[];
+	hostSteps?: readonly HostStepNodeV1[];
+	preflight?: WorkflowPreflightV1;
+	trace?: readonly WorkflowChecklistTraceEntry[];
+	now?: number;
+}
+
+const MAX_TEXT = 160;
+const TERMINAL_STATES = new Set<WorkflowChecklistState>(["complete", "blocked", "failed", "paused", "stopped"]);
+
+function text(value: unknown, fallback?: string): string | undefined {
+	if (typeof value !== "string") return fallback;
+	const clean = sanitizeDisplayText(value).replace(/\s+/g, " ").trim();
+	return clean ? clean.slice(0, MAX_TEXT) : fallback;
+}
+
+function keyText(value: unknown, fallback: string): string {
+	return text(value, fallback) ?? fallback;
+}
+
+function normalizedStatus(value: unknown): string {
+	return typeof value === "string" ? value.toLowerCase() : "queued";
+}
+
+function finite(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function count(value: unknown): number | undefined {
+	const number = finite(value);
+	return number !== undefined && number >= 0 ? Math.round(number) : undefined;
+}
+
+function explicitBlocked(source: Pick<WorkflowChecklistStep, "activityState" | "toolBudgetBlocked" | "turnBudgetExceeded" | "timedOut" | "acceptance" | "review" | "watchdog"> & { verdict?: unknown; stale?: unknown }): boolean {
+	const acceptance = normalizedStatus(source.acceptance?.status);
+	const review = normalizedStatus(source.review?.status ?? source.acceptance?.reviewResult?.status);
+	return source.toolBudgetBlocked === true
+		|| source.turnBudgetExceeded === true
+		|| source.activityState === "needs_attention"
+		|| source.timedOut === true
+		|| source.watchdog?.phase === "stale"
+		|| source.stale === true
+		|| source.verdict === "inconclusive"
+		|| acceptance === "rejected"
+		|| acceptance === "blockers"
+		|| review === "blockers"
+		|| review === "review-required";
+}
+
+function checklistState(source: Pick<WorkflowChecklistStep, "status" | "activityState" | "toolBudgetBlocked" | "turnBudgetExceeded" | "timedOut" | "acceptance" | "review" | "watchdog"> & { verdict?: unknown; stale?: unknown }): WorkflowChecklistState {
+	if (explicitBlocked(source)) return "blocked";
+	switch (normalizedStatus(source.status)) {
+		case "complete":
+		case "completed":
+		case "done":
+		case "pass":
+		case "accepted": return "complete";
+		case "running":
+		case "started":
+		case "active": return "running";
+		case "failed":
+		case "error":
+		case "fail": return "failed";
+		case "blocked":
+		case "rejected":
+		case "partial":
+		case "needs_attention": return "blocked";
+		case "paused":
+		case "detached": return "paused";
+		case "stopped":
+		case "cancelled":
+		case "canceled": return "stopped";
+		default: return "queued";
+	}
+}
+
+function duration(step: Pick<WorkflowChecklistStep, "durationMs" | "startedAt" | "endedAt">, now: number | undefined, state: WorkflowChecklistState): number | undefined {
+	const explicit = finite(step.durationMs);
+	const startedAt = finite(step.startedAt);
+	if (explicit !== undefined) return Math.max(0, explicit);
+	if (startedAt === undefined) return undefined;
+	const end = state === "running" ? now : finite(step.endedAt) ?? now;
+	return end === undefined ? undefined : Math.max(0, end - startedAt);
+}
+
+function laneFor(key: string, phase: string, lanes: ReadonlyMap<string, WorkflowPreflightLaneV1>): WorkflowPreflightLaneV1 | undefined {
+	return lanes.get(key) ?? lanes.get(phase) ?? [...lanes.values()].find((lane) => key.startsWith(`${lane.key}.`));
+}
+
+function stepKey(step: WorkflowChecklistStep): string | undefined {
+	return step.key ?? step.workflowKey ?? step.runId;
+}
+
+function stepItem(step: WorkflowChecklistStep, index: number, phase: string, key = stepKey(step) ?? `step-${index + 1}`, label = step.label ?? step.description ?? stepKey(step) ?? step.agent ?? key, preflight?: WorkflowPreflightLaneV1): WorkflowChecklistItem {
+	const state = checklistState(step);
+	return {
+		key: keyText(key, `step-${index + 1}`),
+		label: keyText(label, key),
+		phase,
+		state,
+		...(text(step.agent) ? { agent: text(step.agent) } : {}),
+		...(step.context ? { context: step.context } : {}),
+		...(finite(step.startedAt) !== undefined ? { startedAt: finite(step.startedAt) } : {}),
+		...(duration(step, undefined, state) !== undefined ? { durationMs: duration(step, undefined, state) } : {}),
+		...(text(step.currentTool) ? { currentTool: text(step.currentTool) } : {}),
+		...(finite(step.currentToolStartedAt) !== undefined ? { currentToolStartedAt: finite(step.currentToolStartedAt) } : {}),
+		...(text(step.currentPath) ? { currentPath: text(step.currentPath) } : {}),
+		...(count(step.toolCount) !== undefined ? { toolCount: count(step.toolCount) } : {}),
+		...(text(step.outputName) ? { outputName: text(step.outputName) } : {}),
+		...(text(step.error) ? { error: text(step.error) } : {}),
+		...(preflight ? { preflight } : {}),
+	};
+}
+
+function hostItem(host: HostStepNodeV1, phase: string, key = host.id): WorkflowChecklistItem {
+	const state = checklistState({ status: host.state, verdict: host.verdict, stale: host.freshness?.stale });
+	return {
+		key: keyText(key, "host-step"),
+		label: keyText(host.label, "host step"),
+		phase,
+		state,
+		kind: "host",
+		monitorKind: host.monitorKind,
+		...(text(host.provider) ? { provider: text(host.provider) } : {}),
+		...(text(host.role) ? { role: text(host.role) } : {}),
+		...(host.verdict ? { verdict: host.verdict } : {}),
+		...(text(host.target) ? { target: text(host.target) } : {}),
+		...(text(host.reasonCode) ? { reasonCode: text(host.reasonCode) } : {}),
+		...(text(host.detail) ? { error: text(host.detail) } : {}),
+		...(host.freshness?.stale !== undefined ? { stale: host.freshness.stale } : {}),
+		...(text(host.reportPath) ? { reportPath: text(host.reportPath) } : {}),
+	};
+}
+
+function graphNodes(graph: WorkflowGraphSnapshot | undefined): WorkflowGraphNode[] {
+	const out: WorkflowGraphNode[] = [];
+	const visit = (node: WorkflowGraphNode): void => {
+		if (node.kind === "parallel-group" || node.kind === "dynamic-parallel-group") {
+			for (const child of node.children ?? []) visit(child);
+			if (!node.children?.length) out.push(node);
+		} else {
+			out.push(node);
+		}
+	};
+	for (const node of graph?.nodes ?? []) visit(node);
+	return out;
+}
+
+function traceSources(trace: readonly WorkflowChecklistTraceEntry[] | undefined): WorkflowChecklistTraceEntry[] {
+	const latest = new Map<string, WorkflowChecklistTraceEntry>();
+	for (const entry of trace ?? []) {
+		const state = normalizedStatus(entry.state);
+		if ((entry.operation !== undefined && entry.operation !== "run" && entry.operation !== "host") || !entry.key || state === "delivered" || state === "missed") continue;
+		const existing = latest.get(entry.key);
+		latest.set(entry.key, state === "reused" && existing ? { ...existing, ...entry, state: existing.state } : { ...existing, ...entry });
+	}
+	return [...latest.values()];
+}
+
+function traceItem(entry: WorkflowChecklistTraceEntry, index: number, preflight: WorkflowPreflightLaneV1 | undefined): WorkflowChecklistItem {
+	const phase = keyText(entry.generatedLaneKey ?? entry.phase ?? preflight?.key, "Workflow");
+	const item = stepItem({ key: entry.key, label: entry.label, phase, agent: entry.agent, status: entry.state === "started" ? "running" : entry.state, durationMs: entry.durationMs, error: entry.error }, index, phase, entry.key, entry.label ?? entry.key, preflight);
+	if (entry.operation === "host") item.kind = "host";
+	return item;
+}
+
+function phaseFor(phases: Map<string, WorkflowChecklistPhase>, label: string): WorkflowChecklistPhase {
+	let phase = phases.get(label);
+	if (!phase) {
+		phase = { key: label, label, state: "queued", items: [], total: 0, done: 0, running: 0, queued: 0, blocked: 0, failed: 0, paused: 0, stopped: 0, parallel: false };
+		phases.set(label, phase);
+	}
+	return phase;
+}
+
+function add(phases: Map<string, WorkflowChecklistPhase>, phase: string, item: WorkflowChecklistItem): void {
+	phaseFor(phases, phase).items.push(item);
+}
+
+function mergeNodeStep(node: WorkflowGraphNode, step: WorkflowChecklistStep, phase: string, trace: WorkflowChecklistTraceEntry | undefined, preflight: WorkflowPreflightLaneV1 | undefined): WorkflowChecklistItem {
+	const state = checklistState(step);
+	const nodeState = checklistState({ status: node.status, acceptance: node.acceptanceStatus ? { status: node.acceptanceStatus } : undefined });
+	const status = TERMINAL_STATES.has(nodeState) && !TERMINAL_STATES.has(state)
+		? nodeState
+		: trace && !TERMINAL_STATES.has(state)
+		? (trace.state === "started" ? "running" : trace.state)
+		: normalizedStatus(step.status) === "pending" && normalizedStatus(node.status) !== "pending" ? node.status : step.status;
+	return stepItem({ ...step, status, key: node.id, label: step.label ?? node.label, phase: step.phase ?? phase, agent: step.agent ?? node.agent, outputName: step.outputName ?? node.outputName, error: step.error ?? trace?.error ?? node.error, acceptance: step.acceptance ?? (node.acceptanceStatus ? { status: node.acceptanceStatus } : undefined), durationMs: step.durationMs ?? trace?.durationMs }, node.flatIndex ?? 0, phase, node.id, step.label ?? node.label, preflight);
+}
+
+function priority(item: WorkflowChecklistItem): number {
+	return item.state === "blocked" ? 0 : item.state === "failed" ? 1 : item.state === "running" ? 2 : item.state === "paused" ? 3 : item.state === "stopped" ? 4 : item.state === "queued" ? 5 : 6;
+}
+
+function applyNow(item: WorkflowChecklistItem, now: number | undefined): WorkflowChecklistItem {
+	return item.durationMs === undefined && item.startedAt !== undefined && now !== undefined ? { ...item, durationMs: Math.max(0, now - item.startedAt) } : item;
+}
+
+function finalize(phase: WorkflowChecklistPhase): void {
+	phase.total = phase.items.length;
+	phase.done = phase.items.filter((item) => item.state === "complete").length;
+	phase.running = phase.items.filter((item) => item.state === "running").length;
+	phase.queued = phase.items.filter((item) => item.state === "queued").length;
+	phase.blocked = phase.items.filter((item) => item.state === "blocked").length;
+	phase.failed = phase.items.filter((item) => item.state === "failed").length;
+	phase.paused = phase.items.filter((item) => item.state === "paused").length;
+	phase.stopped = phase.items.filter((item) => item.state === "stopped").length;
+	phase.parallel = phase.total > 1;
+	phase.state = phase.blocked ? "blocked" : phase.failed ? "failed" : phase.running ? "running" : phase.paused ? "paused" : phase.stopped ? "stopped" : phase.queued ? "queued" : "complete";
+}
+
+export function projectWorkflowChecklist(input: WorkflowChecklistInput): WorkflowChecklistProjection {
+	const phases = new Map<string, WorkflowChecklistPhase>();
+	const lanes = new Map((input.preflight?.lanes ?? []).map((lane) => [lane.key, lane]));
+	const steps = (input.steps ?? []) as readonly WorkflowChecklistStep[];
+	const nodes = graphNodes(input.graph);
+	const trace = traceSources(input.trace);
+	const traceByKey = new Map(trace.map((entry) => [entry.key, entry]));
+	const phaseByNode = new Map<string, string>();
+	const graphPhaseLabels = new Set<string>();
+	for (const phase of input.graph?.phases ?? []) {
+		const title = keyText(phase.title, "Workflow");
+		graphPhaseLabels.add(title);
+		phaseFor(phases, title);
+		for (const nodeId of phase.nodeIds) if (!phaseByNode.has(nodeId)) phaseByNode.set(nodeId, title);
+	}
+
+	const stepsByKey = new Map<string, Array<{ step: WorkflowChecklistStep; index: number }>>();
+	for (const [index, step] of steps.entries()) {
+		const key = stepKey(step);
+		if (!key) continue;
+		stepsByKey.set(key, [...(stepsByKey.get(key) ?? []), { step, index }]);
+	}
+
+	const usedSteps = new Set<number>();
+	const hostById = new Map((input.hostSteps ?? []).map((host) => [host.id, host]));
+	const graphKeys = new Set(nodes.map((node) => node.id));
+	const stepKeys = new Set([...stepsByKey.keys()]);
+	const hostKeys = new Set(hostById.keys());
+
+	for (const node of nodes) {
+		const host = node.hostStep ?? hostById.get(node.id);
+		const phase = keyText(phaseByNode.get(node.id) ?? node.phase ?? (host ? host.label : node.label), "Workflow");
+		if (host) {
+			add(phases, phase, hostItem(host, phase, node.id));
+			hostById.delete(node.id);
+			continue;
+		}
+		const matches = (stepsByKey.get(node.id) ?? []).filter(({ index }) => !usedSteps.has(index));
+		if (matches.length) {
+			for (const match of matches) {
+				usedSteps.add(match.index);
+				add(phases, phase, applyNow(mergeNodeStep(node, match.step, phase, traceByKey.get(stepKey(match.step) ?? node.id), laneFor(node.id, phase, lanes)), input.now));
+			}
+			continue;
+		}
+		add(phases, phase, applyNow(mergeNodeStep(node, { key: node.id, label: node.label, phase, agent: node.agent, status: node.status, outputName: node.outputName, error: node.error, acceptance: node.acceptanceStatus ? { status: node.acceptanceStatus } : undefined }, phase, traceByKey.get(node.id), laneFor(node.id, phase, lanes)), input.now));
+	}
+
+	for (const [index, step] of steps.entries()) {
+		if (usedSteps.has(index)) continue;
+		const key = keyText(stepKey(step), `step-${index + 1}`);
+		const traceEntry = traceByKey.get(key);
+		const phase = keyText(step.phase ?? laneFor(key, "", lanes)?.key ?? traceEntry?.generatedLaneKey ?? traceEntry?.phase, "Workflow");
+		add(phases, phase, applyNow(stepItem(step, index, phase, key, step.label ?? step.key ?? step.agent, laneFor(key, phase, lanes)), input.now));
+	}
+
+	for (const host of hostById.values()) add(phases, keyText(host.label, "Host"), hostItem(host, keyText(host.label, "Host")));
+	for (const entry of trace) {
+		if (graphKeys.has(entry.key) || stepKeys.has(entry.key) || hostKeys.has(entry.key)) continue;
+		const item = traceItem(entry, phases.size, laneFor(entry.key, entry.generatedLaneKey ?? entry.phase ?? "", lanes));
+		add(phases, item.phase, item);
+	}
+	for (const lane of input.preflight?.lanes ?? []) if (!graphKeys.has(lane.key) && !graphPhaseLabels.has(lane.key) && !phases.get(lane.key)?.items.length) add(phases, lane.key, { key: lane.key, label: lane.key, phase: lane.key, state: "queued", preflight: lane });
+
+	const finalized = [...phases.values()].filter((phase) => phase.items.length > 0);
+	for (const phase of finalized) {
+		phase.items = phase.items.map((item) => applyNow(item, input.now));
+		finalize(phase);
+	}
+	const all = finalized.flatMap((phase) => phase.items);
+	const counts = (state: WorkflowChecklistState): number => all.filter((item) => item.state === state).length;
+	const bottleneck = [...all].sort((left, right) => priority(left) - priority(right))[0];
+	return { phases: finalized, total: all.length, done: counts("complete"), running: counts("running"), queued: counts("queued"), blocked: counts("blocked"), failed: counts("failed"), paused: counts("paused"), stopped: counts("stopped"), ...(bottleneck && bottleneck.state !== "complete" ? { bottleneck } : {}) };
+}
+
+function stateLabel(state: WorkflowChecklistState): string {
+	return state === "running" ? "active" : state;
+}
+
+export function formatWorkflowChecklistSummary(projection: WorkflowChecklistProjection): string {
+	if (!projection.total) return "";
+	return [`${projection.done}/${projection.total} done`, projection.running ? `${projection.running} active` : undefined, projection.queued ? `${projection.queued} queued` : undefined, projection.blocked ? `${projection.blocked} blocked` : undefined, projection.failed ? `${projection.failed} failed` : undefined, projection.paused ? `${projection.paused} paused` : undefined, projection.stopped ? `${projection.stopped} stopped` : undefined].filter((value): value is string => Boolean(value)).join(" · ");
+}
+
+export function formatWorkflowChecklistPhase(phase: WorkflowChecklistPhase): string {
+	const counts = [phase.total > 1 && phase.done ? `${phase.done} done` : undefined, phase.running ? `${phase.running} active` : undefined, phase.queued ? `${phase.queued} queued` : undefined, phase.blocked ? `${phase.blocked} blocked` : undefined, phase.failed ? `${phase.failed} failed` : undefined, phase.paused ? `${phase.paused} paused` : undefined, phase.stopped ? `${phase.stopped} stopped` : undefined].filter((value): value is string => Boolean(value));
+	return counts.length ? `${phase.label} ${counts.join(" · ")}` : phase.label;
+}
+
+export function formatWorkflowChecklistBottleneck(item: WorkflowChecklistItem | undefined): string | undefined {
+	if (!item) return undefined;
+	const identity = [item.label, item.agent && item.agent !== item.label ? item.agent : undefined].filter((value): value is string => Boolean(value)).join(" · ") || item.key;
+	const details = [item.context ? `(${item.context})` : undefined, item.currentTool ? `${item.currentTool}${item.durationMs !== undefined ? ` ${formatDurationText(item.durationMs)}` : ""}` : undefined, !item.currentTool && item.currentPath ? item.currentPath : undefined, !item.currentTool && item.durationMs !== undefined ? formatDurationText(item.durationMs) : undefined, item.toolCount !== undefined ? `${item.toolCount} tools` : undefined, item.outputName ? `out:${item.outputName}` : undefined, item.error ? `error:${item.error.replace(/\bOutput:/g, "output:")}` : undefined].filter((value): value is string => Boolean(value));
+	return [identity, ...details].join(" · ");
+}
+
+function formatWorkflowChecklistItem(item: WorkflowChecklistItem): string {
+	const identity = [item.label, item.agent && item.agent !== item.label ? item.agent : undefined].filter((value): value is string => Boolean(value)).join(" · ") || item.key;
+	const details = [item.kind && item.monitorKind ? item.monitorKind : undefined, item.provider ? `provider:${item.provider}` : undefined, item.role ? `role:${item.role}` : undefined, item.target, item.currentTool, !item.currentTool && item.currentPath ? item.currentPath : undefined, item.durationMs !== undefined ? formatDurationText(item.durationMs) : undefined, item.toolCount !== undefined ? `${item.toolCount} tools` : undefined, item.outputName ? `out:${item.outputName}` : undefined, item.reportPath ? `out:${item.reportPath}` : undefined, item.stale ? "stale" : undefined, item.reasonCode ? `reason:${item.reasonCode}` : undefined, item.error ? `error:${item.error.replace(/\bOutput:/g, "output:")}` : undefined].filter((value): value is string => Boolean(value));
+	return `${identity}${item.context ? ` (${item.context})` : ""}${item.state === "complete" ? "" : ` · ${stateLabel(item.state)}`}${details.length ? ` · ${details.join(" · ")}` : ""}`;
+}
+
+function formatDurationText(ms: number): string {
+	const seconds = Math.max(0, Math.round(ms / 1000));
+	return seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+export function formatWorkflowChecklistText(projection: WorkflowChecklistProjection, indent = "", options: { includeItems?: boolean } = {}): string[] {
+	if (!projection.total) return [];
+	const lines = [`${indent}Workflow checklist: ${formatWorkflowChecklistSummary(projection)}`];
+	for (const phase of projection.phases) {
+		const phaseMarker = phase.state === "complete" ? "✓" : phase.state === "running" ? "⠼" : phase.state === "blocked" ? "!" : phase.state === "failed" ? "✗" : phase.state === "paused" || phase.state === "stopped" ? "■" : "◦";
+		lines.push(`${indent}  ${phaseMarker} ${formatWorkflowChecklistPhase(phase)}`);
+		if (options.includeItems === false) continue;
+		for (const item of phase.items) {
+			const marker = item.state === "complete" ? "✓" : item.state === "running" ? "⠼" : item.state === "blocked" ? "!" : item.state === "failed" ? "✗" : item.state === "paused" || item.state === "stopped" ? "■" : "◦";
+			lines.push(`${indent}    ${marker} ${formatWorkflowChecklistItem(item)}`);
+		}
+	}
+	const bottleneck = formatWorkflowChecklistBottleneck(projection.bottleneck);
+	if (bottleneck) lines.push(`${indent}  bottleneck · ${bottleneck}`);
+	return lines;
+}

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -1100,8 +1100,10 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.toolCount === 1, "changed status load");
 			await waitForCondition(() => ui.widgets.length > widgetsAfterStatusLoaded, "changed status widget replacement");
 
+			const requestsBeforeTerminal = ui.renderRequests;
 			writeStatus(4000, 1, "complete");
 			await waitForCondition(() => state.asyncJobs.get("run-unchanged")?.status === "complete", "terminal status load");
+			await waitForCondition(() => ui.renderRequests > requestsBeforeTerminal, "terminal status widget redraw");
 			const widgetsAfterTerminal = ui.widgets.length;
 			const requestsAfterTerminal = ui.renderRequests;
 			await new Promise((resolve) => setTimeout(resolve, 35));

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2400,6 +2400,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			assert.match(result.content[0]?.text ?? "", /reviewed auth/);
 			assert.equal(result.details.mode, "workflow");
 			assert.equal(result.details.results.length, 2);
+			assert.deepEqual(result.details.results.map((entry) => entry.workflowKey), ["scan", "review"]);
 			assert.equal(result.details.workflow?.value && (result.details.workflow.value as { stateType?: unknown }).stateType, "object");
 			assert.ok(result.details.missionId);
 			const missionFiles = fs.readdirSync(path.join(agentDir, "missions", "projects"), { recursive: true })

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -33,37 +33,6 @@ function result(agent: string, output: string) {
 	};
 }
 
-function countedWorkflowJob(onNodesRead: () => void): AsyncJobState {
-	const nodes = [
-		{ id: "step-0", kind: "step", agent: "scout", label: "Scout", status: "completed", flatIndex: 0, stepIndex: 0 },
-		{ id: "step-1", kind: "step", agent: "reviewer", label: "Review", status: "running", flatIndex: 1, stepIndex: 1 },
-	] as const;
-	return {
-		asyncId: "workflow-run",
-		asyncDir: "/tmp/workflow-run",
-		status: "running",
-		mode: "workflow",
-		agents: ["scout", "reviewer"],
-		currentStep: 1,
-		startedAt: 0,
-		updatedAt: 1000,
-		steps: [
-			{ index: 0, agent: "scout", status: "completed", workflowKey: "step-0" },
-			{ index: 1, agent: "reviewer", status: "running", workflowKey: "step-1" },
-		],
-		workflowGraph: {
-			runId: "workflow-run",
-			mode: "workflow",
-			phases: [],
-			currentNodeId: "step-1",
-			get nodes() {
-				onNodesRead();
-				return nodes;
-			},
-		} as never,
-	};
-}
-
 test("row clips content to the available width", () => {
 	const rendered = row("abcdef", 6, theme as any);
 	assert.equal(visibleWidth(rendered), 6);
@@ -317,6 +286,32 @@ test("compact multi-result cards prefer bounded workflow labels over raw tasks",
 	assert.match(text, /Ctrl\+Alt\+F Fleet/);
 });
 
+test("workflow checklist does not map child-local result indexes onto graph nodes", () => {
+	const text = componentText(renderSubagentResult({
+		content: [{ type: "text", text: "failed" }],
+			details: {
+			mode: "workflow",
+			results: [
+				{ ...result("scout", "ok"), index: 0 },
+				{ ...result("writer", "failed"), index: 0, exitCode: 1 },
+			],
+			workflowGraph: {
+				runId: "workflow-local-indexes",
+				mode: "workflow",
+				phases: [{ title: "inventory", nodeIds: ["inventory"] }, { title: "write", nodeIds: ["writer"] }],
+				nodes: [
+					{ id: "inventory", kind: "agent", agent: "scout", label: "Inventory", status: "completed", flatIndex: 0 },
+					{ id: "writer", kind: "agent", agent: "writer", label: "Writer", status: "failed", flatIndex: 1 },
+				],
+			},
+		},
+	}, { expanded: true }, theme as any));
+
+	assert.match(text, /Checklist 1\/2 done · 1 failed/);
+	assert.match(text, /✗ write 1 failed/);
+	assert.match(text, /✗ Writer · writer · failed/);
+});
+
 test("compact chain rendering uses workflow graph labels and parallel groups", () => {
 	const component = renderSubagentResult({
 		content: [{ type: "text", text: "done" }],
@@ -355,23 +350,6 @@ test("compact chain rendering uses workflow graph labels and parallel groups", (
 	assert.match(text, /Review A/);
 	assert.match(text, /Review B/);
 	assert.match(text, /Step 3\/3: Writer/);
-});
-
-test("widget rendering reuses one staged workflow projection", () => {
-	let nodeReads = 0;
-	const lines = buildWidgetLines([countedWorkflowJob(() => nodeReads++)], theme as any, 120, false, 0);
-
-	assert.equal(nodeReads, 1);
-	assert.match(lines.join("\n"), /staged lane · stage 2\/2 · Review · reviewer · running/);
-	assert.match(lines.join("\n"), /Stage 2\/2: Review/);
-});
-
-test("widget render keys reuse one staged workflow projection", () => {
-	let nodeReads = 0;
-
-	widgetRenderKey(countedWorkflowJob(() => nodeReads++));
-
-	assert.equal(nodeReads, 1);
 });
 
 test("compact chain rendering shows failed zero-child dynamic fanout groups", () => {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -360,6 +360,37 @@ describe("async run status inspection", () => {
 		}
 	});
 
+	it("shows host steps in exact workflow status checklist", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-workflow-host-checklist-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-workflow-host");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "run-workflow-host",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				workflowGraph: { runId: "run-workflow-host", mode: "workflow", phases: [], nodes: [{ id: "ci", kind: "host-step", label: "CI", status: "running", hostStep: { version: 1, kind: "host-step", monitorKind: "ci", id: "ci", label: "CI", state: "running", updatedAt: 200 } }] },
+			}, null, 2), "utf-8");
+
+			const result = inspectSubagentStatus({ id: "run-workflow-host" }, {
+				asyncDirRoot: asyncRoot,
+				resultsDir: path.join(root, "results"),
+				kill: () => true,
+				now: () => 250,
+			});
+
+			const text = textContent(result);
+			assert.equal(result.isError, undefined);
+			assert.match(text, /Workflow checklist: 0\/1 done · 1 active/);
+			assert.match(text, /CI 1 active/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("refuses to tail status outputFile paths outside the async directory", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-transcript-escape-"));
 		try {

--- a/test/unit/workflow-checklist.test.ts
+++ b/test/unit/workflow-checklist.test.ts
@@ -1,0 +1,189 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatWorkflowChecklistBottleneck, formatWorkflowChecklistText, projectWorkflowChecklist } from "../../src/workflows/workflow-checklist.ts";
+import type { HostStepNodeV1, WorkflowGraphSnapshot } from "../../src/shared/types.ts";
+
+function graph(): WorkflowGraphSnapshot {
+	return {
+		runId: "workflow-checklist",
+		mode: "workflow",
+		phases: [
+			{ title: "inventory", nodeIds: ["inventory"] },
+			{ title: "writers", nodeIds: ["writer-a", "writer-b"] },
+			{ title: "reviews", nodeIds: ["review"] },
+			{ title: "gate", nodeIds: ["gate"] },
+		],
+		nodes: [
+			{ id: "inventory", kind: "step", label: "inventory", agent: "scout", status: "completed", flatIndex: 0 },
+			{ id: "writer-a", kind: "agent", label: "writer-a", agent: "writer", status: "completed", flatIndex: 1 },
+			{ id: "writer-b", kind: "agent", label: "writer-b", agent: "writer", status: "running", flatIndex: 2 },
+			{ id: "review", kind: "step", label: "review", agent: "reviewer", status: "pending", flatIndex: 3 },
+			{ id: "gate", kind: "step", label: "gate", agent: "reviewer", status: "pending", acceptanceStatus: "rejected", flatIndex: 4 },
+		],
+	};
+}
+
+test("workflow checklist fuses graph phases with loaded child state without duplicate rows", () => {
+	const projection = projectWorkflowChecklist({
+		graph: graph(),
+		steps: [
+			{ workflowKey: "inventory", agent: "scout", status: "complete" },
+			{ workflowKey: "writer-a", agent: "writer", status: "complete" },
+			{ workflowKey: "writer-b", agent: "writer", status: "running", currentTool: "grep", toolCount: 18, startedAt: 1000 },
+			{ workflowKey: "review", agent: "reviewer", status: "pending", context: "fork" },
+		],
+		now: 5000,
+	});
+
+	assert.deepEqual(projection.phases.map((phase) => [phase.label, phase.state, phase.total, phase.done]), [
+		["inventory", "complete", 1, 1],
+		["writers", "running", 2, 1],
+		["reviews", "queued", 1, 0],
+		["gate", "blocked", 1, 0],
+	]);
+	assert.deepEqual([projection.total, projection.done, projection.running, projection.queued, projection.blocked], [5, 2, 1, 1, 1]);
+	assert.equal(projection.phases.flatMap((phase) => phase.items).length, 5);
+	assert.equal(projection.phases[1]!.items[1]!.durationMs, 4000);
+	assert.equal(projection.phases[2]!.items[0]!.context, "fork");
+	assert.equal(projection.bottleneck?.key, "gate");
+});
+
+test("workflow checklist preserves explicit host monitor verdicts and trace lane identity", () => {
+	const host: HostStepNodeV1 = {
+		version: 1,
+		kind: "host-step",
+		monitorKind: "ci",
+		id: "ci",
+		label: "CI",
+		provider: "buildkite",
+		state: "done",
+		verdict: "inconclusive",
+		target: "main",
+		freshness: { expectedRef: "main", stale: true },
+		updatedAt: 1000,
+	};
+	const projection = projectWorkflowChecklist({
+		hostSteps: [host],
+		preflight: { version: 1, coverage: "partial", lanes: [{ key: "reviewers", mode: "review" }] },
+		trace: [
+			{ operation: "run", key: "reviewers.a", generatedLaneKey: "reviewers", state: "started", agent: "reviewer" },
+			{ operation: "run", key: "reviewers.a", generatedLaneKey: "reviewers", state: "completed", agent: "reviewer" },
+		],
+	});
+
+	assert.deepEqual(projection.phases.map((phase) => phase.label), ["CI", "reviewers"]);
+	assert.equal(projection.phases[0]!.items[0]!.state, "blocked");
+	assert.equal(projection.phases[0]!.items[0]!.monitorKind, "ci");
+	assert.equal(projection.phases[0]!.items[0]!.verdict, "inconclusive");
+	assert.equal(projection.phases[1]!.items[0]!.state, "complete");
+	assert.equal(projection.phases[1]!.items[0]!.preflight?.mode, "review");
+	assert.match(formatWorkflowChecklistBottleneck(projection.bottleneck) ?? "", /CI/);
+});
+
+test("workflow checklist counts one host monitor when host status and trace share an id", () => {
+	const host: HostStepNodeV1 = {
+		version: 1,
+		kind: "host-step",
+		monitorKind: "ci",
+		id: "ci",
+		label: "CI",
+		state: "done",
+		verdict: "pass",
+		updatedAt: 1000,
+	};
+	const projection = projectWorkflowChecklist({
+		hostSteps: [host],
+		trace: [{ operation: "host", key: "ci", state: "completed", label: "CI" }],
+	});
+
+	assert.equal(projection.total, 1);
+	assert.deepEqual(projection.phases.flatMap((phase) => phase.items).map((item) => [item.key, item.kind, item.state]), [["ci", "host", "complete"]]);
+});
+
+test("workflow checklist keeps terminal child state newer than stale running trace", () => {
+	const projection = projectWorkflowChecklist({
+		graph: graph(),
+		steps: [{ workflowKey: "writer-b", agent: "writer", status: "complete" }],
+		trace: [{ operation: "run", key: "writer-b", state: "started", agent: "writer" }],
+	});
+
+	assert.equal(projection.running, 0);
+	assert.equal(projection.phases[1]!.items[1]!.state, "complete");
+});
+
+test("workflow checklist keeps terminal graph state newer than stale running child state", () => {
+	const snapshot = graph();
+	snapshot.nodes[2] = { ...snapshot.nodes[2]!, status: "failed", error: "writer failed" };
+	const projection = projectWorkflowChecklist({
+		graph: snapshot,
+		steps: [{ workflowKey: "writer-b", agent: "writer", status: "running" }],
+		trace: [{ operation: "run", key: "writer-b", state: "started", agent: "writer" }],
+	});
+
+	assert.equal(projection.running, 0);
+	assert.equal(projection.failed, 1);
+	assert.equal(projection.phases[1]!.state, "failed");
+	assert.equal(projection.phases[1]!.items[1]!.state, "failed");
+});
+
+test("workflow checklist keeps terminal graph state newer than stale trace without loaded child state", () => {
+	const snapshot = graph();
+	snapshot.nodes[2] = { ...snapshot.nodes[2]!, status: "failed", error: "writer failed" };
+	const projection = projectWorkflowChecklist({
+		graph: snapshot,
+		trace: [{ operation: "run", key: "writer-b", state: "started", agent: "writer" }],
+	});
+
+	assert.equal(projection.running, 0);
+	assert.equal(projection.failed, 1);
+	assert.equal(projection.phases[1]!.items[1]!.state, "failed");
+});
+
+test("workflow checklist keeps graph acceptance blockers ahead of stale running child state", () => {
+	const snapshot = graph();
+	snapshot.nodes[2] = { ...snapshot.nodes[2]!, acceptanceStatus: "rejected" };
+	const projection = projectWorkflowChecklist({
+		graph: snapshot,
+		steps: [{ workflowKey: "writer-b", agent: "writer", status: "running" }],
+		trace: [{ operation: "run", key: "writer-b", state: "started", agent: "writer" }],
+	});
+
+	assert.equal(projection.running, 0);
+	assert.equal(projection.blocked, 2);
+	assert.equal(projection.phases[1]!.items[1]!.state, "blocked");
+});
+
+test("workflow checklist does not duplicate preflight lanes already represented by graph nodes", () => {
+	const projection = projectWorkflowChecklist({
+		graph: graph(),
+		preflight: { version: 1, lanes: [{ key: "writer-b", mode: "mutation" }, { key: "writers", mode: "mutation" }, { key: "deploy", mode: "gate" }] },
+	});
+
+	assert.equal(projection.total, 6);
+	assert.deepEqual(projection.phases.map((phase) => phase.label), ["inventory", "writers", "reviews", "gate", "deploy"]);
+	assert.equal(projection.phases.at(-1)?.items[0]?.state, "queued");
+});
+
+test("workflow checklist text exposes aggregate, phase, and bottleneck signals with bounded errors", () => {
+	const projection = projectWorkflowChecklist({
+		trace: [{ operation: "run", key: "review", state: "failed", label: "reviewer", agent: "reviewer", error: "Output: secret details" }],
+	});
+	const text = formatWorkflowChecklistText(projection).join("\n");
+	assert.match(text, /Workflow checklist: 0\/1 done · 1 failed/);
+	assert.match(text, /reviewer/);
+	assert.match(text, /bottleneck/);
+	assert.doesNotMatch(text, /Output:/);
+});
+
+test("workflow checklist text can suppress item rows for status surfaces", () => {
+	const projection = projectWorkflowChecklist({
+		graph: graph(),
+		steps: [{ workflowKey: "writer-b", agent: "writer", status: "running" }],
+	});
+	const text = formatWorkflowChecklistText(projection, "", { includeItems: false }).join("\n");
+
+	assert.match(text, /Workflow checklist:/);
+	assert.match(text, /writers 1 done · 1 active/);
+	assert.doesNotMatch(text, /writer-b · writer · active/);
+});


### PR DESCRIPTION
## Summary
- add a pure workflow checklist projection for workflow graph, child, host-step, preflight, and trace facts
- show stacked checklist progress in async status, debug status, Fleet, live widgets, and workflow chat progress
- keep text status phase/summary-only so existing detailed child/stage rows remain authoritative

Closes #1806.

## Validation
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/workflow-checklist.test.ts test/unit/render-helpers.test.ts test/integration/render-widget.test.ts test/unit/workflow-chat-progress.test.ts test/unit/fleet-status.test.ts test/integration/async-status.test.ts test/unit/run-status.test.ts`
- `npm run typecheck`
- `git diff --check`

## Review evidence
- Minimality challenge: `/Users/nicobailon/.pi/agent/memory/extensions-subagent/lane-reports/issue-1806-minimality-challenge.md`
- Final review: `/Users/nicobailon/.pi/agent/memory/extensions-subagent/lane-reports/issue-1806-final-review.md`
