### PR TITLE
Prioritize collapsed workflow checklist layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Make Worktrunk a first-class managed worktree provider with automatic selection when available and native Git fallback when not (#1800).
 - Let Fleet open selected async children in their child-specific Herdr inspector with plain-input guidance. Thanks to [@stekman08](https://github.com/stekman08) for #1790.
 
+### Changed
+- Make workflow checklist phases the primary collapsed progress view while retaining child detail when expanded (#1810).
+
 ### Fixed
 - Clear parent required-tool diagnostics when launching nested zero-tool children so a grandchild cannot overwrite and fail its parent's otherwise valid result. Thanks to [@robertvangor](https://github.com/robertvangor) for #1802.
 - Release active async capacity after terminal workflow settlement even when persisted step status remains stale. Thanks to [@boggylp](https://github.com/boggylp) for #1804.

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1296,10 +1296,22 @@ function workflowChecklistItemLine(item: WorkflowChecklistItem, theme: Theme, in
 	return `${indent}${workflowChecklistGlyph(item, theme, frame)} ${theme.bold(identity || item.key)}${context}${state}${details ? ` ${theme.fg("dim", `· ${details}`)}` : ""}`;
 }
 
-function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | undefined, theme: Theme, indent: string, expanded: boolean, frame?: number): string[] {
+const COLLAPSED_WORKFLOW_PHASE_LIMIT = 4;
+
+function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | undefined, theme: Theme, indent: string, expanded: boolean, frame?: number, includeSummary = true, limitPhases = !expanded, includeBottleneckOutput = expanded): string[] {
 	if (!checklist?.total) return [];
-	const lines = [`${indent}${theme.fg("dim", `Checklist ${formatWorkflowChecklistSummary(checklist)}`)}`];
-	for (const phase of checklist.phases) {
+	const lines = includeSummary ? [`${indent}${theme.fg("dim", `Checklist ${formatWorkflowChecklistSummary(checklist)}`)}`] : [];
+	const phases = !limitPhases || checklist.phases.length <= COLLAPSED_WORKFLOW_PHASE_LIMIT
+		? checklist.phases
+		: checklist.phases
+			.map((phase, index) => ({ phase, index }))
+			.sort((left, right) => Number(left.phase.state !== "running") - Number(right.phase.state !== "running")
+				|| Number(left.phase.state === "complete") - Number(right.phase.state === "complete")
+				|| left.index - right.index)
+			.slice(0, COLLAPSED_WORKFLOW_PHASE_LIMIT)
+			.sort((left, right) => left.index - right.index)
+			.map(({ phase }) => phase);
+	for (const phase of phases) {
 		const phaseItem = phase.items.find((item) => item.state === "running") ?? phase.items[0];
 		const glyph = workflowChecklistGlyph({
 			state: phase.state,
@@ -1315,7 +1327,7 @@ function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | u
 			}
 		}
 	}
-	const bottleneck = formatWorkflowChecklistBottleneck(checklist.bottleneck);
+	const bottleneck = formatWorkflowChecklistBottleneck(checklist.bottleneck, { includeOutput: includeBottleneckOutput });
 	if (bottleneck) {
 		const tone = checklist.bottleneck?.state === "blocked" || checklist.bottleneck?.state === "failed" ? "error" : checklist.bottleneck?.state === "running" ? "accent" : "warning";
 		lines.push(`${indent}${theme.fg(tone, `bottleneck · ${bottleneck}`)}`);
@@ -1814,12 +1826,15 @@ function buildForegroundResultEntries(
 	return label.itemTitle === "Agent" ? withDuplicateForegroundLabels(entries, label.totalCount) : entries;
 }
 
-function widgetStats(job: AsyncJobState, theme: Theme, projection = buildWorkflowWidgetProjection(job)): string {
+function widgetStats(job: AsyncJobState, theme: Theme, projection = buildWorkflowWidgetProjection(job), collapsed = false): string {
 	const parts: string[] = [];
 	const { stageProgress } = projection;
 	const stepsTotal = stageProgress?.total ?? job.stepsTotal ?? (job.agents?.length ?? 1);
 	const isSingleChild = isSingleChildAsyncJob(job);
-	if (stageProgress) {
+	const checklistPrimary = collapsed && job.mode === "workflow" && projection.checklist !== undefined;
+	if (checklistPrimary) {
+		parts.push(formatWorkflowChecklistSummary(projection.checklist!));
+	} else if (stageProgress) {
 		const currentStage = stageProgress.current !== undefined ? projection.stages[stageProgress.current] : undefined;
 		const focus = currentStage
 			? [compactTaskText(undefined, currentStage.label) ?? boundedLaneValue(currentStage.id), currentStage.agent ? boundedLaneValue(currentStage.agent) : "", workflowNodeStatusLabel(currentStage.status)].filter(Boolean)
@@ -1851,7 +1866,7 @@ function widgetStats(job: AsyncJobState, theme: Theme, projection = buildWorkflo
 	} else if (stepsTotal > 1) {
 		parts.push(`steps ${stepsTotal}`);
 	}
-	if (projection.checklist) parts.push(formatWorkflowChecklistSummary(projection.checklist));
+	if (projection.checklist && !checklistPrimary) parts.push(formatWorkflowChecklistSummary(projection.checklist));
 	if (job.toolCount !== undefined) parts.push(formatToolUseStat(job.toolCount));
 	if (job.totalTokens?.total) parts.push(formatTokenUsage(job.totalTokens, "token"));
 	if (job.startedAt !== undefined && job.updatedAt !== undefined) parts.push(formatDuration(Math.max(0, job.updatedAt - job.startedAt)));
@@ -2134,6 +2149,15 @@ function hostStepWidgetLines(job: AsyncJobState, theme: Theme, indent: string): 
 
 function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, frame?: number, projection = buildWorkflowWidgetProjection(job)): string[] {
 	const { steps } = projection;
+	const checklistPrimary = !expanded && job.mode === "workflow" && projection.checklist !== undefined;
+	if (checklistPrimary) {
+		const lines = [
+			...workflowPreflightLines(job, false),
+			...workflowChecklistWidgetLines(projection.checklist, theme, "  ", false, frame, false),
+		];
+		if (job.status === "running" || projection.checklist!.running > 0) lines.push(`  ${theme.fg("accent", liveDetailHintText())}`);
+		return lines;
+	}
 	if (!steps.length) {
 		const lane = projectAsyncLane(job, laneStepForJob(job, steps));
 		return [
@@ -2181,7 +2205,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 }
 
 function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, frame?: number, projection = buildWorkflowWidgetProjection(job)): string[] {
-	const stats = widgetStats(job, theme, projection);
+	const stats = widgetStats(job, theme, projection, !expanded);
 	const count = job.mode === "workflow"
 		? projection.checklist?.total ?? projection.stageProgress?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length
 		: job.mode === "chain" ? job.chainStepCount : projection.stageProgress?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length;
@@ -2189,7 +2213,8 @@ function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number,
 	const title = isSingleChildAsyncJob(job)
 		? "async subagent"
 		: `async subagent ${mode}${count && count > 1 ? ` (${count})` : ""}`;
-	const collapseDetails = job.steps?.length === 1 && shouldCollapseSingleChildDetails(job, job.steps[0]!);
+	const checklistPrimary = !expanded && job.mode === "workflow" && projection.checklist !== undefined;
+	const collapseDetails = !checklistPrimary && job.steps?.length === 1 && shouldCollapseSingleChildDetails(job, job.steps[0]!);
 	const summary = `${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, mode)}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`;
 	return [
 		`${theme.fg("toolTitle", themeBold(theme, title))} ${theme.fg("dim", "· background")}`,
@@ -2356,10 +2381,11 @@ function progressiveHeaderLine(jobs: AsyncJobState[], theme: Theme, width: numbe
 }
 
 function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number, frame?: number, projection = buildWorkflowWidgetProjection(job)): string {
-	const stats = widgetStats(job, theme, projection);
-	const activity = widgetActivity(job);
+	const checklistPrimary = job.mode === "workflow" && projection.checklist !== undefined;
+	const stats = widgetStats(job, theme, projection, true);
+	const activity = checklistPrimary ? "" : widgetActivity(job);
 	const status = job.status === "complete" ? "done" : job.status;
-	const lane = projectAsyncLane(job, laneStepForJob(job, projection.steps));
+	const lane = checklistPrimary ? undefined : projectAsyncLane(job, laneStepForJob(job, projection.steps));
 	const laneSummary = lane
 		? [lane.label ?? lane.role, lane.phase ? `phase:${lane.phase}` : undefined, lane.output ? `out:${lane.output}` : undefined, lane.workspace ? `workspace:${lane.workspace}` : `ref:${lane.ref}`].filter(Boolean).join(" · ")
 		: "";
@@ -2526,13 +2552,22 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 	let slots = MAX_WIDGET_JOBS;
 	const appendJob = (job: AsyncJobState): void => {
 		const projection = projectionFor(job);
-		const stats = widgetStats(job, theme, projection);
+		const checklistPrimary = !expanded && job.mode === "workflow" && projection.checklist !== undefined;
+		const stats = widgetStats(job, theme, projection, !expanded);
+		const details = checklistPrimary
+			? [
+				...workflowChecklistWidgetLines(projection.checklist, theme, "  ", false, frame, false),
+				...(job.status === "running" || projection.checklist!.running > 0 ? [`  ${theme.fg("accent", liveDetailHintText())}`] : []),
+			]
+			: [
+				`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
+				...widgetLaneDetailLines(job, theme, projection),
+				...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
+				...widgetParallelAgentDetails(job, theme, expanded, width, frame),
+			];
 		items.push([
 			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
-			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
-			...widgetLaneDetailLines(job, theme, projection),
-			...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
-			...widgetParallelAgentDetails(job, theme, expanded, width, frame),
+			...details,
 		]);
 	};
 
@@ -2749,7 +2784,7 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 	if (d.preflight) c.addChild(new Text(truncLine(theme.fg("dim", formatWorkflowPreflightPlanSummary(d.preflight, { indent: rowIndent })), width), 0, 0));
 	if (phase) c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}Phase  ${phase}`), width), 0, 0));
 	const checklist = projectWorkflowChecklist({ hostSteps: workflow?.receipt?.hostSteps, preflight: d.preflight, trace: workflow?.trace, now: Date.now() });
-	for (const line of workflowChecklistWidgetLines(checklist, theme, rowIndent, false, frame)) {
+	for (const line of workflowChecklistWidgetLines(checklist, theme, rowIndent, false, frame, true, !expanded, expanded)) {
 		c.addChild(new Text(truncLine(line, width), 0, 0));
 	}
 	if (rows.length === 0) {
@@ -2810,7 +2845,9 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 	}
 	const multiLabel = buildMultiProgressLabel(d, hasRunning);
 	const itemTitle = multiLabel.itemTitle;
-	const stats = statJoin(theme, [multiLabel.headerLabel, formatProgressStats(theme, totalSummary), formatTotalCostStat(d.totalCost)]);
+	const workflowChecklist = foregroundWorkflowChecklist(d);
+	const checklistPrimary = d.mode === "workflow" && workflowChecklist !== undefined;
+	const stats = statJoin(theme, [checklistPrimary ? formatWorkflowChecklistSummary(workflowChecklist) : multiLabel.headerLabel, formatProgressStats(theme, totalSummary), formatTotalCostStat(d.totalCost)]);
 	const aggregatePresentation = semanticResultPresentation({
 		running: hasRunning,
 		detached,
@@ -2828,7 +2865,13 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 	const rowIndent = mainWindowIndent(layout, 1);
 	const detailIndent = mainWindowIndent(layout, 2);
 	c.addChild(new Text(truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
-	const workflowChecklist = foregroundWorkflowChecklist(d);
+	if (checklistPrimary) {
+		for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, rowIndent, false, frame, false)) {
+			c.addChild(new Text(truncLine(line, width), 0, 0));
+		}
+		if (hasRunning || workflowChecklist.running > 0) c.addChild(new Text(truncLine(theme.fg("accent", `${rowIndent}${liveDetailHintText()}`), width), 0, 0));
+		return c;
+	}
 	for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, rowIndent, false, frame)) {
 		c.addChild(new Text(truncLine(line, width), 0, 0));
 	}

--- a/src/workflows/workflow-checklist.ts
+++ b/src/workflows/workflow-checklist.ts
@@ -404,10 +404,11 @@ export function formatWorkflowChecklistPhase(phase: WorkflowChecklistPhase): str
 	return counts.length ? `${phase.label} ${counts.join(" · ")}` : phase.label;
 }
 
-export function formatWorkflowChecklistBottleneck(item: WorkflowChecklistItem | undefined): string | undefined {
+export function formatWorkflowChecklistBottleneck(item: WorkflowChecklistItem | undefined, options: { includeOutput?: boolean } = {}): string | undefined {
 	if (!item) return undefined;
 	const identity = [item.label, item.agent && item.agent !== item.label ? item.agent : undefined].filter((value): value is string => Boolean(value)).join(" · ") || item.key;
-	const details = [item.context ? `(${item.context})` : undefined, item.currentTool ? `${item.currentTool}${item.durationMs !== undefined ? ` ${formatDurationText(item.durationMs)}` : ""}` : undefined, !item.currentTool && item.currentPath ? item.currentPath : undefined, !item.currentTool && item.durationMs !== undefined ? formatDurationText(item.durationMs) : undefined, item.toolCount !== undefined ? `${item.toolCount} tools` : undefined, item.outputName ? `out:${item.outputName}` : undefined, item.error ? `error:${item.error.replace(/\bOutput:/g, "output:")}` : undefined].filter((value): value is string => Boolean(value));
+	const includeOutput = options.includeOutput ?? true;
+	const details = [item.context ? `(${item.context})` : undefined, item.currentTool ? `${item.currentTool}${item.durationMs !== undefined ? ` ${formatDurationText(item.durationMs)}` : ""}` : undefined, !item.currentTool && item.currentPath ? item.currentPath : undefined, !item.currentTool && item.durationMs !== undefined ? formatDurationText(item.durationMs) : undefined, item.toolCount !== undefined ? `${item.toolCount} tools` : undefined, includeOutput && item.outputName ? `out:${item.outputName}` : undefined, item.error ? `error:${item.error.replace(/\bOutput:/g, "output:")}` : undefined].filter((value): value is string => Boolean(value));
 	return [identity, ...details].join(" · ");
 }
 

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -307,9 +307,13 @@ describe("subagent async widget rendering", () => {
 		};
 
 		const text = buildWidgetLines([job], theme, 180).join("\n");
-		assert.match(text, /ci: CI checks · running · provider:local-tests · PR #1614/);
-		assert.match(text, /gate: Review gate · inconclusive · provider:opaque-provider · reason:stale-head · stale · out:gate.json/);
+		assert.match(text, /CI checks 1 active/);
+		assert.match(text, /Review gate 1 blocked/);
 		assert.doesNotMatch(text, /async subagent .*CI checks/);
+
+		const expanded = buildWidgetLines([job], theme, 180, true).join("\n");
+		assert.match(expanded, /ci: CI checks · running · provider:local-tests · PR #1614/);
+		assert.match(expanded, /gate: Review gate · inconclusive · provider:opaque-provider · reason:stale-head · stale · out:gate.json/);
 	});
 
 	it("keeps simple one-off async rows on the existing fallback projection", () => {
@@ -928,14 +932,14 @@ describe("subagent async widget rendering", () => {
 
 	it("keeps the active runs.lanes stage in focus before collapsed history", () => {
 		resetWidgetLayout();
-		withStdoutSize(60, 120, () => {
+		withStdoutSize(30, 120, () => {
 			const stageKeys = ["scope-scout", "red-tests", "label-helpers", "summary-title", "detail-row", "tiers-noise", "validation", "minimality-challenge", "fresh-review"];
 			const nodeIds = stageKeys.map((key) => `issue-1695.${key}`);
-			const statuses = stageKeys.map((_, index) => index < 3 ? "completed" : index === 3 ? "running" : "pending");
+			const statuses = stageKeys.map((_, index) => index < 7 ? "completed" : index === 7 ? "running" : "pending");
 			const workflowGraph = {
 				runId: "workflow-1695",
 				mode: "workflow",
-				phases: [{ title: "issue-1695 staged lane", nodeIds }],
+				phases: stageKeys.map((title, index) => ({ title, nodeIds: [nodeIds[index]!] })),
 				nodes: stageKeys.map((key, index) => ({
 					id: nodeIds[index],
 					kind: "step",
@@ -945,7 +949,7 @@ describe("subagent async widget rendering", () => {
 					flatIndex: index,
 					stepIndex: index,
 				})),
-				currentNodeId: nodeIds[3],
+				currentNodeId: nodeIds[7],
 			};
 			const job = {
 				asyncId: "workflow-1695",
@@ -953,11 +957,11 @@ describe("subagent async widget rendering", () => {
 				status: "running",
 				mode: "workflow",
 				agents: ["scout", "worker"],
-				currentStep: 3,
-				stepsTotal: 4,
+				currentStep: 7,
+				stepsTotal: stageKeys.length,
 				updatedAt: 200,
 				workflowGraph,
-				steps: stageKeys.slice(0, 4).map((key, index) => ({
+				steps: stageKeys.slice(0, 8).map((key, index) => ({
 					index,
 					agent: index === 0 ? "scout" : "worker",
 					status: statuses[index],
@@ -973,14 +977,13 @@ describe("subagent async widget rendering", () => {
 			renderWidget(ui.ctx as never, [job]);
 			const lines = renderWidgetLines(ui.widgets.at(-1));
 			const text = lines.join("\n");
-			const activeIndex = lines.findIndex((line) => line.includes("summary-title"));
-			const hiddenIndex = lines.findIndex((line) => /lines hidden/.test(line));
-			assert.ok(hiddenIndex >= 0, `collapsed history should expose a hidden-lines marker:\n${text}`);
-			assert.ok(activeIndex >= 0, `active stage should remain visible:\n${text}`);
-			assert.ok(activeIndex < hiddenIndex, `active stage must precede the hidden-lines marker:\n${text}`);
-			assert.match(text, /stage\s+4\/9/i);
-			assert.match(text, /summary-title task/);
-			assert.match(lines[activeIndex]!, /worker/);
+			assert.match(text, /7\/9 done · 1 active · 1 queued/);
+			assert.match(text, /minimality-challenge 1 active/);
+			assert.match(text, /fresh-review 1 queued/);
+			assert.match(text, /bottleneck · minimality-challenge/);
+			assert.match(text, /Press configured-expand-key for live detail/);
+			assert.doesNotMatch(text, /label-helpers/);
+			assert.doesNotMatch(text, /Step \d+\/9|task:|workspace:|out(?:put)?:/i);
 		});
 		resetWidgetLayout();
 	});
@@ -1018,7 +1021,7 @@ describe("subagent async widget rendering", () => {
 			stepsTotal: stages.length,
 			workflowGraph,
 			steps: stages,
-		}], theme, 220, false).join("\n");
+		}], theme, 220, true).join("\n");
 		const rowIndex = (label: string): number => text.split("\n").findIndex((line) => line.includes(label));
 		const completed = rowIndex("completed-history");
 		const failed = rowIndex("failed-stage");

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -312,6 +312,107 @@ test("workflow checklist does not map child-local result indexes onto graph node
 	assert.match(text, /✗ Writer · writer · failed/);
 });
 
+test("collapsed workflow widgets lead with checklist phases while expanded widgets keep child detail", () => {
+	const now = 50_000;
+	const workflowGraph = {
+		runId: "workflow-collapsed",
+		mode: "workflow" as const,
+		phases: [
+			{ title: "inventory", nodeIds: ["inventory"] },
+			{ title: "writers", nodeIds: ["writer-a", "writer-b"] },
+			{ title: "reviews", nodeIds: ["review"] },
+			{ title: "gates", nodeIds: ["gate"] },
+		],
+		nodes: [
+			{ id: "inventory", kind: "step" as const, label: "inventory", agent: "scout", status: "completed" as const, flatIndex: 0 },
+			{ id: "writer-a", kind: "agent" as const, label: "writer-a", agent: "writer", status: "running" as const, flatIndex: 1 },
+			{ id: "writer-b", kind: "agent" as const, label: "writer-b", agent: "writer", status: "pending" as const, flatIndex: 2 },
+			{ id: "review", kind: "step" as const, label: "review", agent: "reviewer", status: "pending" as const, flatIndex: 3 },
+			{ id: "gate", kind: "step" as const, label: "gate", agent: "reviewer", status: "pending" as const, flatIndex: 4 },
+		],
+	};
+	const job: AsyncJobState = {
+		asyncId: "workflow-collapsed",
+		asyncDir: "/tmp/workflow-collapsed",
+		cwd: "/tmp/workflow",
+		status: "running",
+		mode: "workflow",
+		agents: ["scout", "writer", "reviewer"],
+		stepsTotal: 5,
+		currentStep: 1,
+		toolCount: 38,
+		startedAt: 1_000,
+		updatedAt: now,
+		workflowGraph,
+		steps: [
+			{ index: 0, workflowKey: "inventory", agent: "scout", status: "complete", description: "Inspect the repository" },
+			{ index: 1, workflowKey: "writer-a", agent: "writer", status: "running", description: "Review auth flow", currentTool: "edit", currentToolStartedAt: now - 2_000, toolCount: 19, outputName: "review-a.md" },
+			{ index: 2, workflowKey: "writer-b", agent: "writer", status: "pending", description: "Review billing flow", outputName: "review-b.md" },
+		],
+	};
+
+	const collapsed = buildWidgetLines([job], theme, 240).join("\n");
+	assert.match(collapsed, /1\/5 done · 1 active · 3 queued/);
+	assert.match(collapsed, /✓ inventory/);
+	assert.match(collapsed, /writers 1 active · 1 queued/);
+	assert.match(collapsed, /◦ reviews 1 queued/);
+	assert.match(collapsed, /◦ gates 1 queued/);
+	assert.match(collapsed, /bottleneck/);
+	assert.match(collapsed, /Press configured-expand-key for live detail · Ctrl\+Alt\+F Fleet/);
+	assert.equal((collapsed.match(/1\/5 done · 1 active · 3 queued/g) ?? []).length, 1);
+	assert.doesNotMatch(collapsed, /Step \d\/\d|task:|workspace:|ref:|out(?:put)?:/i);
+
+	const expanded = buildWidgetLines([job], theme, 240, true).join("\n");
+	assert.match(expanded, /Stage 2\/5/);
+	assert.match(expanded, /task: .*Review auth flow/);
+	assert.match(expanded, /workspace:\/tmp\/workflow/);
+	assert.match(expanded, /out:review-a\.md/);
+	assert.match(expanded, /output: [\\/]tmp[\\/]workflow-collapsed[\\/]output-1\.log/);
+
+	const generic = buildWidgetLines([{
+		asyncId: "workflow-generic",
+		asyncDir: "/tmp/workflow-generic",
+		status: "running",
+		mode: "workflow",
+		agents: ["reviewer", "scout"],
+		stepsTotal: 2,
+		steps: [
+			{ index: 0, agent: "reviewer", status: "running" },
+			{ index: 1, agent: "scout", status: "running" },
+		],
+	} as AsyncJobState], theme, 240).join("\n");
+	assert.match(generic, /Workflow 2 active/);
+});
+
+test("compact foreground workflow results use checklist phases instead of child rows", () => {
+	const workflowGraph = {
+		runId: "foreground-workflow",
+		mode: "workflow" as const,
+		phases: [{ title: "inventory", nodeIds: ["inventory"] }, { title: "writers", nodeIds: ["writer"] }],
+		nodes: [
+			{ id: "inventory", kind: "step" as const, label: "inventory", agent: "scout", status: "completed" as const, flatIndex: 0 },
+			{ id: "writer", kind: "agent" as const, label: "writer", agent: "writer", status: "running" as const, flatIndex: 1 },
+		],
+	};
+	const text = componentText(renderSubagentResult({
+		content: [{ type: "text", text: "running" }],
+		details: {
+			mode: "workflow",
+			results: [
+				{ ...result("scout", "done"), workflowKey: "inventory" },
+				{ ...result("writer", ""), workflowKey: "writer", task: "raw task that should stay in expanded detail", progress: { status: "running", index: 1, agent: "writer", toolCount: 7, tokens: 0, durationMs: 2_000 } },
+			],
+			workflowGraph,
+		},
+	} as never, { expanded: false }, theme as any));
+
+	assert.match(text, /1\/2 done · 1 active/);
+	assert.match(text, /✓ inventory/);
+	assert.match(text, /writers 1 active/);
+	assert.match(text, /Press configured-expand-key for live detail · Ctrl\+Alt\+F Fleet/);
+	assert.doesNotMatch(text, /Step \d\/\d|task:|workspace:|ref:|out(?:put)?:/i);
+});
+
 test("compact chain rendering uses workflow graph labels and parallel groups", () => {
 	const component = renderSubagentResult({
 		content: [{ type: "text", text: "done" }],

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -434,6 +434,7 @@ describe("workflow chat progress rendering", () => {
 			key: `step-${index}`,
 			state: "started" as const,
 			label: `review ${index}`,
+			phase: `phase-${index}`,
 		}));
 		const result = {
 			content: [{ type: "text" as const, text: "Workflow running." }],
@@ -454,6 +455,7 @@ describe("workflow chat progress rendering", () => {
 		const expanded = renderSubagentResult(result, { expanded: true }, theme as any, undefined, { horizontalSpacing: 0, compactResultMaxLines: 3 }).render(120);
 		assert.ok(expanded.length > 3);
 		assert.match(expanded[1]!, /^  Repo   pi-subagents\s*$/);
+		assert.match(expanded.join("\n"), /phase-9 1 active/);
 		assert.doesNotMatch(expanded.join("\n"), /rows hidden · .* expands/);
 	});
 


### PR DESCRIPTION
## Summary

- make collapsed workflow widgets and compact foreground workflow results checklist-first
- hide verbose child plumbing (`Step`, `task`, `workspace`/`ref`, `out`/`output`) until expanded/live detail
- keep active/queued phases, bottleneck, and live-detail/Fleet hints visible under normal collapsed budgets

Closes #1810.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/render-helpers.test.ts test/unit/workflow-chat-progress.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `npm run typecheck`
- `git diff --check`

## Review evidence

Fresh Sol review after the collapsed bottleneck output fix: No issues found.
Report: `/Users/nicobailon/.pi/agent/memory/extensions-subagent/lane-reports/issue-1810/final-review-after-output-fix.final-review-output-fix.json`
