### PR TITLE
Isolate agent dir during unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Make workflow checklist phases the primary collapsed progress view while retaining child detail when expanded (#1810).
 
 ### Fixed
+- Isolate test agent-directory writes from inherited `PI_CODING_AGENT_DIR` during isolated runs. Thanks to [@mapleluvr](https://github.com/mapleluvr) for #1809.
 - Clear parent required-tool diagnostics when launching nested zero-tool children so a grandchild cannot overwrite and fail its parent's otherwise valid result. Thanks to [@robertvangor](https://github.com/robertvangor) for #1802.
 - Release active async capacity after terminal workflow settlement even when persisted step status remains stale. Thanks to [@boggylp](https://github.com/boggylp) for #1804.
 - Make `subagents.agentOverrides.<name>` replace matching custom-agent frontmatter fields, consistently with builtin agents. Thanks to [@expoli](https://github.com/expoli) for #1796.

--- a/test/support/isolated-temp-root.mjs
+++ b/test/support/isolated-temp-root.mjs
@@ -2,8 +2,19 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-if (!process.env.PI_SUBAGENTS_TEMP_ROOT) {
-	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-test-root-"));
-	process.env.PI_SUBAGENTS_TEMP_ROOT = tempRoot;
+const configuredTempRoot = process.env.PI_SUBAGENTS_TEMP_ROOT?.trim();
+const tempRoot = configuredTempRoot
+	? path.resolve(configuredTempRoot)
+	: fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-test-root-"));
+process.env.PI_SUBAGENTS_TEMP_ROOT = tempRoot;
+
+const nestedTestProcess = process.env.PI_SUBAGENTS_TEST_LOADER === "1";
+const isolatedHome = path.join(tempRoot, "home");
+process.env.HOME = isolatedHome;
+process.env.USERPROFILE = isolatedHome;
+if (!nestedTestProcess) delete process.env.PI_CODING_AGENT_DIR;
+process.env.PI_SUBAGENTS_TEST_LOADER = "1";
+
+if (!configuredTempRoot) {
 	process.on("exit", () => fs.rmSync(tempRoot, { recursive: true, force: true }));
 }

--- a/test/unit/temp-paths.test.ts
+++ b/test/unit/temp-paths.test.ts
@@ -78,6 +78,56 @@ describe("shared temp paths", () => {
 		}
 	});
 
+	it("isolates agent-dir profile writes from an inherited PI_CODING_AGENT_DIR", () => {
+		const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-isolation-"));
+		const tempRoot = path.join(fixture, "temp-root");
+		const callerAgentDir = path.join(fixture, "caller-agent");
+		try {
+			const loaderUrl = new URL("../support/isolated-temp-root.mjs", import.meta.url).href;
+			const profilesUrl = new URL("../../src/profiles/profiles.ts", import.meta.url).href;
+			const utilsUrl = new URL("../../src/shared/utils.ts", import.meta.url).href;
+			const script = `
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { applySubagentProfile, getSubagentProfilesDir } from ${JSON.stringify(profilesUrl)};
+import { getAgentDir } from ${JSON.stringify(utilsUrl)};
+
+const profilesDir = getSubagentProfilesDir();
+fs.mkdirSync(profilesDir, { recursive: true });
+fs.writeFileSync(path.join(profilesDir, "isolated.json"), JSON.stringify({ subagents: { agentOverrides: { worker: { thinking: "high" } } } }));
+const result = applySubagentProfile("isolated");
+console.log(JSON.stringify({ agentDir: getAgentDir(), profilePath: path.join(profilesDir, "isolated.json"), settingsPath: result.settingsPath }));
+`;
+			const env = {
+				...process.env,
+				PI_CODING_AGENT_DIR: callerAgentDir,
+				PI_SUBAGENTS_TEMP_ROOT: tempRoot,
+			};
+			delete env.PI_SUBAGENTS_TEST_LOADER;
+			const result = spawnSync(process.execPath, [
+				"--experimental-strip-types",
+				"--import", loaderUrl,
+				"--input-type=module",
+				"--eval", script,
+			], {
+				cwd: process.cwd(),
+				encoding: "utf-8",
+				env,
+			});
+			assert.equal(result.status, 0, result.stderr);
+			const output = JSON.parse(result.stdout.trim()) as { agentDir: string; profilePath: string; settingsPath: string };
+			const isolatedAgentDir = path.join(tempRoot, "home", ".pi", "agent");
+			assert.equal(output.agentDir, isolatedAgentDir);
+			assert.equal(output.profilePath, path.join(isolatedAgentDir, "profiles", "pi-subagents", "isolated.json"));
+			assert.equal(output.settingsPath, path.join(isolatedAgentDir, "settings.json"));
+			assert.equal(fs.existsSync(output.profilePath), true);
+			assert.equal(fs.existsSync(output.settingsPath), true);
+			assert.equal(fs.existsSync(callerAgentDir), false);
+		} finally {
+			fs.rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
 	it("anchors shared temp directories under one scoped root", () => {
 		assert.equal(path.dirname(RESULTS_DIR), TEMP_ROOT_DIR);
 		assert.equal(path.dirname(ASYNC_DIR), TEMP_ROOT_DIR);


### PR DESCRIPTION
Closes #1809.

## Summary
- isolate the test preload from inherited `PI_CODING_AGENT_DIR` by redirecting HOME/USERPROFILE under the temp root
- preserve explicit nested test-process `PI_CODING_AGENT_DIR` overrides
- add a subprocess regression proving profile/settings writes stay out of the caller agent dir
- credit @mapleluvr in the changelog

## Validation
- `PI_CODING_AGENT_DIR="$fake" node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/profiles.test.ts test/unit/temp-paths.test.ts test/unit/path-resolution.test.ts test/unit/pi-coding-agent-dir.test.ts`
- `PI_CODING_AGENT_DIR="$fake" node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/agent-disabled.test.ts test/unit/agent-frontmatter.test.ts test/unit/skills-fallback.test.ts`
- `npm run typecheck`
- `git diff --check`

Focused fresh review: no issues found.
