### PR TITLE
Accept-fast-in-async-recovery-descriptors

### DIFF
--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -316,7 +316,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid async recovery descriptor '${descriptorPath}': expected an object.`);
 	const parsed = value as Record<string, unknown>;
 	const allowedFields = new Set([
-		"version", "launchContractDigest", "sourceRunId", "agentContract", "agent", "sessionFile", "cwd", "model", "modelProvider", "modelOverrideFromParent", "modelOrigin", "fallbackModels", "thinking", "thinkingCeiling", "tools", "allowNestedSubagents", "extensions",
+		"version", "launchContractDigest", "sourceRunId", "agentContract", "agent", "sessionFile", "cwd", "model", "modelProvider", "modelOverrideFromParent", "modelOrigin", "fallbackModels", "fast", "thinking", "thinkingCeiling", "tools", "allowNestedSubagents", "extensions",
 		"subagentOnlyExtensions", "mcpDirectTools", "excludeTools", "mutationTools", "systemPrompt", "systemPromptMode", "inheritProjectContext", "inheritGlobalContext", "inheritSkills", "skills",
 		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "structuredOutputSchema", "acceptance", "sessionDir", "artifactConfig",
 		"artifactsDir", "maxOutput", "controlConfig", "context", "intercomBridge", "absoluteDeadlineAt", "initialTurnBudget", "initialToolBudget", "maxSubagentDepth", "share", "capabilityCeiling",
@@ -349,6 +349,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 	if (parsed.outputMode !== "inline" && parsed.outputMode !== "file-only") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': outputMode is invalid.`);
 	if (parsed.context !== undefined && parsed.context !== "fresh" && parsed.context !== "fork") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': context is invalid.`);
 	if (parsed.modelOverrideFromParent !== undefined && typeof parsed.modelOverrideFromParent !== "boolean") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': modelOverrideFromParent must be a boolean.`);
+	if (parsed.fast !== undefined && typeof parsed.fast !== "boolean") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': fast must be a boolean.`);
 	if (parsed.modelOrigin !== undefined && parsed.modelOrigin !== "explicit" && parsed.modelOrigin !== "inherited" && parsed.modelOrigin !== "configured") throw new Error(`Invalid async recovery descriptor '${descriptorPath}': modelOrigin must be 'explicit', 'inherited', or 'configured'.`);
 	if (parsed.modelOrigin === undefined && parsed.model !== undefined) parsed.modelOrigin = parsed.modelOverrideFromParent ? "inherited" : "configured";
 	for (const field of ["inheritProjectContext", "inheritSkills", "share"] as const) {

--- a/test/unit/async-recovery-descriptor.test.ts
+++ b/test/unit/async-recovery-descriptor.test.ts
@@ -49,6 +49,31 @@ describe("async recovery descriptor", () => {
 		}
 	});
 
+	it("accepts the fast launch setting written by async execution", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-recovery-fast-"));
+		try {
+			fs.writeFileSync(path.join(root, "recovery-descriptor.json"), JSON.stringify({
+				version: 1,
+				runFanoutBudget: runFanoutBudget("run-fast"),
+				sourceRunId: "run-fast",
+				agent: "worker",
+				cwd: root,
+				fast: true,
+				systemPromptMode: "replace",
+				inheritGlobalContext: false,
+				inheritProjectContext: false,
+				inheritSkills: false,
+				outputMode: "inline",
+				maxSubagentDepth: 2,
+				share: false,
+			}), "utf-8");
+
+			assert.equal(readAsyncRecoveryDescriptor(root)?.fast, true);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("defaults inheritGlobalContext from inheritProjectContext for descriptors from older versions", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-async-recovery-legacy-global-context-"));
 		try {


### PR DESCRIPTION
## Summary
- accept the optional `fast` field that async execution already persists in recovery descriptors
- validate that a defined `fast` value is boolean
- add a regression test for the written descriptor shape

## Root cause
`async-execution.ts` persisted `fast`, but `readAsyncRecoveryDescriptor()` omitted it from its strict allowlist, so resumed runs failed with `unknown field 'fast'`.

## Validation
- `npm run typecheck`
- targeted `async-recovery-descriptor.test.ts` (7 passed)
- `npm run test:unit` reached 2,848 passes; existing concurrent Herdr/orca temp-root failures prevented a clean aggregate result
- independent exact-head review: OK
