### PR TITLE
test: support task-file mock assertions

### DIFF
--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -15,7 +15,7 @@ import * as fs from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
-import { createEventBus, createMockPi, createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir, tryImport } from "../support/helpers.ts";
+import { createEventBus, createMockPi, createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir, resolveMockPiCallArgs, tryImport } from "../support/helpers.ts";
 import type { MockPi } from "../support/helpers.ts";
 import { deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest } from "../../src/runs/background/control-channel.ts";
 import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
@@ -158,6 +158,7 @@ interface AsyncStatusPayload {
 
 interface MockPiCallRecord {
 	args?: string[];
+	effectiveArgs?: string[];
 	systemPrompts?: Array<{ mode?: string; path?: string; text?: string; error?: string }>;
 	requiredChildTools?: string[];
 }
@@ -382,7 +383,7 @@ async function waitForMockPiCall(mockPi: MockPi, index: number, timeoutMs = 30_0
 		if (callFile) {
 			const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
 			assert.ok(Array.isArray(payload.args), "expected recorded args");
-			return { args: payload.args, systemPrompts: payload.systemPrompts ?? [] };
+			return { args: resolveMockPiCallArgs(payload), systemPrompts: payload.systemPrompts ?? [] };
 		}
 		if (Date.now() > deadline) assert.fail(`Timed out waiting for recorded mock pi call ${index}`);
 		await new Promise((resolve) => setTimeout(resolve, 100));
@@ -401,7 +402,7 @@ function readLastMockPiArgs(mockPi: MockPi): string[] {
 	assert.ok(callFile, "expected a recorded mock pi call");
 	const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
 	assert.ok(Array.isArray(payload.args), "expected recorded args");
-	return payload.args;
+	return resolveMockPiCallArgs(payload);
 }
 
 function readMockPiArgs(mockPi: MockPi, index: number): string[] {
@@ -412,7 +413,7 @@ function readMockPiArgs(mockPi: MockPi, index: number): string[] {
 	assert.ok(callFile, `expected recorded call ${index}`);
 	const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
 	assert.ok(Array.isArray(payload.args), "expected recorded args");
-	return payload.args;
+	return resolveMockPiCallArgs(payload);
 }
 
 function readMockPiRequiredTools(mockPi: MockPi, index: number): string[] {
@@ -431,9 +432,10 @@ function readMockPiArgsMatching(mockPi: MockPi, text: string): string[] {
 		.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
 		.sort();
 	for (const callFile of callFiles) {
-		const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as { args?: string[] };
+		const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
 		assert.ok(Array.isArray(payload.args), "expected recorded args");
-		if (payload.args.join("\n").includes(text)) return payload.args;
+		const args = resolveMockPiCallArgs(payload);
+		if (args.join("\n").includes(text)) return args;
 	}
 	assert.fail(`expected recorded call containing ${text}`);
 }
@@ -1378,8 +1380,8 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		await waitForMockPiCall(mockPi, 0);
 		const callFile = fs.readdirSync(mockPi.dir).find((name) => name.endsWith(".json"));
 		assert.ok(callFile);
-		const call = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as { args?: string[] };
-		assert.match(call.args?.join("\n") ?? "", new RegExp(sentinel));
+		const call = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
+		assert.match(resolveMockPiCallArgs(call).join("\n"), new RegExp(sentinel));
 
 		const payload = await readAsyncPayload(id);
 		const artifactPaths = payload.results[0]?.artifactPaths;
@@ -2476,7 +2478,10 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(fs.readFileSync(artifactPaths[0], "utf-8"), "chain first report");
 		assert.equal(fs.readFileSync(artifactPaths[1], "utf-8"), "chain second report");
 		const calls = fs.readdirSync(mockPi.dir).filter((name) => name.startsWith("call-")).sort();
-		const taskArgs = calls.map((name) => (JSON.parse(fs.readFileSync(path.join(mockPi.dir, name), "utf-8")) as MockPiCallRecord).args?.at(-1) ?? "");
+		const taskArgs = calls.map((name) => {
+			const call = JSON.parse(fs.readFileSync(path.join(mockPi.dir, name), "utf-8")) as MockPiCallRecord;
+			return resolveMockPiCallArgs(call).at(-1) ?? "";
+		});
 		assert.ok(taskArgs.find((task) => task.includes("Write first"))?.includes(path.join("parallel-0", "0-worker", "context.md")));
 		assert.ok(taskArgs.find((task) => task.includes("Write second"))?.includes(path.join("parallel-0", "1-worker", "context.md")));
 	});

--- a/test/integration/fork-context-execution.test.ts
+++ b/test/integration/fork-context-execution.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MockPi } from "../support/helpers.ts";
-import { createEventBus, createMockPi, createTempDir, events, removeTempDir, tryImport } from "../support/helpers.ts";
+import { createEventBus, createMockPi, createTempDir, events, removeTempDir, resolveMockPiCallArgs, tryImport } from "../support/helpers.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { ACTIVE_ASYNC_CAPACITY_DIR, acquireActiveAsyncCapacity, activeAsyncCapacitySessionKey } from "../../src/runs/background/active-async-capacity.ts";
 import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
@@ -161,23 +161,23 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 			.sort()
 			.at(-1);
 		assert.ok(callFile, "expected a recorded mock pi call");
-		return readRecordedArgs(callFile);
+		return readRecordedArgs(callFile, true);
 	}
 
 	function readAllCallArgs(): string[][] {
 		return fs.readdirSync(mockPi.dir)
 			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
 			.sort()
-			.map(readRecordedArgs);
+			.map((name) => readRecordedArgs(name));
 	}
 
-	function readRecordedArgs(callFile: string): string[] {
-		const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8"));
+	function readRecordedArgs(callFile: string, effective = false): string[] {
+		const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as { args?: string[]; effectiveArgs?: string[] };
 		assert.equal(typeof payload, "object", "expected recorded args payload");
 		assert.notEqual(payload, null, "expected recorded args payload");
 		assert.ok("args" in payload, "expected recorded args payload");
 		assert.ok(Array.isArray(payload.args), "expected recorded args");
-		return payload.args;
+		return effective ? resolveMockPiCallArgs(payload) : payload.args;
 	}
 
 	function readSessionArgsFromCalls(): string[] {
@@ -190,16 +190,6 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 				return sessionFile;
 			})
 			.filter((sessionFile): sessionFile is string => Boolean(sessionFile));
-	}
-
-	function readCallArgsForTask(taskText: string): string[] {
-		const args = readAllCallArgs().find((callArgs) => {
-			const prompt = callArgs.at(-1) ?? "";
-			return prompt.startsWith(`Task: ${taskText}\n`)
-				|| prompt.includes(`\n\nTask:\n${taskText}\n`);
-		});
-		assert.ok(args, `expected a recorded mock pi call for task '${taskText}'`);
-		return args;
 	}
 
 	function isTaskFileArg(arg: string): boolean {
@@ -317,7 +307,7 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		);
 
 		assert.equal(result.isError, undefined);
-		const args = readCallArgs();
+		const args = readAllCallArgs()[0] ?? [];
 		const taskArg = args.at(-1) ?? "";
 		if (process.platform === "darwin") {
 			assert.ok(isTaskFileArg(taskArg));
@@ -1323,7 +1313,7 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		);
 
 		assert.equal(result.isError, undefined);
-		const args = readCallArgs();
+		const args = readAllCallArgs()[0] ?? [];
 		const taskArg = args.at(-1) ?? "";
 		if (process.platform === "darwin") {
 			assert.ok(isTaskFileArg(taskArg));

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -24,6 +24,7 @@ import {
 	makeAgent,
 	makeMinimalCtx,
 	events,
+	resolveMockPiCallArgs,
 	tryImport,
 } from "../support/helpers.ts";
 import registerSubagentExtension from "../../src/extension/index.ts";
@@ -166,6 +167,7 @@ interface RunSyncResult {
 
 interface MockPiCallRecord {
 	args?: string[];
+	effectiveArgs?: string[];
 	cwd?: string;
 	systemPrompts?: Array<{ mode?: string; path?: string; text?: string; error?: string }>;
 }
@@ -339,7 +341,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		removeTempDir(tempDir);
 	});
 
-	function readCall(): { args: string[]; cwd?: string; systemPrompts: NonNullable<MockPiCallRecord["systemPrompts"]> } {
+	function readCall(): { args: string[]; effectiveArgs?: string[]; cwd?: string; systemPrompts: NonNullable<MockPiCallRecord["systemPrompts"]> } {
 		const callFile = fs.readdirSync(mockPi.dir)
 			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
 			.sort()
@@ -347,18 +349,22 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.ok(callFile, "expected a recorded mock pi call");
 		const payload = JSON.parse(fs.readFileSync(path.join(mockPi.dir, callFile), "utf-8")) as MockPiCallRecord;
 		assert.ok(Array.isArray(payload.args), "expected recorded args");
-		return { args: payload.args, cwd: payload.cwd, systemPrompts: payload.systemPrompts ?? [] };
+		return { args: payload.args, effectiveArgs: payload.effectiveArgs, cwd: payload.cwd, systemPrompts: payload.systemPrompts ?? [] };
 	}
 
 	function readCallArgs(): string[] {
-		return readCall().args;
+		const call = readCall();
+		return resolveMockPiCallArgs(call);
 	}
 
-	function readAllCallArgs(): string[][] {
+	function readAllCallArgs(effective = false): string[][] {
 		return fs.readdirSync(mockPi.dir)
 			.filter((name) => name.startsWith("call-") && name.endsWith(".json"))
 			.sort()
-			.map((name) => (JSON.parse(fs.readFileSync(path.join(mockPi.dir, name), "utf-8")) as MockPiCallRecord).args);
+			.map((name) => {
+				const call = JSON.parse(fs.readFileSync(path.join(mockPi.dir, name), "utf-8")) as MockPiCallRecord;
+				return effective ? resolveMockPiCallArgs(call) : call.args ?? [];
+			});
 	}
 
 	function makeExecutor(
@@ -6787,7 +6793,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const [firstArgs, resumedArgs] = readAllCallArgs();
 		assert.equal(firstArgs?.[firstArgs.indexOf("--session") + 1], sessionFile);
 		assert.equal(resumedArgs?.[resumedArgs.indexOf("--session") + 1], sessionFile);
-		assert.match(resumedArgs?.at(-1) ?? "", /Continue from the current files and transcript/);
+		assert.match(readAllCallArgs(true)[1]?.at(-1) ?? "", /Continue from the current files and transcript/);
 		assert.equal(fs.readFileSync(path.join(tempDir, "side-effect.txt"), "utf-8"), "done");
 	});
 
@@ -7332,7 +7338,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		);
 
 		const call = readCall();
-		const taskArg = call.args.at(-1) ?? "";
+		const taskArg = resolveMockPiCallArgs(call).at(-1) ?? "";
 		const systemPrompt = call.systemPrompts[0]?.text ?? "";
 		assert.equal(result.isError, undefined);
 		assert.match(taskArg, new RegExp(`Write your findings to exactly this path: ${escapeRegExp(overridePath)}`));
@@ -7359,7 +7365,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		);
 
 		const call = readCall();
-		const taskArg = call.args.at(-1) ?? "";
+		const taskArg = resolveMockPiCallArgs(call).at(-1) ?? "";
 		const systemPrompt = call.systemPrompts[0]?.text ?? "";
 		assert.equal(result.isError, undefined);
 		assert.equal(fs.readFileSync(outputPath, "utf-8"), "complete read-only analysis");

--- a/test/support/helpers.ts
+++ b/test/support/helpers.ts
@@ -13,6 +13,10 @@ export function createMockPi(): MockPi {
 	return _createMockPi();
 }
 
+export function resolveMockPiCallArgs(call: { args?: readonly string[]; effectiveArgs?: readonly string[] }): string[] {
+	return [...(call.effectiveArgs ?? call.args ?? [])];
+}
+
 export function createTempDir(prefix = "pi-subagent-test-"): string {
 	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }

--- a/test/support/mock-pi-script.mjs
+++ b/test/support/mock-pi-script.mjs
@@ -56,12 +56,26 @@ function hasArgMatcher(response) {
 	return Object.prototype.hasOwnProperty.call(response ?? {}, "matchArgIncludes");
 }
 
+function resolveTaskFileArg(arg) {
+	if (typeof arg !== "string" || !arg.startsWith("@") || !arg.endsWith("task.md")) return arg;
+	try {
+		return fs.readFileSync(arg.slice(1), "utf-8");
+	} catch {
+		return arg;
+	}
+}
+
+function resolveTaskFileArgs(args) {
+	return args.map(resolveTaskFileArg);
+}
+
 function responseMatchesArgs(response, args) {
 	const matcher = response?.matchArgIncludes;
 	if (matcher === undefined) return true;
 	const needles = Array.isArray(matcher) ? matcher : [matcher];
 	if (needles.length === 0) return true;
-	const haystack = args.join("\n");
+	const effectiveArgs = resolveTaskFileArgs(args);
+	const haystack = `${args.join("\n")}\n${effectiveArgs.join("\n")}`;
 	return needles.every((needle) => typeof needle === "string" && haystack.includes(needle));
 }
 
@@ -360,9 +374,10 @@ async function main() {
 	}
 	writeSessionFile(args);
 	writeToolDiagnostic(response);
+	const effectiveArgs = resolveTaskFileArgs(args);
 	const callPath = path.join(queueDir, `call-${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2)}.json`);
 	const callTempPath = `${callPath}.tmp-${process.pid}-${Date.now()}`;
-	fs.writeFileSync(callTempPath, JSON.stringify({ args, cwd: process.cwd(), systemPrompts: readSystemPromptRecords(args), requiredChildTools: readRequiredToolsEnv() }), "utf-8");
+	fs.writeFileSync(callTempPath, JSON.stringify({ args, effectiveArgs, cwd: process.cwd(), systemPrompts: readSystemPromptRecords(args), requiredChildTools: readRequiredToolsEnv() }), "utf-8");
 	fs.renameSync(callTempPath, callPath);
 
 	if (typeof response.delay === "number" && response.delay > 0) {


### PR DESCRIPTION
## Summary

Closes #1816.

This is a test-only fix for integration assertions under task-file delivery mode.

- Capture `effectiveArgs` in the mock Pi call record before temporary `@.../task.md` files are cleaned up.
- Match queued mock responses against both raw argv and effective task-file contents.
- Update async, foreground, and fork-context integration assertions to use effective task content only where the test contract is about prompt/task content.
- Preserve raw argv checks for delivery-mode assertions.

## Scope

No production code changed. No docs or changelog entry because this only fixes the repository's local integration harness/assertions.

## Review flow

- Writer reproduced the local failure class and produced the candidate.
- Retained deletion-first challenge removed redundant support code and reduced the diff from 86 insertions / 28 deletions to 57 insertions / 37 deletions.
- Simplifier found no further safe cleanup.
- Fresh reviewer found no issues and no materially smaller safe shape.

## Verification

- Initial reproduction: full `npm run test:integration` failed with 38 task-file-related assertion/matcher failures.
- Writer full integration baseline after fix: `npm run test:integration` passed — 910 passed, 0 failed, 6 skipped.
- Post-challenge focused async task-file assertions/matcher tests: 3 passed.
- Post-challenge focused foreground task-file assertions: 3 passed.
- Post-challenge focused fork delivery-mode assertions: 2 passed.
- Simplifier focused checks: async 3 passed, foreground 6 passed, fork 2 passed, mock Pi unit 1 passed.
- Fresh review checks: focused async 3 passed, foreground 6 passed, fork 2 passed.
- Parent checks on final diff:
  - `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/mock-pi.test.ts` passed.
  - `npm run typecheck` passed.
  - `git diff --check` passed.
  - Final `npm run test:integration` passed locally after the challenge/simplification/review flow.
