### PR TITLE
fix: keep preflight hints out of runtime status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Reject no-op watchdog settings: `delivery`, `showDuringRun`, `syncBacklog`, `lateWarningPolicy`, `compactAtPercent`, `reviewRetryDelayMs`, `maxReviewFailures`, `asyncCompletion`, and `guidance.systemPromptPath`.
 - Remove watchdog auto-follow. Pi 0.84+ already continues after displayed boundary warnings; repeated identical warnings stop after `subagents.watchdog.stalemateRepeats`. The `autoFollow` settings block is now unknown.
 
+### Fixed
+- Keep advisory preflight lanes out of runtime workflow rows and queued checklist counts (#1821). Thanks [@stekman08](https://github.com/stekman08).
+
 ## [0.63.0] - 2026-09-01
 
 ### Highlights

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -2,7 +2,7 @@ import { sanitizeDisplayText, truncateDisplayText } from "../../shared/display-t
 import { formatModelThinking } from "../../shared/formatters.ts";
 import type { AsyncJobState, AsyncJobStep, HostStepFreshnessV1, HostStepMonitorKind, HostStepNodeV1, HostStepState, HostStepVerdict, NestedRunSummary, NestedStepSummary, SubagentRunMode, WorkflowGraphSnapshot, WorkflowPreflightLaneV1, WorkflowPreflightV1 } from "../../shared/types.ts";
 import { HOST_STEP_MAX_COUNT, HOST_STEP_MAX_DETAIL_CHARS, HOST_STEP_MAX_LABEL_CHARS, HOST_STEP_MAX_PROVIDER_CHARS, HOST_STEP_MAX_REASON_CHARS, HOST_STEP_MAX_REF_CHARS, HOST_STEP_MAX_ROLE_CHARS, HOST_STEP_MAX_TARGET_CHARS, hostStepReportName, parseHostStepNode, validHostStepNodes } from "./host-step-status.ts";
-import { workflowKeyMatchesPreflightLane } from "../../workflows/workflow-preflight.ts";
+import { workflowPreflightLaneForRuntimeKey } from "../../workflows/workflow-preflight.ts";
 import { workflowGraphStageNodes } from "./workflow-graph.ts";
 
 export const ASYNC_STATUS_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
@@ -483,9 +483,8 @@ export function projectAsyncWorkflowRows(
 	const graph = isWorkflowGraph(hostStepsOrPreflight) ? hostStepsOrPreflight : undefined;
 	const hostSteps = isWorkflowPreflight(hostStepsOrPreflight) || graph ? undefined : hostStepsOrPreflight;
 	const loaded = steps ?? [];
-	const preflightForKey = (key: string, groupKeys: readonly (string | undefined)[] = []): WorkflowPreflightLaneV1 | undefined => preflight?.lanes.find((lane) =>
-		groupKeys.includes(lane.key) || workflowKeyMatchesPreflightLane(key, lane.key),
-	);
+	const preflightForKey = (key: string, groupKeys: readonly (string | undefined)[] = []): WorkflowPreflightLaneV1 | undefined =>
+		workflowPreflightLaneForRuntimeKey(preflight, key, groupKeys);
 	if (graph) {
 		const loadedIndexesByKey = new Map<string, number[]>();
 		for (const [index, step] of loaded.entries()) {

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -2,6 +2,7 @@ import { sanitizeDisplayText, truncateDisplayText } from "../../shared/display-t
 import { formatModelThinking } from "../../shared/formatters.ts";
 import type { AsyncJobState, AsyncJobStep, HostStepFreshnessV1, HostStepMonitorKind, HostStepNodeV1, HostStepState, HostStepVerdict, NestedRunSummary, NestedStepSummary, SubagentRunMode, WorkflowGraphSnapshot, WorkflowPreflightLaneV1, WorkflowPreflightV1 } from "../../shared/types.ts";
 import { HOST_STEP_MAX_COUNT, HOST_STEP_MAX_DETAIL_CHARS, HOST_STEP_MAX_LABEL_CHARS, HOST_STEP_MAX_PROVIDER_CHARS, HOST_STEP_MAX_REASON_CHARS, HOST_STEP_MAX_REF_CHARS, HOST_STEP_MAX_ROLE_CHARS, HOST_STEP_MAX_TARGET_CHARS, hostStepReportName, parseHostStepNode, validHostStepNodes } from "./host-step-status.ts";
+import { workflowKeyMatchesPreflightLane } from "../../workflows/workflow-preflight.ts";
 import { workflowGraphStageNodes } from "./workflow-graph.ts";
 
 export const ASYNC_STATUS_SNAPSHOT_KIND = "pi-subagents.async-status-snapshot";
@@ -472,7 +473,7 @@ function projectWorkflowGraphRow(node: WorkflowGraphSnapshot["nodes"][number], p
 	};
 }
 
-/** Project loaded workflow child facts plus stored preflight hints into compact rows. */
+/** Project authoritative workflow facts into compact rows, annotated by preflight hints. */
 export function projectAsyncWorkflowRows(
 	steps: readonly AsyncJobStep[] | undefined,
 	hostStepsOrPreflight?: readonly HostStepNodeV1[] | WorkflowGraphSnapshot | WorkflowPreflightV1,
@@ -482,7 +483,9 @@ export function projectAsyncWorkflowRows(
 	const graph = isWorkflowGraph(hostStepsOrPreflight) ? hostStepsOrPreflight : undefined;
 	const hostSteps = isWorkflowPreflight(hostStepsOrPreflight) || graph ? undefined : hostStepsOrPreflight;
 	const loaded = steps ?? [];
-	const declared = new Map<string, WorkflowPreflightLaneV1>();
+	const preflightForKey = (key: string, groupKeys: readonly (string | undefined)[] = []): WorkflowPreflightLaneV1 | undefined => preflight?.lanes.find((lane) =>
+		groupKeys.includes(lane.key) || workflowKeyMatchesPreflightLane(key, lane.key),
+	);
 	if (graph) {
 		const loadedIndexesByKey = new Map<string, number[]>();
 		for (const [index, step] of loaded.entries()) {
@@ -493,7 +496,6 @@ export function projectAsyncWorkflowRows(
 		}
 		const consumed = new Set<number>();
 		const childRows: AsyncStatusWorkflowRow[] = [];
-		for (const lane of preflight?.lanes ?? []) declared.set(lane.key, lane);
 		const graphStages = workflowGraphStageNodes(graph);
 		const graphKeys = new Set(graphStages.map((node) => node.id));
 		const graphPhaseByNodeId = new Map<string, string>();
@@ -502,60 +504,27 @@ export function projectAsyncWorkflowRows(
 				if (graphKeys.has(nodeId) && !graphPhaseByNodeId.has(nodeId)) graphPhaseByNodeId.set(nodeId, phase.title);
 			}
 		}
-		const graphLaneKeys = new Set(graphPhaseByNodeId.values());
-		const preflightForNode = (node: WorkflowGraphSnapshot["nodes"][number]): WorkflowPreflightLaneV1 | undefined => {
-			const phaseTitle = graphPhaseByNodeId.get(node.id);
-			return declared.get(node.id) ?? (node.phase ? declared.get(node.phase) : undefined) ?? (phaseTitle ? declared.get(phaseTitle) : undefined);
-		};
 		for (const node of graphStages) {
+			const lane = preflightForKey(node.id, [node.phase, graphPhaseByNodeId.get(node.id)]);
 			const indexes = (loadedIndexesByKey.get(node.id) ?? []).filter((index) => !consumed.has(index));
-			if (indexes.length > 0) {
-				for (const index of indexes) {
-					consumed.add(index);
-					childRows.push(projectLoadedWorkflowRow(loaded[index]!, index, preflightForNode(node)));
-				}
-			} else {
-				childRows.push(projectWorkflowGraphRow(node, preflightForNode(node)));
-			}
-		}
-		for (const lane of preflight?.lanes ?? []) {
-			if (graphKeys.has(lane.key) || graphLaneKeys.has(lane.key)) continue;
-			const indexes = (loadedIndexesByKey.get(lane.key) ?? []).filter((index) => !consumed.has(index));
 			if (indexes.length > 0) {
 				for (const index of indexes) {
 					consumed.add(index);
 					childRows.push(projectLoadedWorkflowRow(loaded[index]!, index, lane));
 				}
 			} else {
-				childRows.push({ name: lane.key, state: "planned", preflight: lane });
+				childRows.push(projectWorkflowGraphRow(node, lane));
 			}
 		}
 		for (const [index, step] of loaded.entries()) {
-			if (!consumed.has(index)) childRows.push(projectLoadedWorkflowRow(step, index, step.workflowKey ? declared.get(step.workflowKey) : undefined));
+			if (!consumed.has(index)) childRows.push(projectLoadedWorkflowRow(step, index, step.workflowKey ? preflightForKey(step.workflowKey, [step.phase]) : undefined));
 		}
 		return [...childRows, ...validHostStepList(graph).map(hostStepRow)];
 	}
-	const loadedIndexByKey = new Map<string, number>();
-	for (const [index, step] of loaded.entries()) {
-		if (step.workflowKey !== undefined && !loadedIndexByKey.has(step.workflowKey)) loadedIndexByKey.set(step.workflowKey, index);
-	}
-	const consumed = new Set<number>();
-	const childRows: AsyncStatusWorkflowRow[] = [];
-	for (const lane of preflight?.lanes ?? []) {
-		declared.set(lane.key, lane);
-		const index = loadedIndexByKey.get(lane.key);
-		if (index === undefined) {
-			childRows.push({ name: lane.key, state: "planned", preflight: lane });
-			continue;
-		}
-		consumed.add(index);
-		childRows.push(projectLoadedWorkflowRow(loaded[index]!, index, lane));
-	}
-	for (const [index, step] of loaded.entries()) {
-		if (consumed.has(index)) continue;
-		childRows.push(projectLoadedWorkflowRow(step, index, step.workflowKey ? declared.get(step.workflowKey) : undefined));
-	}
-	return [...childRows, ...validHostStepList(hostSteps).map(hostStepRow)];
+	return [
+		...loaded.map((step, index) => projectLoadedWorkflowRow(step, index, step.workflowKey ? preflightForKey(step.workflowKey, [step.phase]) : undefined)),
+		...validHostStepList(hostSteps).map(hostStepRow),
+	];
 }
 
 function projectLoadedWorkflowRow(step: AsyncJobStep, index: number, preflight?: WorkflowPreflightLaneV1): AsyncStatusWorkflowRow {

--- a/src/workflows/chat-progress.ts
+++ b/src/workflows/chat-progress.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Details, WorkflowPreflightLaneV1, WorkflowPreflightV1 } from "../shared/types.ts";
+import { workflowKeyMatchesPreflightLane } from "./workflow-preflight.ts";
 
 export const WORKFLOW_CHAT_PROGRESS_MODES = ["auto", "off", "live-card"] as const;
 export type WorkflowChatProgressMode = typeof WORKFLOW_CHAT_PROGRESS_MODES[number];
@@ -111,7 +112,6 @@ function cleanLabel(value: unknown): string | undefined {
 
 export function buildWorkflowChatProgressRows(trace: NonNullable<Details["workflow"]>["trace"], preflight?: WorkflowPreflightV1): WorkflowChatProgressRow[] {
 	const rows = new Map<string, WorkflowChatProgressRow>();
-	for (const lane of preflight?.lanes ?? []) rows.set(lane.key, { key: lane.key, state: "planned", preflight: lane });
 	for (const entry of trace) {
 		if (entry.operation !== "run") continue;
 		const existing = rows.get(entry.key);
@@ -124,8 +124,9 @@ export function buildWorkflowChatProgressRows(trace: NonNullable<Details["workfl
 			}
 			continue;
 		}
+		const lane = preflight?.lanes.find((candidate) => workflowKeyMatchesPreflightLane(entry.key, candidate.key, entry.generatedLaneKey));
 		const next: WorkflowChatProgressRow = existing ?? { key: entry.key, state: "running" };
-		if (existing?.preflight) next.preflight = existing.preflight;
+		if (lane && !next.preflight) next.preflight = lane;
 		next.state = entry.state === "completed"
 			? "complete"
 			: entry.state === "failed"

--- a/src/workflows/chat-progress.ts
+++ b/src/workflows/chat-progress.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Details, WorkflowPreflightLaneV1, WorkflowPreflightV1 } from "../shared/types.ts";
-import { workflowKeyMatchesPreflightLane } from "./workflow-preflight.ts";
+import { workflowPreflightLaneForRuntimeKey } from "./workflow-preflight.ts";
 
 export const WORKFLOW_CHAT_PROGRESS_MODES = ["auto", "off", "live-card"] as const;
 export type WorkflowChatProgressMode = typeof WORKFLOW_CHAT_PROGRESS_MODES[number];
@@ -124,7 +124,7 @@ export function buildWorkflowChatProgressRows(trace: NonNullable<Details["workfl
 			}
 			continue;
 		}
-		const lane = preflight?.lanes.find((candidate) => workflowKeyMatchesPreflightLane(entry.key, candidate.key, entry.generatedLaneKey));
+		const lane = workflowPreflightLaneForRuntimeKey(preflight, entry.key, [entry.generatedLaneKey]);
 		const next: WorkflowChatProgressRow = existing ?? { key: entry.key, state: "running" };
 		if (lane && !next.preflight) next.preflight = lane;
 		next.state = entry.state === "completed"

--- a/src/workflows/workflow-checklist.ts
+++ b/src/workflows/workflow-checklist.ts
@@ -323,10 +323,8 @@ export function projectWorkflowChecklist(input: WorkflowChecklistInput): Workflo
 	const trace = traceSources(input.trace);
 	const traceByKey = new Map(trace.map((entry) => [entry.key, entry]));
 	const phaseByNode = new Map<string, string>();
-	const graphPhaseLabels = new Set<string>();
 	for (const phase of input.graph?.phases ?? []) {
 		const title = keyText(phase.title, "Workflow");
-		graphPhaseLabels.add(title);
 		phaseFor(phases, title);
 		for (const nodeId of phase.nodeIds) if (!phaseByNode.has(nodeId)) phaseByNode.set(nodeId, title);
 	}
@@ -377,7 +375,6 @@ export function projectWorkflowChecklist(input: WorkflowChecklistInput): Workflo
 		const item = traceItem(entry, phases.size, laneFor(entry.key, entry.generatedLaneKey ?? entry.phase ?? "", lanes));
 		add(phases, item.phase, item);
 	}
-	for (const lane of input.preflight?.lanes ?? []) if (!graphKeys.has(lane.key) && !graphPhaseLabels.has(lane.key) && !phases.get(lane.key)?.items.length) add(phases, lane.key, { key: lane.key, label: lane.key, phase: lane.key, state: "queued", preflight: lane });
 
 	const finalized = [...phases.values()].filter((phase) => phase.items.length > 0);
 	for (const phase of finalized) {

--- a/src/workflows/workflow-checklist.ts
+++ b/src/workflows/workflow-checklist.ts
@@ -1,5 +1,6 @@
 import type { AsyncJobStep, HostStepNodeV1, WorkflowGraphNode, WorkflowGraphSnapshot, WorkflowPreflightLaneV1, WorkflowPreflightV1 } from "../shared/types.ts";
 import { sanitizeDisplayText } from "../shared/display-text.ts";
+import { workflowPreflightLaneForRuntimeKey } from "./workflow-preflight.ts";
 
 export type WorkflowChecklistState = "complete" | "running" | "queued" | "blocked" | "failed" | "paused" | "stopped";
 
@@ -189,8 +190,8 @@ function duration(step: Pick<WorkflowChecklistStep, "durationMs" | "startedAt" |
 	return end === undefined ? undefined : Math.max(0, end - startedAt);
 }
 
-function laneFor(key: string, phase: string, lanes: ReadonlyMap<string, WorkflowPreflightLaneV1>): WorkflowPreflightLaneV1 | undefined {
-	return lanes.get(key) ?? lanes.get(phase) ?? [...lanes.values()].find((lane) => key.startsWith(`${lane.key}.`));
+function laneFor(preflight: WorkflowPreflightV1 | undefined, key: string, preferredKeys: readonly (string | undefined)[] = []): WorkflowPreflightLaneV1 | undefined {
+	return workflowPreflightLaneForRuntimeKey(preflight, key, preferredKeys);
 }
 
 function stepKey(step: WorkflowChecklistStep): string | undefined {
@@ -264,7 +265,7 @@ function traceSources(trace: readonly WorkflowChecklistTraceEntry[] | undefined)
 }
 
 function traceItem(entry: WorkflowChecklistTraceEntry, index: number, preflight: WorkflowPreflightLaneV1 | undefined): WorkflowChecklistItem {
-	const phase = keyText(entry.generatedLaneKey ?? entry.phase ?? preflight?.key, "Workflow");
+	const phase = keyText(preflight?.key ?? entry.generatedLaneKey ?? entry.phase, "Workflow");
 	const item = stepItem({ key: entry.key, label: entry.label, phase, agent: entry.agent, status: entry.state === "started" ? "running" : entry.state, durationMs: entry.durationMs, error: entry.error }, index, phase, entry.key, entry.label ?? entry.key, preflight);
 	if (entry.operation === "host") item.kind = "host";
 	return item;
@@ -317,7 +318,6 @@ function finalize(phase: WorkflowChecklistPhase): void {
 
 export function projectWorkflowChecklist(input: WorkflowChecklistInput): WorkflowChecklistProjection {
 	const phases = new Map<string, WorkflowChecklistPhase>();
-	const lanes = new Map((input.preflight?.lanes ?? []).map((lane) => [lane.key, lane]));
 	const steps = (input.steps ?? []) as readonly WorkflowChecklistStep[];
 	const nodes = graphNodes(input.graph);
 	const trace = traceSources(input.trace);
@@ -354,25 +354,26 @@ export function projectWorkflowChecklist(input: WorkflowChecklistInput): Workflo
 		if (matches.length) {
 			for (const match of matches) {
 				usedSteps.add(match.index);
-				add(phases, phase, applyNow(mergeNodeStep(node, match.step, phase, traceByKey.get(stepKey(match.step) ?? node.id), laneFor(node.id, phase, lanes)), input.now));
+				add(phases, phase, applyNow(mergeNodeStep(node, match.step, phase, traceByKey.get(stepKey(match.step) ?? node.id), laneFor(input.preflight, node.id, [phase])), input.now));
 			}
 			continue;
 		}
-		add(phases, phase, applyNow(mergeNodeStep(node, { key: node.id, label: node.label, phase, agent: node.agent, status: node.status, outputName: node.outputName, error: node.error, acceptance: node.acceptanceStatus ? { status: node.acceptanceStatus } : undefined }, phase, traceByKey.get(node.id), laneFor(node.id, phase, lanes)), input.now));
+		add(phases, phase, applyNow(mergeNodeStep(node, { key: node.id, label: node.label, phase, agent: node.agent, status: node.status, outputName: node.outputName, error: node.error, acceptance: node.acceptanceStatus ? { status: node.acceptanceStatus } : undefined }, phase, traceByKey.get(node.id), laneFor(input.preflight, node.id, [phase])), input.now));
 	}
 
 	for (const [index, step] of steps.entries()) {
 		if (usedSteps.has(index)) continue;
 		const key = keyText(stepKey(step), `step-${index + 1}`);
 		const traceEntry = traceByKey.get(key);
-		const phase = keyText(step.phase ?? laneFor(key, "", lanes)?.key ?? traceEntry?.generatedLaneKey ?? traceEntry?.phase, "Workflow");
-		add(phases, phase, applyNow(stepItem(step, index, phase, key, step.label ?? step.key ?? step.agent, laneFor(key, phase, lanes)), input.now));
+		const lane = laneFor(input.preflight, key, [step.phase, traceEntry?.generatedLaneKey, traceEntry?.phase]);
+		const phase = keyText(lane?.key ?? step.phase ?? traceEntry?.generatedLaneKey ?? traceEntry?.phase, "Workflow");
+		add(phases, phase, applyNow(stepItem(step, index, phase, key, step.label ?? step.key ?? step.agent, lane), input.now));
 	}
 
 	for (const host of hostById.values()) add(phases, keyText(host.label, "Host"), hostItem(host, keyText(host.label, "Host")));
 	for (const entry of trace) {
 		if (graphKeys.has(entry.key) || stepKeys.has(entry.key) || hostKeys.has(entry.key)) continue;
-		const item = traceItem(entry, phases.size, laneFor(entry.key, entry.generatedLaneKey ?? entry.phase ?? "", lanes));
+		const item = traceItem(entry, phases.size, laneFor(input.preflight, entry.key, [entry.generatedLaneKey, entry.phase]));
 		add(phases, item.phase, item);
 	}
 

--- a/src/workflows/workflow-preflight.ts
+++ b/src/workflows/workflow-preflight.ts
@@ -160,16 +160,17 @@ export function workflowPreflightLaneForRuntimeKey(
 	if (!lanes) return undefined;
 	const exact = lanes.find((lane) => lane.key === key);
 	if (exact) return exact;
+	let closestRoot: WorkflowPreflightLaneV1 | undefined;
+	for (const lane of lanes) {
+		if (key.startsWith(`${lane.key}.`) && (!closestRoot || lane.key.length > closestRoot.key.length)) closestRoot = lane;
+	}
+	if (closestRoot) return closestRoot;
 	for (const preferredKey of preferredKeys) {
 		if (!preferredKey) continue;
 		const preferred = lanes.find((lane) => lane.key === preferredKey);
 		if (preferred) return preferred;
 	}
-	let closestRoot: WorkflowPreflightLaneV1 | undefined;
-	for (const lane of lanes) {
-		if (key.startsWith(`${lane.key}.`) && (!closestRoot || lane.key.length > closestRoot.key.length)) closestRoot = lane;
-	}
-	return closestRoot;
+	return undefined;
 }
 
 function declaredLaneCoversWorkflowKey(entry: WorkflowTraceLike, laneKey: string): boolean {

--- a/src/workflows/workflow-preflight.ts
+++ b/src/workflows/workflow-preflight.ts
@@ -146,8 +146,12 @@ function declaredKeys(preflight: WorkflowPreflightV1): Set<string> {
  * Treat declared lane keys as plan roots: `lane` is the lane itself and
  * `lane.stage` is a stage by convention, even without generated provenance.
  */
+export function workflowKeyMatchesPreflightLane(key: string, laneKey: string, generatedLaneKey?: string): boolean {
+	return generatedLaneKey === laneKey || key === laneKey || key.startsWith(`${laneKey}.`);
+}
+
 function declaredLaneCoversWorkflowKey(entry: WorkflowTraceLike, laneKey: string): boolean {
-	return entry.key === laneKey || entry.key.startsWith(`${laneKey}.`);
+	return workflowKeyMatchesPreflightLane(entry.key, laneKey, entry.generatedLaneKey);
 }
 
 function keyCoveredByDeclaredLane(entry: WorkflowTraceLike, declared: ReadonlySet<string>): boolean {

--- a/src/workflows/workflow-preflight.ts
+++ b/src/workflows/workflow-preflight.ts
@@ -150,6 +150,28 @@ export function workflowKeyMatchesPreflightLane(key: string, laneKey: string, ge
 	return generatedLaneKey === laneKey || key === laneKey || key.startsWith(`${laneKey}.`);
 }
 
+/** Select the most specific advisory lane without allowing declaration order to override an exact runtime key. */
+export function workflowPreflightLaneForRuntimeKey(
+	preflight: WorkflowPreflightV1 | undefined,
+	key: string,
+	preferredKeys: readonly (string | undefined)[] = [],
+): WorkflowPreflightLaneV1 | undefined {
+	const lanes = preflight?.lanes;
+	if (!lanes) return undefined;
+	const exact = lanes.find((lane) => lane.key === key);
+	if (exact) return exact;
+	for (const preferredKey of preferredKeys) {
+		if (!preferredKey) continue;
+		const preferred = lanes.find((lane) => lane.key === preferredKey);
+		if (preferred) return preferred;
+	}
+	let closestRoot: WorkflowPreflightLaneV1 | undefined;
+	for (const lane of lanes) {
+		if (key.startsWith(`${lane.key}.`) && (!closestRoot || lane.key.length > closestRoot.key.length)) closestRoot = lane;
+	}
+	return closestRoot;
+}
+
 function declaredLaneCoversWorkflowKey(entry: WorkflowTraceLike, laneKey: string): boolean {
 	return workflowKeyMatchesPreflightLane(entry.key, laneKey, entry.generatedLaneKey);
 }

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -206,6 +206,21 @@ describe("async status projection", () => {
 		]);
 	});
 
+	it("prefers an exact preflight lane over an earlier broad declaration", () => {
+		const rows = projectAsyncWorkflowRows([
+			{ agent: "reviewer", workflowKey: "writer.quality", status: "running" },
+		], {
+			version: 1,
+			coverage: "partial",
+			lanes: [
+				{ key: "writer", mode: "mutation" },
+				{ key: "writer.quality", mode: "review" },
+			],
+		});
+
+		assert.equal(rows[0]?.preflight?.mode, "review");
+	});
+
 	it("projects known runs.lanes stages from the workflow graph, including pending stages", () => {
 		const rows = projectAsyncWorkflowRows([{
 			agent: "scout",

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -206,9 +206,9 @@ describe("async status projection", () => {
 		]);
 	});
 
-	it("prefers an exact preflight lane over an earlier broad declaration", () => {
+	it("prefers a specific preflight lane over an earlier broad phase alias", () => {
 		const rows = projectAsyncWorkflowRows([
-			{ agent: "reviewer", workflowKey: "writer.quality", status: "running" },
+			{ agent: "reviewer", workflowKey: "writer.quality.deep", phase: "writer", status: "running" },
 		], {
 			version: 1,
 			coverage: "partial",

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -189,9 +189,9 @@ describe("async status projection", () => {
 		assert.deepEqual(rows, []);
 	});
 
-	it("projects stored preflight lanes as planned rows and merges launched facts", () => {
+	it("annotates authoritative children without projecting unmatched preflight lanes", () => {
 		const rows = projectAsyncWorkflowRows([
-			{ agent: "worker", workflowKey: "writer", label: "Writer", status: "running" },
+			{ agent: "worker", workflowKey: "writer.implementation", label: "Writer", status: "running" },
 		], {
 			version: 1,
 			coverage: "complete",
@@ -202,8 +202,7 @@ describe("async status projection", () => {
 		});
 
 		assert.deepEqual(rows.map((row) => ({ name: row.name, state: row.state, mode: row.preflight?.mode })), [
-			{ name: "writer · Writer (worker)", state: "running", mode: "mutation" },
-			{ name: "review", state: "planned", mode: "review" },
+			{ name: "writer.implementation · Writer (worker)", state: "running", mode: "mutation" },
 		]);
 	});
 

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -1006,6 +1006,27 @@ describe("below-editor subagent FleetView", () => {
 		assert.deepEqual(workflow?.workflowRows?.map((row) => row.name), ["review (reviewer)"]);
 	});
 
+	it("keeps advisory preflight declarations out of Fleet runtime rows and counts", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("workflow-preflight", {
+			asyncId: "workflow-preflight",
+			asyncDir: "/tmp/workflow-preflight",
+			status: "running",
+			mode: "workflow",
+			startedAt: 10,
+			updatedAt: 20,
+			preflight: { version: 1, coverage: "partial", lanes: [{ key: "pr14", mode: "review" }] },
+			steps: [{ agent: "reviewer", workflowKey: "pr14-quality", status: "running" }],
+		});
+
+		const workflow = collectFleetStatusEntries(state).find((entry) => entry.key === "async:workflow-preflight");
+		assert.deepEqual(workflow?.workflowRows?.map((row) => [row.name, row.state]), [["pr14-quality (reviewer)", "running"]]);
+		assert.deepEqual(
+			workflow?.workflowChecklist && { total: workflow.workflowChecklist.total, running: workflow.workflowChecklist.running, queued: workflow.workflowChecklist.queued },
+			{ total: 1, running: 1, queued: 0 },
+		);
+	});
+
 	it("renders bounded workflow progress rows under the workflow parent", () => {
 		const state = stateForTest();
 		const workflowJob = {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -391,6 +391,39 @@ describe("async run status inspection", () => {
 		}
 	});
 
+	it("keeps preflight as a plan hint outside the runtime checklist", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-workflow-preflight-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const asyncDir = path.join(asyncRoot, "run-workflow-preflight");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "run-workflow-preflight",
+				mode: "workflow",
+				state: "running",
+				startedAt: 100,
+				lastUpdate: 200,
+				preflight: { version: 1, lanes: [{ key: "pr14", mode: "review" }] },
+				steps: [{ agent: "reviewer", workflowKey: "pr14-quality", status: "running" }],
+			}, null, 2), "utf-8");
+
+			const result = inspectSubagentStatus({ id: "run-workflow-preflight" }, {
+				asyncDirRoot: asyncRoot,
+				resultsDir: path.join(root, "results"),
+				kill: () => true,
+				now: () => 250,
+			});
+
+			const text = textContent(result);
+			assert.equal(result.isError, undefined);
+			assert.match(text, /Plan: 1 lane · pr14/);
+			assert.match(text, /Workflow checklist: 0\/1 done · 1 active/);
+			assert.doesNotMatch(text, /1 queued/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("refuses to tail status outputFile paths outside the async directory", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-run-status-transcript-escape-"));
 		try {

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -297,7 +297,7 @@ describe("workflow chat progress rendering", () => {
 		assert.doesNotMatch(text, /failed\s+detaches/);
 	});
 
-	it("seeds declared preflight lanes as planned before workflow trace entries", () => {
+	it("keeps advisory preflight lanes in plan metadata instead of runtime rows", () => {
 		const preflight = {
 			version: 1 as const,
 			coverage: "partial" as const,
@@ -306,40 +306,41 @@ describe("workflow chat progress rendering", () => {
 				{ key: "review", mode: "review" as const, expectedOutput: "review.md" },
 			],
 		};
-		assert.deepEqual(buildWorkflowChatProgressRows([], preflight).map((row) => ({ key: row.key, state: row.state })), [
-			{ key: "writer", state: "planned" },
-			{ key: "review", state: "planned" },
-		]);
-		const text = componentText(renderSubagentResult({
-			content: [{ type: "text", text: "Workflow running." }],
+		assert.deepEqual(buildWorkflowChatProgressRows([], preflight), []);
+		const result = {
+			content: [{ type: "text" as const, text: "Workflow running." }],
 			details: {
-				mode: "workflow",
+				mode: "workflow" as const,
 				runId: "wf_planned",
 				results: [],
 				preflight,
-				chatProgress: { mode: "live-card", repoRelation: "same", repoLabel: "pi-subagents" },
+				chatProgress: { mode: "live-card" as const, repoRelation: "same" as const, repoLabel: "pi-subagents" },
 				workflow: { trace: [], emits: [], console: [] },
 			},
-		}, { expanded: false }, theme as any));
-		assert.match(text, /planned\s+writer/);
-		assert.match(text, /planned\s+review/);
+		};
+		const text = componentText(renderSubagentResult(result, { expanded: false }, theme as any));
+		assert.match(text, /Plan: 2 lanes · writer, review/);
+		assert.match(text, /waiting for workflow child launches/);
+		assert.doesNotMatch(text, /planned\s+writer/);
+		assert.doesNotMatch(text, /planned\s+review/);
 		assert.doesNotMatch(text, /mode:mutation/);
 		assert.doesNotMatch(text, /expected:review\.md/);
-		assert.doesNotMatch(text, /waiting for workflow child launches/);
 
-		const expanded = componentText(renderSubagentResult({
-			content: [{ type: "text", text: "Workflow running." }],
-			details: {
-				mode: "workflow",
-				runId: "wf_planned",
-				results: [],
-				preflight,
-				chatProgress: { mode: "live-card", repoRelation: "same", repoLabel: "pi-subagents" },
-				workflow: { trace: [], emits: [], console: [] },
-			},
-		}, { expanded: true }, theme as any));
-		assert.match(expanded, /mode:mutation/);
-		assert.match(expanded, /expected:review\.md/);
+		const expanded = componentText(renderSubagentResult(result, { expanded: true }, theme as any));
+		assert.match(expanded, /Plan: 2 lanes · writer, review/);
+		assert.doesNotMatch(expanded, /planned\s+writer/);
+		assert.doesNotMatch(expanded, /planned\s+review/);
+	});
+
+	it("annotates an authoritative dotted child without adding its declared root", () => {
+		const preflight = { version: 1 as const, coverage: "partial" as const, lanes: [{ key: "pr14", mode: "review" as const }] };
+		const rows = buildWorkflowChatProgressRows([
+			{ operation: "run", key: "pr14.quality", generatedLaneKey: "pr14", state: "started", agent: "reviewer" },
+		], preflight);
+
+		assert.deepEqual(rows.map((row) => ({ key: row.key, state: row.state, mode: row.preflight?.mode })), [
+			{ key: "pr14.quality", state: "running", mode: "review" },
+		]);
 	});
 
 	it("uses the compact plan preview for collapsed workflow launch output", () => {

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -343,7 +343,7 @@ describe("workflow chat progress rendering", () => {
 		]);
 	});
 
-	it("prefers an exact preflight lane over an earlier broad declaration", () => {
+	it("prefers a specific preflight lane over an earlier broad generated alias", () => {
 		const preflight = {
 			version: 1 as const,
 			coverage: "partial" as const,
@@ -353,7 +353,7 @@ describe("workflow chat progress rendering", () => {
 			],
 		};
 		const rows = buildWorkflowChatProgressRows([
-			{ operation: "run", key: "writer.quality", state: "started", agent: "reviewer" },
+			{ operation: "run", key: "writer.quality.deep", generatedLaneKey: "writer", state: "started", agent: "reviewer" },
 		], preflight);
 
 		assert.equal(rows[0]?.preflight?.mode, "review");

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -343,6 +343,22 @@ describe("workflow chat progress rendering", () => {
 		]);
 	});
 
+	it("prefers an exact preflight lane over an earlier broad declaration", () => {
+		const preflight = {
+			version: 1 as const,
+			coverage: "partial" as const,
+			lanes: [
+				{ key: "writer", mode: "mutation" as const },
+				{ key: "writer.quality", mode: "review" as const },
+			],
+		};
+		const rows = buildWorkflowChatProgressRows([
+			{ operation: "run", key: "writer.quality", state: "started", agent: "reviewer" },
+		], preflight);
+
+		assert.equal(rows[0]?.preflight?.mode, "review");
+	});
+
 	it("uses the compact plan preview for collapsed workflow launch output", () => {
 		const preflight = {
 			version: 1 as const,

--- a/test/unit/workflow-checklist.test.ts
+++ b/test/unit/workflow-checklist.test.ts
@@ -154,15 +154,31 @@ test("workflow checklist keeps graph acceptance blockers ahead of stale running 
 	assert.equal(projection.phases[1]!.items[1]!.state, "blocked");
 });
 
-test("workflow checklist does not duplicate preflight lanes already represented by graph nodes", () => {
+test("workflow checklist uses preflight only to annotate authoritative work", () => {
 	const projection = projectWorkflowChecklist({
 		graph: graph(),
-		preflight: { version: 1, lanes: [{ key: "writer-b", mode: "mutation" }, { key: "writers", mode: "mutation" }, { key: "deploy", mode: "gate" }] },
+		preflight: { version: 1, coverage: "partial", lanes: [{ key: "writer-b", mode: "mutation" }, { key: "writers", mode: "mutation" }, { key: "deploy", mode: "gate" }] },
 	});
 
-	assert.equal(projection.total, 6);
-	assert.deepEqual(projection.phases.map((phase) => phase.label), ["inventory", "writers", "reviews", "gate", "deploy"]);
-	assert.equal(projection.phases.at(-1)?.items[0]?.state, "queued");
+	assert.equal(projection.total, 5);
+	assert.deepEqual(projection.phases.map((phase) => phase.label), ["inventory", "writers", "reviews", "gate"]);
+	assert.equal(projection.queued, 1);
+	assert.equal(projection.phases[2]?.items[0]?.key, "review");
+});
+
+test("workflow checklist does not turn unmatched preflight metadata into queued work", () => {
+	const preflight = { version: 1 as const, coverage: "partial" as const, lanes: [{ key: "pr14", mode: "review" as const }] };
+	const declarationOnly = projectWorkflowChecklist({ preflight });
+	const mismatchedRuntime = projectWorkflowChecklist({
+		preflight,
+		trace: [{ operation: "run", key: "pr14-quality", state: "started", agent: "reviewer" }],
+	});
+
+	assert.deepEqual(declarationOnly, { phases: [], total: 0, done: 0, running: 0, queued: 0, blocked: 0, failed: 0, paused: 0, stopped: 0 });
+	assert.equal(mismatchedRuntime.total, 1);
+	assert.equal(mismatchedRuntime.running, 1);
+	assert.equal(mismatchedRuntime.queued, 0);
+	assert.deepEqual(mismatchedRuntime.phases.flatMap((phase) => phase.items).map((item) => item.key), ["pr14-quality"]);
 });
 
 test("workflow checklist text exposes aggregate, phase, and bottleneck signals with bounded errors", () => {

--- a/test/unit/workflow-checklist.test.ts
+++ b/test/unit/workflow-checklist.test.ts
@@ -181,6 +181,24 @@ test("workflow checklist does not turn unmatched preflight metadata into queued 
 	assert.deepEqual(mismatchedRuntime.phases.flatMap((phase) => phase.items).map((item) => item.key), ["pr14-quality"]);
 });
 
+test("workflow checklist prefers specific dotted preflight lanes over generated aliases", () => {
+	const projection = projectWorkflowChecklist({
+		preflight: {
+			version: 1,
+			coverage: "partial",
+			lanes: [
+				{ key: "writer", mode: "mutation" },
+				{ key: "writer.quality", mode: "review" },
+			],
+		},
+		trace: [{ operation: "run", key: "writer.quality.deep", generatedLaneKey: "writer", state: "started", agent: "reviewer" }],
+	});
+
+	assert.equal(projection.total, 1);
+	assert.deepEqual(projection.phases.map((phase) => phase.label), ["writer.quality"]);
+	assert.equal(projection.phases[0]?.items[0]?.preflight?.mode, "review");
+});
+
 test("workflow checklist text exposes aggregate, phase, and bottleneck signals with bounded errors", () => {
 	const projection = projectWorkflowChecklist({
 		trace: [{ operation: "run", key: "review", state: "failed", label: "reviewer", agent: "reviewer", error: "Output: secret details" }],

--- a/test/unit/workflow-preflight.test.ts
+++ b/test/unit/workflow-preflight.test.ts
@@ -151,5 +151,11 @@ describe("workflow preflight metadata", () => {
 
 		const exactTrace = [{ operation: "run", key: "audit", state: "completed" as const }];
 		assert.deepEqual(workflowPreflightWarnings(lanes, exactTrace, { settled: true }), []);
+
+		const hyphenatedTrace = [{ operation: "run", key: "audit-quality", state: "completed" as const }];
+		assert.deepEqual(workflowPreflightWarnings(lanes, hyphenatedTrace, { settled: true }), [
+			"Preflight advisory: workflow key 'audit-quality' launched without a declared lane.",
+			"Preflight advisory: declared lane 'audit' was not launched.",
+		]);
 	});
 });

--- a/test/unit/workflow-preflight.test.ts
+++ b/test/unit/workflow-preflight.test.ts
@@ -133,7 +133,7 @@ describe("workflow preflight metadata", () => {
 		};
 
 		assert.equal(workflowPreflightLaneForRuntimeKey(overlapping, "writer.quality")?.mode, "review");
-		assert.equal(workflowPreflightLaneForRuntimeKey(overlapping, "writer.quality.deep")?.mode, "review");
+		assert.equal(workflowPreflightLaneForRuntimeKey(overlapping, "writer.quality.deep", ["writer"])?.mode, "review");
 		assert.equal(workflowPreflightLaneForRuntimeKey(overlapping, "generated", ["writer"])?.mode, "mutation");
 	});
 

--- a/test/unit/workflow-preflight.test.ts
+++ b/test/unit/workflow-preflight.test.ts
@@ -13,6 +13,7 @@ import {
 	formatWorkflowPreflightWarningSummary,
 	normalizeWorkflowPreflight,
 	validateWorkflowPreflight,
+	workflowPreflightLaneForRuntimeKey,
 	workflowPreflightWarnings,
 } from "../../src/workflows/workflow-preflight.ts";
 
@@ -119,6 +120,21 @@ describe("workflow preflight metadata", () => {
 		assert.deepEqual(workflowPreflightWarnings(manyLanes, [], { settled: false }), []);
 		assert.ok(workflowPreflightWarnings(manyLanes, [], { settled: true }).some((warning) => warning.includes("declared lane 'declared-0' was not launched")));
 		assert.ok(WORKFLOW_PREFLIGHT_MAX_CLAIMS > 0);
+	});
+
+	it("selects exact lanes before generated or dotted-root matches", () => {
+		const overlapping = {
+			version: 1 as const,
+			coverage: "partial" as const,
+			lanes: [
+				{ key: "writer", mode: "mutation" as const },
+				{ key: "writer.quality", mode: "review" as const },
+			],
+		};
+
+		assert.equal(workflowPreflightLaneForRuntimeKey(overlapping, "writer.quality")?.mode, "review");
+		assert.equal(workflowPreflightLaneForRuntimeKey(overlapping, "writer.quality.deep")?.mode, "review");
+		assert.equal(workflowPreflightLaneForRuntimeKey(overlapping, "generated", ["writer"])?.mode, "mutation");
 	});
 
 	it("treats exact and direct dotted keys as declared lane stages by convention", () => {


### PR DESCRIPTION
## Problem

Advisory `preflight.lanes` could create planned workflow rows and queued checklist items without a corresponding workflow graph node, trace entry, child status, or host step. This made status and Fleet appear to have work waiting when no runtime work existed.

Closes #1821.

## Summary

- derive chat, async/Fleet, and checklist runtime rows only from authoritative workflow facts
- use preflight lanes only to annotate exact, dotted, or generated-lane runtime children
- keep preflight plan summaries and mismatch warnings separate and preserve the existing workflow-key convention
- leave scheduling, launch authority, concurrency, and child execution unchanged

## Verification

- focused status regression set: 122 passed
- GitHub Tests: passed on Ubuntu and Windows
  - unit: 2,872 passed, 4 skipped on Ubuntu
  - integration: 910 passed, 6 skipped on Ubuntu
  - E2E: optional real Pi runtime unavailable, so no E2E test ran
- `npm run typecheck`: passed
- `git diff --check`: passed
- LSP: no diagnostics in changed production files
- Pi-Lens: no findings in the final change delta
- independent read-only review: PASS
- Greptile: 5/5 after both lane-precedence findings were fixed and resolved
