### PR TITLE
Fix workflow child control attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - Keep advisory preflight lanes out of runtime workflow rows and queued checklist counts (#1821). Thanks [@stekman08](https://github.com/stekman08).
 - Preserve effective thinking in completed async step results. Thanks to [@Nickonomic](https://github.com/Nickonomic) for #1823.
+- Forward workflow child control overrides through new and retained launches, and suppress idle needs-attention notices before the first assistant turn (#1817). Thanks [@rrocxela](https://github.com/rrocxela).
 
 ## [0.63.0] - 2026-09-01
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -3745,6 +3745,7 @@ async function runSubagent(
 				config: controlConfig,
 				startedAt: step.startedAt ?? overallStartTime,
 				lastActivityAt,
+				turnCount: step.turnCount,
 				currentTool: step.currentTool,
 				thinking: step.thinking,
 				now,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -965,6 +965,7 @@ async function runSingleAttempt(
 				config: controlConfig,
 				startedAt: startTime,
 				lastActivityAt: progress.lastActivityAt,
+				turnCount: progress.turnCount,
 				currentTool: progress.currentTool,
 				thinking: resolvedThinking,
 				now,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2070,7 +2070,7 @@ async function resumeAsyncRun(input: {
 		// place rather than allocating a second provider worktree around it.
 		worktree: input.params.worktree === true && !("managedWorktree" in target && target.managedWorktree === true),
 		lane: input.params.lane ?? recoveryDescriptor?.lane,
-		controlConfig: recoveryDescriptor?.controlConfig ?? resolveControlConfig(input.deps.config.control, input.params.control),
+		controlConfig: resolveRevivalControlConfig({ globalConfig: input.deps.config.control, requestedControl: input.params.control, recoveryControlConfig: recoveryDescriptor?.controlConfig }),
 		intercomBridge: input.params.intercomBridge ?? recoveryDescriptor?.intercomBridge,
 		controlIntercomTarget: intercomBridge.active ? intercomBridge.orchestratorTarget : undefined,
 		childIntercomTarget: intercomBridge.active ? (agent, index) => resolveSubagentIntercomTarget(runId, agent, index) : undefined,
@@ -4443,6 +4443,7 @@ export function prepareWorkflowLaunchParams(
 		if (output !== undefined && typeof output !== "string" && typeof output !== "boolean") throw new Error("output must be a path string or boolean.");
 		const outputMode = Object.hasOwn(childParams, "outputMode") ? childParams.outputMode : workflowDefaults.outputMode;
 		if (outputMode !== undefined && outputMode !== "inline" && outputMode !== "file-only") throw new Error("outputMode must be 'inline' or 'file-only'.");
+		const control = mergeWorkflowControlOverrides(workflowDefaults.control, childParams.control as ControlConfig | undefined);
 		return {
 			action: "resume",
 			id: childParams.resume.trim(),
@@ -4461,14 +4462,17 @@ export function prepareWorkflowLaunchParams(
 			...(options.missionDetached ? { mission: false } : {}),
 			...(timeoutMs !== undefined ? { timeoutMs: timeoutMs as number } : {}),
 			...(toolBudget !== undefined ? { toolBudget: toolBudget as ToolBudgetConfig } : {}),
+			...(control !== undefined ? { control } : {}),
 			...(intercomBridge !== undefined ? { intercomBridge: intercomBridge as IntercomBridgeConfig } : {}),
 			...(capabilityCeiling ? { capabilityCeiling } : {}),
 		};
 	}
+	const control = mergeWorkflowControlOverrides(workflowDefaults.control, childParams.control as ControlConfig | undefined);
 	const launchParams = {
 		...workflowDefaults,
 		async: options.externalAsyncRequired === true && childParams.async === undefined && workflowDefaults.async === undefined ? true : false,
 		...childParams,
+		...(control !== undefined ? { control } : {}),
 		...(options.externalAsyncRequired === true && childParams.async === undefined && workflowDefaults.async === undefined ? { workflowAwaitAsync: true } : {}),
 		...(options.missionDetached ? { mission: false } : {}),
 		workflowParentRunId: parentWorkflowRunId,
@@ -4485,6 +4489,17 @@ export function prepareWorkflowLaunchParams(
 	const normalizedGate = normalizeGateParams(launchParams);
 	if (!normalizedGate.ok) throw new Error(normalizedGate.error);
 	return normalizedGate.params;
+}
+
+function mergeWorkflowControlOverrides(workflowControl: ControlConfig | undefined, childControl: ControlConfig | undefined): ControlConfig | undefined {
+	if (childControl === undefined) return workflowControl;
+	if (workflowControl === undefined) return childControl;
+	return { ...workflowControl, ...childControl };
+}
+
+export function resolveRevivalControlConfig(input: { globalConfig?: ControlConfig; requestedControl?: ControlConfig; recoveryControlConfig?: ResolvedControlConfig }): ResolvedControlConfig {
+	if (input.requestedControl === undefined) return input.recoveryControlConfig ?? resolveControlConfig(input.globalConfig, undefined);
+	return resolveControlConfig(input.recoveryControlConfig ?? input.globalConfig, input.requestedControl);
 }
 
 type GateParamsNormalizationResult =

--- a/src/runs/shared/subagent-control.ts
+++ b/src/runs/shared/subagent-control.ts
@@ -45,11 +45,12 @@ export function resolveControlConfig(
 	const enabled = override?.enabled ?? globalConfig?.enabled ?? DEFAULT_CONTROL_CONFIG.enabled;
 	const overrideNeedsAttentionAfterMs = parsePositiveInt(override?.needsAttentionAfterMs);
 	const globalNeedsAttentionAfterMs = parsePositiveInt(globalConfig?.needsAttentionAfterMs);
+	const globalNeedsAttentionAfterMsIsExplicit = (globalConfig as Partial<ResolvedControlConfig> | undefined)?.needsAttentionAfterMsIsExplicit ?? globalNeedsAttentionAfterMs !== undefined;
 	const needsAttentionAfterMs = overrideNeedsAttentionAfterMs
 		?? globalNeedsAttentionAfterMs
 		?? DEFAULT_CONTROL_CONFIG.needsAttentionAfterMs;
 	const needsAttentionAfterMsIsExplicit = overrideNeedsAttentionAfterMs !== undefined
-		|| globalNeedsAttentionAfterMs !== undefined;
+		|| globalNeedsAttentionAfterMsIsExplicit;
 	const activeNoticeAfterMs = parsePositiveInt(override?.activeNoticeAfterMs)
 		?? parsePositiveInt(globalConfig?.activeNoticeAfterMs)
 		?? DEFAULT_CONTROL_CONFIG.activeNoticeAfterMs;
@@ -98,11 +99,12 @@ export function deriveActivityState(input: {
 	config: ResolvedControlConfig;
 	startedAt: number;
 	lastActivityAt?: number;
+	turnCount?: number;
 	currentTool?: string;
 	thinking?: string | false;
 	now?: number;
 }): ActivityState | undefined {
-	if (!input.config.enabled || input.currentTool) return undefined;
+	if (!input.config.enabled || input.currentTool || (input.turnCount ?? 0) === 0) return undefined;
 	const now = input.now ?? Date.now();
 	const lastActivity = input.lastActivityAt ?? input.startedAt;
 	const ageMs = Math.max(0, now - lastActivity);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1886,7 +1886,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 	it("notifies the parent when an async workflow child needs attention", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({
 			steps: [
-				{ jsonl: [events.toolStart("read", { path: "src/example.ts" }), events.toolEnd("read"), events.toolResult("read", "contents")] },
+				{ jsonl: [events.toolStart("read", { path: "src/example.ts" }), events.toolEnd("read"), events.toolResult("read", "contents"), events.assistantMessage("Started")] },
 				{ delay: 2_500, jsonl: [events.assistantMessage("Done")] },
 			],
 		});
@@ -6866,7 +6866,12 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 	it("delivers delegated activity-state transitions despite heartbeat suppression", async () => {
 		const attentionUpdates: Array<{ details?: { progress?: ProgressSummary[] } }> = [];
 		const attentionReleasePath = path.join(tempDir, "release-delegated-attention");
-		mockPi.onCall({ output: "Done", waitForPath: attentionReleasePath });
+		mockPi.onCall({
+			steps: [
+				{ jsonl: [events.assistantMessage("Started")] },
+				{ waitForPath: attentionReleasePath, jsonl: [events.assistantMessage("Done")] },
+			],
+		});
 		const attentionRun = runSync!(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
 			suppressUnchangedDelegationUpdates: true,
 			controlConfig: {
@@ -6881,7 +6886,13 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			onUpdate: (update: { details?: { progress?: ProgressSummary[] } }) => attentionUpdates.push(update),
 		});
 		try {
-			const deadline = Date.now() + 5_000;
+			const turnDeadline = Date.now() + 15_000;
+			while (!attentionUpdates.some((update) => (update.details?.progress?.[0]?.turnCount ?? 0) > 0) && Date.now() < turnDeadline) {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+			assert.ok(attentionUpdates.some((update) => (update.details?.progress?.[0]?.turnCount ?? 0) > 0), "test fixture should complete one assistant turn before waiting for idle attention");
+
+			const deadline = Date.now() + 15_000;
 			while (!attentionUpdates.some((update) => update.details?.progress?.[0]?.activityState === "needs_attention") && Date.now() < deadline) {
 				await new Promise((resolve) => setTimeout(resolve, 50));
 			}
@@ -6922,6 +6933,31 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		} finally {
 			fs.writeFileSync(activeReleasePath, "release", "utf-8");
 			await activeRun;
+		}
+	});
+
+	it("does not deliver idle attention before a child completes its first assistant turn", async () => {
+		const updates: Array<{ details?: { progress?: ProgressSummary[] } }> = [];
+		const releasePath = path.join(tempDir, "release-zero-turn-attention");
+		mockPi.onCall({ output: "Done", waitForPath: releasePath });
+
+		const runPromise = runSync!(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			controlConfig: {
+				enabled: true,
+				needsAttentionAfterMs: 200,
+				activeNoticeAfterMs: 999_999,
+				notifyOn: ["needs_attention"],
+				notifyChannels: ["event"],
+			},
+			onUpdate: (update: { details?: { progress?: ProgressSummary[] } }) => updates.push(update),
+		});
+		try {
+			await new Promise((resolve) => setTimeout(resolve, 500));
+			assert.equal(updates.some((update) => update.details?.progress?.[0]?.activityState === "needs_attention"), false);
+		} finally {
+			fs.writeFileSync(releasePath, "release", "utf-8");
+			const result = await runPromise;
+			assert.equal(result.exitCode, 0);
 		}
 	});
 

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -1429,28 +1429,28 @@ describe("scripted workflow runtime", () => {
 		);
 	});
 
-	it("passes per-child worktree controls through runs.run and runs.all", async () => {
-		const launches: Array<{ key: string; worktree: unknown }> = [];
+	it("passes per-child workflow controls through runs.run and runs.all", async () => {
+		const launches: Array<{ key: string; worktree: unknown; control: unknown }> = [];
 		await runWorkflowScript({
 			script: `
-				const one = await runs.run("one", { agent: "worker", task: "one", worktree: true });
+				const one = await runs.run("one", { agent: "worker", task: "one", worktree: true, control: { needsAttentionAfterMs: 111 } });
 				const rest = await runs.all([
-					{ key: "two", agent: "worker", task: "two", worktree: true },
-					{ key: "three", agent: "reviewer", task: "three", worktree: false }
+					{ key: "two", agent: "worker", task: "two", worktree: true, control: { activeNoticeAfterMs: 222 } },
+					{ key: "three", agent: "reviewer", task: "three", worktree: false, control: { enabled: false } }
 				]);
 				return [one.key, ...rest.map((entry) => entry.key)];
 			`,
 			timeoutMs: 2_000,
 			async launch(key, params) {
-				launches.push({ key, worktree: params.worktree });
+				launches.push({ key, worktree: params.worktree, control: params.control });
 				return { key, ok: true, output: key, artifactPaths: [], results: [] };
 			},
 			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
 		});
 		assert.deepEqual(launches, [
-			{ key: "one", worktree: true },
-			{ key: "two", worktree: true },
-			{ key: "three", worktree: false },
+			{ key: "one", worktree: true, control: { needsAttentionAfterMs: 111 } },
+			{ key: "two", worktree: true, control: { activeNoticeAfterMs: 222 } },
+			{ key: "three", worktree: false, control: { enabled: false } },
 		]);
 	});
 

--- a/test/unit/subagent-control.test.ts
+++ b/test/unit/subagent-control.test.ts
@@ -20,11 +20,15 @@ const config = resolveControlConfig(undefined, {
 describe("subagent control attention state", () => {
 	it("marks a run as needing attention only after the idle threshold", () => {
 		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, now: 50 }), undefined);
-		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, now: 400 }), "needs_attention");
+		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, turnCount: 1, now: 400 }), "needs_attention");
 		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, currentTool: "bash", now: 400 }), undefined);
-		assert.equal(deriveActivityState({ config, startedAt: 0, now: 400 }), "needs_attention");
+		assert.equal(deriveActivityState({ config, startedAt: 0, turnCount: 1, now: 400 }), "needs_attention");
 	});
 
+	it("does not mark a zero-turn run as needing attention", () => {
+		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, turnCount: 0, now: 400 }), undefined);
+		assert.equal(deriveActivityState({ config, startedAt: 0, lastActivityAt: 0, now: 400 }), undefined);
+	});
 
 	it("builds compact needs-attention control events", () => {
 		const event = buildControlEvent({
@@ -103,25 +107,34 @@ describe("subagent control attention state", () => {
 	it("scales the default idle threshold for higher thinking levels", () => {
 		const defaults = resolveControlConfig();
 
-		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, now: 60_001 }), "needs_attention");
-		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, thinking: "low", now: 60_001 }), "needs_attention");
-		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, thinking: "minimal", now: 60_001 }), "needs_attention");
-		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, thinking: "high", now: 60_001 }), undefined);
-		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, thinking: "high", now: 300_001 }), "needs_attention");
+		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, turnCount: 1, now: 60_001 }), "needs_attention");
+		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, turnCount: 1, thinking: "low", now: 60_001 }), "needs_attention");
+		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, turnCount: 1, thinking: "minimal", now: 60_001 }), "needs_attention");
+		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, turnCount: 1, thinking: "high", now: 60_001 }), undefined);
+		assert.equal(deriveActivityState({ config: defaults, startedAt: 0, turnCount: 1, thinking: "high", now: 300_001 }), "needs_attention");
 	});
 
 	it("keeps explicit idle threshold overrides higher priority than thinking scale", () => {
 		const explicit = resolveControlConfig(undefined, { needsAttentionAfterMs: 90_000 });
 
 		assert.equal(explicit.needsAttentionAfterMsIsExplicit, true);
-		assert.equal(deriveActivityState({ config: explicit, startedAt: 0, thinking: "high", now: 90_001 }), "needs_attention");
+		assert.equal(deriveActivityState({ config: explicit, startedAt: 0, turnCount: 1, thinking: "high", now: 90_001 }), "needs_attention");
+	});
+
+	it("preserves inherited default idle scaling when merging a resolved control config", () => {
+		const inherited = resolveControlConfig();
+		const merged = resolveControlConfig(inherited, { activeNoticeAfterMs: 123_000 });
+
+		assert.equal(merged.needsAttentionAfterMsIsExplicit, false);
+		assert.equal(merged.activeNoticeAfterMs, 123_000);
+		assert.equal(deriveActivityState({ config: merged, startedAt: 0, turnCount: 1, thinking: "high", now: 60_001 }), undefined);
 	});
 
 	it("treats recovered resolved configs without explicitness metadata as fixed thresholds", () => {
 		const recovered = { ...resolveControlConfig(undefined, { needsAttentionAfterMs: 90_000 }) };
 		delete recovered.needsAttentionAfterMsIsExplicit;
 
-		assert.equal(deriveActivityState({ config: recovered, startedAt: 0, thinking: "high", now: 90_001 }), "needs_attention");
+		assert.equal(deriveActivityState({ config: recovered, startedAt: 0, turnCount: 1, thinking: "high", now: 90_001 }), "needs_attention");
 	});
 
 	it("marks non-exempt open tools for attention at the active threshold", () => {

--- a/test/unit/workflow-launch-params.test.ts
+++ b/test/unit/workflow-launch-params.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { prepareWorkflowLaunchParams, promptAuditRedoParams, sanitizeRunPathSegment } from "../../src/runs/foreground/subagent-executor.ts";
+import { prepareWorkflowLaunchParams, promptAuditRedoParams, resolveRevivalControlConfig, sanitizeRunPathSegment } from "../../src/runs/foreground/subagent-executor.ts";
+import { resolveControlConfig } from "../../src/runs/shared/subagent-control.ts";
 
 describe("workflow launch params", () => {
 	it("keeps omitted workflow child async foreground", () => {
@@ -30,6 +31,20 @@ describe("workflow launch params", () => {
 		);
 		assert.equal(params.globalConcurrencyLimit, undefined);
 		assert.equal(params.maxSubagentSpawnsPerRun, undefined);
+	});
+
+	it("merges partial control overrides into workflow child defaults", () => {
+		const params = prepareWorkflowLaunchParams(
+			{ control: { needsAttentionAfterMs: 111, activeNoticeAfterMs: 222 } },
+			{ agent: "worker", task: "Run", control: { activeNoticeAfterMs: 333 } },
+			"workflow-run",
+			"run",
+		);
+
+		assert.deepEqual(params.control, {
+			needsAttentionAfterMs: 111,
+			activeNoticeAfterMs: 333,
+		});
 	});
 
 	it("marks only new async workflow children to preserve live supervisor-detach awaits", () => {
@@ -236,6 +251,40 @@ describe("workflow launch params", () => {
 				intercomBridge: { mode: "off" },
 			},
 		);
+	});
+
+	it("forwards control defaults and overrides to retained workflow children", () => {
+		assert.deepEqual(
+			prepareWorkflowLaunchParams(
+				{ control: { needsAttentionAfterMs: 111, activeNoticeAfterMs: 222 } },
+				{ resume: "retained-run", task: "Continue", control: { activeNoticeAfterMs: 333 } },
+				"workflow-run",
+				"continue",
+			),
+			{
+				action: "resume",
+				id: "retained-run",
+				message: "Continue",
+				workflowParentRunId: "workflow-run",
+				workflowKey: "continue",
+				control: {
+					needsAttentionAfterMs: 111,
+					activeNoticeAfterMs: 333,
+				},
+			},
+		);
+	});
+
+	it("lets retained workflow child control overrides amend recovered control configs", () => {
+		const recovered = resolveControlConfig(undefined, { needsAttentionAfterMs: 111, activeNoticeAfterMs: 222 });
+		const control = resolveRevivalControlConfig({
+			recoveryControlConfig: recovered,
+			requestedControl: { activeNoticeAfterMs: 333, notifyChannels: [] },
+		});
+
+		assert.equal(control.needsAttentionAfterMs, 111);
+		assert.equal(control.activeNoticeAfterMs, 333);
+		assert.deepEqual(control.notifyChannels, []);
 	});
 
 	it("does not inherit parent deadlines for retained workflow children", () => {


### PR DESCRIPTION
## Summary

- forward workflow child `control` overrides through new and retained workflow launches
- merge partial child control overrides with workflow defaults instead of replacing the whole object
- suppress idle `needs_attention` before a child has completed its first assistant turn

Closes #1817.

Thanks to [@rrocxela](https://github.com/rrocxela) for the report.

## Validation

- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/unit/subagent-control.test.ts test/unit/workflow-launch-params.test.ts test/unit/scripted-workflow.test.ts test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
