### PR TITLE
fix: accept calendar-style Claude Code versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Replace collapsed async workflow role rollups with a compact lane view while keeping full details available when expanded (#1827). Thanks [@nicobailon](https://github.com/nicobailon).
 
+### Fixed
+- Accept calendar/platform `claude --version` output during Claude Code adapter preflight while retaining required launch-flag validation. Thanks [@drouhard](https://github.com/drouhard).
+
 ## [0.64.0] - 2026-09-02
 
 ### Highlights

--- a/src/runs/shared/claude-code-adapter.ts
+++ b/src/runs/shared/claude-code-adapter.ts
@@ -118,7 +118,11 @@ export function resolveClaudeCodeLaunch(input: {
 			versionArgs: [...prefix, "--version"],
 			helpArgs: [...prefix, "--help"],
 			validate(result) {
-				if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)? \(Claude Code\)$/.test(result.version)) throw new Error(`Unsupported Claude Code version response: ${JSON.stringify(result.version)}.`);
+				// Claude Code now publishes both semver (`2.1.259 (Claude Code)`) and
+				// calendar/platform (`2026.4.24 macos-arm64 (2026-04-27)`) versions.
+				// The launch flags are validated from --help below, so only require a
+				// recognizable release identifier here rather than one display format.
+				if (!/^(?:\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)? \(Claude Code\)|\d{4}\.\d{1,2}\.\d{1,2} [A-Za-z0-9._-]+ \(\d{4}-\d{2}-\d{2}\))$/.test(result.version)) throw new Error(`Unsupported Claude Code version response: ${JSON.stringify(result.version)}.`);
 				for (const required of ["Claude Code - starts an interactive session", "--print", "--input-format", "stream-json", "--verbose", "--permission-mode", writer ? "acceptEdits" : "plan", "--tools", "--strict-mcp-config", "--mcp-config", "--setting-sources", "--no-session-persistence", "--disable-slash-commands", "--no-chrome"]) {
 					if (!result.help.includes(required)) throw new Error(`Claude Code help does not document required option ${JSON.stringify(required)}.`);
 				}

--- a/test/unit/claude-code-adapter.test.ts
+++ b/test/unit/claude-code-adapter.test.ts
@@ -113,7 +113,9 @@ describe("Claude Code adapter", () => {
 		const launch = resolveClaudeCodeLaunch({ adapter: CLAUDE_CODE_ADAPTER_ID, command: "claude" });
 		const help = "Claude Code - starts an interactive session --print --input-format stream-json --verbose --permission-mode plan --tools --strict-mcp-config --mcp-config --setting-sources --no-session-persistence --disable-slash-commands --no-chrome";
 		const evidence = { binaryPath: "/tmp/claude", binaryMtimeMs: 1, version: "2.1.150 (Claude Code)", help, cacheHit: false };
+		assert.doesNotThrow(() => launch.preflight.validate?.({ ...evidence, version: "2026.4.24 macos-arm64 (2026-04-27)" }));
 		assert.throws(() => launch.preflight.validate?.({ ...evidence, version: "Claude unknown" }), /Unsupported Claude Code version response/);
+		assert.throws(() => launch.preflight.validate?.({ ...evidence, version: "2026.4.24 macos-arm64 (not-a-date)" }), /Unsupported Claude Code version response/);
 		assert.throws(() => launch.preflight.validate?.({ ...evidence, help: "Claude Code - starts an interactive session --print" }), /does not document required option/);
 	});
 


### PR DESCRIPTION
## Summary
- accept the current calendar/platform output of `claude --version`
- retain strict rejection of unrecognized values and existing `--help` flag validation
- cover the reported `2026.4.24 macos-arm64 (2026-04-27)` output

## Validation
- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/claude-code-adapter.test.ts`
- verified the installed Claude Code reports `2.1.259 (Claude Code)` and exposes all adapter-required flags