### PR TITLE
fix: make async workflow widgets lane-shaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Replace collapsed async workflow role rollups with a compact lane view while keeping full details available when expanded (#1827). Thanks [@nicobailon](https://github.com/nicobailon).
+
 ## [0.64.0] - 2026-09-02
 
 ### Highlights

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -94,6 +94,10 @@ export function liveDetailHintText(): string {
 	return `Press ${liveDetailKeyText()} for live detail · ${formatShortcutLabel(FLEET_OPEN_SHORTCUT)} Fleet`;
 }
 
+function workflowDetailHintText(): string {
+	return `Press ${liveDetailKeyText()} for details · ${formatShortcutLabel(FLEET_OPEN_SHORTCUT)} Fleet`;
+}
+
 function foregroundSingleHintText(shortcut?: string): string {
 	if (!shortcut) return liveDetailHintText();
 	const label = formatShortcutLabel(shortcut);
@@ -609,15 +613,8 @@ function widgetLaneDetailLines(job: AsyncJobState, theme: Theme, projection?: Wo
 	return lane ? formatLaneProjectionLines(lane, theme, "  ") : [];
 }
 
-function workflowPreflightLines(job: AsyncJobState, expanded = false): string[] {
+function workflowPreflightLines(job: AsyncJobState): string[] {
 	if (job.mode !== "workflow" || !job.preflight) return [];
-	if (!expanded) {
-		const warning = formatWorkflowPreflightWarningSummary(job.workflow?.preflightWarnings, { indent: "  ", hint: "expand for debug" });
-		return [
-			formatWorkflowPreflightPlanSummary(job.preflight, { indent: "  " }),
-			...(warning ? [warning] : []),
-		];
-	}
 	return [
 		...formatWorkflowPreflight(job.preflight, { indent: "  " }).split("\n"),
 		...(job.workflow?.preflightWarnings ? formatWorkflowPreflightWarnings(job.workflow.preflightWarnings, { indent: "  " }).split("\n") : []),
@@ -1058,6 +1055,7 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 	return JSON.stringify({
 		asyncDir: job.asyncDir,
 		status: job.status,
+		description: job.mode === "workflow" ? job.description : undefined,
 		activityState: job.activityState,
 		lastActivityAt: job.lastActivityAt,
 		currentTool: job.currentTool,
@@ -1075,8 +1073,8 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 			currentNodeId: job.workflowGraph.currentNodeId,
 			stages: projection.stages.map((node) => [node.id, node.status, node.agent, node.phase, node.label, node.flatIndex, node.outputName, node.structured, node.error]),
 		} : undefined,
-		preflight: expanded ? job.preflight : job.preflight ? formatWorkflowPreflightPlanSummary(job.preflight) : undefined,
-		preflightWarnings: expanded ? job.workflow?.preflightWarnings : job.workflow?.preflightWarnings?.length || undefined,
+		preflight: expanded ? job.preflight : job.preflight?.lanes.map((lane) => [lane.key, lane.mode, lane.decision, lane.claims, lane.expectedOutput]),
+		preflightWarnings: expanded ? job.workflow?.preflightWarnings : undefined,
 		checklist: projection.checklist ? {
 			total: projection.checklist.total,
 			done: projection.checklist.done,
@@ -1084,7 +1082,7 @@ export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
 			queued: projection.checklist.queued,
 			blocked: projection.checklist.blocked,
 			failed: projection.checklist.failed,
-			phases: projection.checklist.phases.map((phase) => [phase.key, phase.state, phase.done, phase.total, phase.running, phase.queued, phase.blocked, phase.failed, phase.paused, phase.stopped, phase.items.map((item) => [item.key, item.state, item.currentTool, item.currentPath, item.durationMs, item.toolCount, item.error])]),
+			phases: projection.checklist.phases.map((phase) => [phase.key, phase.state, phase.done, phase.total, phase.running, phase.queued, phase.blocked, phase.failed, phase.paused, phase.stopped, phase.items.map((item) => [item.key, item.label, item.agent, item.state, item.preflight?.key, item.preflight?.mode, item.preflight?.decision, item.preflight?.claims, item.preflight?.expectedOutput, item.currentTool, item.currentPath, item.durationMs, item.toolCount, item.error])]),
 		} : undefined,
 		steps: job.steps?.map((step, index) => widgetStepRenderKey(step, index, expanded)),
 		nestedChildren: nestedRenderKey(job.nestedChildren, expanded),
@@ -1337,6 +1335,208 @@ function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | u
 		const tone = checklist.bottleneck?.state === "blocked" || checklist.bottleneck?.state === "failed" ? "error" : checklist.bottleneck?.state === "running" ? "accent" : "warning";
 		lines.push(`${indent}${theme.fg(tone, `bottleneck · ${bottleneck}`)}`);
 	}
+	return lines;
+}
+
+interface CompactWorkflowLaneRow {
+	key: string;
+	state: WorkflowChecklistState;
+	agent?: string;
+	mode?: string;
+	decision?: string;
+	claims?: string;
+	expectedOutput?: string;
+	label?: string;
+	toolUses?: number;
+	durationMs?: number;
+}
+
+interface CompactWorkflowLaneCounts {
+	total: number;
+	done: number;
+	active: number;
+	queued: number;
+	blocked: number;
+	failed: number;
+	paused: number;
+	stopped: number;
+}
+
+function compactWorkflowLaneState(items: readonly WorkflowChecklistItem[]): WorkflowChecklistState {
+	let state: WorkflowChecklistState | undefined;
+	for (const item of items) {
+		if (state === undefined || workflowChecklistItemPriority(item.state) < workflowChecklistItemPriority(state)) state = item.state;
+	}
+	return state ?? "queued";
+}
+
+function compactWorkflowLaneOwner(items: readonly WorkflowChecklistItem[]): string | undefined {
+	const owners = [...new Set(items.map((item) => item.agent ?? item.role).filter((value): value is string => Boolean(value?.trim())))];
+	if (owners.length === 0) return undefined;
+	return boundedLaneValue(owners.length > 2 ? `${owners.slice(0, 2).join(", ")} +${owners.length - 2}` : owners.join(", "), 32);
+}
+
+function compactWorkflowLaneLabel(items: readonly WorkflowChecklistItem[], key: string): string | undefined {
+	const labels = [...new Set(items.map((item) => item.label).filter((value): value is string => Boolean(value?.trim() && value.trim() !== key)))];
+	if (labels.length === 0) return undefined;
+	return boundedLaneValue(labels.length > 1 ? `${labels[0]} +${labels.length - 1}` : labels[0], 48);
+}
+
+function compactWorkflowLaneRow(key: string, items: readonly WorkflowChecklistItem[], lane = items.find((item) => item.preflight)?.preflight, fallbackState: WorkflowChecklistState = "queued"): CompactWorkflowLaneRow {
+	const state = items.length ? compactWorkflowLaneState(items) : fallbackState;
+	const toolCounts = items.map((item) => item.toolCount).filter((value): value is number => value !== undefined);
+	const durations = items.map((item) => item.durationMs).filter((value): value is number => value !== undefined);
+	const label = compactWorkflowLaneLabel(items, key);
+	return {
+		key: boundedLaneValue(key, 40) ?? key,
+		state,
+		agent: compactWorkflowLaneOwner(items),
+		...(lane?.mode ? { mode: lane.mode } : {}),
+		...(lane?.decision ? { decision: boundedLaneValue(lane.decision, 56) } : {}),
+		...(lane?.claims?.length ? { claims: boundedLaneValue(lane.claims.join(", "), 56) } : {}),
+		...(lane?.expectedOutput ? { expectedOutput: boundedLaneValue(lane.expectedOutput, 56) } : {}),
+		...(label ? { label } : {}),
+		...(toolCounts.length ? { toolUses: toolCounts.reduce((sum, value) => sum + value, 0) } : {}),
+		...(durations.length ? { durationMs: Math.max(...durations) } : {}),
+	};
+}
+
+function compactWorkflowFallbackState(job: AsyncJobState): WorkflowChecklistState {
+	if (job.activityState === "needs_attention" || job.timedOut || job.toolBudgetBlocked || job.turnBudgetExceeded) return "blocked";
+	switch (job.status) {
+		case "complete": return "complete";
+		case "failed": return "failed";
+		case "paused": return "paused";
+		case "stopped": return "stopped";
+		case "partial":
+		case "rejected": return "blocked";
+		default: return "queued";
+	}
+}
+
+/** Flatten the loaded checklist into one compact row per declared lane. */
+function compactWorkflowLaneRows(job: AsyncJobState, checklist: WorkflowChecklistProjection | undefined): CompactWorkflowLaneRow[] {
+	const groups = new Map<string, WorkflowChecklistItem[]>();
+	for (const item of checklist?.phases.flatMap((phase) => phase.items) ?? []) {
+		const key = item.preflight?.key ?? item.key;
+		const group = groups.get(key);
+		if (group) group.push(item);
+		else groups.set(key, [item]);
+	}
+
+	const rows: CompactWorkflowLaneRow[] = [];
+	const preflightKeys = new Set(job.preflight?.lanes.map((lane) => lane.key) ?? []);
+	if (job.preflight?.lanes.length) {
+		for (const lane of job.preflight.lanes) {
+			rows.push(compactWorkflowLaneRow(lane.key, groups.get(lane.key) ?? [], lane, compactWorkflowFallbackState(job)));
+		}
+	}
+
+	for (const [key, items] of groups) {
+		if (preflightKeys.has(key)) continue;
+		rows.push(compactWorkflowLaneRow(key, items));
+	}
+	return rows;
+}
+
+function compactWorkflowLaneCounts(rows: readonly CompactWorkflowLaneRow[]): CompactWorkflowLaneCounts {
+	const counts: CompactWorkflowLaneCounts = { total: rows.length, done: 0, active: 0, queued: 0, blocked: 0, failed: 0, paused: 0, stopped: 0 };
+	for (const row of rows) {
+		switch (row.state) {
+			case "complete": counts.done++; break;
+			case "running": counts.active++; break;
+			case "queued": counts.queued++; break;
+			case "blocked": counts.blocked++; break;
+			case "failed": counts.failed++; break;
+			case "paused": counts.paused++; break;
+			case "stopped": counts.stopped++; break;
+		}
+	}
+	return counts;
+}
+
+function compactWorkflowLaneLine(row: CompactWorkflowLaneRow, theme: Theme, indent: string, frame?: number): string {
+	const owner = row.agent && row.mode ? `${row.agent}/${row.mode}` : row.agent ?? row.mode;
+	const state = row.state === "complete" ? undefined : row.state === "running" ? "active" : row.state;
+	const intent = [
+		row.decision,
+		row.claims,
+		row.expectedOutput,
+		!row.mode && row.label ? row.label : undefined,
+	].filter((value): value is string => Boolean(value));
+	return `${indent}${workflowChecklistGlyph({ state: row.state, durationMs: row.durationMs, toolCount: row.toolUses }, theme, frame)} ${theme.bold(row.key)}${owner ? ` ${theme.fg("dim", `· ${owner}`)}` : ""}${state ? ` ${theme.fg("dim", `· ${state}`)}` : ""}${intent.length ? ` ${theme.fg("dim", `· ${intent.join(" · ")}`)}` : ""}`;
+}
+
+function compactWorkflowShortId(job: AsyncJobState): string {
+	return job.asyncId.slice(0, 8);
+}
+
+function compactWorkflowDisplayLabel(job: AsyncJobState): string {
+	return boundedLaneValue(job.description, 64) ?? compactWorkflowShortId(job);
+}
+
+function compactWorkflowStats(job: AsyncJobState, rows: readonly CompactWorkflowLaneRow[], theme: Theme, projection: WorkflowWidgetProjection): string {
+	const counts = compactWorkflowLaneCounts(rows);
+	const total = counts.total || projection.stageProgress?.total || job.stepsTotal || job.agents?.length || 0;
+	const progress = [
+		total > 0 ? `${counts.done}/${total} done` : undefined,
+		counts.active ? `${counts.active} active` : undefined,
+		counts.queued ? `${counts.queued} queued` : undefined,
+		counts.blocked ? `${counts.blocked} blocked` : undefined,
+		counts.failed ? `${counts.failed} failed` : undefined,
+		counts.paused ? `${counts.paused} paused` : undefined,
+		counts.stopped ? `${counts.stopped} stopped` : undefined,
+	].filter((value): value is string => Boolean(value));
+	const rowToolUses = rows.map((row) => row.toolUses).filter((value): value is number => value !== undefined);
+	const toolUses = job.toolCount ?? (rowToolUses.length ? rowToolUses.reduce((sum, value) => sum + value, 0) : undefined);
+	const rowDuration = rows.map((row) => row.durationMs).filter((value): value is number => value !== undefined);
+	const durationMs = job.startedAt !== undefined && job.updatedAt !== undefined
+		? Math.max(0, job.updatedAt - job.startedAt)
+		: rowDuration.length ? Math.max(...rowDuration) : undefined;
+	return statJoin(theme, [
+		`id: ${compactWorkflowShortId(job)}`,
+		...progress,
+		toolUses !== undefined ? formatToolUseStat(toolUses) : undefined,
+		durationMs !== undefined ? formatDuration(durationMs) : undefined,
+	].filter((value): value is string => Boolean(value)));
+}
+
+interface CompactWorkflowBottleneck {
+	text: string;
+	tone: "warning" | "error";
+}
+
+function compactWorkflowBottleneck(rows: readonly CompactWorkflowLaneRow[], job: AsyncJobState): CompactWorkflowBottleneck | undefined {
+	let row: CompactWorkflowLaneRow | undefined;
+	for (const candidate of rows) {
+		if (candidate.state !== "blocked" && candidate.state !== "failed" && candidate.state !== "paused" && candidate.state !== "stopped") continue;
+		if (!row || workflowChecklistItemPriority(candidate.state) < workflowChecklistItemPriority(row.state)) row = candidate;
+	}
+	if (row) return { text: `${row.key} · ${row.state}`, tone: row.state === "blocked" || row.state === "failed" ? "error" : "warning" };
+	if (job.activityState === "needs_attention" || job.timedOut || job.toolBudgetBlocked || job.turnBudgetExceeded) return { text: `workflow · ${job.activityState === "needs_attention" ? "needs attention" : "blocked"}`, tone: job.activityState === "needs_attention" ? "warning" : "error" };
+	if (job.status === "failed" || job.status === "partial" || job.status === "rejected") return { text: `workflow · ${job.status}`, tone: "error" };
+	if (job.status === "paused" || job.status === "stopped") return { text: `workflow · ${job.status}`, tone: "warning" };
+	return undefined;
+}
+
+function compactWorkflowHeaderLine(job: AsyncJobState, theme: Theme, width?: number): string {
+	const label = compactWorkflowDisplayLabel(job);
+	const full = `${theme.fg("toolTitle", themeBold(theme, `async workflow: ${label}`))} ${theme.fg("dim", "─ background")}`;
+	if (width === undefined || visibleWidth(full) <= width) return full;
+	return `${theme.fg("toolTitle", themeBold(theme, `async workflow ${label}`))} ${theme.fg("dim", "· background")}`;
+}
+
+function compactWorkflowWidgetBodyLines(job: AsyncJobState, theme: Theme, frame: number | undefined, projection: WorkflowWidgetProjection): string[] {
+	const rows = compactWorkflowLaneRows(job, projection.checklist);
+	const lines = [`  ${compactWorkflowStats(job, rows, theme, projection)}`];
+	if (rows.length) {
+		for (const row of rows) lines.push(compactWorkflowLaneLine(row, theme, "  ", frame));
+	} else {
+		lines.push(`  ${theme.fg("dim", "◦ waiting for workflow lanes")}`);
+	}
+	const bottleneck = compactWorkflowBottleneck(rows, job);
+	if (bottleneck) lines.push(`  ${theme.fg(bottleneck.tone, `bottleneck · ${bottleneck.text}`)}`);
+	if (job.status === "running" || rows.some((row) => row.state === "running")) lines.push(`  ${theme.fg("accent", workflowDetailHintText())}`);
 	return lines;
 }
 
@@ -2154,19 +2354,13 @@ function hostStepWidgetLines(job: AsyncJobState, theme: Theme, indent: string): 
 
 function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, frame?: number, projection = buildWorkflowWidgetProjection(job)): string[] {
 	const { steps } = projection;
-	const checklistPrimary = !expanded && job.mode === "workflow" && projection.checklist !== undefined;
-	if (checklistPrimary) {
-		const lines = [
-			...workflowPreflightLines(job, false),
-			...workflowChecklistWidgetLines(projection.checklist, theme, "  ", false, frame, false),
-		];
-		if (job.status === "running" || projection.checklist!.running > 0) lines.push(`  ${theme.fg("accent", liveDetailHintText())}`);
-		return lines;
+	if (!expanded && job.mode === "workflow") {
+		return compactWorkflowWidgetBodyLines(job, theme, frame, projection);
 	}
 	if (!steps.length) {
 		const lane = projectAsyncLane(job, laneStepForJob(job, steps));
 		return [
-			...workflowPreflightLines(job, expanded),
+			...(expanded ? workflowPreflightLines(job) : []),
 			...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
 			...(lane ? formatLaneProjectionLines(lane, theme, "  ") : []),
 			...hostStepWidgetLines(job, theme, "  "),
@@ -2176,7 +2370,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 	}
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
 	const lines: string[] = [
-		...workflowPreflightLines(job, expanded),
+		...(expanded ? workflowPreflightLines(job) : []),
 		...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
 	];
 	const group = activeParallelWidgetGroup(job);
@@ -2210,6 +2404,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 }
 
 function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, frame?: number, projection = buildWorkflowWidgetProjection(job)): string[] {
+	if (!expanded && job.mode === "workflow") return [compactWorkflowHeaderLine(job, theme, width), ...compactWorkflowWidgetBodyLines(job, theme, frame, projection)].map((line) => truncLine(line, width));
 	const stats = widgetStats(job, theme, projection, !expanded);
 	const count = job.mode === "workflow"
 		? projection.checklist?.total ?? projection.stageProgress?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length
@@ -2386,11 +2581,17 @@ function progressiveHeaderLine(jobs: AsyncJobState[], theme: Theme, width: numbe
 }
 
 function progressiveJobLine(job: AsyncJobState, theme: Theme, width: number, frame?: number, projection = buildWorkflowWidgetProjection(job)): string {
-	const checklistPrimary = job.mode === "workflow" && projection.checklist !== undefined;
-	const stats = widgetStats(job, theme, projection, true);
-	const activity = checklistPrimary ? "" : widgetActivity(job);
+	const compactWorkflow = job.mode === "workflow";
+	const compactRows = compactWorkflow ? compactWorkflowLaneRows(job, projection.checklist) : undefined;
+	const stats = compactWorkflow ? compactWorkflowStats(job, compactRows ?? [], theme, projection) : widgetStats(job, theme, projection, true);
+	if (compactWorkflow) {
+		const bottleneck = compactWorkflowBottleneck(compactRows ?? [], job);
+		const suffix = [stats, bottleneck ? theme.fg(bottleneck.tone, `bottleneck · ${bottleneck.text}`) : undefined].filter((value): value is string => Boolean(value)).join(` ${theme.fg("dim", "·")} `);
+		return truncLine(`  ${widgetStatusGlyph(job, theme, frame)} ${compactWorkflowHeaderLine(job, theme, Math.max(0, width - 4))}${suffix ? ` ${theme.fg("dim", "·")} ${suffix}` : ""}`, width);
+	}
+	const activity = widgetActivity(job);
 	const status = job.status === "complete" ? "done" : job.status;
-	const lane = checklistPrimary ? undefined : projectAsyncLane(job, laneStepForJob(job, projection.steps));
+	const lane = projectAsyncLane(job, laneStepForJob(job, projection.steps));
 	const laneSummary = lane
 		? [lane.label ?? lane.role, lane.phase ? `phase:${lane.phase}` : undefined, lane.output ? `out:${lane.output}` : undefined, lane.workspace ? `workspace:${lane.workspace}` : `ref:${lane.ref}`].filter(Boolean).join(" · ")
 		: "";
@@ -2557,12 +2758,11 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 	let slots = MAX_WIDGET_JOBS;
 	const appendJob = (job: AsyncJobState): void => {
 		const projection = projectionFor(job);
-		const checklistPrimary = !expanded && job.mode === "workflow" && projection.checklist !== undefined;
-		const stats = widgetStats(job, theme, projection, !expanded);
-		const details = checklistPrimary
+		const compactWorkflow = !expanded && job.mode === "workflow";
+		const stats = compactWorkflow ? "" : widgetStats(job, theme, projection, !expanded);
+		const details = compactWorkflow
 			? [
-				...workflowChecklistWidgetLines(projection.checklist, theme, "  ", false, frame, false),
-				...(job.status === "running" || projection.checklist!.running > 0 ? [`  ${theme.fg("accent", liveDetailHintText())}`] : []),
+				...compactWorkflowWidgetBodyLines(job, theme, frame, projection),
 			]
 			: [
 				`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
@@ -2571,7 +2771,9 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 				...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 			];
 		items.push([
-			`${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
+			compactWorkflow
+				? compactWorkflowHeaderLine(job, theme, width)
+				: `${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			...details,
 		]);
 	};

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -91,17 +91,28 @@ function resetWidgetLayout(): void {
 }
 
 describe("subagent async widget rendering", () => {
-	it("renders compact workflow plan status by default and keeps details expanded", () => {
+	it("renders compact workflow lanes by default and keeps details expanded", () => {
 		const job = {
-			asyncId: "workflow-preflight",
+			asyncId: "a6b9aa6b-workflow",
 			asyncDir: "/tmp/workflow-preflight",
 			status: "running",
 			mode: "workflow",
+			description: "Review workflow",
+			toolCount: 5,
+			startedAt: 100,
+			updatedAt: 2_600,
 			preflight: {
 				version: 1,
 				coverage: "partial",
-				lanes: [{ key: "review", mode: "review", claims: ["src/tui"], expectedOutput: "review.md" }],
+				lanes: [
+					{ key: "write", mode: "mutation", decision: "apply the smallest fix", claims: ["src/tui"], expectedOutput: "fix.md" },
+					{ key: "review", mode: "review", decision: "check the compact surface", claims: ["src/tui"], expectedOutput: "review.md" },
+				],
 			},
+			steps: [
+				{ index: 0, workflowKey: "review", agent: "reviewer", label: "Review the compact surface", status: "running", toolCount: 2 },
+				{ index: 1, workflowKey: "write", agent: "worker", label: "Apply the smallest fix", status: "complete", toolCount: 3 },
+			],
 			workflow: {
 				trace: [],
 				emits: [],
@@ -110,18 +121,50 @@ describe("subagent async widget rendering", () => {
 			},
 		};
 		const compact = buildWidgetLines([job], theme, 180).join("\n");
-		assert.match(compact, /Plan: 1 lane · review/);
-		assert.match(compact, /Plan note: 1 preflight mismatch · expand for debug\./);
-		assert.doesNotMatch(compact, /key \| mode \| decision \| claims \| expected output \| independence/);
-		assert.doesNotMatch(compact, /review \| review \|/);
-		assert.doesNotMatch(compact, /Preflight advisory/);
+		assert.match(compact, /async workflow: Review workflow ─ background/);
+		assert.match(compact, /id: a6b9aa6b · 1\/2 done · 1 active · 5 tool uses · 2\.5s/);
+		assert.match(compact, /write · worker\/mutation · apply the smallest fix · src\/tui · fix\.md/);
+		assert.match(compact, /review · reviewer\/review · active · check the compact surface · src\/tui · review\.md/);
+		assert.doesNotMatch(compact, /Plan:|Plan note:|preflight mismatch|Preflight advisory/);
+		assert.doesNotMatch(compact, /decision:|claims:|expected:/);
+		assert.doesNotMatch(compact, /output:\s|next:/i);
 
 		const expanded = buildWidgetLines([job], theme, 180, true).join("\n");
-		assert.match(expanded, /Preflight: v1 · partial · 1 lane/);
-		assert.match(expanded, /review \| review \|/);
+		assert.match(expanded, /Preflight: v1 · partial · 2 lanes/);
+		assert.match(expanded, /write \| mutation \| apply the smallest fix \| src\/tui \| fix\.md/);
+		assert.match(expanded, /review \| review \| check the compact surface \| src\/tui \| review\.md/);
 		assert.match(expanded, /expected output \| independence/);
 		assert.match(expanded, /Preflight warnings:/);
 		assert.match(expanded, /review\.extra.*without a declared lane/);
+	});
+
+	it("degrades compact workflow rows without preflight metadata", () => {
+		const job = {
+			asyncId: "workflow-fallback-123",
+			asyncDir: "/tmp/workflow-fallback",
+			status: "running",
+			mode: "workflow",
+			steps: [
+				{ index: 0, workflowKey: "scope", agent: "scout", label: "Scope the request", description: "Inspect the repository", status: "complete", outputName: "scope.md" },
+				{ index: 1, workflowKey: "implement", agent: "worker", label: "Implement the fix", description: "Change only the renderer", status: "running", outputName: "fix.md" },
+			],
+		};
+		const compact = buildWidgetLines([job], theme, 180).join("\n");
+		assert.match(compact, /async workflow: workflow ─ background/);
+		assert.match(compact, /scope · scout · Scope the request/);
+		assert.match(compact, /implement · worker · active · Implement the fix/);
+		assert.doesNotMatch(compact, /Plan:|next:|output:/i);
+
+		const narrow = buildWidgetLines([job], theme, 72);
+		assert.match(narrow[1] ?? "", /id: workflow · 1\/2 done · 1 active/);
+		for (const line of narrow) assert.ok(visibleWidth(line) <= 72, `workflow row exceeds width: ${visibleWidth(line)}`);
+		const tightHeader = buildWidgetLines([{ ...job, description: "backlog-wave" }], theme, 40)[0] ?? "";
+		assert.match(tightHeader, /async workflow backlog-wave · background/);
+		assert.doesNotMatch(tightHeader, /workflow:/);
+		const longJob = { ...job, steps: job.steps.map((step, index) => ({ ...step, label: `${step.label} ${"with a deliberately long lane description ".repeat(4)}`, description: index === 1 ? `${step.description} ${"and more detail ".repeat(8)}` : step.description })) };
+		const truncated = buildWidgetLines([longJob], theme, 72);
+		assert.match(truncated[1] ?? "", /id: workflow · 1\/2 done · 1 active/);
+		assert.ok(truncated.some((line) => line.includes("...")), "narrow lane rows should be truncated");
 	});
 
 	it("projects known workflow metadata into a compact lane row", () => {
@@ -307,13 +350,33 @@ describe("subagent async widget rendering", () => {
 		};
 
 		const text = buildWidgetLines([job], theme, 180).join("\n");
-		assert.match(text, /CI checks 1 active/);
-		assert.match(text, /Review gate 1 blocked/);
-		assert.doesNotMatch(text, /async subagent .*CI checks/);
+		assert.match(text, /async workflow: host-run ─ background/);
+		assert.match(text, /id: host-run · 0\/2 done · 1 active · 1 blocked/);
+		assert.match(text, /ci-1 · active · CI checks/);
+		assert.match(text, /gate-1 · blocked · Review gate/);
+		assert.match(text, /bottleneck · gate-1 · blocked/);
+		assert.doesNotMatch(text, /Plan:|next:|output:/i);
 
 		const expanded = buildWidgetLines([job], theme, 180, true).join("\n");
 		assert.match(expanded, /ci: CI checks · running · provider:local-tests · PR #1614/);
 		assert.match(expanded, /gate: Review gate · inconclusive · provider:opaque-provider · reason:stale-head · stale · out:gate.json/);
+	});
+
+	it("chooses the most severe compact workflow bottleneck", () => {
+		const text = buildWidgetLines([{
+			asyncId: "workflow-bottleneck-severity",
+			asyncDir: "/tmp/workflow-bottleneck-severity",
+			status: "running",
+			mode: "workflow",
+			steps: [
+				{ index: 0, workflowKey: "paused-first", agent: "worker", status: "paused" },
+				{ index: 1, workflowKey: "failed-later", agent: "reviewer", status: "failed", error: "review failed" },
+			],
+		}], theme, 180).join("\n");
+		assert.match(text, /paused-first · worker · paused/);
+		assert.match(text, /failed-later · reviewer · failed/);
+		assert.match(text, /bottleneck · failed-later · failed/);
+		assert.doesNotMatch(text, /bottleneck · paused-first/);
 	});
 
 	it("keeps simple one-off async rows on the existing fallback projection", () => {
@@ -930,7 +993,7 @@ describe("subagent async widget rendering", () => {
 		resetWidgetLayout();
 	});
 
-	it("keeps the active runs.lanes stage in focus before collapsed history", () => {
+	it("renders loaded workflow lanes without normal-running bottleneck noise", () => {
 		resetWidgetLayout();
 		withStdoutSize(30, 120, () => {
 			const stageKeys = ["scope-scout", "red-tests", "label-helpers", "summary-title", "detail-row", "tiers-noise", "validation", "minimality-challenge", "fresh-review"];
@@ -973,17 +1036,16 @@ describe("subagent async widget rendering", () => {
 					...(index < 3 ? { lastActivityAt: 100 } : { currentTool: "read", currentToolStartedAt: 190, lastActivityAt: 195 }),
 				})),
 			};
-			const ui = createUiContext();
-			renderWidget(ui.ctx as never, [job]);
-			const lines = renderWidgetLines(ui.widgets.at(-1));
+			const lines = buildWidgetLines([job], theme, 220);
 			const text = lines.join("\n");
-			assert.match(text, /7\/9 done · 1 active · 1 queued/);
-			assert.match(text, /minimality-challenge 1 active/);
-			assert.match(text, /fresh-review 1 queued/);
-			assert.match(text, /bottleneck · minimality-challenge/);
-			assert.match(text, /Press configured-expand-key for live detail/);
-			assert.doesNotMatch(text, /label-helpers/);
-			assert.doesNotMatch(text, /Step \d+\/9|task:|workspace:|out(?:put)?:/i);
+			assert.match(text, /async workflow: workflow ─ background/);
+			assert.match(text, /id: workflow · 7\/9 done · 1 active · 1 queued/);
+			assert.match(text, /issue-1695\.minimality-challenge · worker · active/);
+			assert.match(text, /issue-1695\.fresh-review · worker · queued/);
+			assert.doesNotMatch(text, /bottleneck ·/);
+			assert.match(text, /Press configured-expand-key for details/);
+			assert.match(text, /label-helpers/);
+			assert.doesNotMatch(text, /Step \d+\/9|task:|workspace:|out(?:put)?:|next:/i);
 		});
 		resetWidgetLayout();
 	});

--- a/test/unit/render-helpers.test.ts
+++ b/test/unit/render-helpers.test.ts
@@ -312,7 +312,7 @@ test("workflow checklist does not map child-local result indexes onto graph node
 	assert.match(text, /✗ Writer · writer · failed/);
 });
 
-test("collapsed workflow widgets lead with checklist phases while expanded widgets keep child detail", () => {
+test("collapsed async workflow widgets render compact lane rows while expanded widgets keep child detail", () => {
 	const now = 50_000;
 	const workflowGraph = {
 		runId: "workflow-collapsed",
@@ -354,11 +354,12 @@ test("collapsed workflow widgets lead with checklist phases while expanded widge
 	const collapsed = buildWidgetLines([job], theme, 240).join("\n");
 	assert.match(collapsed, /1\/5 done · 1 active · 3 queued/);
 	assert.match(collapsed, /✓ inventory/);
-	assert.match(collapsed, /writers 1 active · 1 queued/);
-	assert.match(collapsed, /◦ reviews 1 queued/);
-	assert.match(collapsed, /◦ gates 1 queued/);
-	assert.match(collapsed, /bottleneck/);
-	assert.match(collapsed, /Press configured-expand-key for live detail · Ctrl\+Alt\+F Fleet/);
+	assert.match(collapsed, /writer-a · writer · active/);
+	assert.match(collapsed, /writer-b · writer · queued/);
+	assert.match(collapsed, /review · reviewer · queued/);
+	assert.match(collapsed, /gate · reviewer · queued/);
+	assert.doesNotMatch(collapsed, /bottleneck/);
+	assert.match(collapsed, /Press configured-expand-key for details · Ctrl\+Alt\+F Fleet/);
 	assert.equal((collapsed.match(/1\/5 done · 1 active · 3 queued/g) ?? []).length, 1);
 	assert.doesNotMatch(collapsed, /Step \d\/\d|task:|workspace:|ref:|out(?:put)?:/i);
 
@@ -381,7 +382,9 @@ test("collapsed workflow widgets lead with checklist phases while expanded widge
 			{ index: 1, agent: "scout", status: "running" },
 		],
 	} as AsyncJobState], theme, 240).join("\n");
-	assert.match(generic, /Workflow 2 active/);
+	assert.match(generic, /id: workflow · 0\/2 done · 2 active/);
+	assert.match(generic, /step-1 · reviewer · active · reviewer/);
+	assert.match(generic, /step-2 · scout · active · scout/);
 });
 
 test("compact foreground workflow results use checklist phases instead of child rows", () => {


### PR DESCRIPTION
## Summary
- replace the collapsed async workflow widget with a lane-shaped compact view
- use existing workflow checklist/preflight metadata for ordered lane rows and aggregate counts
- keep full workflow/preflight/debug detail in the expanded `ctrl+o` view

Fixes #1827

## Validation
- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts`
- `npm run test:integration`
- `git diff --check`
