### PR TITLE
Nest Worktrees By Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Accept calendar/platform `claude --version` output during Claude Code adapter preflight while retaining required launch-flag validation. Thanks [@drouhard](https://github.com/drouhard).
 - Show passive local command availability for external CLI agents in capability listings without replacing launch preflight (#1829). Thanks [@drouhard](https://github.com/drouhard).
+- Nest native managed worktrees under per-project directories while preserving unsafe-location checks (#1831). Thanks [@moofone](https://github.com/moofone).
 
 ## [0.64.0] - 2026-09-02
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,9 +404,9 @@ The default injected guidance tells children to use `contact_supervisor` with `r
 { "worktreeBaseDir": "/Users/matt/code/.worktrees/pi-subagents" }
 ```
 
-Sets the dedicated root directory for `worktree: true` runs. Relative paths resolve from the repository root, `~/...` expands to your home directory, and `PI_SUBAGENTS_WORKTREE_DIR` is used when config is unset. When both are unset, the dedicated root defaults to `{dirname(repoRoot)}/worktrees` — a `worktrees` directory beside the repository checkout, under the repo's parent (not beside that parent).
+Sets the native dedicated root directory for `worktree: true` runs. Relative paths resolve from the repository root, `~/...` expands to your home directory, and `PI_SUBAGENTS_WORKTREE_DIR` is used when config is unset. When native allocation is used and both are unset, the dedicated root defaults to `{dirname(repoRoot)}/worktrees`, a `worktrees` directory alongside the repository checkout.
 
-Each run's worktree leaf is `{dedicatedRoot}/{projectName}/pi-worktree-{runId}-{index}`, where `{projectName}` is the repository directory name (`basename(repoRoot)`), `{runId}` identifies the run, and `{index}` counts the children within the run. `worktreeBaseDir` and `PI_SUBAGENTS_WORKTREE_DIR` override only the dedicated root; the `{projectName}/pi-worktree-{runId}-{index}` nesting under it always applies. Unsafe locations are rejected instead of created: setup fails when the dedicated root sits inside the repository checkout or the Pi extensions directory, or when a worktree would land directly inside the repository parent.
+Each native worktree leaf is `{dedicatedRoot}/{projectName}/pi-worktree-{runId}-{index}`, where `{projectName}` is the repository directory name (`basename(repoRoot)`), `{runId}` identifies the run, and `{index}` counts the children within the run. `worktreeBaseDir` and `PI_SUBAGENTS_WORKTREE_DIR` override only the dedicated root; the `{projectName}/pi-worktree-{runId}-{index}` nesting under it always applies for native allocation. Unsafe locations are rejected instead of created: setup fails when the dedicated root sits inside the repository checkout or the Pi extensions directory, or when a worktree would land directly inside the repository parent.
 
 ## `worktreeProvider`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,7 +404,9 @@ The default injected guidance tells children to use `contact_supervisor` with `r
 { "worktreeBaseDir": "/Users/matt/code/.worktrees/pi-subagents" }
 ```
 
-Sets the base directory for `worktree: true` runs. Relative paths resolve from the repository root, `~/...` expands to your home directory, and `PI_SUBAGENTS_WORKTREE_DIR` is used when config is unset. The default remains the system temp directory.
+Sets the dedicated root directory for `worktree: true` runs. Relative paths resolve from the repository root, `~/...` expands to your home directory, and `PI_SUBAGENTS_WORKTREE_DIR` is used when config is unset. When both are unset, the dedicated root defaults to `{dirname(repoRoot)}/worktrees` — a `worktrees` directory beside the repository checkout, under the repo's parent (not beside that parent).
+
+Each run's worktree leaf is `{dedicatedRoot}/{projectName}/pi-worktree-{runId}-{index}`, where `{projectName}` is the repository directory name (`basename(repoRoot)`), `{runId}` identifies the run, and `{index}` counts the children within the run. `worktreeBaseDir` and `PI_SUBAGENTS_WORKTREE_DIR` override only the dedicated root; the `{projectName}/pi-worktree-{runId}-{index}` nesting under it always applies. Unsafe locations are rejected instead of created: setup fails when the dedicated root sits inside the repository checkout or the Pi extensions directory, or when a worktree would land directly inside the repository parent.
 
 ## `worktreeProvider`
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -94,7 +94,7 @@ The complete plain-JSON inventory is validated before the first launch (maximum 
 | `missionId` | string | - | Attach a workflow to an existing project mission instead of creating its default enclosing mission. |
 | `mission` | object/false | auto-create | Override the default enclosing mission with `{ title \| summary, objective?, goal?, budget?, labels? }`. Set exactly one non-empty `title` or `summary`; `objective` and `labels` are optional. `goal` may only be `true`, requires `budget.tokens`, and enables continuation notices. Pass `false` for an intentionally ephemeral workflow with no mission for it or its children and no `state` global. Explicit mission persistence failures are strict. |
 | `handoffPath` | string | - | Aggregate handoff manifest for `action: "worktree.discard"` or lane evidence actions, or optional explicit metadata for `action: "worktree.cleanup"`. |
-| `repo` | string | runtime cwd | Repository path for `action: "worktree.cleanup"`; plan mode only. The configured worktree base filters candidates but never discovers them. |
+| `repo` | string | runtime cwd | Repository path for `action: "worktree.cleanup"`; plan mode only. The configured worktree base filters candidates by their per-project folder under it but never discovers them. |
 | `planId` | string | - | Reserved for a future `worktree.cleanup` apply action; rejected by the current plan-only action. |
 | `mode` | `steer \| follow_up \| auto \| plan \| apply` | - | Delivery mode for `action: "steer"`; `worktree.cleanup` currently accepts `plan` only. Apply/removal is reserved for a later change. |
 | `laneId` | string | - | Exact `runId` stored in the handoff manifest for `lane.status`, `lane.recordMerge`, or `lane.recordSupersession`. |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -369,7 +369,7 @@ Each child uses the existing worktree lifecycle: it branches from clean HEAD, jo
 
 A top-level `{ workflowScript, worktree: true }` makes isolation the default for every workflow child. An individual child can override that default with `worktree: false`. Keep one writer when parallel writes are not intentionally isolated.
 
-Configure the worktree base directory and setup hook in [configuration.md](configuration.md).
+Each managed worktree lives at `{dedicatedRoot}/{projectName}/pi-worktree-{runId}-{index}` — in path terms `{parent}/worktrees/{project}/pi-worktree-{runId}-{index}`. With `worktreeBaseDir` and `PI_SUBAGENTS_WORKTREE_DIR` unset, `{dedicatedRoot}` defaults to `{dirname(repoRoot)}/worktrees`: a `worktrees` directory beside the repository checkout, under the repo's parent. The config key and environment variable override only the dedicated root; the `{projectName}/pi-worktree-{runId}-{index}` nesting under it always applies. Configure the worktree base directory and setup hook in [configuration.md](configuration.md).
 
 ### Lane metadata lifecycle
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -369,7 +369,7 @@ Each child uses the existing worktree lifecycle: it branches from clean HEAD, jo
 
 A top-level `{ workflowScript, worktree: true }` makes isolation the default for every workflow child. An individual child can override that default with `worktree: false`. Keep one writer when parallel writes are not intentionally isolated.
 
-Each managed worktree lives at `{dedicatedRoot}/{projectName}/pi-worktree-{runId}-{index}` — in path terms `{parent}/worktrees/{project}/pi-worktree-{runId}-{index}`. With `worktreeBaseDir` and `PI_SUBAGENTS_WORKTREE_DIR` unset, `{dedicatedRoot}` defaults to `{dirname(repoRoot)}/worktrees`: a `worktrees` directory beside the repository checkout, under the repo's parent. The config key and environment variable override only the dedicated root; the `{projectName}/pi-worktree-{runId}-{index}` nesting under it always applies. Configure the worktree base directory and setup hook in [configuration.md](configuration.md).
+When native Git worktree allocation is used, each managed worktree lives at `{dedicatedRoot}/{projectName}/pi-worktree-{runId}-{index}` — in path terms `{parent}/worktrees/{project}/pi-worktree-{runId}-{index}`. With `worktreeBaseDir` and `PI_SUBAGENTS_WORKTREE_DIR` unset and native allocation selected, `{dedicatedRoot}` defaults to `{dirname(repoRoot)}/worktrees`, a `worktrees` directory alongside the repository checkout. The config key and environment variable override only the native dedicated root; the `{projectName}/pi-worktree-{runId}-{index}` nesting under it always applies for native allocation. Configure the worktree provider, base directory, and setup hook in [configuration.md](configuration.md).
 
 ### Lane metadata lifecycle
 

--- a/src/runs/shared/worktree-cleanup-plan.ts
+++ b/src/runs/shared/worktree-cleanup-plan.ts
@@ -593,7 +593,7 @@ function isPatchCaptured(record: ManifestMetadataRecord, worktreePath: string): 
 function buildManagedEntry(input: {
 	repoRoot: string;
 	baseDir: string;
-	containmentInvalid?: boolean;
+	containmentInvalid: boolean;
 	targetHead: string;
 	rootPath: string;
 	git: GitWorktreeRecord;

--- a/src/runs/shared/worktree-cleanup-plan.ts
+++ b/src/runs/shared/worktree-cleanup-plan.ts
@@ -243,11 +243,11 @@ function resolveRepoRoot(repo: string): string {
 	return realpathExisting(toplevel);
 }
 
-function resolveCleanupBaseDir(repoRoot: string, configuredBaseDir: string | undefined, requestedRepo: string): string {
+function resolveCleanupBaseDir(repoRoot: string, configuredBaseDir: string | undefined): string {
 	const raw = configuredBaseDir ?? process.env.PI_SUBAGENTS_WORKTREE_DIR;
 	let dedicatedRoot: string;
 	if (raw === undefined) {
-		dedicatedRoot = path.join(path.dirname(path.resolve(requestedRepo)), "worktrees");
+		dedicatedRoot = path.join(path.dirname(repoRoot), "worktrees");
 	} else {
 		const trimmed = raw.trim();
 		if (!trimmed) throw new Error("worktree base directory cannot be empty");
@@ -735,7 +735,7 @@ export function buildWorktreeCleanupPlan(input: BuildWorktreeCleanupPlanInput): 
 	const repoRoot = resolveRepoRoot(input.repo);
 	const now = input.now ?? Date.now();
 	if (!Number.isFinite(now)) throw new Error("worktree cleanup plan timestamp must be finite");
-	const baseDir = resolveCleanupBaseDir(repoRoot, input.worktreeBaseDir, input.repo);
+	const baseDir = resolveCleanupBaseDir(repoRoot, input.worktreeBaseDir);
 	const containmentInvalid = cleanupContainmentInvalid(repoRoot, baseDir);
 	const gitRecords = listGitWorktrees(repoRoot);
 	const targetHead = runGitChecked(repoRoot, ["rev-parse", "HEAD"]);

--- a/src/runs/shared/worktree-cleanup-plan.ts
+++ b/src/runs/shared/worktree-cleanup-plan.ts
@@ -243,12 +243,22 @@ function resolveRepoRoot(repo: string): string {
 	return realpathExisting(toplevel);
 }
 
-function resolveCleanupBaseDir(repoRoot: string, configuredBaseDir: string | undefined): string {
-	const raw = configuredBaseDir ?? process.env.PI_SUBAGENTS_WORKTREE_DIR ?? os.tmpdir();
-	const trimmed = raw.trim();
-	if (!trimmed) throw new Error("worktree base directory cannot be empty");
-	const expanded = trimmed.startsWith("~/") ? path.join(os.homedir(), trimmed.slice(2)) : trimmed;
-	return path.resolve(path.isAbsolute(expanded) ? expanded : path.resolve(repoRoot, expanded));
+function resolveCleanupBaseDir(repoRoot: string, configuredBaseDir: string | undefined, requestedRepo: string): string {
+	const raw = configuredBaseDir ?? process.env.PI_SUBAGENTS_WORKTREE_DIR;
+	let dedicatedRoot: string;
+	if (raw === undefined) {
+		dedicatedRoot = path.join(path.dirname(path.resolve(requestedRepo)), "worktrees");
+	} else {
+		const trimmed = raw.trim();
+		if (!trimmed) throw new Error("worktree base directory cannot be empty");
+		const expanded = trimmed.startsWith("~/") ? path.join(os.homedir(), trimmed.slice(2)) : trimmed;
+		dedicatedRoot = path.isAbsolute(expanded) ? expanded : path.resolve(repoRoot, expanded);
+	}
+	return path.resolve(path.join(dedicatedRoot, path.basename(repoRoot)));
+}
+
+function cleanupContainmentInvalid(repoRoot: string, projectDir: string): boolean {
+	return samePath(projectDir, repoRoot) || pathInside(repoRoot, projectDir, true);
 }
 
 export function parseGitWorktreeList(raw: string): GitWorktreeRecord[] {
@@ -579,6 +589,7 @@ function isPatchCaptured(record: ManifestMetadataRecord, worktreePath: string): 
 function buildManagedEntry(input: {
 	repoRoot: string;
 	baseDir: string;
+	containmentInvalid?: boolean;
 	targetHead: string;
 	rootPath: string;
 	git: GitWorktreeRecord;
@@ -605,7 +616,7 @@ function buildManagedEntry(input: {
 	if (pathInspection.missing) return blockedEntry(entry, "stale", "unknown", "worktree path is missing from disk");
 	if (pathInspection.symlink) return blockedEntry(entry, "unknown", "unknown", "worktree path is a symlink; cleanup requires a real directory");
 	if (!pathInspection.directory || !pathInspection.realpath) return blockedEntry(entry, "unknown", "unknown", "worktree path is not a directory");
-	if (!pathInside(baseDir, pathInspection.realpath, true)) return blockedEntry(entry, "ineligible", "keep", `worktree real path is outside configured base directory '${baseDir}'`);
+	if (input.containmentInvalid || !pathInside(baseDir, pathInspection.realpath, true)) return blockedEntry(entry, "ineligible", "keep", `worktree real path is outside configured base directory '${baseDir}'`);
 
 	if (rootPath === comparablePath(pathInspection.realpath)) return blockedEntry(entry, "ineligible", "keep", "worktree is the repository root");
 	if (!git.branch) return blockedEntry(entry, "unknown", "unknown", "detached worktrees have no metadata-recorded branch");
@@ -724,7 +735,8 @@ export function buildWorktreeCleanupPlan(input: BuildWorktreeCleanupPlanInput): 
 	const repoRoot = resolveRepoRoot(input.repo);
 	const now = input.now ?? Date.now();
 	if (!Number.isFinite(now)) throw new Error("worktree cleanup plan timestamp must be finite");
-	const baseDir = resolveCleanupBaseDir(repoRoot, input.worktreeBaseDir);
+	const baseDir = resolveCleanupBaseDir(repoRoot, input.worktreeBaseDir, input.repo);
+	const containmentInvalid = cleanupContainmentInvalid(repoRoot, baseDir);
 	const gitRecords = listGitWorktrees(repoRoot);
 	const targetHead = runGitChecked(repoRoot, ["rev-parse", "HEAD"]);
 	const rootPath = comparablePath(repoRoot);
@@ -749,6 +761,7 @@ export function buildWorktreeCleanupPlan(input: BuildWorktreeCleanupPlanInput): 
 		else entries.push(buildManagedEntry({
 			repoRoot,
 			baseDir,
+			containmentInvalid,
 			targetHead,
 			rootPath,
 			git,

--- a/src/runs/shared/worktree-cleanup-plan.ts
+++ b/src/runs/shared/worktree-cleanup-plan.ts
@@ -13,6 +13,7 @@ import type {
 	ParallelHandoffGroup,
 	ParallelHandoffManifest,
 } from "../../shared/types.ts";
+import { getAgentDir } from "../../shared/utils.ts";
 import { isTerminalParallelHandoffChildStatus } from "./parallel-handoff.ts";
 
 export const WORKTREE_CLEANUP_PLAN_VERSION = 1 as const;
@@ -246,7 +247,7 @@ function resolveRepoRoot(repo: string): string {
 function resolveCleanupBaseDir(repoRoot: string, configuredBaseDir: string | undefined): string {
 	const raw = configuredBaseDir ?? process.env.PI_SUBAGENTS_WORKTREE_DIR;
 	let dedicatedRoot: string;
-	if (raw === undefined) {
+	if (raw === undefined || (configuredBaseDir === undefined && !raw.trim())) {
 		dedicatedRoot = path.join(path.dirname(repoRoot), "worktrees");
 	} else {
 		const trimmed = raw.trim();
@@ -258,7 +259,10 @@ function resolveCleanupBaseDir(repoRoot: string, configuredBaseDir: string | und
 }
 
 function cleanupContainmentInvalid(repoRoot: string, projectDir: string): boolean {
-	return samePath(projectDir, repoRoot) || pathInside(repoRoot, projectDir, true);
+	const extensionsDir = path.join(getAgentDir(), "extensions");
+	return samePath(projectDir, repoRoot)
+		|| pathInside(repoRoot, projectDir, true)
+		|| pathInside(extensionsDir, projectDir);
 }
 
 export function parseGitWorktreeList(raw: string): GitWorktreeRecord[] {
@@ -616,6 +620,8 @@ function buildManagedEntry(input: {
 	if (pathInspection.missing) return blockedEntry(entry, "stale", "unknown", "worktree path is missing from disk");
 	if (pathInspection.symlink) return blockedEntry(entry, "unknown", "unknown", "worktree path is a symlink; cleanup requires a real directory");
 	if (!pathInspection.directory || !pathInspection.realpath) return blockedEntry(entry, "unknown", "unknown", "worktree path is not a directory");
+	const extensionsDir = path.join(getAgentDir(), "extensions");
+	if (pathInside(extensionsDir, pathInspection.realpath)) return blockedEntry(entry, "ineligible", "keep", `worktree real path is inside Pi extensions directory '${extensionsDir}'`);
 	if (input.containmentInvalid || !pathInside(baseDir, pathInspection.realpath, true)) return blockedEntry(entry, "ineligible", "keep", `worktree real path is outside configured base directory '${baseDir}'`);
 
 	if (rootPath === comparablePath(pathInspection.realpath)) return blockedEntry(entry, "ineligible", "keep", "worktree is the repository root");

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -468,20 +468,6 @@ function ensureProjectWorktreeDir(dedicatedRoot: string, repoRoot: string): void
 	}
 }
 
-/**
- * Creates the project folder (parents included) so `git worktree add` can
- * create the leaf inside it. Call only after the planned location passes the
- * safety checks below.
- */
-function ensureProjectWorktreeDir(dedicatedRoot: string, repoRoot: string): void {
-	try {
-		fs.mkdirSync(path.join(dedicatedRoot, path.basename(repoRoot)), { recursive: true });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`failed to create worktree base directory ${dedicatedRoot}: ${message}`);
-	}
-}
-
 function buildNativeWorktreePath(dedicatedRoot: string, repoRoot: string, runId: string, index: number): string {
 	return path.join(dedicatedRoot, path.basename(repoRoot), `pi-worktree-${sanitizeWorktreePathComponent(runId, 120)}-${index}`);
 }
@@ -504,7 +490,11 @@ function assertSafeWorktreeLocation(worktreePath: string, repoRoot: string, dedi
 	const projectDir = normalizeComparableCwd(path.join(dedicatedRoot, path.basename(repoRoot)));
 	const repoParent = normalizeComparableCwd(path.dirname(resolvedRepoRoot));
 	const leafParent = normalizeComparableCwd(path.dirname(resolvedLeaf));
+	const extensionsDir = normalizeComparableCwd(path.join(getAgentDir(), "extensions"));
 
+	if (isPathInside(extensionsDir, projectDir) || isPathInside(extensionsDir, resolvedLeaf)) {
+		throw new Error(`worktree path cannot be inside Pi extensions directory: ${extensionsDir}. Choose a directory outside it.`);
+	}
 	if (isPathInside(resolvedRepoRoot, resolvedLeaf)) {
 		throw new Error(`worktree path would land inside the repository checkout: ${resolvedLeaf}`);
 	}

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -214,7 +214,13 @@ function normalizeComparableCwd(cwd: string): string {
 	const missingSegments: string[] = [];
 	while (true) {
 		try {
-			return path.join(fs.realpathSync(existing), ...missingSegments.reverse());
+			let realpath: string;
+			try {
+				realpath = fs.realpathSync.native(existing);
+			} catch {
+				realpath = fs.realpathSync(existing);
+			}
+			return path.join(realpath, ...missingSegments.reverse());
 		} catch {
 			const parent = path.dirname(existing);
 			if (parent === existing) return resolved;
@@ -447,11 +453,14 @@ function resolveWorktreeDedicatedRoot(configuredBaseDir: string | undefined, rep
 		expanded = path.isAbsolute(candidate) ? candidate : path.resolve(repoRoot, candidate);
 	}
 	const extensionsDir = normalizeComparableCwd(path.join(getAgentDir(), "extensions"));
-	const relativeToExtensions = path.relative(extensionsDir, normalizeComparableCwd(expanded));
-	if (!relativeToExtensions || (!relativeToExtensions.startsWith(`..${path.sep}`) && relativeToExtensions !== ".." && !path.isAbsolute(relativeToExtensions))) {
+	if (isPathInside(extensionsDir, normalizeComparableCwd(expanded))) {
 		throw new Error(`worktree base directory cannot be inside Pi extensions directory: ${extensionsDir}. Choose a directory outside it.`);
 	}
 	return expanded;
+}
+
+function buildNativeProjectPath(dedicatedRoot: string, repoRoot: string): string {
+	return path.join(dedicatedRoot, path.basename(repoRoot));
 }
 
 /**
@@ -461,7 +470,7 @@ function resolveWorktreeDedicatedRoot(configuredBaseDir: string | undefined, rep
  */
 function ensureProjectWorktreeDir(dedicatedRoot: string, repoRoot: string): void {
 	try {
-		fs.mkdirSync(path.join(dedicatedRoot, path.basename(repoRoot)), { recursive: true });
+		fs.mkdirSync(buildNativeProjectPath(dedicatedRoot, repoRoot), { recursive: true });
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new Error(`failed to create worktree base directory ${dedicatedRoot}: ${message}`);
@@ -469,7 +478,7 @@ function ensureProjectWorktreeDir(dedicatedRoot: string, repoRoot: string): void
 }
 
 function buildNativeWorktreePath(dedicatedRoot: string, repoRoot: string, runId: string, index: number): string {
-	return path.join(dedicatedRoot, path.basename(repoRoot), `pi-worktree-${sanitizeWorktreePathComponent(runId, 120)}-${index}`);
+	return path.join(buildNativeProjectPath(dedicatedRoot, repoRoot), `pi-worktree-${sanitizeWorktreePathComponent(runId, 120)}-${index}`);
 }
 
 function isPathInside(parent: string, child: string): boolean {
@@ -487,7 +496,7 @@ function isStrictChildPath(parent: string, child: string): boolean {
 function assertSafeWorktreeLocation(worktreePath: string, repoRoot: string, dedicatedRoot: string): void {
 	const resolvedLeaf = normalizeComparableCwd(worktreePath);
 	const resolvedRepoRoot = normalizeComparableCwd(repoRoot);
-	const projectDir = normalizeComparableCwd(path.join(dedicatedRoot, path.basename(repoRoot)));
+	const projectDir = normalizeComparableCwd(buildNativeProjectPath(dedicatedRoot, repoRoot));
 	const repoParent = normalizeComparableCwd(path.dirname(resolvedRepoRoot));
 	const leafParent = normalizeComparableCwd(path.dirname(resolvedLeaf));
 	const extensionsDir = normalizeComparableCwd(path.join(getAgentDir(), "extensions"));
@@ -1131,7 +1140,7 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 			options?.beforeCreate?.(plannedSetup);
 			for (let index = 0; index < count; index++) {
 				worktrees.push(createNativeWorktree(
-						 repo.toplevel,
+					repo.toplevel,
 					repo.cwdRelative,
 					runId,
 					index,

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -472,6 +472,36 @@ function buildNativeWorktreePath(dedicatedRoot: string, repoRoot: string, runId:
 	return path.join(dedicatedRoot, path.basename(repoRoot), `pi-worktree-${sanitizeWorktreePathComponent(runId, 120)}-${index}`);
 }
 
+function isPathInside(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child);
+	if (!relative || relative === ".") return true;
+	return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function isStrictChildPath(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child);
+	return Boolean(relative) && relative !== "." && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+/** Fail closed before `git worktree add`: reject unsafe planned/realpath locations. */
+function assertSafeWorktreeLocation(worktreePath: string, repoRoot: string, dedicatedRoot: string): void {
+	const resolvedLeaf = normalizeComparableCwd(worktreePath);
+	const resolvedRepoRoot = normalizeComparableCwd(repoRoot);
+	const projectDir = normalizeComparableCwd(path.join(dedicatedRoot, path.basename(repoRoot)));
+	const repoParent = normalizeComparableCwd(path.dirname(resolvedRepoRoot));
+	const leafParent = normalizeComparableCwd(path.dirname(resolvedLeaf));
+
+	if (isPathInside(resolvedRepoRoot, resolvedLeaf)) {
+		throw new Error(`worktree path would land inside the repository checkout: ${resolvedLeaf}`);
+	}
+	if (leafParent === repoParent) {
+		throw new Error(`worktree path would be a direct child of the repository parent: ${resolvedLeaf}`);
+	}
+	if (!isStrictChildPath(projectDir, resolvedLeaf)) {
+		throw new Error(`worktree path must be a strict child of the project worktree directory ${projectDir}: ${resolvedLeaf}`);
+	}
+}
+
 function resolveRepoCwdRelative(cwd: string): string {
 	const repoCheck = runGit(cwd, ["rev-parse", "--is-inside-work-tree"]);
 	if (repoCheck.status !== 0 || repoCheck.stdout.trim() !== "true") {

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -428,31 +428,48 @@ export function shouldDeferWorktreeCwd(requested: WorktreeProvider | undefined, 
 	return (requested ?? DEFAULT_WORKTREE_PROVIDER) !== "native" && !hasConfiguredWorktreeBaseDir(baseDir);
 }
 
-function resolveWorktreeBaseDir(configuredBaseDir: string | undefined, repoRoot: string): string {
+/**
+ * Resolves the dedicated worktree root: the configured base directory or
+ * PI_SUBAGENTS_WORKTREE_DIR when set, otherwise a `worktrees` folder sibling
+ * to the repository. Managed leaves always nest one level deeper under the
+ * project folder (`basename(repoRoot)`).
+ */
+function resolveWorktreeDedicatedRoot(configuredBaseDir: string | undefined, repoRoot: string): string {
 	const rawBaseDir = configuredBaseDir ?? process.env.PI_SUBAGENTS_WORKTREE_DIR;
-	if (rawBaseDir === undefined || (configuredBaseDir === undefined && !rawBaseDir.trim())) return os.tmpdir();
+	let expanded: string;
+	if (rawBaseDir === undefined || (configuredBaseDir === undefined && !rawBaseDir.trim())) {
+		expanded = path.join(path.dirname(repoRoot), "worktrees");
+	} else {
+		const trimmed = rawBaseDir.trim();
+		if (!trimmed) throw new Error("worktree base directory cannot be empty");
 
-	const trimmed = rawBaseDir.trim();
-	if (!trimmed) throw new Error("worktree base directory cannot be empty");
-
-	const expanded = trimmed.startsWith("~/") ? path.join(os.homedir(), trimmed.slice(2)) : trimmed;
-	const resolved = path.isAbsolute(expanded) ? expanded : path.resolve(repoRoot, expanded);
+		const candidate = trimmed.startsWith("~/") ? path.join(os.homedir(), trimmed.slice(2)) : trimmed;
+		expanded = path.isAbsolute(candidate) ? candidate : path.resolve(repoRoot, candidate);
+	}
 	const extensionsDir = normalizeComparableCwd(path.join(getAgentDir(), "extensions"));
-	const relativeToExtensions = path.relative(extensionsDir, normalizeComparableCwd(resolved));
+	const relativeToExtensions = path.relative(extensionsDir, normalizeComparableCwd(expanded));
 	if (!relativeToExtensions || (!relativeToExtensions.startsWith(`..${path.sep}`) && relativeToExtensions !== ".." && !path.isAbsolute(relativeToExtensions))) {
 		throw new Error(`worktree base directory cannot be inside Pi extensions directory: ${extensionsDir}. Choose a directory outside it.`);
 	}
-	try {
-		fs.mkdirSync(resolved, { recursive: true });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		throw new Error(`failed to create worktree base directory ${resolved}: ${message}`);
-	}
-	return resolved;
+	return expanded;
 }
 
-function buildNativeWorktreePath(baseDir: string, runId: string, index: number): string {
-	return path.join(baseDir, `pi-worktree-${sanitizeWorktreePathComponent(runId, 120)}-${index}`);
+/**
+ * Creates the project folder (parents included) so `git worktree add` can
+ * create the leaf inside it. Call only after the planned location passes the
+ * safety checks below.
+ */
+function ensureProjectWorktreeDir(dedicatedRoot: string, repoRoot: string): void {
+	try {
+		fs.mkdirSync(path.join(dedicatedRoot, path.basename(repoRoot)), { recursive: true });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`failed to create worktree base directory ${dedicatedRoot}: ${message}`);
+	}
+}
+
+function buildNativeWorktreePath(dedicatedRoot: string, repoRoot: string, runId: string, index: number): string {
+	return path.join(dedicatedRoot, path.basename(repoRoot), `pi-worktree-${sanitizeWorktreePathComponent(runId, 120)}-${index}`);
 }
 
 function resolveRepoCwdRelative(cwd: string): string {
@@ -470,7 +487,9 @@ function resolveRepoCwdRelative(cwd: string): string {
 export function resolveExpectedWorktreeAgentCwd(cwd: string, runId: string, index: number, baseDir?: string): string {
 	const cwdRelative = resolveRepoCwdRelative(cwd);
 	const repoRoot = runGitChecked(cwd, ["rev-parse", "--show-toplevel"]).trim();
-	const worktreePath = buildNativeWorktreePath(resolveWorktreeBaseDir(baseDir, repoRoot), runId, index);
+	const dedicatedRoot = resolveWorktreeDedicatedRoot(baseDir, repoRoot);
+	const worktreePath = buildNativeWorktreePath(dedicatedRoot, repoRoot, runId, index);
+	assertSafeWorktreeLocation(worktreePath, repoRoot, dedicatedRoot);
 	return cwdRelative ? path.join(worktreePath, cwdRelative) : worktreePath;
 }
 
@@ -660,13 +679,15 @@ function createNativeWorktree(
 	baseCommit: string,
 	setupHook: ResolvedWorktreeSetupHook | undefined,
 	agent: string | undefined,
-	baseDir: string,
+	dedicatedRoot: string,
 	labels: Array<string | undefined> | undefined,
 	tasks: Array<string | undefined> | undefined,
 	branchPrefix: string | undefined,
 ): WorktreeInfo {
 	const naming = buildWorktreeNaming({ runId, index, agent, label: labels?.[index], task: tasks?.[index], branchPrefix });
-	const worktreePath = buildNativeWorktreePath(baseDir, runId, index);
+	const worktreePath = buildNativeWorktreePath(dedicatedRoot, toplevel, runId, index);
+	assertSafeWorktreeLocation(worktreePath, toplevel, dedicatedRoot);
+	ensureProjectWorktreeDir(dedicatedRoot, toplevel);
 	const add = runGit(toplevel, ["worktree", "add", worktreePath, "-b", naming.requestedBranch, baseCommit]);
 	if (add.status !== 0) {
 		const message = add.stderr.trim() || add.stdout.trim() || `failed to create worktree ${worktreePath}`;
@@ -1047,9 +1068,9 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 	if (!Number.isSafeInteger(count) || count < 0) throw new Error("worktree count must be a non-negative integer");
 	const repo = resolveRepoState(cwd);
 	const setupHook = resolveWorktreeSetupHook(repo.toplevel, options?.setupHook);
-	let provider = resolveWorktreeProvider(options?.provider, options?.baseDir);
+	const provider = resolveWorktreeProvider(options?.provider, options?.baseDir);
 	const branchPrefix = normalizeWorktreeBranchPrefix(options?.branchPrefix);
-	let baseDir = provider === "native" ? resolveWorktreeBaseDir(options?.baseDir, repo.toplevel) : undefined;
+	const dedicatedRoot = provider === "native" ? resolveWorktreeDedicatedRoot(options?.baseDir, repo.toplevel) : undefined;
 	const worktrees: WorktreeInfo[] = [];
 
 	try {
@@ -1059,7 +1080,8 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 				baseCommit: repo.baseCommit,
 				worktrees: Array.from({ length: count }, (_, index) => {
 					const naming = buildWorktreeNaming({ runId, index, agent: options?.agents?.[index], label: options?.labels?.[index], task: options?.tasks?.[index], branchPrefix });
-					const worktreePath = buildNativeWorktreePath(baseDir!, runId, index);
+					const worktreePath = buildNativeWorktreePath(dedicatedRoot!, repo.toplevel, runId, index);
+					assertSafeWorktreeLocation(worktreePath, repo.toplevel, dedicatedRoot!);
 					return {
 						path: worktreePath,
 						agentCwd: repo.cwdRelative ? path.join(worktreePath, repo.cwdRelative) : worktreePath,
@@ -1082,7 +1104,7 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 					repo.baseCommit,
 					setupHook,
 					options?.agents?.[index],
-					baseDir!,
+					dedicatedRoot!,
 					options?.labels,
 					options?.tasks,
 					branchPrefix,

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -455,6 +455,20 @@ function resolveWorktreeDedicatedRoot(configuredBaseDir: string | undefined, rep
 }
 
 /**
+ * Creates the project folder (parents included) so `git worktree add` can create
+ * the leaf inside it. Must only run after `assertSafeWorktreeLocation` accepted
+ * the planned leaf — an unsafe base must never be materialized on disk.
+ */
+function ensureProjectWorktreeDir(dedicatedRoot: string, repoRoot: string): void {
+	try {
+		fs.mkdirSync(path.join(dedicatedRoot, path.basename(repoRoot)), { recursive: true });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`failed to create worktree base directory ${dedicatedRoot}: ${message}`);
+	}
+}
+
+/**
  * Creates the project folder (parents included) so `git worktree add` can
  * create the leaf inside it. Call only after the planned location passes the
  * safety checks below.

--- a/test/unit/worktree-cleanup-plan.test.ts
+++ b/test/unit/worktree-cleanup-plan.test.ts
@@ -366,21 +366,6 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("uses sibling worktrees project folder as default cleanup containment root", () => {
-		const repo = createRepo("pi-cleanup-plan-default-root-");
-		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
-		delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
-		try {
-			const plan = buildPlan({ repo, now: 61_000, planId: "default-root-plan" });
-			const realRepo = fs.realpathSync(repo);
-			assert.equal(plan.baseDirs[0], path.join(path.dirname(realRepo), "worktrees", path.basename(realRepo)));
-		} finally {
-			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
-			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
-			fs.rmSync(repo, { recursive: true, force: true });
-		}
-	});
-
 	it("uses git toplevel parent as default cleanup root when input.repo is a subdirectory", () => {
 		const repo = createRepo("pi-cleanup-plan-subdir-root-");
 		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
@@ -392,7 +377,7 @@ describe("worktree cleanup plan", () => {
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			const plan = buildPlan({ repo: path.join(repo, "packages", "app"), now: 61_500, planId: "subdir-root-plan" });
-			const realRepo = fs.realpathSync(repo);
+			const realRepo = __testables.realpathExisting(repo);
 			assert.equal(plan.baseDirs[0], path.join(path.dirname(realRepo), "worktrees", path.basename(realRepo)));
 			const entry = entriesByPath(plan).get(__testables.realpathExisting(setup.worktrees[0]!.path)) ?? plan.entries[0];
 			assert.equal(entry?.decision, "remove");

--- a/test/unit/worktree-cleanup-plan.test.ts
+++ b/test/unit/worktree-cleanup-plan.test.ts
@@ -388,7 +388,7 @@ describe("worktree cleanup plan", () => {
 		let setup: WorktreeSetup | undefined;
 		try {
 			fs.mkdirSync(path.join(repo, "packages", "app"), { recursive: true });
-			setup = createWorktrees(repo, "from-subdir", 1);
+			setup = createWorktrees(repo, "from-subdir", 1, { provider: "native" });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			const plan = buildPlan({ repo: path.join(repo, "packages", "app"), now: 61_500, planId: "subdir-root-plan" });
@@ -468,6 +468,54 @@ describe("worktree cleanup plan", () => {
 		} finally {
 			removeGeneratedWorktrees(repo, setup);
 			fs.rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps a worktree whose project directory resolves into Pi extensions", () => {
+		const repo = createRepo("pi-cleanup-plan-extension-project-");
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-home-"));
+		const agentDir = path.join(tempHome, ".pi", "agent");
+		const extensionsDir = path.join(agentDir, "extensions");
+		const baseDir = path.join(tempHome, "worktree-root");
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		const projectDir = path.join(baseDir, path.basename(repo));
+		const worktreePath = path.join(projectDir, "pi-worktree-extension-project-0");
+		const branch = "pi-parallel-extension-project-0";
+		let setup: WorktreeSetup | undefined;
+		try {
+			fs.mkdirSync(extensionsDir, { recursive: true });
+			fs.mkdirSync(baseDir, { recursive: true });
+			fs.symlinkSync(extensionsDir, projectDir, process.platform === "win32" ? "junction" : "dir");
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+			process.env.HOME = tempHome;
+			process.env.USERPROFILE = tempHome;
+
+			git(repo, ["worktree", "add", "-b", branch, worktreePath]);
+			setup = {
+				cwd: repo,
+				worktrees: [{ path: worktreePath, agentCwd: worktreePath, branch, index: 0, nodeModulesLinked: false, syntheticPaths: [] }],
+				baseCommit: git(repo, ["rev-parse", "HEAD"]),
+			};
+			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
+			writeManifest({ repo, manifestPath, setup, preserved: true });
+			const plan = buildPlan({ repo, worktreeBaseDir: baseDir, now: 64_000, planId: "extension-project-plan" });
+			const entry = entriesByPath(plan).get(__testables.realpathExisting(worktreePath)) ?? plan.entries[0];
+			assert.equal(entry?.decision, "keep");
+			assert.equal(entry?.state, "ineligible");
+			assert.match(entry?.reasons.join(" ") ?? "", /Pi extensions directory/i);
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+			removeGeneratedWorktrees(repo, setup);
+			fs.rmSync(repo, { recursive: true, force: true });
+			fs.rmSync(baseDir, { recursive: true, force: true });
+			fs.rmSync(tempHome, { recursive: true, force: true });
 		}
 	});
 

--- a/test/unit/worktree-cleanup-plan.test.ts
+++ b/test/unit/worktree-cleanup-plan.test.ts
@@ -346,4 +346,115 @@ describe("worktree cleanup plan", () => {
 			fs.rmSync(baseDir, { recursive: true, force: true });
 		}
 	});
+
+	it("treats nested project directory as cleanup containment root", () => {
+		const repo = createRepo("pi-cleanup-plan-nested-root-");
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-nested-base-"));
+		let setup: WorktreeSetup | undefined;
+		try {
+			setup = createWorktrees(repo, "nested-root", 1, { baseDir });
+			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
+			writeManifest({ repo, manifestPath, setup });
+			const plan = buildPlan({ repo, worktreeBaseDir: baseDir, now: 60_000, planId: "nested-root-plan" });
+			assert.equal(plan.baseDirs[0], path.join(baseDir, path.basename(repo)));
+			assert.equal(plan.entries[0]?.decision, "remove");
+			assert.equal(plan.entries[0]?.state, "safe");
+		} finally {
+			removeGeneratedWorktrees(repo, setup);
+			fs.rmSync(repo, { recursive: true, force: true });
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("uses sibling worktrees project folder as default cleanup containment root", () => {
+		const repo = createRepo("pi-cleanup-plan-default-root-");
+		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
+		delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
+		try {
+			const plan = buildPlan({ repo, now: 61_000, planId: "default-root-plan" });
+			assert.equal(plan.baseDirs[0], path.join(path.dirname(repo), "worktrees", path.basename(repo)));
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
+			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("marks flat dedicatedRoot leaves ineligible", () => {
+		const repo = createRepo("pi-cleanup-plan-flat-leaf-");
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-flat-base-"));
+		const worktreePath = path.join(baseDir, "pi-worktree-flat-0");
+		const branch = "pi-parallel-flat-0";
+		let setup: WorktreeSetup | undefined;
+		try {
+			git(repo, ["worktree", "add", "-b", branch, worktreePath]);
+			setup = {
+				cwd: repo,
+				worktrees: [{
+					path: worktreePath,
+					agentCwd: worktreePath,
+					branch,
+					index: 0,
+					nodeModulesLinked: false,
+					syntheticPaths: [],
+				}],
+				baseCommit: git(repo, ["rev-parse", "HEAD"]),
+			};
+			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
+			writeManifest({ repo, manifestPath, setup, preserved: true });
+			const plan = buildPlan({ repo, worktreeBaseDir: baseDir, now: 62_000, planId: "flat-leaf-plan" });
+			const entry = entriesByPath(plan).get(__testables.realpathExisting(worktreePath)) ?? plan.entries[0];
+			assert.equal(entry?.decision, "keep");
+			assert.equal(entry?.state, "ineligible");
+			assert.match(entry?.reasons.join(" ") ?? "", /outside configured base directory|outside the project worktree directory/i);
+		} finally {
+			removeGeneratedWorktrees(repo, setup);
+			fs.rmSync(repo, { recursive: true, force: true });
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("marks checkout-internal worktrees ineligible when base is the repos parent", () => {
+		const repo = createRepo("pi-cleanup-plan-checkout-internal-");
+		const worktreePath = path.join(repo, "pi-worktree-internal-0");
+		const branch = "pi-parallel-internal-0";
+		let setup: WorktreeSetup | undefined;
+		try {
+			git(repo, ["worktree", "add", "-b", branch, worktreePath]);
+			setup = {
+				cwd: repo,
+				worktrees: [{
+					path: worktreePath,
+					agentCwd: worktreePath,
+					branch,
+					index: 0,
+					nodeModulesLinked: false,
+					syntheticPaths: [],
+				}],
+				baseCommit: git(repo, ["rev-parse", "HEAD"]),
+			};
+			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
+			writeManifest({ repo, manifestPath, setup, preserved: true });
+			const plan = buildPlan({ repo, worktreeBaseDir: path.dirname(repo), now: 63_000, planId: "checkout-internal-plan" });
+			const entry = entriesByPath(plan).get(__testables.realpathExisting(worktreePath)) ?? plan.entries[0];
+			assert.equal(entry?.decision, "keep");
+			assert.equal(entry?.state, "ineligible");
+			assert.notEqual(entry?.decision, "remove");
+		} finally {
+			removeGeneratedWorktrees(repo, setup);
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects empty cleanup worktree base directory", () => {
+		const repo = createRepo("pi-cleanup-plan-empty-base-");
+		try {
+			assert.throws(
+				() => buildWorktreeCleanupPlan({ repo, worktreeBaseDir: "   " }),
+				/worktree base directory cannot be empty/,
+			);
+		} finally {
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
+	});
 });

--- a/test/unit/worktree-cleanup-plan.test.ts
+++ b/test/unit/worktree-cleanup-plan.test.ts
@@ -372,10 +372,35 @@ describe("worktree cleanup plan", () => {
 		delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
 		try {
 			const plan = buildPlan({ repo, now: 61_000, planId: "default-root-plan" });
-			assert.equal(plan.baseDirs[0], path.join(path.dirname(repo), "worktrees", path.basename(repo)));
+			const realRepo = fs.realpathSync(repo);
+			assert.equal(plan.baseDirs[0], path.join(path.dirname(realRepo), "worktrees", path.basename(realRepo)));
 		} finally {
 			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
 			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	it("uses git toplevel parent as default cleanup root when input.repo is a subdirectory", () => {
+		const repo = createRepo("pi-cleanup-plan-subdir-root-");
+		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
+		delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
+		let setup: WorktreeSetup | undefined;
+		try {
+			fs.mkdirSync(path.join(repo, "packages", "app"), { recursive: true });
+			setup = createWorktrees(repo, "from-subdir", 1);
+			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
+			writeManifest({ repo, manifestPath, setup });
+			const plan = buildPlan({ repo: path.join(repo, "packages", "app"), now: 61_500, planId: "subdir-root-plan" });
+			const realRepo = fs.realpathSync(repo);
+			assert.equal(plan.baseDirs[0], path.join(path.dirname(realRepo), "worktrees", path.basename(realRepo)));
+			const entry = entriesByPath(plan).get(__testables.realpathExisting(setup.worktrees[0]!.path)) ?? plan.entries[0];
+			assert.equal(entry?.decision, "remove");
+			assert.equal(entry?.state, "safe");
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
+			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
+			removeGeneratedWorktrees(repo, setup);
 			fs.rmSync(repo, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -37,11 +37,19 @@ function createRepo(prefix: string): string {
 	fs.writeFileSync(path.join(repoDir, "tracked.txt"), "initial\n", "utf-8");
 	git(repoDir, ["add", "-A"]);
 	git(repoDir, ["commit", "-m", "initial commit"]);
-	return repoDir;
+	// Keep the returned path identical to `git rev-parse --show-toplevel` (realpaths
+	// symlinked tmpdir prefixes on macOS) so absolute path assertions line up.
+	return fs.realpathSync(repoDir);
 }
 
 function cleanupRepo(repoDir: string): void {
 	try { fs.rmSync(repoDir, { recursive: true, force: true }); } catch {}
+}
+
+/** Removes only this repo's nested project folder; never the shared dedicated root. */
+function cleanupProjectWorktrees(repoDir: string, baseDir?: string): void {
+	const dedicatedRoot = baseDir ?? path.join(path.dirname(repoDir), "worktrees");
+	try { fs.rmSync(path.join(dedicatedRoot, path.basename(repoDir)), { recursive: true, force: true }); } catch {}
 }
 
 function createHookScript(_repoDir: string, fileName: string, source: string): string {
@@ -78,6 +86,7 @@ describe("worktree", () => {
 			}
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -100,6 +109,7 @@ describe("worktree", () => {
 			assert.equal(fs.existsSync(setup.worktrees[0]!.path), true);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -241,6 +251,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(setup.worktrees[0]!.agentCwd, path.join(setup.worktrees[0]!.path, "packages", "app"));
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -256,9 +267,17 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		try {
 			assert.equal(
 				resolveExpectedWorktreeAgentCwd(nestedDir, "preview", 2),
-				path.join(os.tmpdir(), "pi-worktree-preview-2", "packages", "app"),
+				path.join(
+					path.dirname(repoDir),
+					"worktrees",
+					path.basename(repoDir),
+					"pi-worktree-preview-2",
+					"packages",
+					"app",
+				),
 			);
 		} finally {
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -269,12 +288,15 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		let setup: WorktreeSetup | undefined;
 		try {
 			setup = createWorktrees(repoDir, "base-dir", 1, { baseDir });
-			assert.equal(setup.worktrees[0]!.path, path.join(baseDir, "pi-worktree-base-dir-0"));
+			assert.equal(
+				setup.worktrees[0]!.path,
+				path.join(baseDir, path.basename(repoDir), "pi-worktree-base-dir-0"),
+			);
 			assert.ok(fs.existsSync(baseDir), "configured base directory should be created");
 		} finally {
 			if (setup) cleanupWorktrees(setup);
 			cleanupRepo(repoDir);
-			fs.rmSync(path.dirname(baseDir), { recursive: true, force: true });
+			cleanupProjectWorktrees(repoDir, baseDir);
 		}
 	});
 
@@ -347,7 +369,10 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		try {
 			process.env.PI_SUBAGENTS_WORKTREE_DIR = baseDir;
 			setup = createWorktrees(repoDir, "env-base-dir", 1);
-			assert.equal(setup.worktrees[0]!.path, path.join(baseDir, "pi-worktree-env-base-dir-0"));
+			assert.equal(
+				setup.worktrees[0]!.path,
+				path.join(baseDir, path.basename(repoDir), "pi-worktree-env-base-dir-0"),
+			);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
 			if (previous === undefined) {
@@ -356,7 +381,76 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 				process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
 			}
 			cleanupRepo(repoDir);
-			fs.rmSync(baseDir, { recursive: true, force: true });
+			cleanupProjectWorktrees(repoDir, baseDir);
+		}
+	});
+
+	it("nests default worktrees under sibling worktrees project folder", () => {
+		const repoDir = fs.realpathSync(createRepo("pi-worktree-nest-default-"));
+		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
+		try {
+			delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
+			const agentCwd = resolveExpectedWorktreeAgentCwd(repoDir, "nest-default", 0);
+			assert.equal(
+				agentCwd,
+				path.join(path.dirname(repoDir), "worktrees", path.basename(repoDir), "pi-worktree-nest-default-0"),
+			);
+			assert.notEqual(path.dirname(agentCwd), os.tmpdir());
+		} finally {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
+			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
+			fs.rmSync(path.join(path.dirname(repoDir), "worktrees", path.basename(repoDir)), { recursive: true, force: true });
+			cleanupRepo(repoDir);
+		}
+	});
+
+	it("nests configured base directory under project folder", () => {
+		const repoDir = fs.realpathSync(createRepo("pi-worktree-nest-base-dir-"));
+		const baseDir = path.join(os.tmpdir(), `pi-worktree-nest-base-${Date.now().toString(36)}`, "nested");
+		let setup: WorktreeSetup | undefined;
+		try {
+			setup = createWorktrees(repoDir, "nest-base-dir", 1, { baseDir });
+			const projectDir = path.join(baseDir, path.basename(repoDir));
+			assert.equal(setup.worktrees[0]!.path, path.join(projectDir, "pi-worktree-nest-base-dir-0"));
+			assert.ok(fs.existsSync(projectDir), "nested project directory should exist");
+			assert.ok(fs.existsSync(setup.worktrees[0]!.path), "nested worktree leaf should exist");
+		} finally {
+			if (setup) cleanupWorktrees(setup);
+			fs.rmSync(path.join(baseDir, path.basename(repoDir)), { recursive: true, force: true });
+			cleanupRepo(repoDir);
+		}
+	});
+
+	it("nests PI_SUBAGENTS_WORKTREE_DIR under project folder", () => {
+		const repoDir = fs.realpathSync(createRepo("pi-worktree-nest-env-"));
+		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
+		const baseDir = path.join(os.tmpdir(), `pi-worktree-nest-env-base-${Date.now().toString(36)}`);
+		let setup: WorktreeSetup | undefined;
+		try {
+			process.env.PI_SUBAGENTS_WORKTREE_DIR = baseDir;
+			setup = createWorktrees(repoDir, "nest-env", 1);
+			assert.equal(
+				setup.worktrees[0]!.path,
+				path.join(baseDir, path.basename(repoDir), "pi-worktree-nest-env-0"),
+			);
+		} finally {
+			if (setup) cleanupWorktrees(setup);
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
+			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
+			fs.rmSync(path.join(baseDir, path.basename(repoDir)), { recursive: true, force: true });
+			cleanupRepo(repoDir);
+		}
+	});
+
+	it("rejects empty worktree base directory", () => {
+		const repoDir = createRepo("pi-worktree-empty-base-");
+		try {
+			assert.throws(
+				() => createWorktrees(repoDir, "empty-base", 1, { baseDir: "   " }),
+				/worktree base directory cannot be empty/,
+			);
+		} finally {
+			cleanupRepo(repoDir);
 		}
 	});
 
@@ -383,6 +477,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(setup.worktrees.length, 1);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -463,6 +558,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.match(summary, /Full patches:/);
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -490,6 +586,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			}
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -517,6 +614,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			setup = undefined;
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -541,6 +639,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			setup = undefined;
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -571,6 +670,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			setup = undefined;
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -594,6 +694,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(fs.realpathSync(symlinkPath), fs.realpathSync(nodeModulesDir));
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -623,6 +724,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(fs.lstatSync(path.join(setup.worktrees[0]!.path, "node_modules")).isSymbolicLink(), true);
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -646,6 +748,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".venv"] }));
 			assert.ok(setup.worktrees[0]!.syntheticPaths.includes(".venv"));
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -666,6 +769,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 			assert.equal(setup.worktrees.length, 1);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -696,6 +800,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: ["tracked.txt"] }));
 				/cannot mark tracked paths as synthetic/i,
 			);
 		} finally {
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -714,6 +819,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [payload.worktreePath + "/
 				/synthetic path must be relative/i,
 			);
 		} finally {
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -740,6 +846,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".env.local"] }));
 			assert.doesNotMatch(patch, /\.env\.local/);
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -764,6 +871,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 			const branchList = git(repoDir, ["branch", "--list", "pi-subagents/task-hook-cleanup-s0-t*"]);
 			assert.equal(branchList.trim(), "", "temporary branches should be cleaned up after setup failure");
 		} finally {
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -786,6 +894,7 @@ setTimeout(() => {
 				/timed out/i,
 			);
 		} finally {
+			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -361,6 +361,85 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
+	it("rejects a final project directory inside Pi extensions", () => {
+		const sourceRepo = createRepo("pi-worktree-extension-project-");
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
+		const repoDir = path.join(tempHome, "extensions");
+		const agentDir = path.join(tempHome, ".pi", "agent");
+		const extensionsDir = path.join(agentDir, "extensions");
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		try {
+			fs.renameSync(sourceRepo, repoDir);
+			fs.mkdirSync(extensionsDir, { recursive: true });
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+			process.env.HOME = tempHome;
+			process.env.USERPROFILE = tempHome;
+
+			assert.throws(
+				() => createWorktrees(repoDir, "extension-project", 1, { provider: "native", baseDir: agentDir }),
+				/worktree path cannot be inside Pi extensions directory/i,
+			);
+			assert.throws(
+				() => resolveExpectedWorktreeAgentCwd(repoDir, "extension-project", 0, agentDir),
+				/worktree path cannot be inside Pi extensions directory/i,
+			);
+			assert.deepEqual(git(repoDir, ["worktree", "list", "--porcelain"]).split("\n").filter((line) => line.startsWith("worktree ")), [`worktree ${git(repoDir, ["rev-parse", "--show-toplevel"])}`]);
+			assert.deepEqual(fs.readdirSync(extensionsDir), []);
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+			cleanupRepo(repoDir);
+			cleanupRepo(sourceRepo);
+			fs.rmSync(tempHome, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a project directory symlink into Pi extensions", () => {
+		const repoDir = createRepo("pi-worktree-extension-project-symlink-");
+		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
+		const agentDir = path.join(tempHome, ".pi", "agent");
+		const extensionsDir = path.join(agentDir, "extensions");
+		const baseDir = path.join(tempHome, "worktree-root");
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		try {
+			fs.mkdirSync(extensionsDir, { recursive: true });
+			fs.mkdirSync(baseDir, { recursive: true });
+			fs.symlinkSync(extensionsDir, path.join(baseDir, path.basename(repoDir)), process.platform === "win32" ? "junction" : "dir");
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+			process.env.HOME = tempHome;
+			process.env.USERPROFILE = tempHome;
+
+			assert.throws(
+				() => createWorktrees(repoDir, "extension-project-symlink", 1, { provider: "native", baseDir }),
+				/worktree path cannot be inside Pi extensions directory/i,
+			);
+			assert.throws(
+				() => resolveExpectedWorktreeAgentCwd(repoDir, "extension-project-symlink", 0, baseDir),
+				/worktree path cannot be inside Pi extensions directory/i,
+			);
+			assert.deepEqual(git(repoDir, ["worktree", "list", "--porcelain"]).split("\n").filter((line) => line.startsWith("worktree ")), [`worktree ${git(repoDir, ["rev-parse", "--show-toplevel"])}`]);
+			assert.deepEqual(fs.readdirSync(extensionsDir), []);
+		} finally {
+			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+			cleanupRepo(repoDir);
+			fs.rmSync(baseDir, { recursive: true, force: true });
+			fs.rmSync(tempHome, { recursive: true, force: true });
+		}
+	});
+
 	it("uses PI_SUBAGENTS_WORKTREE_DIR when no base directory is configured", () => {
 		const repoDir = createRepo("pi-worktree-env-base-dir-");
 		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -454,6 +454,58 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
+	it("rejects worktree paths that would land inside the repository checkout", () => {
+		const repoDir = createRepo("pi-worktree-inside-");
+		const repoParent = path.dirname(repoDir);
+		const leakedLeaf = "pi-worktree-inside-0";
+		try {
+			assert.throws(
+				() => createWorktrees(repoDir, "inside", 1, { baseDir: repoParent }),
+				/inside the repository/i,
+			);
+			assert.throws(
+				() => resolveExpectedWorktreeAgentCwd(repoDir, "inside", 0, repoParent),
+				/inside the repository/i,
+			);
+
+			const porcelain = git(repoDir, ["worktree", "list", "--porcelain"]);
+			const worktreeLines = porcelain.split("\n").filter((line) => line.startsWith("worktree "));
+			assert.deepEqual(worktreeLines, [`worktree ${repoDir}`]);
+			assert.equal(fs.existsSync(path.join(repoDir, leakedLeaf)), false);
+			assert.equal(fs.existsSync(path.join(repoParent, leakedLeaf)), false);
+		} finally {
+			cleanupRepo(repoDir);
+		}
+	});
+
+	it("rejects worktree paths that are direct children of the repository parent", () => {
+		const repoDir = createRepo("pi-worktree-parent-child-");
+		const repoParent = path.dirname(repoDir);
+		const dedicatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-parent-child-root-"));
+		const projectDir = path.join(dedicatedRoot, path.basename(repoDir));
+		const leakedLeaf = path.join(repoParent, "pi-worktree-parent-child-0");
+		try {
+			fs.symlinkSync(repoParent, projectDir, process.platform === "win32" ? "junction" : "dir");
+			assert.throws(
+				() => createWorktrees(repoDir, "parent-child", 1, { baseDir: dedicatedRoot }),
+				/direct child of the repository parent/i,
+			);
+			assert.throws(
+				() => resolveExpectedWorktreeAgentCwd(repoDir, "parent-child", 0, dedicatedRoot),
+				/direct child of the repository parent/i,
+			);
+
+			const porcelain = git(repoDir, ["worktree", "list", "--porcelain"]);
+			const worktreeLines = porcelain.split("\n").filter((line) => line.startsWith("worktree "));
+			assert.deepEqual(worktreeLines, [`worktree ${repoDir}`]);
+			assert.equal(fs.existsSync(leakedLeaf), false);
+		} finally {
+			try { fs.rmSync(leakedLeaf, { recursive: true, force: true }); } catch {}
+			fs.rmSync(dedicatedRoot, { recursive: true, force: true });
+			cleanupRepo(repoDir);
+		}
+	});
+
 	it("createWorktrees rejects dirty repositories", () => {
 		const repoDir = createRepo("pi-worktree-dirty-");
 		try {

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -506,6 +506,30 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
+	it("does not mkdir inside the checkout when rejecting unsafe locations", () => {
+		const repoDir = createRepo("pi-worktree-no-mkdir-inside-");
+		try {
+			assert.throws(
+				() => createWorktrees(repoDir, "inside-self", 1, { baseDir: repoDir }),
+				/inside the repository/i,
+			);
+			assert.throws(
+				() => resolveExpectedWorktreeAgentCwd(repoDir, "inside-self", 0, repoDir),
+				/inside the repository/i,
+			);
+			assert.equal(fs.existsSync(path.join(repoDir, path.basename(repoDir))), false);
+
+			assert.throws(
+				() => createWorktrees(repoDir, "rel-worktrees", 1, { baseDir: "worktrees" }),
+				/inside the repository/i,
+			);
+			assert.equal(fs.existsSync(path.join(repoDir, "worktrees")), false);
+			assert.equal(fs.existsSync(path.join(repoDir, "worktrees", path.basename(repoDir))), false);
+		} finally {
+			cleanupRepo(repoDir);
+		}
+	});
+
 	it("createWorktrees rejects dirty repositories", () => {
 		const repoDir = createRepo("pi-worktree-dirty-");
 		try {

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -37,12 +37,12 @@ function createRepo(prefix: string): string {
 	fs.writeFileSync(path.join(repoDir, "tracked.txt"), "initial\n", "utf-8");
 	git(repoDir, ["add", "-A"]);
 	git(repoDir, ["commit", "-m", "initial commit"]);
-	// Keep the returned path identical to `git rev-parse --show-toplevel` (realpaths
-	// symlinked tmpdir prefixes on macOS) so absolute path assertions line up.
+	// Match Git's canonical top-level path for macOS symlinked temp roots.
 	return fs.realpathSync(repoDir);
 }
 
-function cleanupRepo(repoDir: string): void {
+function cleanupRepo(repoDir: string, baseDir?: string): void {
+	cleanupProjectWorktrees(repoDir, baseDir);
 	try { fs.rmSync(repoDir, { recursive: true, force: true }); } catch {}
 }
 
@@ -86,7 +86,6 @@ describe("worktree", () => {
 			}
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -109,7 +108,6 @@ describe("worktree", () => {
 			assert.equal(fs.existsSync(setup.worktrees[0]!.path), true);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -251,7 +249,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(setup.worktrees[0]!.agentCwd, path.join(setup.worktrees[0]!.path, "packages", "app"));
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -265,19 +262,19 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		git(repoDir, ["commit", "-m", "add nested dir"]);
 
 		try {
+			const repoRoot = git(nestedDir, ["rev-parse", "--show-toplevel"]);
 			assert.equal(
 				resolveExpectedWorktreeAgentCwd(nestedDir, "preview", 2),
 				path.join(
-					path.dirname(repoDir),
+					path.dirname(repoRoot),
 					"worktrees",
-					path.basename(repoDir),
+					path.basename(repoRoot),
 					"pi-worktree-preview-2",
 					"packages",
 					"app",
 				),
 			);
 		} finally {
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -295,8 +292,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.ok(fs.existsSync(baseDir), "configured base directory should be created");
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupRepo(repoDir);
-			cleanupProjectWorktrees(repoDir, baseDir);
+			cleanupRepo(repoDir, baseDir);
 		}
 	});
 
@@ -434,8 +430,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			else process.env.HOME = previousHome;
 			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
 			else process.env.USERPROFILE = previousUserProfile;
-			cleanupRepo(repoDir);
-			fs.rmSync(baseDir, { recursive: true, force: true });
+			cleanupRepo(repoDir, baseDir);
 			fs.rmSync(tempHome, { recursive: true, force: true });
 		}
 	});
@@ -459,65 +454,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			} else {
 				process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
 			}
-			cleanupRepo(repoDir);
-			cleanupProjectWorktrees(repoDir, baseDir);
-		}
-	});
-
-	it("nests default worktrees under sibling worktrees project folder", () => {
-		const repoDir = fs.realpathSync(createRepo("pi-worktree-nest-default-"));
-		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
-		try {
-			delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
-			const agentCwd = resolveExpectedWorktreeAgentCwd(repoDir, "nest-default", 0);
-			assert.equal(
-				agentCwd,
-				path.join(path.dirname(repoDir), "worktrees", path.basename(repoDir), "pi-worktree-nest-default-0"),
-			);
-			assert.notEqual(path.dirname(agentCwd), os.tmpdir());
-		} finally {
-			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
-			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
-			fs.rmSync(path.join(path.dirname(repoDir), "worktrees", path.basename(repoDir)), { recursive: true, force: true });
-			cleanupRepo(repoDir);
-		}
-	});
-
-	it("nests configured base directory under project folder", () => {
-		const repoDir = fs.realpathSync(createRepo("pi-worktree-nest-base-dir-"));
-		const baseDir = path.join(os.tmpdir(), `pi-worktree-nest-base-${Date.now().toString(36)}`, "nested");
-		let setup: WorktreeSetup | undefined;
-		try {
-			setup = createWorktrees(repoDir, "nest-base-dir", 1, { baseDir });
-			const projectDir = path.join(baseDir, path.basename(repoDir));
-			assert.equal(setup.worktrees[0]!.path, path.join(projectDir, "pi-worktree-nest-base-dir-0"));
-			assert.ok(fs.existsSync(projectDir), "nested project directory should exist");
-			assert.ok(fs.existsSync(setup.worktrees[0]!.path), "nested worktree leaf should exist");
-		} finally {
-			if (setup) cleanupWorktrees(setup);
-			fs.rmSync(path.join(baseDir, path.basename(repoDir)), { recursive: true, force: true });
-			cleanupRepo(repoDir);
-		}
-	});
-
-	it("nests PI_SUBAGENTS_WORKTREE_DIR under project folder", () => {
-		const repoDir = fs.realpathSync(createRepo("pi-worktree-nest-env-"));
-		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
-		const baseDir = path.join(os.tmpdir(), `pi-worktree-nest-env-base-${Date.now().toString(36)}`);
-		let setup: WorktreeSetup | undefined;
-		try {
-			process.env.PI_SUBAGENTS_WORKTREE_DIR = baseDir;
-			setup = createWorktrees(repoDir, "nest-env", 1);
-			assert.equal(
-				setup.worktrees[0]!.path,
-				path.join(baseDir, path.basename(repoDir), "pi-worktree-nest-env-0"),
-			);
-		} finally {
-			if (setup) cleanupWorktrees(setup);
-			if (previous === undefined) delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
-			else process.env.PI_SUBAGENTS_WORKTREE_DIR = previous;
-			fs.rmSync(path.join(baseDir, path.basename(repoDir)), { recursive: true, force: true });
-			cleanupRepo(repoDir);
+			cleanupRepo(repoDir, baseDir);
 		}
 	});
 
@@ -549,7 +486,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 
 			const porcelain = git(repoDir, ["worktree", "list", "--porcelain"]);
 			const worktreeLines = porcelain.split("\n").filter((line) => line.startsWith("worktree "));
-			assert.deepEqual(worktreeLines, [`worktree ${repoDir}`]);
+			assert.deepEqual(worktreeLines, [`worktree ${git(repoDir, ["rev-parse", "--show-toplevel"])}`]);
 			assert.equal(fs.existsSync(path.join(repoDir, leakedLeaf)), false);
 			assert.equal(fs.existsSync(path.join(repoParent, leakedLeaf)), false);
 		} finally {
@@ -576,7 +513,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 
 			const porcelain = git(repoDir, ["worktree", "list", "--porcelain"]);
 			const worktreeLines = porcelain.split("\n").filter((line) => line.startsWith("worktree "));
-			assert.deepEqual(worktreeLines, [`worktree ${repoDir}`]);
+			assert.deepEqual(worktreeLines, [`worktree ${git(repoDir, ["rev-parse", "--show-toplevel"])}`]);
 			assert.equal(fs.existsSync(leakedLeaf), false);
 		} finally {
 			try { fs.rmSync(leakedLeaf, { recursive: true, force: true }); } catch {}
@@ -632,7 +569,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(setup.worktrees.length, 1);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -713,7 +649,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.match(summary, /Full patches:/);
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -741,7 +676,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			}
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -769,7 +703,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			setup = undefined;
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -794,7 +727,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			setup = undefined;
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -825,7 +757,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			setup = undefined;
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -849,7 +780,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(fs.realpathSync(symlinkPath), fs.realpathSync(nodeModulesDir));
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -879,7 +809,6 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(fs.lstatSync(path.join(setup.worktrees[0]!.path, "node_modules")).isSymbolicLink(), true);
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -903,7 +832,6 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".venv"] }));
 			assert.ok(setup.worktrees[0]!.syntheticPaths.includes(".venv"));
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -924,7 +852,6 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 			assert.equal(setup.worktrees.length, 1);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -955,7 +882,6 @@ process.stdout.write(JSON.stringify({ syntheticPaths: ["tracked.txt"] }));
 				/cannot mark tracked paths as synthetic/i,
 			);
 		} finally {
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -974,7 +900,6 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [payload.worktreePath + "/
 				/synthetic path must be relative/i,
 			);
 		} finally {
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -1001,7 +926,6 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".env.local"] }));
 			assert.doesNotMatch(patch, /\.env\.local/);
 		} finally {
 			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -1026,7 +950,6 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 			const branchList = git(repoDir, ["branch", "--list", "pi-subagents/task-hook-cleanup-s0-t*"]);
 			assert.equal(branchList.trim(), "", "temporary branches should be cleaned up after setup failure");
 		} finally {
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
 	});
@@ -1049,34 +972,8 @@ setTimeout(() => {
 				/timed out/i,
 			);
 		} finally {
-			cleanupProjectWorktrees(repoDir);
 			cleanupRepo(repoDir);
 		}
-	});
-
-	it("configuration docs describe nested worktree default", () => {
-		const configuration = fs.readFileSync(
-			path.resolve(import.meta.dirname, "..", "..", "docs", "configuration.md"),
-			"utf-8",
-		);
-		assert.match(configuration, /\{dirname\(repoRoot\)\}\/worktrees/);
-		assert.match(configuration, /\{dedicatedRoot\}\/\{projectName\}\/pi-worktree-\{runId\}-\{index\}/);
-		assert.match(configuration, /PI_SUBAGENTS_WORKTREE_DIR/);
-		assert.doesNotMatch(configuration, /The default remains the system temp directory/);
-	});
-
-	it("workflow docs point at nested worktree layout", () => {
-		const workflows = fs.readFileSync(
-			path.resolve(import.meta.dirname, "..", "..", "docs", "workflows.md"),
-			"utf-8",
-		);
-		const sectionStart = workflows.indexOf("## Worktree isolation");
-		assert.notEqual(sectionStart, -1, "Worktree isolation section missing");
-		const rest = workflows.slice(sectionStart);
-		const nextHeading = rest.indexOf("\n## ", 1);
-		const section = nextHeading === -1 ? rest : rest.slice(0, nextHeading);
-		assert.match(section, /\{dirname\(repoRoot\)\}\/worktrees/);
-		assert.match(section, /\{parent\}\/worktrees\/\{project\}\/pi-worktree-\{runId\}-\{index\}/);
 	});
 });
 

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -950,6 +950,31 @@ setTimeout(() => {
 			cleanupRepo(repoDir);
 		}
 	});
+
+	it("configuration docs describe nested worktree default", () => {
+		const configuration = fs.readFileSync(
+			path.resolve(import.meta.dirname, "..", "..", "docs", "configuration.md"),
+			"utf-8",
+		);
+		assert.match(configuration, /\{dirname\(repoRoot\)\}\/worktrees/);
+		assert.match(configuration, /\{dedicatedRoot\}\/\{projectName\}\/pi-worktree-\{runId\}-\{index\}/);
+		assert.match(configuration, /PI_SUBAGENTS_WORKTREE_DIR/);
+		assert.doesNotMatch(configuration, /The default remains the system temp directory/);
+	});
+
+	it("workflow docs point at nested worktree layout", () => {
+		const workflows = fs.readFileSync(
+			path.resolve(import.meta.dirname, "..", "..", "docs", "workflows.md"),
+			"utf-8",
+		);
+		const sectionStart = workflows.indexOf("## Worktree isolation");
+		assert.notEqual(sectionStart, -1, "Worktree isolation section missing");
+		const rest = workflows.slice(sectionStart);
+		const nextHeading = rest.indexOf("\n## ", 1);
+		const section = nextHeading === -1 ? rest : rest.slice(0, nextHeading);
+		assert.match(section, /\{dirname\(repoRoot\)\}\/worktrees/);
+		assert.match(section, /\{parent\}\/worktrees\/\{project\}\/pi-worktree-\{runId\}-\{index\}/);
+	});
 });
 
 describe("manifest-backed worktree discard", () => {


### PR DESCRIPTION
Managed isolation currently creates `{baseDir}/pi-worktree-{runId}-{index}` and defaults `baseDir` to `os.tmpdir()` (`src/runs/shared/worktree.ts` `resolveWorktreeBaseDir` / `buildWorktreePath`; `docs/configuration.md` `worktreeBaseDir`). That either dumps leaves in temp or, when an operator points the base at a repos parent such as `~/Dev/git`, pollutes the parent (or, after naive `{base}/{project}` nesting, writes inside the checkout).

This Feature keeps the existing `worktreeBaseDir` / `PI_SUBAGENTS_WORKTREE_DIR` override and the existing leaf name. Unset dedicated root becomes `{dirname(repoRoot)}/worktrees`. Every managed worktree is `{dedicatedRoot}/{basename(repoRoot)}/pi-worktree-{runId}-{index}`. Create and cleanup refuse paths that are not strictly inside that project folder, including inside `repoRoot` or as a direct child of `{dirname(repoRoot)}`. VISION.md: compose from the current isolation primitive; one invariant; no new runner or config key.

## Tasks

- Task 1 — Nest paths under project folder
- Task 2 — Reject unsafe create locations
- Task 3 — Cleanup uses nested project dir
- Task 4 — Document nested worktree default
- Task 5 — QA: Cleanup default root follows input.repo instead of git toplevel
- Task 6 — QA: Rejected in-checkout bases mkdir inside the checkout before failing