### PR TITLE
Flush settled workflow assembly on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Replace collapsed async workflow role rollups with a compact lane view while keeping full details available when expanded (#1827). Thanks [@nicobailon](https://github.com/nicobailon).
 
 ### Fixed
+- Flush async workflow result assembly after session replacement when every child is already terminal, without permitting stale-context launches (#1833). Thanks [@redcomet168](https://github.com/redcomet168).
 - Accept calendar/platform `claude --version` output during Claude Code adapter preflight while retaining required launch-flag validation. Thanks [@drouhard](https://github.com/drouhard).
 - Show passive local command availability for external CLI agents in capability listings without replacing launch preflight (#1829). Thanks [@drouhard](https://github.com/drouhard).
 - Nest native managed worktrees under per-project directories while preserving unsafe-location checks (#1831). Thanks [@moofone](https://github.com/moofone).

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5205,6 +5205,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							globalConcurrencyLimit: requestParams.globalConcurrencyLimit ?? deps.config.globalConcurrencyLimit,
 							timeoutMs: timeout,
 							signal: controller.signal,
+							continueAfterAbortWhenChildrenSettled: (abortError) => {
+								if (abortError.message !== "Workflow stopped because the extension session was replaced or reloaded.") return false;
+								const activeAsyncChild = [...(deps.state.asyncJobs?.values() ?? [])].some((job) => job.parentWorkflowRunId === workflowRunId && (job.status === "queued" || job.status === "running"));
+								const activeForegroundChild = [...deps.state.foregroundControls.values()].some((control) => control.parentWorkflowRunId === workflowRunId && (control.activeChildren?.size ?? 0) > 0);
+								return !activeAsyncChild && !activeForegroundChild;
+							},
 							registerStopChild: (stop) => {
 								if (stop) deps.state.workflowChildStops?.set(workflowRunId, stop);
 								else deps.state.workflowChildStops?.delete(workflowRunId);

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -10,6 +10,7 @@ import { normalizeWorkflowHostCommandParams, type WorkflowHostCommandParams, typ
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const requireFromPackage = createRequire(import.meta.url);
+const WORKFLOW_ASSEMBLY_FLUSH_TIMEOUT_MS = 5_000;
 
 export interface WorkflowScriptValidationError {
 	message: string;
@@ -1070,6 +1071,8 @@ export interface RunWorkflowScriptOptions {
 	oneUsePermit?: { claim: (key: string) => string | undefined };
 	timeoutMs?: number;
 	signal?: AbortSignal;
+	/** Let an async workflow flush pure result assembly after reload once every child is terminal. */
+	continueAfterAbortWhenChildrenSettled?: (abortError: Error) => boolean;
 	/** Maximum children executing concurrently within this workflow. Defaults to 20. */
 	globalConcurrencyLimit?: number;
 	admit?: (calls: Array<{ key: string; params: Record<string, unknown> }>) => void | Promise<void>;
@@ -1682,6 +1685,9 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 	let acceptanceRecoveryBarrier: { key: string } | undefined;
 	let settled = false;
 	let finishing = false;
+	let assemblyAbortRequested = false;
+	let assemblyFlushTimer: ReturnType<typeof setTimeout> | undefined;
+	let abortError: Error | undefined;
 
 	const partial = (): Omit<WorkflowScriptResult, "value"> => ({ emits, console: consoleEntries, trace, children: childOrder.flatMap((key) => {
 		const child = children.get(key);
@@ -1750,6 +1756,10 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 		const finish = (outcome: { value: unknown } | { error: Error & { workflowErrorKind?: unknown } }) => {
 			if (settled || finishing) return;
 			finishing = true;
+			if (assemblyFlushTimer !== undefined) {
+				clearTimeout(assemblyFlushTimer);
+				assemblyFlushTimer = undefined;
+			}
 			childController.abort("error" in outcome ? outcome.error : new Error("Workflow script completed."));
 			void Promise.allSettled([...steers.values(), ...hostCalls.values()].map(({ promise }) => promise)).then(() => {
 				if (settled) return;
@@ -1781,6 +1791,26 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				: typeof signalReason === "string"
 					? new Error(signalReason)
 					: new Error("Workflow script aborted.");
+			if (finishing) return;
+			abortError = error;
+			const allChildrenSettled = launches.size > 0
+				&& [...launches.keys()].every((key) => children.has(key));
+			let mayFlushAssembly = false;
+			try {
+				mayFlushAssembly = options.continueAfterAbortWhenChildrenSettled?.(error) === true;
+			} catch (callbackError) {
+				const callbackMessage = callbackError instanceof Error ? callbackError.message : String(callbackError);
+				return finish({ error: new Error(`Workflow assembly flush eligibility failed: ${callbackMessage}`) });
+			}
+			if (mayFlushAssembly && allChildrenSettled) {
+				// A reloaded async workflow may already be past its last child launch.
+				// Keep the worker alive for pure result assembly, but abort the child
+				// signal so any later launch or side effect cannot use stale context.
+				assemblyAbortRequested = true;
+				childController.abort(error);
+				assemblyFlushTimer = setTimeout(() => finish({ error }), WORKFLOW_ASSEMBLY_FLUSH_TIMEOUT_MS);
+				return;
+			}
 			for (const key of launches.keys()) {
 				if (children.has(key)) continue;
 				stoppedLaunches.add(key);
@@ -1873,6 +1903,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				return;
 			}
 			if (message.type !== "call" || typeof message.callId !== "number" || typeof message.method !== "string" || !isRecord(message.args)) return;
+			if (assemblyAbortRequested) return finish({ error: abortError ?? new Error("Workflow context was replaced or reloaded.") });
 
 			const respond = (promise: Promise<unknown>, responsePath?: string, onBoundaryError?: (error: unknown) => void) => {
 				void promise.then(

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1386,6 +1386,58 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.rmSync(resultPath, { force: true });
 	});
 
+	it("flushes async workflow assembly after cleanup once children are terminal", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "child output" });
+		const asyncJobs: SubagentState["asyncJobs"] = new Map();
+		const workflowControllers = new Map<string, AbortController>();
+		const executor = makeExecutor([makeAgent("echo")], {}, false, undefined, true, asyncJobs, workflowControllers);
+		const started = await executor.execute(
+			`workflow-reload-assembly-${Date.now()}`,
+			{
+				async: true,
+				mission: false,
+				workflowScript: `const child = await runs.run("work", { agent: "echo", task: "Finish child" }); let checksum = 0; for (let index = 0; index < 100000000; index += 1) checksum = (checksum + index) % 97; return { phase: "assembled", output: child.output, checksum };`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(started.isError, undefined, started.content[0]?.text ?? "workflow launch failed");
+		const workflowRunId = started.details.asyncId;
+		assert.ok(workflowRunId);
+		const asyncDir = started.details.asyncDir;
+		assert.ok(asyncDir);
+		const statusPath = path.join(asyncDir, "status.json");
+		let childCompleted = false;
+		for (let attempt = 0; attempt < 500; attempt += 1) {
+			const status = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as { workflow?: { trace?: Array<{ key?: string; state?: string }> } };
+			childCompleted = status.workflow?.trace?.some((entry) => entry.key === "work" && entry.state === "completed") ?? false;
+			if (childCompleted) break;
+			await new Promise((resolve) => setTimeout(resolve, 2));
+		}
+		assert.equal(childCompleted, true, "expected the child to settle before simulating session cleanup");
+		const controller = workflowControllers.get(workflowRunId);
+		assert.ok(controller, "expected a live workflow controller before simulated cleanup");
+		controller.abort(new Error("Workflow stopped because the extension session was replaced or reloaded."));
+		workflowControllers.clear();
+		asyncJobs.clear();
+
+		let finalStatus: { state?: string; workflow?: { value?: unknown } } = {};
+		for (let attempt = 0; attempt < 500; attempt += 1) {
+			finalStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8")) as typeof finalStatus;
+			if (finalStatus.state === "complete" || finalStatus.state === "failed" || finalStatus.state === "stopped") break;
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+		assert.equal(finalStatus.state, "complete");
+		assert.deepEqual(finalStatus.workflow?.value, { phase: "assembled", output: "child output", checksum: 39 });
+		const resultPath = path.join(DIRS.results, `${workflowRunId}.json`);
+		const result = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as { state?: string; workflow?: { value?: unknown } };
+		assert.equal(result.state, "complete");
+		assert.deepEqual(result.workflow?.value, finalStatus.workflow?.value);
+		fs.rmSync(asyncDir, { recursive: true, force: true });
+		fs.rmSync(resultPath, { force: true });
+	});
+
 	it("delivers a terminal Darwin workflow failure after demand disappears", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const state: SubagentState = {
 			baseCwd: tempDir,

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -2264,6 +2264,68 @@ describe("scripted workflow runtime", () => {
 		assert.equal(childAborted, true);
 	});
 
+	it("flushes result assembly after abort when every child is terminal", async () => {
+		const controller = new AbortController();
+		let launchCount = 0;
+		const result = await runWorkflowScript({
+			script: `const child = await runs.run("done", { agent: "worker", task: "finish" }); return { phase: "assembled", output: child.output };`,
+			signal: controller.signal,
+			continueAfterAbortWhenChildrenSettled: (error) => error.message === "Workflow stopped because the extension session was replaced or reloaded.",
+			onTrace(trace) {
+				if (!controller.signal.aborted && trace.some((entry) => entry.operation === "run" && entry.key === "done" && entry.state === "completed")) controller.abort(new Error("Workflow stopped because the extension session was replaced or reloaded."));
+			},
+			async launch(key) {
+				launchCount += 1;
+				return { key, ok: true, output: "child output", artifactPaths: [], results: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.deepEqual(result.value, { phase: "assembled", output: "child output" });
+		assert.equal(launchCount, 1);
+	});
+
+	it("fails closed with diagnostics when graceful-abort eligibility throws", async () => {
+		const controller = new AbortController();
+		await assert.rejects(
+			runWorkflowScript({
+				script: `await runs.run("done", { agent: "worker", task: "finish" }); return { phase: "assembled" };`,
+				signal: controller.signal,
+				continueAfterAbortWhenChildrenSettled: () => { throw new Error("liveness unavailable"); },
+				onTrace(trace) {
+					if (!controller.signal.aborted && trace.some((entry) => entry.operation === "run" && entry.key === "done" && entry.state === "completed")) controller.abort(new Error("Workflow stopped because the extension session was replaced or reloaded."));
+				},
+				async launch(key) {
+					return { key, ok: true, output: "child output", artifactPaths: [], results: [] };
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && /liveness unavailable/.test(error.message),
+		);
+	});
+
+	it("fails closed if assembly tries to launch after a graceful abort", async () => {
+		const controller = new AbortController();
+		let launchCount = 0;
+		await assert.rejects(
+			runWorkflowScript({
+				script: `await runs.run("done", { agent: "worker", task: "finish" }); return runs.run("late", { agent: "worker", task: "must not launch" });`,
+				signal: controller.signal,
+				continueAfterAbortWhenChildrenSettled: (error) => error.message === "Workflow stopped because the extension session was replaced or reloaded.",
+				onTrace(trace) {
+					if (!controller.signal.aborted && trace.some((entry) => entry.operation === "run" && entry.key === "done" && entry.state === "completed")) controller.abort(new Error("Workflow stopped because the extension session was replaced or reloaded."));
+				},
+				async launch(key) {
+					launchCount += 1;
+					return { key, ok: true, output: "child output", artifactPaths: [], results: [] };
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => error instanceof WorkflowScriptError && error.message === "Workflow stopped because the extension session was replaced or reloaded.",
+		);
+		assert.equal(launchCount, 1);
+	});
+
 	it("ignores a queued child launch message after workflow abort", async () => {
 		const originalOn = Worker.prototype.on;
 		const controller = new AbortController();


### PR DESCRIPTION
## Summary
- let async workflows finish bounded result assembly after session replacement only when every launched child is already terminal
- keep stale-context safety by aborting the child signal and failing closed on any later workflow API call
- exclude queued/running async children, live foreground children, and user/RPC stop aborts from the graceful flush path

Fixes #1833.

Thanks to [@redcomet168](https://github.com/redcomet168) for the report.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/scripted-workflow.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'flushes async workflow assembly after cleanup once children are terminal|stops a live async workflow through its controller|persists parent-stopped workflow children as stopped instead of failed|stops one live async workflow child without stopping the parent or sibling' test/integration/single-execution.test.ts`
- `npm run typecheck`
- `git diff --check`
