### PR TITLE
Graceful workflow teardown: drain-and-flush all-terminal workflows on session replacement

### DIFF
--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -89,6 +89,7 @@ import {
 	SUBAGENT_CONTROL_MESSAGE_TYPE,
 	type SubagentControlMessageDetails,
 } from "./control-notices.ts";
+import { teardownWorkflowControllers } from "./workflow-teardown.ts";
 
 export { loadConfig, resolveAsyncByDefault } from "./config.ts";
 
@@ -962,12 +963,13 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			runtimeCleaned = true;
 			const shuttingDownParentSession = parentSessionEnvValue;
 			// Workflow continuations retain their launch context; abort them before
-			// teardown so a reload cannot launch through a stale context.
-			for (const controller of state.workflowControllers?.values() ?? []) {
-				if (!controller.signal.aborted) controller.abort(new Error("Workflow stopped because the extension session was replaced or reloaded."));
-			}
-			state.workflowControllers?.clear();
-			state.workflowChildStops?.clear();
+			// teardown so a reload cannot launch through a stale context. Workflows
+			// whose child runs are all terminal are only assembling their result, so
+			// they get a bounded, unref'd grace window to flush it (#1833); a workflow
+			// that finishes in time delivers through the replacing runtime's normal
+			// result path, and expiry force-aborts with the same error. Workflows
+			// with any live child run still abort immediately, as before.
+			teardownWorkflowControllers(state);
 			clearRuntimeAgentsForPi(pi);
 			clearTimeout(resultIndexCleanupTimer);
 			clearTimeout(asyncRetentionTimer);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -969,7 +969,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			// that finishes in time delivers through the replacing runtime's normal
 			// result path, and expiry force-aborts with the same error. Workflows
 			// with any live child run still abort immediately, as before.
-			teardownWorkflowControllers(state);
+			// True parent-session shutdown skips the window (graceMs: 0): the process
+			// is exiting, nobody will deliver the flush, and the workflow worker
+			// thread is not unref'd, so the window would only delay exit.
+			teardownWorkflowControllers(state, shuttingDownParentSession ? { graceMs: 0 } : {});
 			clearRuntimeAgentsForPi(pi);
 			clearTimeout(resultIndexCleanupTimer);
 			clearTimeout(asyncRetentionTimer);

--- a/src/extension/workflow-teardown.ts
+++ b/src/extension/workflow-teardown.ts
@@ -1,0 +1,101 @@
+import type { AsyncJobState, AsyncJobStep, SubagentState } from "../shared/types.ts";
+
+/**
+ * Bounded grace window granted at teardown to workflows whose child runs are
+ * all terminal. Such workflows are usually only assembling their result, so
+ * aborting them outright discards completed child work (#1833). The window
+ * lets the workflow script finish assembly and flush its result and wake-up
+ * through the normal delivery path; expiry force-aborts with the standard
+ * teardown error.
+ */
+export const WORKFLOW_TEARDOWN_GRACE_MS = 10_000;
+
+/** Same error style as the immediate teardown abort, used for both paths. */
+export const WORKFLOW_SESSION_REPLACED_MESSAGE = "Workflow stopped because the extension session was replaced or reloaded.";
+
+/** Step statuses that mean the child run settled and no more work is expected from its lane. */
+const TERMINAL_STEP_STATUSES: ReadonlySet<AsyncJobStep["status"]> = new Set<AsyncJobStep["status"]>([
+	"complete",
+	"completed",
+	"failed",
+	"stopped",
+	"rejected",
+]);
+
+export type WorkflowTeardownState = Pick<SubagentState, "asyncJobs" | "workflowControllers">;
+
+export interface WorkflowTeardownTimers {
+	setTimeout: (callback: () => void, delayMs: number) => { unref?: () => void };
+}
+
+export interface WorkflowTeardownOptions {
+	/** Grace window before force-aborting all-terminal workflows. Defaults to {@link WORKFLOW_TEARDOWN_GRACE_MS}. */
+	graceMs?: number;
+	/** Timer source; injectable so tests never wait on real timers. */
+	timers?: WorkflowTeardownTimers;
+}
+
+export interface WorkflowTeardownResult {
+	/** Run ids aborted immediately because at least one child run is still live. */
+	aborted: string[];
+	/** Run ids granted the grace window because every child run is terminal. */
+	graceAbortsScheduled: string[];
+}
+
+/**
+ * True only when the workflow's per-lane projection is inspectable and every
+ * lane has settled. A missing or empty projection means the state is not
+ * synchronously inspectable, so callers must treat the workflow as live and
+ * abort immediately rather than assume it is safe to delay.
+ */
+export function workflowChildRunsAllTerminal(job: AsyncJobState | undefined): boolean {
+	const steps = job?.steps;
+	if (!steps || steps.length === 0) return false;
+	return steps.every((step) => TERMINAL_STEP_STATUSES.has(step.status));
+}
+
+/**
+ * Tear down live workflow controllers for extension cleanup.
+ *
+ * Controllers with any non-terminal child run abort immediately (unchanged
+ * behavior). Controllers whose child runs are all terminal get one bounded,
+ * unref'd grace timer: a workflow that finishes assembly during the window
+ * removes its own controller from `state.workflowControllers` (its normal
+ * settle path) and is skipped at expiry, while the rest are force-aborted
+ * with the standard teardown error. Scheduling the timer keeps cleanup
+ * synchronous; unref'ing it keeps process exit unblocked.
+ */
+export function teardownWorkflowControllers(state: WorkflowTeardownState, options: WorkflowTeardownOptions = {}): WorkflowTeardownResult {
+	const graceMs = options.graceMs ?? WORKFLOW_TEARDOWN_GRACE_MS;
+	const timers: WorkflowTeardownTimers = options.timers ?? { setTimeout };
+	const aborted: string[] = [];
+	const graceAbortsScheduled: string[] = [];
+	const graceEntries: Array<{ runId: string; controller: AbortController }> = [];
+	for (const [runId, controller] of state.workflowControllers ?? []) {
+		if (controller.signal.aborted) continue;
+		if (workflowChildRunsAllTerminal(state.asyncJobs?.get(runId))) {
+			graceEntries.push({ runId, controller });
+			graceAbortsScheduled.push(runId);
+			continue;
+		}
+		controller.abort(new Error(WORKFLOW_SESSION_REPLACED_MESSAGE));
+		aborted.push(runId);
+	}
+	if (graceEntries.length > 0) {
+		const timer = timers.setTimeout(() => {
+			for (const { runId, controller } of graceEntries) {
+				try {
+					// A workflow that finished during the grace window deleted its own
+					// controller; only still-registered controllers need the force abort.
+					if (state.workflowControllers?.get(runId) !== controller) continue;
+					if (!controller.signal.aborted) controller.abort(new Error(WORKFLOW_SESSION_REPLACED_MESSAGE));
+				} catch (error) {
+					console.error(`Failed to force-abort workflow '${runId}' after the teardown grace window:`, error);
+				}
+			}
+		}, graceMs);
+		// The grace window must never keep the process alive past shutdown.
+		timer.unref?.();
+	}
+	return { aborted, graceAbortsScheduled };
+}

--- a/src/extension/workflow-teardown.ts
+++ b/src/extension/workflow-teardown.ts
@@ -63,7 +63,9 @@ export function workflowChildRunsAllTerminal(job: AsyncJobState | undefined): bo
  * removes its own controller from `state.workflowControllers` (its normal
  * settle path) and is skipped at expiry, while the rest are force-aborted
  * with the standard teardown error. Scheduling the timer keeps cleanup
- * synchronous; unref'ing it keeps process exit unblocked.
+ * synchronous; unref'ing the timer unblocks only the timer itself — the
+ * workflow worker thread still pins the event loop for the grace window, so
+ * callers that want a prompt exit pass `graceMs: 0`.
  */
 export function teardownWorkflowControllers(state: WorkflowTeardownState, options: WorkflowTeardownOptions = {}): WorkflowTeardownResult {
 	const graceMs = options.graceMs ?? WORKFLOW_TEARDOWN_GRACE_MS;
@@ -73,6 +75,11 @@ export function teardownWorkflowControllers(state: WorkflowTeardownState, option
 	const graceEntries: Array<{ runId: string; controller: AbortController }> = [];
 	for (const [runId, controller] of state.workflowControllers ?? []) {
 		if (controller.signal.aborted) continue;
+		// Accepted risk (#1833 QA): the all-terminal reading below is a snapshot.
+		// A sequential workflow resting between phases (await run(a); await sleep();
+		// await run(b)) can still launch one more lane through its stale launch
+		// context during the grace window; damage is bounded by the expiry force
+		// abort. A launch-admission latch is a possible follow-up if this bites.
 		if (workflowChildRunsAllTerminal(state.asyncJobs?.get(runId))) {
 			graceEntries.push({ runId, controller });
 			graceAbortsScheduled.push(runId);

--- a/test/unit/workflow-teardown.test.ts
+++ b/test/unit/workflow-teardown.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	WORKFLOW_SESSION_REPLACED_MESSAGE,
+	WORKFLOW_TEARDOWN_GRACE_MS,
+	teardownWorkflowControllers,
+	workflowChildRunsAllTerminal,
+	type WorkflowTeardownState,
+	type WorkflowTeardownTimers,
+} from "../../src/extension/workflow-teardown.ts";
+import type { AsyncJobState, AsyncJobStep } from "../../src/shared/types.ts";
+
+type ScheduledTimer = { callback: () => void; delayMs: number; unrefCount: number };
+
+interface FakeTimerHarness {
+	timers: WorkflowTeardownTimers;
+	scheduled: ScheduledTimer[];
+	fire: (index: number) => void;
+}
+
+function makeFakeTimers(): FakeTimerHarness {
+	const scheduled: ScheduledTimer[] = [];
+	return {
+		scheduled,
+		timers: {
+			setTimeout: (callback: () => void, delayMs: number) => {
+				const entry: ScheduledTimer = { callback, delayMs, unrefCount: 0 };
+				scheduled.push(entry);
+				return {
+					unref: () => {
+						entry.unrefCount += 1;
+					},
+				};
+			},
+		},
+		fire: (index: number) => {
+			const entry = scheduled[index];
+			assert.ok(entry, `expected a grace timer at index ${index}`);
+			entry.callback();
+		},
+	};
+}
+
+function makeJob(runId: string, statuses: Array<AsyncJobStep["status"]>): AsyncJobState {
+	return {
+		asyncId: runId,
+		asyncDir: `/async/${runId}`,
+		status: "running",
+		steps: statuses.map((status, index) => ({ agent: `agent-${index}`, status })),
+	};
+}
+
+function makeState(jobs: Map<string, AsyncJobState>, runIds: string[]): WorkflowTeardownState {
+	return {
+		asyncJobs: jobs,
+		workflowControllers: new Map(runIds.map((runId) => [runId, new AbortController()])),
+	};
+}
+
+describe("workflowChildRunsAllTerminal", () => {
+	it("is false when the job is missing or has no inspectable lanes", () => {
+		assert.equal(workflowChildRunsAllTerminal(undefined), false);
+		assert.equal(workflowChildRunsAllTerminal(makeJob("wf-empty", [])), false);
+	});
+
+	it("is false while any lane is still pending, running, partial, or paused", () => {
+		for (const liveStatus of ["pending", "running", "partial", "paused"] as const) {
+			assert.equal(workflowChildRunsAllTerminal(makeJob("wf-live", ["completed", liveStatus])), false, liveStatus);
+		}
+	});
+
+	it("is true when every lane settled", () => {
+		for (const terminalStatus of ["complete", "completed", "failed", "stopped", "rejected"] as const) {
+			assert.equal(workflowChildRunsAllTerminal(makeJob("wf-done", ["completed", terminalStatus])), true, terminalStatus);
+		}
+	});
+});
+
+describe("teardownWorkflowControllers", () => {
+	it("aborts a workflow with live children immediately and schedules no grace timer", () => {
+		const fake = makeFakeTimers();
+		const job = makeJob("wf-live", ["completed", "running"]);
+		const state = makeState(new Map([["wf-live", job]]), ["wf-live"]);
+		const controller = state.workflowControllers!.get("wf-live")!;
+
+		const result = teardownWorkflowControllers(state, { timers: fake.timers });
+
+		assert.deepEqual(result, { aborted: ["wf-live"], graceAbortsScheduled: [] });
+		assert.equal(controller.signal.aborted, true);
+		assert.equal(controller.signal.reason instanceof Error ? controller.signal.reason.message : String(controller.signal.reason), WORKFLOW_SESSION_REPLACED_MESSAGE);
+		assert.equal(fake.scheduled.length, 0);
+	});
+
+	it("treats an uninspectable job as live and aborts immediately", () => {
+		const fake = makeFakeTimers();
+		const state = makeState(new Map(), ["wf-unknown"]);
+
+		const result = teardownWorkflowControllers(state, { timers: fake.timers });
+
+		assert.deepEqual(result, { aborted: ["wf-unknown"], graceAbortsScheduled: [] });
+		assert.equal(state.workflowControllers!.get("wf-unknown")!.signal.aborted, true);
+		assert.equal(fake.scheduled.length, 0);
+	});
+
+	it("grants the grace window to a workflow whose child runs are all terminal", () => {
+		const fake = makeFakeTimers();
+		const job = makeJob("wf-assembly", ["completed", "failed"]);
+		const state = makeState(new Map([["wf-assembly", job]]), ["wf-assembly"]);
+		const controller = state.workflowControllers!.get("wf-assembly")!;
+
+		const result = teardownWorkflowControllers(state, { timers: fake.timers });
+
+		assert.deepEqual(result, { aborted: [], graceAbortsScheduled: ["wf-assembly"] });
+		assert.equal(controller.signal.aborted, false, "assembly-phase workflow must not be aborted during teardown");
+		assert.equal(fake.scheduled.length, 1);
+		assert.equal(fake.scheduled[0]!.delayMs, WORKFLOW_TEARDOWN_GRACE_MS);
+		assert.ok(fake.scheduled[0]!.unrefCount > 0, "grace timer must be unref'd so process exit is never blocked");
+	});
+
+	it("honors a custom grace window", () => {
+		const fake = makeFakeTimers();
+		const state = makeState(new Map([["wf-assembly", makeJob("wf-assembly", ["completed"])]]), ["wf-assembly"]);
+
+		teardownWorkflowControllers(state, { graceMs: 250, timers: fake.timers });
+
+		assert.equal(fake.scheduled[0]!.delayMs, 250);
+	});
+
+	it("lets a workflow that completes during the grace window settle without a force abort", () => {
+		const fake = makeFakeTimers();
+		const job = makeJob("wf-assembly", ["completed", "completed"]);
+		const state = makeState(new Map([["wf-assembly", job]]), ["wf-assembly"]);
+		const controller = state.workflowControllers!.get("wf-assembly")!;
+
+		teardownWorkflowControllers(state, { graceMs: 5, timers: fake.timers });
+
+		// The workflow finished assembly and its settle path removed its own
+		// controller, exactly like the executor's finally block does after a flush.
+		state.workflowControllers!.delete("wf-assembly");
+		fake.fire(0);
+
+		assert.equal(controller.signal.aborted, false, "flushed workflow must not be force-aborted after expiry");
+	});
+
+	it("force-aborts on grace expiry with the standard teardown error", () => {
+		const fake = makeFakeTimers();
+		const job = makeJob("wf-stuck", ["completed"]);
+		const state = makeState(new Map([["wf-stuck", job]]), ["wf-stuck"]);
+		const controller = state.workflowControllers!.get("wf-stuck")!;
+
+		teardownWorkflowControllers(state, { graceMs: 5, timers: fake.timers });
+		assert.equal(controller.signal.aborted, false);
+
+		fake.fire(0);
+
+		assert.equal(controller.signal.aborted, true);
+		assert.equal(controller.signal.reason instanceof Error ? controller.signal.reason.message : String(controller.signal.reason), WORKFLOW_SESSION_REPLACED_MESSAGE);
+	});
+
+	it("aborts only the live workflow when both kinds are registered", () => {
+		const fake = makeFakeTimers();
+		const jobs = new Map([
+			["wf-assembly", makeJob("wf-assembly", ["completed", "failed"])],
+			["wf-running", makeJob("wf-running", ["completed", "running"])],
+		]);
+		const state = makeState(jobs, ["wf-assembly", "wf-running"]);
+
+		const result = teardownWorkflowControllers(state, { timers: fake.timers });
+
+		assert.deepEqual(result, { aborted: ["wf-running"], graceAbortsScheduled: ["wf-assembly"] });
+		assert.equal(state.workflowControllers!.get("wf-running")!.signal.aborted, true);
+		assert.equal(state.workflowControllers!.get("wf-assembly")!.signal.aborted, false);
+		assert.equal(fake.scheduled.length, 1);
+	});
+
+	it("skips controllers that were already aborted before teardown", () => {
+		const fake = makeFakeTimers();
+		const jobs = new Map([["wf-aborted", makeJob("wf-aborted", ["running"])]]);
+		const state = makeState(jobs, ["wf-aborted"]);
+		const controller = state.workflowControllers!.get("wf-aborted")!;
+		const stopReason = new Error("Workflow stopped.");
+		controller.abort(stopReason);
+
+		const result = teardownWorkflowControllers(state, { timers: fake.timers });
+
+		assert.deepEqual(result, { aborted: [], graceAbortsScheduled: [] });
+		assert.equal(controller.signal.reason, stopReason, "pre-existing abort reason must be preserved");
+		assert.equal(fake.scheduled.length, 0);
+	});
+
+	it("tolerates a timer without unref", () => {
+		const timers: WorkflowTeardownTimers = {
+			setTimeout: (_callback: () => void, _delayMs: number) => ({}),
+		};
+		const state = makeState(new Map([["wf-assembly", makeJob("wf-assembly", ["completed"])]]), ["wf-assembly"]);
+
+		const result = teardownWorkflowControllers(state, { timers });
+
+		assert.deepEqual(result, { aborted: [], graceAbortsScheduled: ["wf-assembly"] });
+	});
+});

--- a/test/unit/workflow-teardown.test.ts
+++ b/test/unit/workflow-teardown.test.ts
@@ -142,6 +142,25 @@ describe("teardownWorkflowControllers", () => {
 		assert.equal(controller.signal.aborted, false, "flushed workflow must not be force-aborted after expiry");
 	});
 
+	it("skips the force abort when the map entry was replaced by a different controller", () => {
+		const fake = makeFakeTimers();
+		const job = makeJob("wf-replaced", ["completed"]);
+		const state = makeState(new Map([["wf-replaced", job]]), ["wf-replaced"]);
+		const staleController = state.workflowControllers!.get("wf-replaced")!;
+
+		teardownWorkflowControllers(state, { graceMs: 5, timers: fake.timers });
+
+		// A replacing runtime registered a fresh controller for the same run id
+		// before expiry; the replacement owns the run now and must survive the
+		// stale entry's grace expiry untouched.
+		const replacement = new AbortController();
+		state.workflowControllers!.set("wf-replaced", replacement);
+		fake.fire(0);
+
+		assert.equal(staleController.signal.aborted, false, "stale controller must be left alone at expiry");
+		assert.equal(replacement.signal.aborted, false, "replacement controller must not be aborted by the stale entry's expiry");
+	});
+
 	it("force-aborts on grace expiry with the standard teardown error", () => {
 		const fake = makeFakeTimers();
 		const job = makeJob("wf-stuck", ["completed"]);


### PR DESCRIPTION
Fixes #1833

## Problem

`cleanup()` unconditionally aborts every live workflow controller when the extension session is replaced or reloaded. That is correct for controllers that could still spawn children, but it also kills workflows whose child runs are **all already terminal** and which are merely in their assembly/post-processing phase — 100% of the expensive work done, assembled result discarded. Recovery was manual (artifacts + git archaeology).

## Fix — drain-and-flush (issue option 1)

New `src/extension/workflow-teardown.ts`:

- Controllers with any **non-terminal** lane (`pending`/`running`/`partial`/`paused`, including detached) abort immediately — unchanged behavior, identical error message.
- Controllers whose lanes are **all terminal** get one bounded **10s grace** (single shared one-shot `unref`'d timer) to finish assembly and flush their result/wake. On expiry, controllers the workflow already removed (its settle `finally` deletes them — the "flushed" signal) are skipped; the rest are force-aborted with the same error.
- Missing/uninspectable job state → conservative immediate abort (old behavior).

The lane projection (`AsyncJobState.steps`) is updated synchronously in the child settle handler (`onTrace → updateTrace → persist`), so the predicate can only fail safe: worst case is an immediate abort, i.e. pre-PR behavior.

**Delivery during grace is covered by existing machinery, verified end-to-end:** a flush landing before the replacing runtime's scan is found via `primeExistingResults` (session-index candidates); one landing after is caught by the new runtime's `fs.watch` on the results dir. `claimPredecessor` preserves ownership across the reload, and the old runtime's epoch/ownership gates make double-delivery impossible.

### True shutdown vs reload

`cleanup()` passes `graceMs: 0` when `shuttingDownParentSession` is set — on a real process shutdown nobody can deliver the flush, so there is no reason to defer exit (the workflow worker thread pins the event loop for the grace window even though the timer itself is `unref`'d). The 10s window applies only to the reload path where a replacing runtime exists.

### Documented trade-off

The all-terminal reading is a snapshot: a sequential workflow between phases (`await run(a); await sleep(); await run(b)`) could launch one more lane through the stale context during the grace window. Damage is bounded by the expiry force-abort (`onAbort` → lanes stopped → `finish` terminates the worker); a launch-admission latch is a possible follow-up if maintainers want that window closed.

### Dropped wholesale map clears

The old `workflowControllers`/`workflowChildStops` `clear()` calls were removed: every workflow's settle `finally` already removes its own entries (including the early-return persist-failure path), the dying runtime's maps have no reachable consumer after cleanup (`currentSessionId` nulled, RPC handlers unsubscribed, delivery epoch-gated), and runIds are UUIDs so replacement collisions can't occur. QA independently attempted to construct a "neither aborted nor self-removed" leak case and could not.

## Tests

- New `test/unit/workflow-teardown.test.ts` (13 tests, fake timers): all-terminal survives grace + skips self-removed entries; live child aborts immediately with the exact message; grace expiry force-aborts; replaced-entry identity guard; mixed sets; uninspectable job; custom grace; `unref` asserted.
- `npm run typecheck` clean; oxlint: zero diagnostics on new files, `index.ts` findings all pre-existing; full `test:unit` 2893 pass / 0 fail (10 `herdr-inspector` cancels reproduce on pristine `main` — environment-dependent, untouched by this diff); scoped adjacent suites 207/207.

🤖 Generated with [pi](https://github.com/nicobailon/pi-subagents) orchestration — happy to split the follow-ups (launch-admission latch, timer clear on early settle) into separate PRs if preferred.
