### PR TITLE
Draft: use pi session APIs for subagents

### DIFF
--- a/src/extension/control-notices.ts
+++ b/src/extension/control-notices.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { controlNotificationKey, formatControlNoticeMessage } from "../runs/shared/subagent-control.ts";
-import type { ControlEvent, SubagentState } from "../shared/types.ts";
+import { appendSessionJournalEntry, sessionJournalEntry, type SessionJournalEntry, type SessionJournalWriter } from "../shared/session-journal.ts";
+import type { ControlEvent } from "../shared/types.ts";
 
 export const SUBAGENT_CONTROL_MESSAGE_TYPE = "subagent_control_notice";
 
@@ -20,8 +21,46 @@ export function formatSubagentControlNotice(details: SubagentControlMessageDetai
 	return details.noticeText ?? content ?? formatControlNoticeMessage(details.event, controlNoticeTarget(details));
 }
 
+type ControlNoticePi = Pick<ExtensionAPI, "sendMessage"> & SessionJournalWriter;
+
+function controlDetailsFromJournalEntry(value: SessionJournalEntry | null | undefined): SubagentControlMessageDetails | undefined {
+	const entry = sessionJournalEntry(value);
+	if (!entry || entry.type !== "custom" && entry.type !== "custom_message") return undefined;
+	if (entry.customType !== SUBAGENT_CONTROL_MESSAGE_TYPE) return undefined;
+	const details = entry.type === "custom" ? entry.data : entry.details;
+	if (!details || typeof details !== "object" || Array.isArray(details)) return undefined;
+	// SAFETY: the guard above establishes that details is a non-array object;
+	// the parsed fields below are validated before this function returns.
+	const candidate = details as Partial<SubagentControlMessageDetails>;
+	const event = candidate.event;
+	if (!event || typeof event !== "object" || Array.isArray(event)) return undefined;
+	// SAFETY: the guard above establishes that event is a non-array object;
+	// each required ControlEvent field is validated immediately below.
+	const controlEvent = event as Partial<ControlEvent>;
+	if ((controlEvent.type !== "active_long_running" && controlEvent.type !== "needs_attention")
+		|| (controlEvent.to !== "active_long_running" && controlEvent.to !== "needs_attention")
+		|| typeof controlEvent.ts !== "number"
+		|| typeof controlEvent.runId !== "string"
+		|| typeof controlEvent.agent !== "string"
+		|| typeof controlEvent.message !== "string") return undefined;
+	// SAFETY: event has passed every required ControlEvent field check above;
+	// candidate is the journal details object that contains that event.
+	return candidate as SubagentControlMessageDetails;
+}
+
+export function restoreVisibleControlNotices(entries: readonly SessionJournalEntry[] | undefined, target = new Set<string>()): number {
+	target.clear();
+	if (!Array.isArray(entries)) return 0;
+	for (const value of entries) {
+		const details = controlDetailsFromJournalEntry(value);
+		if (!details) continue;
+		target.add(controlNotificationKey(details.event, controlNoticeTarget(details)));
+	}
+	return target.size;
+}
+
 function deliverControlNotice(input: {
-	pi: Pick<ExtensionAPI, "sendMessage">;
+	pi: ControlNoticePi;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
 }): void {
@@ -30,20 +69,21 @@ function deliverControlNotice(input: {
 	if (input.visibleControlNotices.has(key)) return;
 	input.visibleControlNotices.add(key);
 	const noticeText = input.details.noticeText ?? formatControlNoticeMessage(input.details.event, childIntercomTarget);
+	const journalDetails = { ...input.details, childIntercomTarget, noticeText };
 	input.pi.sendMessage(
 		{
 			customType: SUBAGENT_CONTROL_MESSAGE_TYPE,
 			content: noticeText,
 			display: true,
-			details: { ...input.details, childIntercomTarget, noticeText },
+			details: journalDetails,
 		},
 		{ triggerTurn: input.details.source === "async" },
 	);
+	appendSessionJournalEntry(input.pi, SUBAGENT_CONTROL_MESSAGE_TYPE, journalDetails);
 }
 
 export function handleSubagentControlNotice(input: {
-	pi: Pick<ExtensionAPI, "sendMessage">;
-	state: SubagentState;
+	pi: ControlNoticePi;
 	visibleControlNotices: Set<string>;
 	details: SubagentControlMessageDetails;
 }): void {

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -5,8 +5,9 @@ import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-age
 import { discoverAgents } from "../agents/agents.ts";
 import { getArtifactsDir } from "../shared/artifacts.ts";
 import { createSubagentExecutor, type SubagentParamsLike } from "../runs/foreground/subagent-executor.ts";
-import { resolveWaitToolConfig } from "../runs/background/wait-config.ts";
-import { SUBAGENT_CHILD_ENV, SUBAGENT_FANOUT_CHILD_ENV } from "../runs/shared/pi-args.ts";
+import { resolveWaitToolConfig, WAIT_TOOL_DEFAULT_TIMEOUT_MS_ENV, WAIT_TOOL_ENABLED_ENV } from "../runs/background/wait-config.ts";
+import { SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV, SUBAGENT_PARENT_CONTROL_INBOX_ENV, SUBAGENT_PARENT_EVENT_SINK_ENV, SUBAGENT_PARENT_ROOT_RUN_ID_ENV } from "../runs/shared/pi-args.ts";
+import { readChildRuntimeConfigFromEnv, type ChildRuntimeConfig } from "../runs/shared/child-runtime-config.ts";
 import { readNestedControlRequests, resolveNestedRouteFromEnv, type NestedRoute, writeNestedControlResult } from "../runs/shared/nested-events.ts";
 import { deliverSubagentIntercomMessageEvent } from "../intercom/result-intercom.ts";
 import { resolveSubagentIntercomTarget } from "../intercom/intercom-bridge.ts";
@@ -51,9 +52,15 @@ function createChildSafeState(): SubagentState {
 	};
 }
 
-function resolveNestedControlRoute(): NestedRoute | undefined {
+function resolveNestedControlRoute(config: ChildRuntimeConfig): NestedRoute | undefined {
+	if (!config.nestedRoute) return undefined;
 	try {
-		return resolveNestedRouteFromEnv();
+		return resolveNestedRouteFromEnv({
+			[SUBAGENT_PARENT_ROOT_RUN_ID_ENV]: config.nestedRoute.rootRunId,
+			[SUBAGENT_PARENT_EVENT_SINK_ENV]: config.nestedRoute.eventSink,
+			[SUBAGENT_PARENT_CONTROL_INBOX_ENV]: config.nestedRoute.controlInbox,
+			[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV]: config.nestedRoute.capabilityToken,
+		});
 	} catch {
 		return undefined;
 	}
@@ -145,8 +152,8 @@ function startNestedControlInboxListener(pi: ExtensionAPI, state: SubagentState,
 	return () => clearInterval(timer);
 }
 
-export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): void {
-	if (process.env[SUBAGENT_CHILD_ENV] !== "1" || process.env[SUBAGENT_FANOUT_CHILD_ENV] !== "1") return;
+export function registerFanoutChildSubagentExtensionWithConfig(pi: ExtensionAPI, childRuntimeConfig: ChildRuntimeConfig): void {
+	if (!childRuntimeConfig.child || !childRuntimeConfig.fanoutChild) return;
 
 	const globalStore = globalThis as Record<string, unknown>;
 	const registeredKey = "__piSubagentFanoutChildRegisteredApis";
@@ -158,7 +165,11 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	registeredApis.add(pi);
 
 	const config = loadConfig();
-	const waitToolConfig = resolveWaitToolConfig(config.waitTool);
+	const waitToolEnv: Record<string, string | undefined> = {
+		[WAIT_TOOL_ENABLED_ENV]: childRuntimeConfig.waitToolEnabledEnv,
+		[WAIT_TOOL_DEFAULT_TIMEOUT_MS_ENV]: childRuntimeConfig.waitToolDefaultTimeoutMsEnv,
+	};
+	const waitToolConfig = resolveWaitToolConfig(config.waitTool, waitToolEnv);
 	const state = createChildSafeState();
 	const executor = createSubagentExecutor({
 		pi,
@@ -190,7 +201,7 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	};
 
 	pi.registerTool(tool);
-	const route = resolveNestedControlRoute();
+	const route = resolveNestedControlRoute(childRuntimeConfig);
 	if (!route) return;
 	const listenerCleanupKey = "__piSubagentFanoutChildNestedControlInboxCleanups";
 	const listenerCleanups = globalStore[listenerCleanupKey] instanceof Map
@@ -202,4 +213,8 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): 
 	previous?.cleanup();
 	const inboxState = previous?.state ?? createNestedControlInboxState();
 	listenerCleanups.set(routeKey, { state: inboxState, cleanup: startNestedControlInboxListener(pi, state, route, inboxState) });
+}
+
+export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI): void {
+	registerFanoutChildSubagentExtensionWithConfig(pi, readChildRuntimeConfigFromEnv(process.env));
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -54,7 +54,7 @@ import { resolveWaitToolConfig } from "../runs/background/subagent-wait.ts";
 import { registerWaitTool } from "../runs/background/wait-tool.ts";
 import { createWaitSubscriptionManager } from "../runs/background/wait-subscriptions.ts";
 import { drainOutstandingWork } from "../runs/background/auto-drain.ts";
-import registerSubagentNotify, { parseSubagentNotifyContent, type SubagentNotifyDetails } from "../runs/background/notify.ts";
+import registerSubagentNotify, { parseSubagentNotifyContent, SUBAGENT_NOTIFY_MESSAGE_TYPE, type SubagentNotifyDetails } from "../runs/background/notify.ts";
 import { formatSteeringNotice, handleSubagentSteeringNotice, SUBAGENT_STEERING_MESSAGE_TYPE, type SubagentSteeringMessageDetails } from "./steering-notices.ts";
 import { SUBAGENT_CHILD_ENV, SUBAGENT_PARENT_SESSION_ENV } from "../runs/shared/pi-args.ts";
 import { resolveCurrentSubagentCapabilityCeiling } from "../runs/shared/capability-ceiling.ts";
@@ -65,6 +65,7 @@ import { formatWorkflowPreflightSummary, normalizeWorkflowPreflight } from "../w
 import { finalizeToolResult } from "./tool-result.ts";
 import { collectGoalContinuationNotices } from "../missions/goal-driver.ts";
 import { restoreForegroundRunHistory } from "../runs/foreground/foreground-history.ts";
+import type { SessionJournalEntry } from "../shared/session-journal.ts";
 import { resolveMissionStoreLocation } from "../missions/store.ts";
 import { listRetainedChildren } from "../runs/background/retained-children.ts";
 import {
@@ -86,6 +87,7 @@ import {
 import {
 	formatSubagentControlNotice,
 	handleSubagentControlNotice,
+	restoreVisibleControlNotices,
 	SUBAGENT_CONTROL_MESSAGE_TYPE,
 	type SubagentControlMessageDetails,
 } from "./control-notices.ts";
@@ -98,12 +100,10 @@ const RUNTIME_REGISTRY_STORE_KEY = "__piSubagentRuntimeRegistry";
 interface SubagentRuntimeEntry {
 	cleanup(): void;
 	sessionManager: object | null;
-	visibleControlNotices: Set<string>;
 }
 
 interface SubagentRuntimeRegistry {
 	bySessionManager: WeakMap<object, SubagentRuntimeEntry>;
-	visibleControlNoticesBySessionManager: WeakMap<object, Set<string>>;
 	activeEntries: Set<SubagentRuntimeEntry>;
 }
 
@@ -111,14 +111,10 @@ function getRuntimeRegistry(): SubagentRuntimeRegistry {
 	const globalStore = globalThis as Record<string, unknown>;
 	const existing = globalStore[RUNTIME_REGISTRY_STORE_KEY] as Partial<SubagentRuntimeRegistry> | undefined;
 	if (existing?.bySessionManager instanceof WeakMap && existing.activeEntries instanceof Set) {
-		if (!(existing.visibleControlNoticesBySessionManager instanceof WeakMap)) {
-			existing.visibleControlNoticesBySessionManager = new WeakMap();
-		}
 		return existing as SubagentRuntimeRegistry;
 	}
 	const registry: SubagentRuntimeRegistry = {
 		bySessionManager: new WeakMap(),
-		visibleControlNoticesBySessionManager: new WeakMap(),
 		activeEntries: new Set(),
 	};
 	globalStore[RUNTIME_REGISTRY_STORE_KEY] = registry;
@@ -618,9 +614,13 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		return new Text(content, 0, 0);
 	});
 
-	pi.registerMessageRenderer<SubagentNotifyDetails>("subagent-notify", (message, options, theme) => {
+	pi.registerMessageRenderer<SubagentNotifyDetails | SubagentNotifyDetails[]>(SUBAGENT_NOTIFY_MESSAGE_TYPE, (message, options, theme) => {
 		const content = typeof message.content === "string" ? message.content : "";
-		const details = (message.details as SubagentNotifyDetails | undefined) ?? parseSubagentNotifyContent(content);
+		const journalDetails = message.details as SubagentNotifyDetails | SubagentNotifyDetails[] | undefined;
+		// Grouped completions already have a complete display projection. Their
+		// journal payload is an array and intentionally bypasses single-item styling.
+		if (Array.isArray(journalDetails)) return new Text(content, 0, 0);
+		const details = journalDetails ?? parseSubagentNotifyContent(content);
 		if (!details) return new Text(content, 0, 0);
 		const icon = details.status === "completed"
 			? theme.fg("success", "✓")
@@ -769,7 +769,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			for (const notice of collectGoalContinuationNotices({ location, ownerSessionId, retainedChildren, turnId: goalTurnId })) {
 				handleSubagentControlNotice({
 					pi,
-					state,
 					visibleControlNotices: new Set(),
 					details: { source: "goal", event: notice.event, noticeText: notice.message },
 				});
@@ -785,6 +784,24 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	});
 
 	let visibleControlNotices = new Set<string>();
+	const rebuildSessionJournalState = (ctx: ExtensionContext): void => {
+		let branchEntries: readonly SessionJournalEntry[] | undefined;
+		if (typeof ctx.sessionManager.getBranch === "function") {
+			try {
+				const entries = ctx.sessionManager.getBranch();
+				if (Array.isArray(entries)) branchEntries = entries;
+			} catch (error) {
+				console.error("Failed to read the selected session branch:", error);
+			}
+		}
+		visibleControlNotices = new Set();
+		restoreVisibleControlNotices(branchEntries, visibleControlNotices);
+		restoreForegroundRunHistory(state, {
+			sessionId: state.currentSessionId,
+			branchEntries,
+			resultsDir: DIRS.results,
+		});
+	};
 	const activeHerdrRuns = () => projectActiveHerdrRuns(state);
 	const herdrStatusBridge = registerHerdrStatusBridge({
 		events: pi.events,
@@ -797,7 +814,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const controlEventHandler = (payload: unknown) => {
 		handleSubagentControlNotice({
 			pi,
-			state,
 			visibleControlNotices,
 			details: payload as SubagentControlMessageDetails,
 		});
@@ -931,8 +947,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		resetJobs(ctx);
 		logSlowPhase("reset-jobs", phaseStartedAt);
 		phaseStartedAt = Date.now();
-		restoreForegroundRunHistory(state, { resultsDir: DIRS.results });
-		logSlowPhase("foreground-history", phaseStartedAt);
+		rebuildSessionJournalState(ctx);
+		logSlowPhase("session-journal-state", phaseStartedAt);
 		phaseStartedAt = Date.now();
 		restoreActiveJobs(ctx);
 		logSlowPhase("active-job-restore", phaseStartedAt);
@@ -957,7 +973,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	let runtimeCleaned = false;
 	const runtimeEntry: SubagentRuntimeEntry = {
 		sessionManager: null,
-		visibleControlNotices,
 		cleanup() {
 			if (runtimeCleaned) return;
 			runtimeCleaned = true;
@@ -1025,13 +1040,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 		const sessionManager = ctx.sessionManager as object;
 		const previousRuntime = runtimeRegistry.bySessionManager.get(sessionManager);
-		const existingVisibleControlNotices = runtimeRegistry.visibleControlNoticesBySessionManager.get(sessionManager);
-		if (existingVisibleControlNotices) {
-			visibleControlNotices = existingVisibleControlNotices;
-		} else {
-			runtimeRegistry.visibleControlNoticesBySessionManager.set(sessionManager, visibleControlNotices);
-		}
-		runtimeEntry.visibleControlNotices = visibleControlNotices;
 		if (runtimeEntry.sessionManager && runtimeEntry.sessionManager !== sessionManager
 			&& runtimeRegistry.bySessionManager.get(runtimeEntry.sessionManager) === runtimeEntry) {
 			runtimeRegistry.bySessionManager.delete(runtimeEntry.sessionManager);
@@ -1085,6 +1093,16 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		rpcBridge.emitReady(ctx);
 		supervisorChannel.start();
 		supervisorChannel.activateTransport();
+	});
+
+	pi.on("session_tree", (_event, ctx) => {
+		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
+		state.lastUiContext = ctx;
+		// Journal entries win; the bounded index remains only for old sessions
+		// whose selected branch predates foreground-history entries.
+		rebuildSessionJournalState(ctx);
+		fleetStatus?.setContext(ctx);
+		fleetStatus?.refresh();
 	});
 
 	pi.on("session_shutdown", async () => {

--- a/src/extension/steering-notices.ts
+++ b/src/extension/steering-notices.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { appendSessionJournalEntry, type SessionJournalWriter } from "../shared/session-journal.ts";
 import type { SteeringNotice, SubagentState } from "../shared/types.ts";
 
 export const SUBAGENT_STEERING_MESSAGE_TYPE = "subagent_steering_notice";
@@ -18,18 +19,22 @@ export function formatSteeringNotice(details: Pick<SubagentSteeringMessageDetail
 	].join("\n");
 }
 
+type SteeringNoticePi = Pick<ExtensionAPI, "sendMessage"> & SessionJournalWriter;
+
 export function handleSubagentSteeringNotice(input: {
-	pi: Pick<ExtensionAPI, "sendMessage">;
+	pi: SteeringNoticePi;
 	state: SubagentState;
 	details: SubagentSteeringMessageDetails;
 }): void {
 	if (!input.details || (input.details.state !== "failed" && input.details.state !== "partial" && input.details.state !== "recovered")) return;
 	if (!input.state.currentSessionId || input.details.currentSessionId !== input.state.currentSessionId) return;
 	const noticeText = input.details.noticeText ?? formatSteeringNotice(input.details);
+	const journalDetails = { ...input.details, noticeText };
 	input.pi.sendMessage({
 		customType: SUBAGENT_STEERING_MESSAGE_TYPE,
 		content: noticeText,
 		display: true,
-		details: { ...input.details, noticeText },
+		details: journalDetails,
 	}, { triggerTurn: true });
+	appendSessionJournalEntry(input.pi, SUBAGENT_STEERING_MESSAGE_TYPE, journalDetails);
 }

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -4,14 +4,7 @@ import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import {
-	SUBAGENT_CHILD_AGENT_ENV,
-	SUBAGENT_CHILD_INDEX_ENV,
-	SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV,
-	SUBAGENT_ORCHESTRATOR_TARGET_ENV,
-	SUBAGENT_RUN_ID_ENV,
-	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
-} from "../runs/shared/pi-args.ts";
+import { readChildRuntimeConfigFromEnv, type ChildSupervisorConfig } from "../runs/shared/child-runtime-config.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type ControlEvent, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
 import { shouldUseNativeFsWatch } from "../shared/watch-strategy.ts";
@@ -124,37 +117,6 @@ function replyPath(channelDir: string, requestId: string): string {
 	return path.join(channelDir, REPLIES_DIR, `${safeSegment(requestId)}.json`);
 }
 
-function readTextEnv(name: string): string | undefined {
-	const value = process.env[name]?.trim();
-	return value ? value : undefined;
-}
-
-function readChildMetadata(): {
-	channelDir: string;
-	runId: string;
-	agent: string;
-	childIndex: number;
-	orchestratorTarget?: string;
-	orchestratorSessionId?: string;
-	childTarget?: string;
-} | undefined {
-	const channelDir = readTextEnv(SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV);
-	const runId = readTextEnv(SUBAGENT_RUN_ID_ENV);
-	const agent = readTextEnv(SUBAGENT_CHILD_AGENT_ENV);
-	const rawIndex = readTextEnv(SUBAGENT_CHILD_INDEX_ENV);
-	const orchestratorSessionId = readTextEnv(SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV);
-	if (!channelDir || !runId || !agent || !orchestratorSessionId || rawIndex === undefined || !/^\d+$/.test(rawIndex)) return undefined;
-	return {
-		channelDir,
-		runId,
-		agent,
-		childIndex: Number(rawIndex),
-		orchestratorTarget: readTextEnv(SUBAGENT_ORCHESTRATOR_TARGET_ENV),
-		orchestratorSessionId,
-		childTarget: readTextEnv("PI_SUBAGENT_INTERCOM_SESSION_NAME"),
-	};
-}
-
 function reasonHeading(reason: SupervisorReason): string {
 	if (reason === "interview_request") return "Subagent requests a structured supervisor interview.";
 	if (reason === "progress_update") return "Subagent progress update.";
@@ -242,9 +204,7 @@ async function waitForReply(channelDir: string, requestId: string, deadline: num
 	throw new Error("Timed out waiting for supervisor reply.");
 }
 
-async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: AbortSignal, toolCallId?: string): Promise<AgentToolResult<Record<string, unknown>>> {
-	const metadata = readChildMetadata();
-	if (!metadata) throw new Error("Native supervisor channel is not available for this subagent.");
+async function sendSupervisorRequest(params: ContactSupervisorParams, signal: AbortSignal | undefined, metadata: ChildSupervisorConfig, toolCallId?: string): Promise<AgentToolResult<Record<string, unknown>>> {
 	if (params.reason !== "progress_update" && !params.message?.trim() && params.reason !== "interview_request") {
 		throw new Error("message is required for supervisor decisions.");
 	}
@@ -310,15 +270,15 @@ function hasTool(pi: ExtensionAPI, name: string): boolean {
 	}
 }
 
-export function registerNativeSupervisorClient(pi: ExtensionAPI): void {
-	if (!readChildMetadata() || hasTool(pi, "contact_supervisor")) return;
+export function registerNativeSupervisorClient(pi: ExtensionAPI, metadata = readChildRuntimeConfigFromEnv(process.env).supervisor): void {
+	if (!metadata || hasTool(pi, "contact_supervisor")) return;
 	const tool: ToolDefinition<typeof ContactSupervisorParamsSchema, Record<string, unknown>> = {
 		name: "contact_supervisor",
 		label: "Contact Supervisor",
 		description: "Contact the parent/supervisor session for a blocking decision, structured interview, or progress update.",
 		parameters: ContactSupervisorParamsSchema,
 		execute(id, params, signal) {
-			return sendSupervisorRequest(params as ContactSupervisorParams, signal, id);
+			return sendSupervisorRequest(params as ContactSupervisorParams, signal, metadata, id);
 		},
 	};
 	pi.registerTool(tool);

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -16,6 +16,7 @@ import {
 } from "./completion-batcher.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, SUBAGENT_FOREGROUND_COMPLETE_EVENT, type ChildWatchdogProgress, type ChildWatchdogWarningSummary, type ParallelHandoffReference, type ScheduleOrigin, type SubagentState } from "../../shared/types.ts";
 import { safeTerminalText } from "../../shared/display-text.ts";
+import { appendSessionJournalEntry, type SessionJournalWriter } from "../../shared/session-journal.ts";
 import { resolveSubagentResultStatus } from "../../intercom/result-intercom.ts";
 import { isUnexplainedProcessSignal } from "../shared/process-signal.ts";
 import type { ResultDeliveryOwnership } from "./result-delivery-ownership.ts";
@@ -125,6 +126,8 @@ export interface CompletionNotifier {
 	deliver(result: CompletionNotification): Promise<boolean>;
 	dispose(): void;
 }
+
+export const SUBAGENT_NOTIFY_MESSAGE_TYPE = "subagent-notify";
 
 const CHILD_OUTPUT_PREVIEW_MAX_BYTES = 4 * 1024;
 const CHILD_OUTPUT_PREVIEW_COUNT = 8;
@@ -261,6 +264,9 @@ function formatWatchdogBlockerLines(details: SubagentNotifyDetails): string[] {
 	return [WATCHDOG_BLOCKERS_HEADING, ...details.watchdogBlockers.map((blocker) => `- ${blocker.agent}: ${blocker.summary} (${blocker.stalemate ? "stalemate" : blocker.addressed ? "addressed" : "unaddressed"})`)];
 }
 
+// Legacy-session fallback: new messages carry structured details and no longer
+// need markdown parsing. Keep this for historical custom_message entries that
+// predate journal-backed details.
 // A stalemate blocker parses back as unaddressed; acceptance treats both as unresolved.
 function parseWatchdogBlockerLines(lines: string[]): SubagentNotifyWatchdogBlocker[] {
 	const blockers: SubagentNotifyWatchdogBlocker[] = [];
@@ -298,6 +304,7 @@ export function formatSingleCompletion(details: SubagentNotifyDetails): string {
 		.join("\n");
 }
 
+/** Parse a legacy notification that was persisted without structured details. */
 export function parseSubagentNotifyContent(content: string): SubagentNotifyDetails | undefined {
 	const lines = content.split("\n");
 	const match = (lines[0] ?? "").match(/^(Background task|Detached foreground task) (completed|failed|paused|stopped): \*\*(.+?)\*\*(?:\s+(\([^)]*\)))?$/);
@@ -395,24 +402,33 @@ interface PendingCompletion {
 	resolve(accepted: boolean): void;
 }
 
-function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage">, items: PendingCompletion[]): boolean {
+function sendCompletion(pi: Pick<ExtensionAPI, "sendMessage"> & SessionJournalWriter, items: PendingCompletion[]): boolean {
 	if (items.length === 0) return true;
 	const details = items.map((item) => item.details);
 	const content = details.length === 1 ? formatSingleCompletion(details[0]!) : formatGroupedCompletion(details);
 	const display = details.some((detail) => detail.source === "foreground" || detail.status !== "completed" || detail.scheduleOrigin !== undefined);
+	const journalDetails = details.length === 1 ? details[0]! : details;
+	const message: {
+		customType: typeof SUBAGENT_NOTIFY_MESSAGE_TYPE;
+		content: string;
+		display: boolean;
+		details?: SubagentNotifyDetails | SubagentNotifyDetails[];
+	} = {
+		customType: SUBAGENT_NOTIFY_MESSAGE_TYPE,
+		content,
+		display,
+	};
+	if (typeof pi.appendEntry === "function") message.details = journalDetails;
 	try {
 		pi.sendMessage(
-			{
-				customType: "subagent-notify",
-				content,
-				display,
-			},
+			message,
 			{ triggerTurn: items.some((item) => item.triggerTurn) },
 		);
-		return true;
 	} catch {
 		return false;
 	}
+	appendSessionJournalEntry(pi, SUBAGENT_NOTIFY_MESSAGE_TYPE, journalDetails);
+	return true;
 }
 
 function completionBatchKey(result: CompletionNotification): string {

--- a/src/runs/foreground/foreground-history.ts
+++ b/src/runs/foreground/foreground-history.ts
@@ -3,10 +3,12 @@ import * as path from "node:path";
 import type { ForegroundResumeChild, ForegroundResumeRun, SubagentState } from "../../shared/types.ts";
 import { DIRS } from "../../shared/types.ts";
 import { writePrivateAtomicJson } from "../../shared/atomic-json.ts";
+import { appendSessionJournalEntry, readCustomJournalEntries, type SessionJournalEntry, type SessionJournalWriter } from "../../shared/session-journal.ts";
 import { utf8Tail } from "../../shared/utf8.ts";
 import { validateAcceptanceInput } from "../shared/acceptance.ts";
 
 export const MAX_REMEMBERED_FOREGROUND_RUNS = 50;
+export const FOREGROUND_RUN_HISTORY_ENTRY_TYPE = "subagent_foreground_run_history";
 const HISTORY_VERSION = 1;
 const MAX_INLINE_OUTPUT_BYTES = 64 * 1024;
 const MAX_RESUME_CONTRACT_BYTES = 64 * 1024;
@@ -131,7 +133,7 @@ function sortAndBound(runs: ForegroundResumeRun[], limit: number): ForegroundRes
 	return [...runs].sort((left, right) => right.updatedAt - left.updatedAt).slice(0, limit);
 }
 
-export function persistForegroundRunHistory(state: SubagentState, options: { resultsDir?: string; limit?: number } = {}): void {
+export function persistForegroundRunHistory(state: SubagentState, options: { resultsDir?: string; limit?: number; journal?: SessionJournalWriter; journalRun?: ForegroundResumeRun } = {}): void {
 	const resultsDir = options.resultsDir ?? DIRS.results;
 	const limit = options.limit ?? MAX_REMEMBERED_FOREGROUND_RUNS;
 	const existing = readIndex(resultsDir);
@@ -141,15 +143,22 @@ export function persistForegroundRunHistory(state: SubagentState, options: { res
 		if (compact) merged.set(compact.runId, compact);
 	}
 	const runs = sortAndBound([...merged.values()], limit);
+	const journalRun = options.journalRun ? compactRun(options.journalRun) : undefined;
+	if (journalRun && options.journal) appendSessionJournalEntry(options.journal, FOREGROUND_RUN_HISTORY_ENTRY_TYPE, journalRun);
 	writePrivateAtomicJson(historyPath(resultsDir), { version: HISTORY_VERSION, runs });
 }
 
-export function restoreForegroundRunHistory(state: SubagentState, options: { resultsDir?: string; sessionId?: string | null; limit?: number } = {}): number {
+export function restoreForegroundRunHistory(state: SubagentState, options: { resultsDir?: string; sessionId?: string | null; limit?: number; branchEntries?: readonly SessionJournalEntry[] } = {}): number {
 	const sessionId = options.sessionId ?? state.currentSessionId;
+	state.foregroundRuns = new Map();
 	if (!sessionId) return 0;
-	const index = readIndex(options.resultsDir ?? DIRS.results);
-	const runs = sortAndBound(index.runs.filter((run) => run.sessionId === sessionId), options.limit ?? MAX_REMEMBERED_FOREGROUND_RUNS);
-	state.foregroundRuns ??= new Map();
+	const journal = readCustomJournalEntries(options.branchEntries, FOREGROUND_RUN_HISTORY_ENTRY_TYPE);
+	const journalRunsById = new Map<string, ForegroundResumeRun>();
+	for (const run of journal.data) {
+		if (isRestorableRun(run)) journalRunsById.set(run.runId, run);
+	}
+	const sourceRuns = journal.present ? [...journalRunsById.values()] : readIndex(options.resultsDir ?? DIRS.results).runs;
+	const runs = sortAndBound(sourceRuns.filter((run) => run.sessionId === sessionId), options.limit ?? MAX_REMEMBERED_FOREGROUND_RUNS);
 	let restored = 0;
 	for (const run of runs) {
 		if (state.foregroundRuns.has(run.runId)) continue;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -6423,6 +6423,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				: undefined;
 			const forkContextResolver = createForkContextResolver(ctx.sessionManager, contextPolicy.usesFork ? "fork" : undefined, {
 				forceThinkingOffForIndex: (index) => forkThinkingRequirements.get(index) ?? true,
+				forkCwdForIndex: () => effectiveCwd,
 				...(pruneSession ? { pruneSession } : {}),
 			});
 			prepareForkSessionForIndex = forkContextResolver.prepareSessionForIndex;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -18,6 +18,7 @@ import {
 } from "./foreground-control.ts";
 import { getLivePromptAudit, rewritePromptWithGuidance, updateLiveEffectivePrompt } from "./prompt-audit.ts";
 import { persistForegroundRunHistory, MAX_REMEMBERED_FOREGROUND_RUNS } from "./foreground-history.ts";
+import type { SessionJournalWriter } from "../../shared/session-journal.ts";
 import { resolveExecutionAgentScope } from "../../agents/agent-scope.ts";
 import { handleManagementAction } from "../../agents/agent-management.ts";
 import { handleRefinementAction } from "../../agents/agent-refinements.ts";
@@ -684,9 +685,14 @@ function trimRememberedForegroundRuns(state: SubagentState): void {
 	}
 }
 
-function persistRememberedForegroundRuns(state: SubagentState): void {
+function persistRememberedForegroundRuns(state: SubagentState, options: { runId?: string; appendEntry?: SessionJournalWriter["appendEntry"] } = {}): void {
 	try {
-		persistForegroundRunHistory(state);
+		const journalRun = options.runId ? state.foregroundRuns?.get(options.runId) : undefined;
+		if (!options.appendEntry || !journalRun || journalRun.sessionId !== state.currentSessionId) {
+			persistForegroundRunHistory(state);
+			return;
+		}
+		persistForegroundRunHistory(state, { journal: { appendEntry: options.appendEntry }, journalRun });
 	} catch (error) {
 		console.error("Failed to persist foreground run history:", error);
 	}
@@ -707,7 +713,7 @@ function foregroundChildActivityFromProgress(progress: SingleResult["progress"] 
 	};
 }
 
-function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; results: SingleResult[]; params: SubagentParamsLike; effectiveOutput?: string | boolean; effectiveOutputMode: OutputMode; extensionBindings?: ExtensionBindings }): void {
+function rememberForegroundRun(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; results: SingleResult[]; params: SubagentParamsLike; effectiveOutput?: string | boolean; effectiveOutputMode: OutputMode; extensionBindings?: ExtensionBindings; appendEntry?: SessionJournalWriter["appendEntry"] }): void {
 	state.foregroundRuns ??= new Map();
 	const previous = state.foregroundRuns.get(input.runId);
 	const updatedAt = Date.now();
@@ -769,7 +775,7 @@ function rememberForegroundRun(state: SubagentState, input: { runId: string; mod
 		}),
 	});
 	trimRememberedForegroundRuns(state);
-	persistRememberedForegroundRuns(state);
+	persistRememberedForegroundRuns(state, { runId: input.runId, appendEntry: input.appendEntry });
 }
 
 function applyControlEventToRememberedForegroundRun(state: SubagentState, event: ControlEvent): void {
@@ -795,7 +801,7 @@ function applyControlEventToRememberedForegroundRun(state: SubagentState, event:
 	};
 }
 
-function updateRememberedForegroundChild(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; index: number; result: SingleResult; events: IntercomEventBus; notify?: boolean }): void {
+function updateRememberedForegroundChild(state: SubagentState, input: { runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; index: number; result: SingleResult; events: IntercomEventBus; notify?: boolean; appendEntry?: SessionJournalWriter["appendEntry"] }): void {
 	state.foregroundRuns ??= new Map();
 	const updatedAt = Date.now();
 	let run = state.foregroundRuns.get(input.runId);
@@ -845,7 +851,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 		...(input.result.capabilityAudit ? { capabilityAudit: input.result.capabilityAudit } : {}),
 	});
 	trimRememberedForegroundRuns(state);
-	persistRememberedForegroundRuns(state);
+	persistRememberedForegroundRuns(state, { runId: input.runId, appendEntry: input.appendEntry });
 	const output = getSingleResultOutput(input.result).trim();
 	const success = terminalStatus === "completed";
 	const summary = !success && input.result.error
@@ -3844,7 +3850,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 						finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result, workflowKey: params.workflowKey, lane });
 					}
 					try {
-						updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events, notify: true });
+						updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events, notify: true, appendEntry: (customType, entry) => deps.pi.appendEntry(customType, entry) });
 					} catch {
 						// Remembered foreground state is best-effort; run history and cleanup must still complete.
 					}
@@ -3939,7 +3945,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		usageBudget: usageBudgetState(data.usageBudget, totalCost),
 		...(worktreeHandoff?.reference ? { parallelHandoff: worktreeHandoff.reference } : {}),
 	}));
-	rememberForegroundRun(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, results: details.results, params, effectiveOutput, effectiveOutputMode, extensionBindings: params.extensionBindings });
+	rememberForegroundRun(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, results: details.results, params, effectiveOutput, effectiveOutputMode, extensionBindings: params.extensionBindings, appendEntry: (customType, entry) => deps.pi.appendEntry(customType, entry) });
 
 	const suppressRoutineResultIntercom = shouldSuppressRoutineResultIntercom({ suppressRoutineResultIntercom: params.suppressRoutineResultIntercom, results: [r] });
 	if (!r.detached && !r.interrupted && !suppressRoutineResultIntercom) {

--- a/src/runs/shared/child-hooks.ts
+++ b/src/runs/shared/child-hooks.ts
@@ -1,0 +1,32 @@
+import type { ExtensionAPI, InlineExtension } from "@earendil-works/pi-coding-agent";
+import { registerFanoutChildSubagentExtensionWithConfig } from "../../extension/fanout-child.ts";
+import { registerSubagentFastModeExtensionWithConfig } from "./fast-mode-extension.ts";
+import { registerSubagentPromptRuntimeWithConfig } from "./subagent-prompt-runtime.ts";
+import type { ChildRuntimeConfig } from "./child-runtime-config.ts";
+
+export const CHILD_PROMPT_RUNTIME_HOOK = "pi-subagents.child.prompt-runtime";
+export const CHILD_FAST_MODE_HOOK = "pi-subagents.child.fast-mode";
+export const CHILD_FANOUT_HOOK = "pi-subagents.child.fanout";
+
+/** Build child extension factories from an explicit runtime configuration. */
+export function createChildHooks(config: ChildRuntimeConfig): InlineExtension[] {
+	const hooks: InlineExtension[] = [
+		{
+			name: CHILD_PROMPT_RUNTIME_HOOK,
+			factory: (pi: ExtensionAPI) => registerSubagentPromptRuntimeWithConfig(pi, config),
+		},
+	];
+	if (config.fastMode === true) {
+		hooks.push({
+			name: CHILD_FAST_MODE_HOOK,
+			factory: (pi: ExtensionAPI) => registerSubagentFastModeExtensionWithConfig(pi, config),
+		});
+	}
+	if (config.child && config.fanoutChild) {
+		hooks.push({
+			name: CHILD_FANOUT_HOOK,
+			factory: (pi: ExtensionAPI) => registerFanoutChildSubagentExtensionWithConfig(pi, config),
+		});
+	}
+	return hooks;
+}

--- a/src/runs/shared/child-runtime-config.ts
+++ b/src/runs/shared/child-runtime-config.ts
@@ -1,0 +1,297 @@
+import {
+	SUBAGENT_CHILD_AGENT_ENV,
+	SUBAGENT_CHILD_ENV,
+	SUBAGENT_CHILD_INDEX_ENV,
+	SUBAGENT_FANOUT_CHILD_ENV,
+	SUBAGENT_FORK_CACHE_KEY_ENV,
+	SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV,
+	SUBAGENT_ORCHESTRATOR_TARGET_ENV,
+	SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV,
+	SUBAGENT_PARENT_CHILD_INDEX_ENV,
+	SUBAGENT_PARENT_CONTROL_INBOX_ENV,
+	SUBAGENT_PARENT_DEPTH_ENV,
+	SUBAGENT_PARENT_EVENT_SINK_ENV,
+	SUBAGENT_PARENT_PATH_ENV,
+	SUBAGENT_PARENT_ROOT_RUN_ID_ENV,
+	SUBAGENT_PARENT_RUN_ID_ENV,
+	SUBAGENT_PARENT_SESSION_ENV,
+	SUBAGENT_RUN_ID_ENV,
+	SUBAGENT_STEER_ACK_DIR_ENV,
+	SUBAGENT_STEER_CAPABILITY_ENV,
+	SUBAGENT_STEER_INBOX_ENV,
+	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
+} from "./pi-args.ts";
+import { decodeSubagentCapabilityCeiling, SUBAGENT_CAPABILITY_CEILING_ENV, type ResolvedSubagentCapabilityCeiling } from "./capability-ceiling.ts";
+import { parseNestedPathEnv, type NestedPathEntry } from "./nested-path.ts";
+import { decodePermissionRules, PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV, type PermissionRules } from "./permissions.ts";
+import { decodeRunFanoutBudgetDescriptor, RUN_FANOUT_BUDGET_ENV } from "./run-fanout-budget.ts";
+import { RUNTIME_EXTENSION_ACK_PATH_ENV } from "./runtime-acknowledged-extensions.ts";
+import { decodeThinkingCeiling, SUBAGENT_THINKING_CEILING_ENV, type ThinkingLevel } from "../../shared/thinking-ceiling.ts";
+import { DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN, DEFAULT_SUBAGENT_MAX_DEPTH, normalizeMaxSubagentDepth, normalizeMaxSubagentSpawnsPerRun, normalizeMaxSubagentSpawnsPerSession, type ResolvedToolBudget, type RunFanoutBudgetDescriptor } from "../../shared/types.ts";
+import { decodeChildWatchdogConfig, CHILD_WATCHDOG_CONFIG_ENV, type ChildWatchdogConfig } from "../../watchdog/child-status.ts";
+import { resolveWaitToolConfig, WAIT_TOOL_DEFAULT_TIMEOUT_MS_ENV, WAIT_TOOL_ENABLED_ENV, type ResolvedWaitToolConfig } from "../background/wait-config.ts";
+import { decodeToolBudgetEnv, TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV } from "./tool-budget.ts";
+import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, MCP_DIRECT_CHILD_TOOLS_ENV, REQUIRED_CHILD_TOOLS_ENV } from "./tool-availability.ts";
+import { STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV, STRUCTURED_OUTPUT_ACCEPTANCE_REQUIRED_ENV, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "./structured-output.ts";
+
+/** Child environment names without shared constants. */
+export const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
+export const SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_GLOBAL_CONTEXT";
+export const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
+export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
+export const SUBAGENT_SESSION_NAME_ENV = "PI_SUBAGENT_SESSION_NAME";
+export const SUBAGENT_DEPTH_ENV = "PI_SUBAGENT_DEPTH";
+export const SUBAGENT_MAX_DEPTH_ENV = "PI_SUBAGENT_MAX_DEPTH";
+export const SUBAGENT_MAX_SPAWNS_PER_SESSION_ENV = "PI_SUBAGENT_MAX_SPAWNS_PER_SESSION";
+export const SUBAGENT_MAX_SPAWNS_PER_RUN_ENV = "PI_SUBAGENT_MAX_SPAWNS_PER_RUN";
+export const SUBAGENT_TOOL_TIMEOUT_ENV = "PI_SUBAGENT_TOOL_TIMEOUT_MS";
+export const SUBAGENT_FS_RETRY_MAX_TOTAL_MS_ENV = "PI_SUBAGENT_FS_RETRY_MAX_TOTAL_MS";
+export const SUBAGENT_PI_BINARY_ENV = "PI_SUBAGENT_PI_BINARY";
+export const SUBAGENT_EXTRA_AGENT_DIRS_ENV = "PI_SUBAGENT_EXTRA_AGENT_DIRS";
+export const SUBAGENT_ASYNC_EVENTS_MAX_BYTES_ENV = "PI_SUBAGENT_ASYNC_EVENTS_MAX_BYTES";
+
+export interface ChildSupervisorConfig {
+	channelDir: string;
+	runId: string;
+	agent: string;
+	childIndex: number;
+	orchestratorTarget?: string;
+	orchestratorSessionId: string;
+	childTarget?: string;
+}
+
+export interface ChildNestedRouteConfig {
+	rootRunId: string;
+	eventSink: string;
+	controlInbox: string;
+	capabilityToken: string;
+}
+
+export interface ChildRuntimeConfig {
+	/** True only for a process launched as a pi-subagents child. */
+	child: boolean;
+	/** True only when this child is authorized to register the fanout tool. */
+	fanoutChild: boolean;
+	/** Prompt-boundary compatibility for the historical non-strict boolean decoder. */
+	fanoutPromptBoundary: boolean | undefined;
+	/** Set by an inline-session caller; it is not represented by an environment variable. */
+	fastMode?: boolean;
+
+	// Identity and routing.
+	orchestratorTarget?: string;
+	orchestratorSessionId?: string;
+	runId?: string;
+	childAgent?: string;
+	childIndex?: number;
+	intercomSessionName?: string;
+	sessionName?: string;
+	supervisor?: ChildSupervisorConfig;
+
+	// Inherited parent/nested routing.
+	parentEventSink?: string;
+	parentControlInbox?: string;
+	parentRootRunId?: string;
+	parentRunId?: string;
+	parentChildIndex?: number;
+	parentDepth?: number;
+	parentPath: NestedPathEntry[];
+	parentCapabilityToken?: string;
+	parentSession?: string;
+	nestedRoute?: ChildNestedRouteConfig;
+
+	// Context and child hooks.
+	inheritProjectContext?: boolean;
+	inheritGlobalContext?: boolean;
+	inheritSkills?: boolean;
+	forkCacheKey?: string;
+	steerInbox?: string;
+	steerCapabilityPath?: string;
+	steerAckDir?: string;
+	runtimeAcknowledgementPath?: string;
+	permissionRules?: PermissionRules;
+	permissionAuditPath?: string;
+	childWatchdog?: ChildWatchdogConfig;
+	childWatchdogRaw?: string;
+	toolBudget?: ResolvedToolBudget;
+	allowZeroToolBudget: boolean;
+	waitTool: ResolvedWaitToolConfig;
+	waitToolEnabledEnv?: string;
+	waitToolDefaultTimeoutMsEnv?: string;
+	requiredChildTools?: string[];
+	mcpDirectChildTools?: string[];
+	childToolDiagnosticPath?: string;
+	structuredOutputCapturePath?: string;
+	structuredOutputSchemaPath?: string;
+	structuredOutputAcceptanceCapturePath?: string;
+	structuredOutputAcceptanceRequired: boolean;
+
+	// Limits inherited by nested children.
+	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	thinkingCeiling?: ThinkingLevel;
+	runFanoutBudget?: RunFanoutBudgetDescriptor;
+	depth: number;
+	maxDepth: number;
+	maxSpawnsPerSession?: number;
+	maxSpawnsPerRun: number;
+	toolTimeoutMs?: string;
+	fsRetryMaxTotalMs?: number;
+
+	// Values retained for nested launch compatibility.
+	piBinary?: string;
+	extraAgentDirs?: string;
+	asyncEventsMaxBytes?: string;
+}
+
+function readText(env: NodeJS.ProcessEnv, name: string): string | undefined {
+	const value = env[name]?.trim();
+	return value ? value : undefined;
+}
+
+function readBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
+	const value = env[name];
+	if (value === undefined) return undefined;
+	return value !== "0";
+}
+
+function readNonNegativeIndex(env: NodeJS.ProcessEnv, name: string): number | undefined {
+	const value = readText(env, name);
+	return value !== undefined && /^\d+$/.test(value) ? Number(value) : undefined;
+}
+
+function readFiniteNumber(env: NodeJS.ProcessEnv, name: string, fallback: number): number {
+	const value = Number(env[name] ?? String(fallback));
+	return Number.isFinite(value) ? value : Number.NaN;
+}
+
+function readRequiredChildTools(env: NodeJS.ProcessEnv): string[] | undefined {
+	const encoded = env[REQUIRED_CHILD_TOOLS_ENV]?.trim();
+	if (!encoded) return undefined;
+	const required = JSON.parse(encoded) as unknown;
+	if (!Array.isArray(required) || required.some((name) => typeof name !== "string" || !name)) {
+		throw new Error(`Invalid ${REQUIRED_CHILD_TOOLS_ENV} payload.`);
+	}
+	return required;
+}
+
+function readMcpDirectChildTools(env: NodeJS.ProcessEnv): string[] | undefined {
+	const encoded = env[MCP_DIRECT_CHILD_TOOLS_ENV]?.trim();
+	if (!encoded) return undefined;
+	try {
+		const tools = JSON.parse(encoded) as unknown;
+		if (!Array.isArray(tools) || tools.some((name) => typeof name !== "string" || !name)) return undefined;
+		return tools;
+	} catch {
+		return undefined;
+	}
+}
+
+function readSupervisor(env: NodeJS.ProcessEnv): ChildSupervisorConfig | undefined {
+	const channelDir = readText(env, SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV);
+	const runId = readText(env, SUBAGENT_RUN_ID_ENV);
+	const agent = readText(env, SUBAGENT_CHILD_AGENT_ENV);
+	const orchestratorSessionId = readText(env, SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV);
+	const childIndex = readNonNegativeIndex(env, SUBAGENT_CHILD_INDEX_ENV);
+	if (!channelDir || !runId || !agent || !orchestratorSessionId || childIndex === undefined) return undefined;
+	return {
+		channelDir,
+		runId,
+		agent,
+		childIndex,
+		orchestratorTarget: readText(env, SUBAGENT_ORCHESTRATOR_TARGET_ENV),
+		orchestratorSessionId,
+		childTarget: readText(env, SUBAGENT_INTERCOM_SESSION_NAME_ENV),
+	};
+}
+
+function readNestedRoute(env: NodeJS.ProcessEnv): ChildNestedRouteConfig | undefined {
+	const rootRunId = readText(env, SUBAGENT_PARENT_ROOT_RUN_ID_ENV);
+	const eventSink = readText(env, SUBAGENT_PARENT_EVENT_SINK_ENV);
+	const controlInbox = readText(env, SUBAGENT_PARENT_CONTROL_INBOX_ENV);
+	const capabilityToken = readText(env, SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV);
+	return rootRunId && eventSink && controlInbox && capabilityToken
+		? { rootRunId, eventSink, controlInbox, capabilityToken }
+		: undefined;
+}
+
+function readFsRetryMaxTotalMs(env: NodeJS.ProcessEnv): number | undefined {
+	const raw = env[SUBAGENT_FS_RETRY_MAX_TOTAL_MS_ENV];
+	if (raw === undefined || raw.trim() === "") return undefined;
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value < 0) {
+		throw new Error(`${SUBAGENT_FS_RETRY_MAX_TOTAL_MS_ENV} must be a non-negative integer number of milliseconds.`);
+	}
+	return value;
+}
+
+/**
+ * Decode the child process contract once. The returned object is deliberately
+ * free of process.env access so the same hook factories can be hosted by an
+ * in-process AgentSession later.
+ */
+export function readChildRuntimeConfigFromEnv(env: NodeJS.ProcessEnv): ChildRuntimeConfig {
+	const child = env[SUBAGENT_CHILD_ENV] === "1";
+	const fanoutChild = env[SUBAGENT_FANOUT_CHILD_ENV] === "1";
+	const capabilityCeiling = fanoutChild ? decodeSubagentCapabilityCeiling(env[SUBAGENT_CAPABILITY_CEILING_ENV]) : undefined;
+	const thinkingCeiling = fanoutChild ? decodeThinkingCeiling(env[SUBAGENT_THINKING_CEILING_ENV]) : undefined;
+	const runFanoutBudget = fanoutChild ? decodeRunFanoutBudgetDescriptor(env[RUN_FANOUT_BUDGET_ENV]) : undefined;
+	const maxDepth = normalizeMaxSubagentDepth(env[SUBAGENT_MAX_DEPTH_ENV]) ?? DEFAULT_SUBAGENT_MAX_DEPTH;
+	return {
+		child,
+		fanoutChild,
+		fanoutPromptBoundary: readBoolean(env, SUBAGENT_FANOUT_CHILD_ENV),
+		orchestratorTarget: readText(env, SUBAGENT_ORCHESTRATOR_TARGET_ENV),
+		orchestratorSessionId: readText(env, SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV),
+		runId: readText(env, SUBAGENT_RUN_ID_ENV),
+		childAgent: readText(env, SUBAGENT_CHILD_AGENT_ENV),
+		childIndex: readNonNegativeIndex(env, SUBAGENT_CHILD_INDEX_ENV),
+		intercomSessionName: readText(env, SUBAGENT_INTERCOM_SESSION_NAME_ENV),
+		sessionName: readText(env, SUBAGENT_SESSION_NAME_ENV),
+		supervisor: readSupervisor(env),
+		parentEventSink: readText(env, SUBAGENT_PARENT_EVENT_SINK_ENV),
+		parentControlInbox: readText(env, SUBAGENT_PARENT_CONTROL_INBOX_ENV),
+		parentRootRunId: readText(env, SUBAGENT_PARENT_ROOT_RUN_ID_ENV),
+		parentRunId: readText(env, SUBAGENT_PARENT_RUN_ID_ENV),
+		parentChildIndex: readNonNegativeIndex(env, SUBAGENT_PARENT_CHILD_INDEX_ENV),
+		parentDepth: readFiniteNumber(env, SUBAGENT_PARENT_DEPTH_ENV, 0),
+		parentPath: parseNestedPathEnv(env[SUBAGENT_PARENT_PATH_ENV]),
+		parentCapabilityToken: readText(env, SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV),
+		parentSession: readText(env, SUBAGENT_PARENT_SESSION_ENV),
+		nestedRoute: readNestedRoute(env),
+		inheritProjectContext: readBoolean(env, SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV),
+		inheritGlobalContext: readBoolean(env, SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV),
+		inheritSkills: readBoolean(env, SUBAGENT_INHERIT_SKILLS_ENV),
+		forkCacheKey: readText(env, SUBAGENT_FORK_CACHE_KEY_ENV),
+		steerInbox: readText(env, SUBAGENT_STEER_INBOX_ENV),
+		steerCapabilityPath: readText(env, SUBAGENT_STEER_CAPABILITY_ENV),
+		steerAckDir: readText(env, SUBAGENT_STEER_ACK_DIR_ENV),
+		runtimeAcknowledgementPath: readText(env, RUNTIME_EXTENSION_ACK_PATH_ENV),
+		permissionRules: decodePermissionRules(env[PERMISSION_POLICY_ENV]),
+		permissionAuditPath: env[PERMISSION_AUDIT_PATH_ENV],
+		childWatchdog: decodeChildWatchdogConfig(env[CHILD_WATCHDOG_CONFIG_ENV]),
+		childWatchdogRaw: env[CHILD_WATCHDOG_CONFIG_ENV],
+		toolBudget: decodeToolBudgetEnv(env[TOOL_BUDGET_ENV], { allowZero: env[TOOL_BUDGET_ZERO_AUTH_ENV] === "1" }),
+		allowZeroToolBudget: env[TOOL_BUDGET_ZERO_AUTH_ENV] === "1",
+		waitTool: resolveWaitToolConfig(undefined, env),
+		waitToolEnabledEnv: env[WAIT_TOOL_ENABLED_ENV],
+		waitToolDefaultTimeoutMsEnv: env[WAIT_TOOL_DEFAULT_TIMEOUT_MS_ENV],
+		requiredChildTools: readRequiredChildTools(env),
+		mcpDirectChildTools: readMcpDirectChildTools(env),
+		childToolDiagnosticPath: readText(env, CHILD_TOOL_DIAGNOSTIC_PATH_ENV),
+		structuredOutputCapturePath: env[STRUCTURED_OUTPUT_CAPTURE_ENV],
+		structuredOutputSchemaPath: env[STRUCTURED_OUTPUT_SCHEMA_ENV],
+		structuredOutputAcceptanceCapturePath: env[STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV],
+		structuredOutputAcceptanceRequired: env[STRUCTURED_OUTPUT_ACCEPTANCE_REQUIRED_ENV] === "1",
+		capabilityCeiling,
+		thinkingCeiling,
+		runFanoutBudget,
+		depth: readFiniteNumber(env, SUBAGENT_DEPTH_ENV, 0),
+		maxDepth,
+		maxSpawnsPerSession: normalizeMaxSubagentSpawnsPerSession(env[SUBAGENT_MAX_SPAWNS_PER_SESSION_ENV]),
+		maxSpawnsPerRun: normalizeMaxSubagentSpawnsPerRun(env[SUBAGENT_MAX_SPAWNS_PER_RUN_ENV]) ?? DEFAULT_MAX_SUBAGENT_SPAWNS_PER_RUN,
+		toolTimeoutMs: env[SUBAGENT_TOOL_TIMEOUT_ENV],
+		fsRetryMaxTotalMs: readFsRetryMaxTotalMs(env),
+		piBinary: readText(env, SUBAGENT_PI_BINARY_ENV),
+		extraAgentDirs: env[SUBAGENT_EXTRA_AGENT_DIRS_ENV],
+		asyncEventsMaxBytes: env[SUBAGENT_ASYNC_EVENTS_MAX_BYTES_ENV],
+	};
+}

--- a/src/runs/shared/fast-mode-extension.ts
+++ b/src/runs/shared/fast-mode-extension.ts
@@ -1,10 +1,15 @@
 import type { BeforeProviderRequestEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readChildRuntimeConfigFromEnv, type ChildRuntimeConfig } from "./child-runtime-config.ts";
 
 export function rewriteFastModeProviderRequest(event: BeforeProviderRequestEvent): unknown {
 	if (!event.payload || typeof event.payload !== "object" || Array.isArray(event.payload)) return event.payload;
 	return { ...event.payload, service_tier: "priority" };
 }
 
-export default function registerSubagentFastModeExtension(pi: ExtensionAPI): void {
+export function registerSubagentFastModeExtensionWithConfig(pi: ExtensionAPI, _config: ChildRuntimeConfig): void {
 	pi.on("before_provider_request", rewriteFastModeProviderRequest);
+}
+
+export default function registerSubagentFastModeExtension(pi: ExtensionAPI): void {
+	registerSubagentFastModeExtensionWithConfig(pi, { ...readChildRuntimeConfigFromEnv(process.env), fastMode: true });
 }

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -4,38 +4,30 @@ import * as path from "node:path";
 import type { BeforeProviderRequestEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { registerNativeSupervisorClient } from "../../intercom/native-supervisor-channel.ts";
 import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
-import { decodePermissionRules, permissionDecision, PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "./permissions.ts";
+import { permissionDecision } from "./permissions.ts";
 import { consumeSteerRequestsFromDir, MAX_STEER_QUEUE_SIZE, steerAckPathFromDir, writeSteerAckAt, writeSteerCapabilityAt, writeSteerRequestToDir, type SteerDeliveryStatus, type SteerRequest } from "../background/control-channel.ts";
-import { SUBAGENT_CHILD_AGENT_ENV, SUBAGENT_CHILD_INDEX_ENV, SUBAGENT_FANOUT_CHILD_ENV, SUBAGENT_FORK_CACHE_KEY_ENV, SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV, SUBAGENT_STEER_ACK_DIR_ENV, SUBAGENT_STEER_CAPABILITY_ENV, SUBAGENT_STEER_INBOX_ENV } from "./pi-args.ts";
-import { RUNTIME_EXTENSION_ACK_EVENT, RUNTIME_EXTENSION_ACK_PATH_ENV, isRuntimeAcknowledgedExtensionId, writeRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
-import { createStructuredOutputToolParameters, MISSING_STRUCTURED_ACCEPTANCE_REPORT_ERROR, STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV, STRUCTURED_OUTPUT_ACCEPTANCE_REQUIRED_ENV, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV, validateStructuredOutputValue } from "./structured-output.ts";
+import { readChildRuntimeConfigFromEnv, type ChildRuntimeConfig } from "./child-runtime-config.ts";
+import { RUNTIME_EXTENSION_ACK_EVENT, isRuntimeAcknowledgedExtensionId, writeRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
+import { createStructuredOutputToolParameters, MISSING_STRUCTURED_ACCEPTANCE_REPORT_ERROR, validateStructuredOutputValue } from "./structured-output.ts";
 import { validateAcceptanceReport } from "./acceptance.ts";
 import {
-	CHILD_TOOL_DIAGNOSTIC_PATH_ENV,
 	formatChildToolDiagnostic,
-	MCP_DIRECT_CHILD_TOOLS_ENV,
-	REQUIRED_CHILD_TOOLS_ENV,
 	writeChildToolDiagnostic,
 	type ChildToolDiagnostic,
 } from "./tool-availability.ts";
-import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV, decodeToolBudgetEnv, shouldBlockToolForBudget, toolBudgetBlockedMessage, toolBudgetSoftNudge } from "./tool-budget.ts";
+import { shouldBlockToolForBudget, toolBudgetBlockedMessage, toolBudgetSoftNudge } from "./tool-budget.ts";
 import type { JsonSchemaObject, ResolvedToolBudget, SubagentState } from "../../shared/types.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { getAgentDir, resolveWatchPath } from "../../shared/utils.ts";
 import { registerChildWatchdog } from "../../watchdog/register-child.ts";
-import { CHILD_WATCHDOG_CONFIG_ENV, decodeChildWatchdogConfig } from "../../watchdog/child-status.ts";
 import { requestWatchdogPermission, type WatchdogPermissionRequest, type WatchdogPermissionResult } from "../../watchdog/permission-arbiter.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../watchdog/types.ts";
-import { resolveWaitToolConfig } from "../background/wait-config.ts";
 import { registerWaitTool } from "../background/wait-tool.ts";
 import { drainOutstandingWork } from "../background/auto-drain.ts";
 
-const SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV = "PI_SUBAGENT_INHERIT_PROJECT_CONTEXT";
-const SUBAGENT_INHERIT_SKILLS_ENV = "PI_SUBAGENT_INHERIT_SKILLS";
-export const SUBAGENT_INTERCOM_SESSION_NAME_ENV = "PI_SUBAGENT_INTERCOM_SESSION_NAME";
+export { SUBAGENT_INTERCOM_SESSION_NAME_ENV, SUBAGENT_SESSION_NAME_ENV } from "./child-runtime-config.ts";
 /** Human-readable child display name (agent + task excerpt) set by the parent
  *  at launch; applied via pi.setSessionName when no intercom target exists. */
-export const SUBAGENT_SESSION_NAME_ENV = "PI_SUBAGENT_SESSION_NAME";
 const STEERING_LEGACY_SETTLE_FALLBACK_MS = 1000;
 const STEERING_SAFETY_POLL_INTERVAL_MS = 5000;
 
@@ -77,44 +69,16 @@ const PROJECT_CONTEXT_LEGACY_HEADER = "\n\n# Project Context\n\nProject-specific
 const SKILLS_HEADER = "\n\nThe following skills provide specialized instructions for specific tasks.";
 const DATE_HEADER = "\nCurrent date:";
 
-function readBooleanEnv(name: string): boolean | undefined {
-	const value = process.env[name];
-	if (value === undefined) return undefined;
-	return value !== "0";
-}
-
-function readRequiredChildTools(): string[] | undefined {
-	const encoded = process.env[REQUIRED_CHILD_TOOLS_ENV]?.trim();
-	if (!encoded) return undefined;
-	const required = JSON.parse(encoded) as unknown;
-	if (!Array.isArray(required) || required.some((name) => typeof name !== "string" || !name)) {
-		throw new Error(`Invalid ${REQUIRED_CHILD_TOOLS_ENV} payload.`);
-	}
-	return required;
-}
-
-function readMcpDirectChildTools(): string[] | undefined {
-	const encoded = process.env[MCP_DIRECT_CHILD_TOOLS_ENV]?.trim();
-	if (!encoded) return undefined;
-	try {
-		const tools = JSON.parse(encoded) as unknown;
-		if (!Array.isArray(tools) || tools.some((name) => typeof name !== "string" || !name)) return undefined;
-		return tools;
-	} catch {
-		return undefined;
-	}
-}
-
-function refreshChildToolDiagnostic(pi: ExtensionAPI): ChildToolDiagnostic | undefined {
-	const filePath = process.env[CHILD_TOOL_DIAGNOSTIC_PATH_ENV]?.trim();
-	const required = readRequiredChildTools();
+function refreshChildToolDiagnostic(pi: ExtensionAPI, config: ChildRuntimeConfig): ChildToolDiagnostic | undefined {
+	const filePath = config.childToolDiagnosticPath;
+	const required = config.requiredChildTools;
 	if (!filePath || !required) return undefined;
 	const available = pi.getAllTools().map((tool) => tool.name);
-	return writeChildToolDiagnostic(filePath, required, available, process.env[SUBAGENT_CHILD_AGENT_ENV]?.trim(), readMcpDirectChildTools());
+	return writeChildToolDiagnostic(filePath, required, available, config.childAgent, config.mcpDirectChildTools);
 }
 
-function registerRuntimeExtensionAcknowledgements(pi: ExtensionAPI): void {
-	const outputPath = process.env[RUNTIME_EXTENSION_ACK_PATH_ENV]?.trim();
+function registerRuntimeExtensionAcknowledgements(pi: ExtensionAPI, config: ChildRuntimeConfig): void {
+	const outputPath = config.runtimeAcknowledgementPath;
 	if (!outputPath) return;
 	const ids: string[] = [];
 	let finalized = false;
@@ -252,7 +216,7 @@ function stripChildBoundaryInstructions(prompt: string): string {
 
 export function rewriteSubagentPrompt(
 	prompt: string,
-	options: { inheritProjectContext: boolean; inheritGlobalContext: boolean; inheritSkills: boolean; fanoutChild?: boolean },
+	options: { inheritProjectContext: boolean; inheritGlobalContext: boolean; inheritSkills: boolean; fanoutChild?: boolean; structuredOutputCapture?: boolean },
 ): string {
 	let rewritten = prompt;
 	if (!options.inheritProjectContext) {
@@ -267,7 +231,9 @@ export function rewriteSubagentPrompt(
 	rewritten = stripSubagentOrchestrationSkill(rewritten);
 	rewritten = stripChildBoundaryInstructions(rewritten);
 	const boundary = options.fanoutChild ? CHILD_FANOUT_BOUNDARY_INSTRUCTIONS : CHILD_SUBAGENT_BOUNDARY_INSTRUCTIONS;
-	const structured = process.env[STRUCTURED_OUTPUT_CAPTURE_ENV] ? `\n\n${STRUCTURED_OUTPUT_INSTRUCTIONS}` : "";
+	const structuredOutputCapture = options.structuredOutputCapture
+		?? Boolean(readChildRuntimeConfigFromEnv(process.env).structuredOutputCapturePath);
+	const structured = structuredOutputCapture ? `\n\n${STRUCTURED_OUTPUT_INSTRUCTIONS}` : "";
 	return `${boundary}${structured}\n\n${rewritten}`;
 }
 
@@ -303,8 +269,8 @@ const PROMPT_CACHE_KEY_APIS = new Set([
 	"openai-responses",
 ]);
 
-export function rewriteForkCacheProviderRequest(event: BeforeProviderRequestEvent, ctx?: Pick<ExtensionContext, "model">): unknown {
-	const forkCacheKey = process.env[SUBAGENT_FORK_CACHE_KEY_ENV]?.trim();
+export function rewriteForkCacheProviderRequest(event: BeforeProviderRequestEvent, ctx?: Pick<ExtensionContext, "model">, configuredForkCacheKey?: string): unknown {
+	const forkCacheKey = configuredForkCacheKey ?? readChildRuntimeConfigFromEnv(process.env).forkCacheKey;
 	if (!forkCacheKey || !PROMPT_CACHE_KEY_APIS.has(ctx?.model?.api ?? "")) return undefined;
 	if (!event || typeof event !== "object") return undefined;
 	const payload = event.payload;
@@ -348,8 +314,8 @@ function stripAssistantSubagentToolCallBlocks(message: unknown): unknown | undef
 	return { ...m, content: filteredContent };
 }
 
-export function stripParentOnlySubagentMessages(messages: unknown[], options: { sanitizeToolIds?: boolean } = {}): unknown[] {
-	const preserveCurrentFanoutToolHistory = process.env[SUBAGENT_FANOUT_CHILD_ENV] === "1";
+export function stripParentOnlySubagentMessages(messages: unknown[], options: { sanitizeToolIds?: boolean; fanoutChild?: boolean } = {}): unknown[] {
+	const preserveCurrentFanoutToolHistory = options.fanoutChild ?? readChildRuntimeConfigFromEnv(process.env).fanoutChild;
 	const sanitizeToolIds = options.sanitizeToolIds ?? true;
 	let changed = false;
 	const filtered: unknown[] = [];
@@ -380,11 +346,12 @@ export function formatSteerMessage(request: SteerRequest): string {
 	].join("\n");
 }
 
-export function registerPermissionGate(
+function registerPermissionGateWithConfig(
 	pi: ExtensionAPI,
+	config: ChildRuntimeConfig,
 	requestPermission: (request: WatchdogPermissionRequest) => Promise<WatchdogPermissionResult> = requestWatchdogPermission,
 ): void {
-	const rules = decodePermissionRules(process.env[PERMISSION_POLICY_ENV]);
+	const rules = config.permissionRules;
 	if (!rules) return;
 	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: { toolName?: string; input?: unknown }, ctx: ExtensionContext) => unknown) => void;
 	onRuntimeEvent("tool_call", async (event, ctx) => {
@@ -392,13 +359,8 @@ export function registerPermissionGate(
 		const decision = permissionDecision(rules, toolName);
 		if (decision === "allow") return undefined;
 		if (decision === "deny") return { block: true, reason: `Blocked by pi-subagents permission rule: '${toolName}' is denied.` };
-		const rawWatchdogConfig = process.env[CHILD_WATCHDOG_CONFIG_ENV];
-		let timeoutMs = 30_000;
-		try {
-			timeoutMs = decodeChildWatchdogConfig(rawWatchdogConfig)?.agentEndTimeoutMs ?? timeoutMs;
-		} catch {
-			// The arbiter reports invalid configuration with the concrete decode error.
-		}
+		const rawWatchdogConfig = config.childWatchdogRaw;
+		const timeoutMs = config.childWatchdog?.agentEndTimeoutMs ?? 30_000;
 		if (ctx.signal?.aborted) return { block: true, reason: "Blocked by pi-subagents permission rule: Watchdog permission decision was cancelled." };
 		let timeout: ReturnType<typeof setTimeout> | undefined;
 		let abort: (() => void) | undefined;
@@ -410,7 +372,7 @@ export function registerPermissionGate(
 					toolName,
 					args: event.input ?? {},
 					rawWatchdogConfig,
-					auditPath: process.env[PERMISSION_AUDIT_PATH_ENV],
+					auditPath: config.permissionAuditPath,
 					...(ctx.signal ? { signal: ctx.signal } : {}),
 				}),
 				new Promise<WatchdogPermissionResult>((resolve) => {
@@ -430,6 +392,13 @@ export function registerPermissionGate(
 		if (result.approved) return undefined;
 		return { block: true, reason: `Blocked by pi-subagents permission rule: ${result.reason}` };
 	});
+}
+
+export function registerPermissionGate(
+	pi: ExtensionAPI,
+	requestPermission: (request: WatchdogPermissionRequest) => Promise<WatchdogPermissionResult> = requestWatchdogPermission,
+): void {
+	registerPermissionGateWithConfig(pi, readChildRuntimeConfigFromEnv(process.env), requestPermission);
 }
 
 function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undefined): void {
@@ -464,13 +433,15 @@ export function registerSteeringInbox(
 		platform?: NodeJS.Platform;
 		timers?: Pick<typeof globalThis, "setInterval" | "clearInterval">;
 	} = {},
+	config?: ChildRuntimeConfig,
 ): void {
-	const steerInbox = process.env[SUBAGENT_STEER_INBOX_ENV]?.trim();
+	const runtimeConfig = config ?? readChildRuntimeConfigFromEnv(process.env);
+	const steerInbox = runtimeConfig.steerInbox;
 	if (!steerInbox) return;
-	const capabilityPath = process.env[SUBAGENT_STEER_CAPABILITY_ENV]?.trim();
-	const ackDir = process.env[SUBAGENT_STEER_ACK_DIR_ENV]?.trim();
+	const capabilityPath = runtimeConfig.steerCapabilityPath;
+	const ackDir = runtimeConfig.steerAckDir;
 	const sendUserMessage = (pi as { sendUserMessage?: (content: string, options?: { deliverAs: "steer" | "followUp" }) => unknown }).sendUserMessage;
-	const childIndex = Number(process.env[SUBAGENT_CHILD_INDEX_ENV]);
+	const childIndex = runtimeConfig.childIndex ?? Number.NaN;
 	const pending = new Map<string, Array<{ request: SteerRequest; deliveryStatus: SteerDeliveryStatus }>>();
 	const queued: Array<{ request: SteerRequest; ready: boolean }> = [];
 	let disposed = false;
@@ -686,13 +657,13 @@ export function registerSteeringInbox(
 	});
 }
 
-export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
-	registerRuntimeExtensionAcknowledgements(pi);
-	registerSteeringInbox(pi);
-	registerPermissionGate(pi);
-	registerToolBudget(pi, decodeToolBudgetEnv(process.env[TOOL_BUDGET_ENV], { allowZero: process.env[TOOL_BUDGET_ZERO_AUTH_ENV] === "1" }));
-	registerChildWatchdog(pi);
-	const waitToolConfig = resolveWaitToolConfig();
+export function registerSubagentPromptRuntimeWithConfig(pi: ExtensionAPI, config: ChildRuntimeConfig): void {
+	registerRuntimeExtensionAcknowledgements(pi, config);
+	registerSteeringInbox(pi, {}, config);
+	registerPermissionGateWithConfig(pi, config);
+	registerToolBudget(pi, config.toolBudget);
+	if (config.childWatchdog) registerChildWatchdog(pi, config.childWatchdog);
+	const waitToolConfig = config.waitTool;
 	const waitState = {
 		baseCwd: "",
 		currentSessionId: null,
@@ -712,7 +683,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 	const registerNativeSupervisorClientOnce = (): void => {
 		if (nativeSupervisorClientRegistered) return;
 		nativeSupervisorClientRegistered = true;
-		registerNativeSupervisorClient(pi);
+		if (config.supervisor) registerNativeSupervisorClient(pi, config.supervisor);
 	};
 	const onRuntimeEvent = pi.on as unknown as (event: string, handler: (event: unknown, ctx?: ExtensionContext) => unknown) => void;
 	onRuntimeEvent("session_start", (_event: unknown, ctx?: ExtensionContext) => {
@@ -721,17 +692,17 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		registerNativeSupervisorClientOnce();
 	});
 	onRuntimeEvent("agent_start", () => {
-		const diagnostic = refreshChildToolDiagnostic(pi);
+		const diagnostic = refreshChildToolDiagnostic(pi, config);
 		if (diagnostic) throw new Error(formatChildToolDiagnostic(diagnostic));
 	});
 	onRuntimeEvent("agent_end", async (_event: unknown, ctx: unknown) => {
 		if ((ctx as { hasUI?: boolean } | undefined)?.hasUI === true) return;
 		await drainOutstandingWork({ state: waitState, events: pi.events });
 	});
-	const structuredOutputPath = process.env[STRUCTURED_OUTPUT_CAPTURE_ENV];
-	const structuredAcceptanceReportPath = process.env[STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV];
-	const structuredAcceptanceReportRequired = process.env[STRUCTURED_OUTPUT_ACCEPTANCE_REQUIRED_ENV] === "1";
-	const structuredSchemaPath = process.env[STRUCTURED_OUTPUT_SCHEMA_ENV];
+	const structuredOutputPath = config.structuredOutputCapturePath;
+	const structuredAcceptanceReportPath = config.structuredOutputAcceptanceCapturePath;
+	const structuredAcceptanceReportRequired = config.structuredOutputAcceptanceRequired;
+	const structuredSchemaPath = config.structuredOutputSchemaPath;
 	if (structuredOutputPath && structuredSchemaPath) {
 		const schema = JSON.parse(fs.readFileSync(structuredSchemaPath, "utf-8")) as JsonSchemaObject;
 		const acceptanceReportMode = structuredAcceptanceReportPath
@@ -781,12 +752,13 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		});
 	}
 
-	onRuntimeEvent("before_provider_request", (event: unknown, ctx?: ExtensionContext) => rewriteForkCacheProviderRequest(event as BeforeProviderRequestEvent, ctx));
+	onRuntimeEvent("before_provider_request", (event: unknown, ctx?: ExtensionContext) => rewriteForkCacheProviderRequest(event as BeforeProviderRequestEvent, ctx, config.forkCacheKey));
 
 	onRuntimeEvent("context", (event: unknown, ctx?: ExtensionContext) => {
 		if (!event || typeof event !== "object" || !("messages" in event) || !Array.isArray(event.messages)) return undefined;
 		const messages = stripParentOnlySubagentMessages(event.messages, {
 			sanitizeToolIds: !COMPOSITE_TOOL_ID_APIS.has(ctx?.model?.api ?? ""),
+			fanoutChild: config.fanoutChild,
 		});
 		if (messages === event.messages) return undefined;
 		return { messages };
@@ -798,17 +770,17 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 		// The intercom target is a routing address and always wins; the display
 		// name (agent + task excerpt, computed by the parent at launch) only
 		// applies when the bridge is not addressing this child.
-		const intercomSessionName = process.env[SUBAGENT_INTERCOM_SESSION_NAME_ENV]?.trim();
-		const displaySessionName = process.env[SUBAGENT_SESSION_NAME_ENV]?.trim();
+		const intercomSessionName = config.intercomSessionName;
+		const displaySessionName = config.sessionName;
 		const childSessionName = intercomSessionName || displaySessionName;
 		if (childSessionName && typeof pi.setSessionName === "function") {
 			pi.setSessionName(childSessionName);
 		}
 
-		const inheritProjectContext = readBooleanEnv(SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV);
-		const inheritGlobalContext = readBooleanEnv(SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV);
-		const inheritSkills = readBooleanEnv(SUBAGENT_INHERIT_SKILLS_ENV);
-		const fanoutChild = readBooleanEnv(SUBAGENT_FANOUT_CHILD_ENV);
+		const inheritProjectContext = config.inheritProjectContext;
+		const inheritGlobalContext = config.inheritGlobalContext;
+		const inheritSkills = config.inheritSkills;
+		const fanoutChild = config.fanoutPromptBoundary;
 		let rewritten = event.systemPrompt;
 		if (inheritProjectContext !== undefined || inheritGlobalContext !== undefined || inheritSkills !== undefined || fanoutChild !== undefined) {
 			rewritten = rewriteSubagentPrompt(event.systemPrompt, {
@@ -816,9 +788,14 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
 				inheritGlobalContext: inheritGlobalContext ?? true,
 				inheritSkills: inheritSkills ?? true,
 				fanoutChild: fanoutChild === true,
+				structuredOutputCapture: Boolean(config.structuredOutputCapturePath),
 			});
 		}
 		if (rewritten === event.systemPrompt) return;
 		return { systemPrompt: rewritten };
 	});
+}
+
+export default function registerSubagentPromptRuntime(pi: ExtensionAPI): void {
+	registerSubagentPromptRuntimeWithConfig(pi, readChildRuntimeConfigFromEnv(process.env));
 }

--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -26,17 +26,19 @@ interface BranchSessionManager {
 	createBranchedSession(leafId: string): string | undefined;
 	getHeader?: () => BranchSessionEntry | null;
 	getEntries?: () => BranchSessionEntry[];
+	getBranch?: (leafId?: string) => BranchSessionEntry[];
 }
 
 interface ForkableSessionManager {
 	getSessionFile(): string | undefined;
 	getLeafId(): string | null;
-	getSessionDir?(): string;
 	openSession?: (path: string, sessionDir?: string) => BranchSessionManager;
 }
 
 interface ForkContextResolverOptions {
 	openSession?: (path: string, sessionDir?: string) => BranchSessionManager;
+	/** Working directory to store in each forked session header. */
+	forkCwdForIndex?: (index: number) => string | undefined;
 	/** Rewrite a created fork before its path can be used to spawn a child. */
 	pruneSession?: (sessionFile: string) => Promise<void>;
 	/** Decide per child index whether a sanitized transcript must also disable the child's
@@ -174,6 +176,35 @@ function readSessionEntries(sessionFile: string): BranchSessionEntry[] {
 	});
 }
 
+/**
+ * `forkFrom` copies every entry in the source file and opens the copy with its
+ * last physical entry as the leaf.  It is therefore equivalent to
+ * `createBranchedSession(leafId)` only when the requested leaf is the complete
+ * persisted history.  Keep the older branch-aware API for sessions that have
+ * siblings or otherwise do not expose enough tree information to prove that
+ * property.
+ */
+function canUseFullHistoryFork(sourceManager: BranchSessionManager, leafId: string): boolean {
+	const entries = sourceManager.getEntries?.();
+	if (!entries || entries.length === 0) return false;
+	const ids = entries.map((entry) => entry.id);
+	if (ids.some((id) => id === undefined) || new Set(ids).size !== entries.length) return false;
+
+	const branch = sourceManager.getBranch?.(leafId);
+	if (branch) {
+		return branch.length === entries.length
+			&& branch.every((entry, index) => entry.id === ids[index]);
+	}
+
+	// Older/test SessionManager shims may not expose getBranch().  A strict
+	// physical-chain check is sufficient for those managers and fails closed for
+	// branched, malformed, or out-of-order transcripts.
+	return entries.at(-1)?.id === leafId
+		&& entries.every((entry, index) => index === 0
+			? entry.parentId === null || entry.parentId === undefined
+			: entry.parentId === entries[index - 1]?.id);
+}
+
 export function createForkContextResolver(
 	sessionManager: ForkableSessionManager,
 	requestedContext: unknown,
@@ -200,6 +231,7 @@ export function createForkContextResolver(
 	const openSession = options.openSession
 		?? sessionManager.openSession
 		?? ((file: string, dir?: string) => SessionManager.open(file, dir));
+	const useForkFrom = !options.openSession && !sessionManager.openSession;
 	// Fork files must not land in the parent's top-level session directory.
 	// Pi's recent-session discovery (`pi -c` → findMostRecentSession) is
 	// non-recursive and picks the largest-mtime *.jsonl in that directory, so
@@ -210,8 +242,7 @@ export function createForkContextResolver(
 	// records the tree relationship. The directory mirrors
 	// getSubagentSessionRoot() plus a "forks" level so fork files never sit
 	// loose next to run-N/ result directories. Derived from the file path
-	// rather than getSessionDir() so it also works when the manager cannot
-	// report its directory.
+	// rather than a manager-reported directory so it works for every manager.
 	const sessionDir = path.join(
 		path.dirname(parentSessionFile),
 		path.basename(parentSessionFile, ".jsonl"),
@@ -229,7 +260,15 @@ export function createForkContextResolver(
 				throw new Error(`Parent session file does not exist: ${parentSessionFile}. Pi has not persisted enough history to fork yet.`);
 			}
 			const sourceManager = openSession(parentSessionFile, sessionDir);
-			const sessionFile = sourceManager.createBranchedSession(leafId);
+			const targetCwd = options.forkCwdForIndex?.(index)
+				?? sourceManager.getHeader?.()?.cwd
+				?? process.cwd();
+			const forkedManager = useForkFrom && canUseFullHistoryFork(sourceManager, leafId)
+				? SessionManager.forkFrom(parentSessionFile, targetCwd, sessionDir)
+				: undefined;
+			const sessionFile = forkedManager
+				? forkedManager.getSessionFile()
+				: sourceManager.createBranchedSession(leafId);
 			if (!sessionFile) {
 				throw new Error("Session manager did not return a forked session file.");
 			}

--- a/src/shared/session-journal.ts
+++ b/src/shared/session-journal.ts
@@ -1,0 +1,49 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export interface SessionJournalEntry {
+	type?: unknown;
+	customType?: unknown;
+	data?: unknown;
+	details?: unknown;
+}
+
+export type SessionJournalWriter = Partial<Pick<ExtensionAPI, "appendEntry">>;
+
+export function appendSessionJournalEntry(
+	writer: SessionJournalWriter | undefined,
+	customType: string,
+	data: Parameters<ExtensionAPI["appendEntry"]>[1],
+): boolean {
+	if (writer?.appendEntry === undefined) return false;
+	try {
+		writer.appendEntry(customType, data);
+		return true;
+	} catch {
+		// Journal persistence is advisory; a notice or completed run must not be
+		// dropped because an in-memory/test session cannot append its entry.
+		return false;
+	}
+}
+
+export function sessionJournalEntry(value: SessionJournalEntry | null | undefined): SessionJournalEntry | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	return value;
+}
+
+export interface CustomJournalEntries {
+	present: boolean;
+	data: unknown[];
+}
+
+export function readCustomJournalEntries(entries: readonly SessionJournalEntry[] | undefined, customType: string): CustomJournalEntries {
+	if (!Array.isArray(entries)) return { present: false, data: [] };
+	const data: unknown[] = [];
+	let present = false;
+	for (const value of entries) {
+		const entry = sessionJournalEntry(value);
+		if (entry?.type !== "custom" || entry.customType !== customType) continue;
+		present = true;
+		data.push(entry.data);
+	}
+	return { present, data };
+}

--- a/src/watchdog/diff-tool.ts
+++ b/src/watchdog/diff-tool.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { truncateHead } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "typebox";
 
 export const WATCHDOG_DIFF_TOOL_NAME = "watchdog_diff";
@@ -47,7 +48,12 @@ function validatePath(value: string | undefined): string | undefined {
 function bound(text: string): string {
 	if (text.length <= WATCHDOG_DIFF_MAX_CHARS) return text;
 	const marker = `\n\n[... ${text.length - WATCHDOG_DIFF_MAX_CHARS} characters omitted; call again with a narrower path ...]`;
-	return `${text.slice(0, WATCHDOG_DIFF_MAX_CHARS - marker.length)}${marker}`;
+	// Pi returns bounded content without a marker; keep the watchdog's actionable marker.
+	const content = truncateHead(text, {
+		maxLines: Number.MAX_SAFE_INTEGER,
+		maxBytes: WATCHDOG_DIFF_MAX_CHARS - marker.length,
+	}).content;
+	return `${content}${marker}`;
 }
 
 /** In a shared cwd, changes already pending when the session started also appear. */

--- a/src/watchdog/register-child.ts
+++ b/src/watchdog/register-child.ts
@@ -5,12 +5,12 @@ import { createMainWatchdogReview } from "./review.ts";
 import { DEFAULT_WATCHDOG_CONFIG } from "./settings.ts";
 import { createWatchdogWarningMessage } from "./warning-format.ts";
 import {
-	CHILD_WATCHDOG_CONFIG_ENV,
 	CHILD_WATCHDOG_STATUS_EVENT,
 	decodeChildWatchdogConfig,
 	type ChildWatchdogConfig,
 	type ChildWatchdogPhase,
 } from "./child-status.ts";
+import { readChildRuntimeConfigFromEnv } from "../runs/shared/child-runtime-config.ts";
 import type { ResolvedWatchdogConfig, WatchdogWarningDetails } from "./types.ts";
 
 export function childResolvedConfig(config: ChildWatchdogConfig): ResolvedWatchdogConfig {
@@ -51,8 +51,8 @@ function writeStatus(event: unknown): void {
 	}
 }
 
-export function registerChildWatchdog(pi: ExtensionAPI, rawConfig = process.env[CHILD_WATCHDOG_CONFIG_ENV]): MainWatchdogRuntime | undefined {
-	const childConfig = decodeChildWatchdogConfig(rawConfig);
+export function registerChildWatchdog(pi: ExtensionAPI, configOrRaw: ChildWatchdogConfig | string | undefined = readChildRuntimeConfigFromEnv(process.env).childWatchdog): MainWatchdogRuntime | undefined {
+	const childConfig = typeof configOrRaw === "string" ? decodeChildWatchdogConfig(configOrRaw) : configOrRaw;
 	if (!childConfig) return undefined;
 	let currentContext: ExtensionContext | undefined;
 	let diffBaseline: WatchdogDiffBaseline | undefined;

--- a/src/watchdog/register-child.ts
+++ b/src/watchdog/register-child.ts
@@ -3,7 +3,7 @@ import { captureWatchdogDiffBaseline, type WatchdogDiffBaseline } from "./diff-t
 import { MainWatchdogRuntime } from "./runtime.ts";
 import { createMainWatchdogReview } from "./review.ts";
 import { DEFAULT_WATCHDOG_CONFIG } from "./settings.ts";
-import { createWatchdogWarningMessage } from "./warning-format.ts";
+import { sendWatchdogWarning } from "./warning-format.ts";
 import {
 	CHILD_WATCHDOG_STATUS_EVENT,
 	decodeChildWatchdogConfig,
@@ -77,7 +77,7 @@ export function registerChildWatchdog(pi: ExtensionAPI, configOrRaw: ChildWatchd
 		reviewChangesOnly: true,
 		displayWarning: (details, options) => {
 			const childDetails = childWarningDetails(details, childConfig);
-			pi.sendMessage(createWatchdogWarningMessage(childDetails, { display: true, details: childDetails }), options);
+			sendWatchdogWarning(pi, childDetails, { display: true, details: childDetails }, options);
 		},
 	});
 	const rememberContext = (ctx: ExtensionContext) => {

--- a/src/watchdog/register-main.ts
+++ b/src/watchdog/register-main.ts
@@ -14,7 +14,7 @@ import {
 	type WatchdogWarning,
 	type WatchdogWarningDetails,
 } from "./types.ts";
-import { createWatchdogWarningMessage } from "./warning-format.ts";
+import { sendWatchdogWarning } from "./warning-format.ts";
 
 interface RegisterMainWatchdogOptions {
 	runtime?: MainWatchdogRuntime;
@@ -370,7 +370,7 @@ async function handleWatchdogCommand(
 		}
 		const warning = createTestWarning(test.severity, test.text);
 		const details = runtime.recordDisplayedWarning(warning);
-		pi.sendMessage(createWatchdogWarningMessage(details, { display: true, details }));
+		sendWatchdogWarning(pi, details, { display: true, details });
 		return;
 	}
 	ctx.ui.notify(`Usage: /subagents-watchdog [status|on|off|session on|session off|recommend-model|model recommended|model <provider/model[:thinking]>|model inherit|thinking ${THINKING_LEVELS.join("|")}|thinking inherit|session model recommended|check|test concern <text>|test blocker <text>]`, "error");
@@ -386,7 +386,7 @@ export function registerMainWatchdog(pi: ExtensionAPI, options: RegisterMainWatc
 		review: options.review ?? createMainWatchdogReview(() => currentContext, { getThinkingLevel: () => pi.getThinkingLevel(), diffBaseline: () => diffBaseline }),
 		reviewDescription: options.review ? "injected seam" : "real model review",
 		reviewChangesOnly: true,
-		displayWarning: (details, options) => pi.sendMessage(createWatchdogWarningMessage(details, { display: true, details }), options),
+		displayWarning: (details, options) => sendWatchdogWarning(pi, details, { display: true, details }, options),
 	});
 
 	pi.registerMessageRenderer<WatchdogWarningDetails>(SUBAGENT_WATCHDOG_WARNING_TYPE, (message, renderOptions, theme) => {

--- a/src/watchdog/rules.ts
+++ b/src/watchdog/rules.ts
@@ -1,8 +1,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { splitKnownThinkingSuffix } from "../shared/model-info.ts";
+import type { SessionJournalWriter } from "../shared/session-journal.ts";
 import { resolveWatchdogConfig } from "./settings.ts";
 import type { WatchdogRulesConfig, WatchdogWarning } from "./types.ts";
-import { createWatchdogWarningMessage } from "./warning-format.ts";
+import { sendWatchdogWarning } from "./warning-format.ts";
 
 export interface WatchdogRuleViolation {
 	agent: string;
@@ -64,7 +65,7 @@ export function applyWatchdogLaunchRules(input: { cwd: string; agent: string; mo
 }
 
 /** For launch paths without a main watchdog runtime (background chain steps). */
-export function sendRuleViolationWarning(pi: Pick<ExtensionAPI, "sendMessage">, violation: WatchdogRuleViolation): void {
+export function sendRuleViolationWarning(pi: Pick<ExtensionAPI, "sendMessage"> & SessionJournalWriter, violation: WatchdogRuleViolation): void {
 	const warning = ruleViolationWarning(violation);
-	pi.sendMessage(createWatchdogWarningMessage(warning, { display: true, details: { state: "displayed", displayedAt: new Date().toISOString() } }), { deliverAs: "steer" });
+	sendWatchdogWarning(pi, warning, { display: true, details: { state: "displayed", displayedAt: new Date().toISOString() } }, { deliverAs: "steer" });
 }

--- a/src/watchdog/runtime.ts
+++ b/src/watchdog/runtime.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { truncateHead, truncateTail, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { computeWatchdogRepoChangeSignature, eventIndicatesRepoEdit, type WatchdogRepoChangeSignature } from "./change-signature.ts";
 import { WatchdogEmissionGuard } from "./emission-guard.ts";
 import {
@@ -98,9 +98,19 @@ const REVIEW_DELTA_SEPARATOR = "\n\n---\n\n";
 
 export function boundWatchdogReviewText(text: string, cap = MAX_REVIEW_INPUT_CHARS): string {
 	if (text.length <= cap) return text;
-	const head = Math.min(REVIEW_INPUT_HEAD_CHARS, Math.floor(cap / 4));
+	const headLimit = Math.min(REVIEW_INPUT_HEAD_CHARS, Math.floor(cap / 4));
 	const marker = `\n\n[... about ${text.length - cap} characters omitted ...]\n\n`;
-	return `${text.slice(0, head)}${marker}${text.slice(text.length - (cap - head - marker.length))}`;
+	// Pi's helpers preserve complete lines and return no marker, so retain the watchdog marker here.
+	const contentLimit = Math.max(0, cap - Buffer.byteLength(marker, "utf-8"));
+	const head = truncateHead(text, {
+		maxLines: Number.MAX_SAFE_INTEGER,
+		maxBytes: headLimit,
+	}).content;
+	const tail = truncateTail(text, {
+		maxLines: Number.MAX_SAFE_INTEGER,
+		maxBytes: Math.max(0, contentLimit - Buffer.byteLength(head, "utf-8")),
+	}).content;
+	return `${head}${marker}${tail}`;
 }
 
 function errorMessage(error: unknown): string {

--- a/src/watchdog/warning-format.ts
+++ b/src/watchdog/warning-format.ts
@@ -1,9 +1,11 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	SUBAGENT_WATCHDOG_WARNING_TYPE,
 	type WatchdogWarning,
 	type WatchdogWarningDetails,
 	type WatchdogWarningMessage,
 } from "./types.ts";
+import { appendSessionJournalEntry, type SessionJournalWriter } from "../shared/session-journal.ts";
 
 function escapeXmlText(value: string): string {
 	return value
@@ -69,4 +71,17 @@ export function createWatchdogWarningMessage(
 		display: options.display ?? true,
 		details,
 	};
+}
+
+type WatchdogWarningPi = Pick<ExtensionAPI, "sendMessage"> & SessionJournalWriter;
+
+export function sendWatchdogWarning(
+	pi: WatchdogWarningPi,
+	warning: WatchdogWarning,
+	options: { display?: boolean; details?: Partial<WatchdogWarningDetails> } = {},
+	deliveryOptions?: Parameters<ExtensionAPI["sendMessage"]>[1],
+): void {
+	const message = createWatchdogWarningMessage(warning, options);
+	pi.sendMessage(message, deliveryOptions);
+	appendSessionJournalEntry(pi, SUBAGENT_WATCHDOG_WARNING_TYPE, message.details);
 }

--- a/test/fixtures/pi-coding-agent-shim/index.mjs
+++ b/test/fixtures/pi-coding-agent-shim/index.mjs
@@ -13,6 +13,50 @@ export function convertToLlm(value) { return value; }
 export function createReadOnlyTools() {
 	return ["read", "grep", "find", "ls"].map((name) => ({ name }));
 }
+
+const DEFAULT_MAX_LINES = 2000;
+const DEFAULT_MAX_BYTES = 50 * 1024;
+
+function splitLinesForCounting(content) {
+	if (content.length === 0) return [];
+	const lines = content.split("\n");
+	if (content.endsWith("\n")) lines.pop();
+	return lines;
+}
+
+function truncateStringToBytesFromEnd(value, maxBytes) {
+	const bytes = Buffer.from(value, "utf-8");
+	if (bytes.length <= maxBytes) return value;
+	let start = bytes.length - maxBytes;
+	while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start++;
+	return bytes.subarray(start).toString("utf-8");
+}
+
+function truncate(content, options, fromTail) {
+	const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+	const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+	const lines = splitLinesForCounting(content);
+	if (lines.length <= maxLines && Buffer.byteLength(content, "utf-8") <= maxBytes) return content;
+	if (!fromTail && Buffer.byteLength(lines[0] ?? "", "utf-8") > maxBytes) return "";
+	const output = [];
+	let outputBytes = 0;
+	for (let index = fromTail ? lines.length - 1 : 0; fromTail ? index >= 0 : index < lines.length; fromTail ? index-- : index++) {
+		if (output.length >= maxLines) break;
+		const line = lines[index];
+		const lineBytes = Buffer.byteLength(line, "utf-8") + (output.length > 0 ? 1 : 0);
+		if (outputBytes + lineBytes > maxBytes) {
+			if (fromTail && output.length === 0) output.unshift(truncateStringToBytesFromEnd(line, maxBytes));
+			break;
+		}
+		if (fromTail) output.unshift(line);
+		else output.push(line);
+		outputBytes += lineBytes;
+	}
+	return output.join("\n");
+}
+
+export function truncateHead(content, options = {}) { return { content: truncate(content, options, false) }; }
+export function truncateTail(content, options = {}) { return { content: truncate(content, options, true) }; }
 export function rawKeyHint(keys, label) { return `${keys} ${label}`; }
 export function keyHint(_binding, label) { return label; }
 

--- a/test/fixtures/pi-coding-agent-shim/index.mjs
+++ b/test/fixtures/pi-coding-agent-shim/index.mjs
@@ -96,6 +96,24 @@ export class SessionManager {
 		return new SessionManager(header.cwd ?? process.cwd(), sessionDir, filePath, header, entries);
 	}
 
+	static forkFrom(sourcePath, targetCwd, sessionDir = path.join(targetCwd, ".pi", "sessions")) {
+		const { header, entries } = readSession(sourcePath);
+		if (!header || header.type !== "session") throw new Error(`Cannot fork: source session has no header: ${sourcePath}`);
+		const id = randomUUID();
+		const timestamp = new Date().toISOString();
+		const childHeader = {
+			type: "session",
+			version: 3,
+			id,
+			timestamp,
+			cwd: path.resolve(targetCwd),
+			parentSession: path.resolve(sourcePath),
+		};
+		const childFile = path.join(sessionDir, `${timestamp.replace(/[:.]/g, "-")}_${id}.jsonl`);
+		writeSession(childFile, childHeader, entries);
+		return new SessionManager(path.resolve(targetCwd), sessionDir, childFile, childHeader, entries);
+	}
+
 	appendMessage(message) {
 		const previous = this.entries.at(-1);
 		const id = randomUUID().slice(0, 8);

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1999,7 +1999,6 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const sent: Array<{ options?: { triggerTurn?: boolean } }> = [];
 		handleSubagentControlNotice({
 			pi: { sendMessage(_message, options) { sent.push({ options: options as { triggerTurn?: boolean } }); } },
-			state: { asyncJobs } as SubagentState,
 			visibleControlNotices: new Set(),
 			details: { event: attentionPayload.event!, source: "async" },
 		});

--- a/test/unit/child-runtime-config.test.ts
+++ b/test/unit/child-runtime-config.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CHILD_FANOUT_HOOK, CHILD_FAST_MODE_HOOK, CHILD_PROMPT_RUNTIME_HOOK, createChildHooks } from "../../src/runs/shared/child-hooks.ts";
+import {
+	readChildRuntimeConfigFromEnv,
+	SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV,
+	SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV,
+	SUBAGENT_INHERIT_SKILLS_ENV,
+	SUBAGENT_INTERCOM_SESSION_NAME_ENV,
+	SUBAGENT_SESSION_NAME_ENV,
+} from "../../src/runs/shared/child-runtime-config.ts";
+import { PERMISSION_AUDIT_PATH_ENV, PERMISSION_POLICY_ENV } from "../../src/runs/shared/permissions.ts";
+import { STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV, STRUCTURED_OUTPUT_ACCEPTANCE_REQUIRED_ENV, STRUCTURED_OUTPUT_CAPTURE_ENV, STRUCTURED_OUTPUT_SCHEMA_ENV } from "../../src/runs/shared/structured-output.ts";
+import { TOOL_BUDGET_ENV, TOOL_BUDGET_ZERO_AUTH_ENV } from "../../src/runs/shared/tool-budget.ts";
+import { CHILD_TOOL_DIAGNOSTIC_PATH_ENV, MCP_DIRECT_CHILD_TOOLS_ENV, REQUIRED_CHILD_TOOLS_ENV } from "../../src/runs/shared/tool-availability.ts";
+import { WAIT_TOOL_DEFAULT_TIMEOUT_MS_ENV, WAIT_TOOL_ENABLED_ENV } from "../../src/runs/background/wait-config.ts";
+import { CHILD_WATCHDOG_CONFIG_ENV } from "../../src/watchdog/child-status.ts";
+import {
+	SUBAGENT_CHILD_AGENT_ENV,
+	SUBAGENT_CHILD_ENV,
+	SUBAGENT_CHILD_INDEX_ENV,
+	SUBAGENT_FANOUT_CHILD_ENV,
+	SUBAGENT_FORK_CACHE_KEY_ENV,
+	SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV,
+	SUBAGENT_ORCHESTRATOR_TARGET_ENV,
+	SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV,
+	SUBAGENT_PARENT_CONTROL_INBOX_ENV,
+	SUBAGENT_PARENT_EVENT_SINK_ENV,
+	SUBAGENT_PARENT_ROOT_RUN_ID_ENV,
+	SUBAGENT_RUN_ID_ENV,
+	SUBAGENT_STEER_ACK_DIR_ENV,
+	SUBAGENT_STEER_CAPABILITY_ENV,
+	SUBAGENT_STEER_INBOX_ENV,
+	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
+} from "../../src/runs/shared/pi-args.ts";
+
+const CHILD_WATCHDOG = JSON.stringify({
+	runId: "run-123",
+	agent: "worker",
+	childIndex: 2,
+	watchdogTailTimeoutMs: 1_000,
+	agentEndTimeoutMs: 2_000,
+	maxWarnings: 3,
+	lsp: { enabled: false, timeoutMs: 1_000, maxFiles: 10, maxDiagnostics: 10 },
+	stalemateRepeats: 2,
+	cadence: { everyNTools: null },
+});
+
+describe("child runtime config", () => {
+	it("decodes child identity, routing, hook contracts, and limits from the supplied environment", () => {
+		const config = readChildRuntimeConfigFromEnv({
+			[SUBAGENT_CHILD_ENV]: "1",
+			[SUBAGENT_FANOUT_CHILD_ENV]: "1",
+			[SUBAGENT_ORCHESTRATOR_TARGET_ENV]: "parent-session",
+			[SUBAGENT_ORCHESTRATOR_SESSION_ID_ENV]: "session-parent",
+			[SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV]: "/tmp/supervisor",
+			[SUBAGENT_RUN_ID_ENV]: "run-123",
+			[SUBAGENT_CHILD_AGENT_ENV]: "worker",
+			[SUBAGENT_CHILD_INDEX_ENV]: "2",
+			[SUBAGENT_INTERCOM_SESSION_NAME_ENV]: "worker-session",
+			[SUBAGENT_SESSION_NAME_ENV]: "Worker task",
+			[SUBAGENT_PARENT_ROOT_RUN_ID_ENV]: "root-123",
+			[SUBAGENT_PARENT_EVENT_SINK_ENV]: "/tmp/nested/events",
+			[SUBAGENT_PARENT_CONTROL_INBOX_ENV]: "/tmp/nested/controls",
+			[SUBAGENT_PARENT_CAPABILITY_TOKEN_ENV]: "cap-123",
+			[SUBAGENT_STEER_INBOX_ENV]: "/tmp/steer",
+			[SUBAGENT_STEER_CAPABILITY_ENV]: "/tmp/steer/capability.json",
+			[SUBAGENT_STEER_ACK_DIR_ENV]: "/tmp/steer/acks",
+			[SUBAGENT_INHERIT_PROJECT_CONTEXT_ENV]: "0",
+			[SUBAGENT_INHERIT_GLOBAL_CONTEXT_ENV]: "1",
+			[SUBAGENT_INHERIT_SKILLS_ENV]: "0",
+			[SUBAGENT_FORK_CACHE_KEY_ENV]: "pi-fork:run-123",
+			[REQUIRED_CHILD_TOOLS_ENV]: JSON.stringify(["read", "write"]),
+			[MCP_DIRECT_CHILD_TOOLS_ENV]: JSON.stringify(["mcp__repo__search"]),
+			[CHILD_TOOL_DIAGNOSTIC_PATH_ENV]: "/tmp/diagnostic.json",
+			[PERMISSION_POLICY_ENV]: JSON.stringify({ write: "deny", read: "ask" }),
+			[PERMISSION_AUDIT_PATH_ENV]: "/tmp/permission-audit.jsonl",
+			[CHILD_WATCHDOG_CONFIG_ENV]: CHILD_WATCHDOG,
+			[TOOL_BUDGET_ENV]: JSON.stringify({ hard: 4, soft: 2, block: ["write"] }),
+			[TOOL_BUDGET_ZERO_AUTH_ENV]: "1",
+			[WAIT_TOOL_ENABLED_ENV]: "false",
+			[WAIT_TOOL_DEFAULT_TIMEOUT_MS_ENV]: "4500",
+			[STRUCTURED_OUTPUT_CAPTURE_ENV]: "/tmp/output.json",
+			[STRUCTURED_OUTPUT_SCHEMA_ENV]: "/tmp/schema.json",
+			[STRUCTURED_OUTPUT_ACCEPTANCE_CAPTURE_ENV]: "/tmp/acceptance.json",
+			[STRUCTURED_OUTPUT_ACCEPTANCE_REQUIRED_ENV]: "1",
+			PI_SUBAGENT_DEPTH: "2",
+			PI_SUBAGENT_MAX_DEPTH: "3",
+			PI_SUBAGENT_MAX_SPAWNS_PER_SESSION: "5",
+			PI_SUBAGENT_MAX_SPAWNS_PER_RUN: "12",
+			PI_SUBAGENT_TOOL_TIMEOUT_MS: "2500",
+		});
+
+		assert.equal(config.child, true);
+		assert.equal(config.fanoutChild, true);
+		assert.equal(config.fanoutPromptBoundary, true);
+		assert.deepEqual(config.supervisor, {
+			channelDir: "/tmp/supervisor",
+			runId: "run-123",
+			agent: "worker",
+			childIndex: 2,
+			orchestratorTarget: "parent-session",
+			orchestratorSessionId: "session-parent",
+			childTarget: "worker-session",
+		});
+		assert.deepEqual(config.nestedRoute, {
+			rootRunId: "root-123",
+			eventSink: "/tmp/nested/events",
+			controlInbox: "/tmp/nested/controls",
+			capabilityToken: "cap-123",
+		});
+		assert.deepEqual(config.parentPath, []);
+		assert.deepEqual(config.requiredChildTools, ["read", "write"]);
+		assert.deepEqual(config.mcpDirectChildTools, ["mcp__repo__search"]);
+		assert.deepEqual(config.permissionRules, { write: "deny", read: "ask" });
+		assert.equal(config.childWatchdog?.agentEndTimeoutMs, 2_000);
+		assert.deepEqual(config.toolBudget, { hard: 4, soft: 2, block: ["write"] });
+		assert.deepEqual(config.waitTool, { enabled: false, defaultTimeoutMs: 4_500 });
+		assert.equal(config.structuredOutputCapturePath, "/tmp/output.json");
+		assert.equal(config.structuredOutputAcceptanceRequired, true);
+		assert.equal(config.depth, 2);
+		assert.equal(config.maxDepth, 3);
+		assert.equal(config.maxSpawnsPerSession, 5);
+		assert.equal(config.maxSpawnsPerRun, 12);
+		assert.equal(config.toolTimeoutMs, "2500");
+	});
+
+	it("does not consult the ambient process environment", () => {
+		const previous = process.env[SUBAGENT_CHILD_ENV];
+		process.env[SUBAGENT_CHILD_ENV] = "1";
+		try {
+			assert.equal(readChildRuntimeConfigFromEnv({}).child, false);
+		} finally {
+			if (previous === undefined) delete process.env[SUBAGENT_CHILD_ENV];
+			else process.env[SUBAGENT_CHILD_ENV] = previous;
+		}
+	});
+
+	it("returns only the hooks enabled by the typed config", () => {
+		const config = readChildRuntimeConfigFromEnv({});
+		assert.deepEqual(createChildHooks(config).map((hook) => typeof hook === "function" ? "function" : hook.name), [CHILD_PROMPT_RUNTIME_HOOK]);
+		assert.deepEqual(createChildHooks({ ...config, fastMode: true, child: true, fanoutChild: true }).map((hook) => typeof hook === "function" ? "function" : hook.name), [CHILD_PROMPT_RUNTIME_HOOK, CHILD_FAST_MODE_HOOK, CHILD_FANOUT_HOOK]);
+	});
+});

--- a/test/unit/control-notices.test.ts
+++ b/test/unit/control-notices.test.ts
@@ -1,24 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { handleSubagentControlNotice } from "../../src/extension/control-notices.ts";
-import type { ControlEvent, SubagentState } from "../../src/shared/types.ts";
-
-function makeState(): SubagentState {
-	return {
-		baseCwd: "/tmp/project",
-		currentSessionId: null,
-		asyncJobs: new Map(),
-		foregroundControls: new Map(),
-		lastForegroundControlId: null,
-		cleanupTimers: new Map(),
-		lastUiContext: null,
-		poller: null,
-		completionSeen: new Map(),
-		watcher: null,
-		watcherRestartTimer: null,
-		resultFileCoalescer: { schedule: () => false, clear: () => {} },
-	};
-}
+import { handleSubagentControlNotice, restoreVisibleControlNotices, SUBAGENT_CONTROL_MESSAGE_TYPE } from "../../src/extension/control-notices.ts";
+import { controlNotificationKey } from "../../src/runs/shared/subagent-control.ts";
+import type { ControlEvent } from "../../src/shared/types.ts";
 
 function needsAttentionEvent(overrides: Partial<ControlEvent> = {}): ControlEvent {
 	return {
@@ -36,11 +20,16 @@ function needsAttentionEvent(overrides: Partial<ControlEvent> = {}): ControlEven
 
 function makeRecorder() {
 	const sent: Array<{ message: unknown; options: unknown }> = [];
+	const entries: string[] = [];
 	return {
 		sent,
+		entries,
 		pi: {
 			sendMessage(message: unknown, options: unknown) {
 				sent.push({ message, options });
+			},
+			appendEntry(customType: string) {
+				entries.push(customType);
 			},
 		},
 	};
@@ -48,46 +37,35 @@ function makeRecorder() {
 
 describe("subagent control notice delivery", () => {
 	it("delivers async needs-attention notices immediately", () => {
-		const state = makeState();
 		const recorder = makeRecorder();
 
 		handleSubagentControlNotice({
 			pi: recorder.pi,
-			state,
 			visibleControlNotices: new Set(),
 			details: { source: "async", event: needsAttentionEvent() },
 		});
 
 		assert.equal(recorder.sent.length, 1);
+		assert.equal(recorder.entries.length, 1);
+		assert.equal(recorder.entries[0], SUBAGENT_CONTROL_MESSAGE_TYPE);
 		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: true });
 	});
 
 	it("delivers goal notices without starting a new turn", () => {
-		const state = makeState();
 		const recorder = makeRecorder();
 
 		handleSubagentControlNotice({
 			pi: recorder.pi,
-			state,
 			visibleControlNotices: new Set(),
 			details: { source: "goal", event: needsAttentionEvent(), noticeText: "Goal is ready." },
 		});
 
 		assert.equal(recorder.sent.length, 1);
+		assert.equal(recorder.entries.length, 1);
 		assert.deepEqual(recorder.sent[0]?.options, { triggerTurn: false });
 	});
 
 	it("does not queue a foreground notice that Pi could flush after completion", () => {
-		const state = makeState();
-		state.foregroundControls.set("run-1", {
-			runId: "run-1",
-			mode: "parallel",
-			startedAt: 0,
-			updatedAt: 0,
-			currentAgent: "worker",
-			currentIndex: 0,
-			currentActivityState: "needs_attention",
-		});
 		const queued: Array<{ message: unknown; options: unknown }> = [];
 		const visible: Array<{ message: unknown; options: unknown }> = [];
 		const pi = {
@@ -98,13 +76,26 @@ describe("subagent control notice delivery", () => {
 
 		handleSubagentControlNotice({
 			pi,
-			state,
 			visibleControlNotices: new Set(),
 			details: { source: "foreground", event: needsAttentionEvent() },
 		});
-		state.foregroundControls.delete("run-1");
 		visible.push(...queued);
 
 		assert.deepEqual(visible, []);
+	});
+
+	it("rebuilds visible notice keys from the selected branch", () => {
+		const first = needsAttentionEvent({ runId: "first" });
+		const second = needsAttentionEvent({ runId: "second" });
+		const visible = new Set(["stale"]);
+		assert.equal(restoreVisibleControlNotices([
+			{ type: "custom", customType: SUBAGENT_CONTROL_MESSAGE_TYPE, data: { source: "async", event: first } },
+		], visible), 1);
+		assert.equal(visible.has(controlNotificationKey(first)), true);
+		assert.equal(restoreVisibleControlNotices([
+			{ type: "custom", customType: SUBAGENT_CONTROL_MESSAGE_TYPE, data: { source: "async", event: second } },
+		], visible), 1);
+		assert.equal(visible.has(controlNotificationKey(first)), false);
+		assert.equal(visible.has(controlNotificationKey(second)), true);
 	});
 });

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -6,7 +6,8 @@ import { describe, it } from "node:test";
 import { visibleWidth, type MarkdownTheme } from "@earendil-works/pi-tui";
 import { EXTERNAL_RUN_REGISTRY_KEY, EXTERNAL_RUN_REGISTRY_VERSION, registerExternalRun } from "../../src/api/external-runs.ts";
 import { collectFleetSnapshot, openSubagentFleet, SubagentFleetComponent } from "../../src/tui/fleet.ts";
-import { persistForegroundRunHistory, restoreForegroundRunHistory } from "../../src/runs/foreground/foreground-history.ts";
+import { FOREGROUND_RUN_HISTORY_ENTRY_TYPE, persistForegroundRunHistory, restoreForegroundRunHistory } from "../../src/runs/foreground/foreground-history.ts";
+import type { SessionJournalEntry } from "../../src/shared/session-journal.ts";
 import { FLEET_STATUS_WIDGET_KEY } from "../../src/tui/fleet-status.ts";
 import { registerLivePromptAudit, rewritePromptWithGuidance } from "../../src/runs/foreground/prompt-audit.ts";
 import { getArtifactPaths, getArtifactsDir, getProjectArtifactsDir } from "../../src/shared/artifacts.ts";
@@ -882,6 +883,62 @@ describe("native subagent fleet", () => {
 			persistForegroundRunHistory(state, { resultsDir });
 			const persisted = JSON.parse(fs.readFileSync(path.join(resultsDir, "foreground-history.json"), "utf-8")) as { runs: Array<{ runId: string }> };
 			assert.deepEqual(persisted.runs.map((run) => run.runId), ["terminal"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("restores foreground history from the selected session branch", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-foreground-journal-"));
+		try {
+			const resultsDir = path.join(root, "results");
+			const entries: SessionJournalEntry[] = [];
+			const appendEntry = (customType: string, data: unknown) => entries.push({ type: "custom", customType, data });
+			const journal = { appendEntry };
+			const state = stateForTest();
+			state.foregroundRuns!.set("branch-a-run", {
+				runId: "branch-a-run",
+				mode: "single",
+				cwd: root,
+				sessionId: "session-current",
+				updatedAt: 100,
+				children: [{ agent: "alpha", index: 0, status: "completed", finalOutput: "alpha done" }],
+			});
+			persistForegroundRunHistory(state, { resultsDir, journal, journalRun: state.foregroundRuns.get("branch-a-run") });
+			const branchA = [...entries];
+
+			state.foregroundRuns!.clear();
+			state.foregroundRuns!.set("branch-b-run", {
+				runId: "branch-b-run",
+				mode: "single",
+				cwd: root,
+				sessionId: "session-current",
+				updatedAt: 200,
+				children: [{ agent: "beta", index: 0, status: "failed", error: "beta failed" }],
+			});
+			persistForegroundRunHistory(state, { resultsDir, journal, journalRun: state.foregroundRuns.get("branch-b-run") });
+			const branchB = entries.slice(branchA.length);
+			assert.equal((branchA[0] as { customType?: string }).customType, FOREGROUND_RUN_HISTORY_ENTRY_TYPE);
+
+			const selected = stateForTest();
+			assert.equal(restoreForegroundRunHistory(selected, { branchEntries: branchA }), 1);
+			assert.deepEqual([...selected.foregroundRuns!.keys()], ["branch-a-run"]);
+			assert.equal(restoreForegroundRunHistory(selected, { branchEntries: branchB }), 1);
+			assert.deepEqual([...selected.foregroundRuns!.keys()], ["branch-b-run"]);
+
+			fs.writeFileSync(path.join(resultsDir, "foreground-history.json"), JSON.stringify({
+				version: 1,
+				runs: [{
+					runId: "legacy-run",
+					mode: "single",
+					cwd: root,
+					sessionId: "session-current",
+					updatedAt: 300,
+					children: [{ agent: "legacy", index: 0, status: "completed", finalOutput: "legacy" }],
+				}],
+			}, null, 2), "utf-8");
+			assert.equal(restoreForegroundRunHistory(selected, { branchEntries: [], resultsDir }), 1);
+			assert.deepEqual([...selected.foregroundRuns!.keys()], ["legacy-run"]);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/fork-context.test.ts
+++ b/test/unit/fork-context.test.ts
@@ -164,10 +164,11 @@ describe("createForkContextResolver", () => {
 		}
 	});
 
-	it("creates forked sessions through the default package opener", () => {
+	it("creates forked sessions through SessionManager.forkFrom", () => {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-default-"));
 		try {
 			const sessionDir = path.join(tempDir, "sessions");
+			const targetCwd = path.join(tempDir, "child-cwd");
 			const parent = SessionManager.create(tempDir, sessionDir);
 			parent.appendMessage({ role: "user", content: "parent prompt" });
 			parent.appendMessage({ role: "assistant", content: "parent response" });
@@ -180,13 +181,16 @@ describe("createForkContextResolver", () => {
 			const resolver = createForkContextResolver({
 				getSessionFile: () => parentSessionFile,
 				getLeafId: () => leafId,
-				getSessionDir: () => sessionDir,
-			}, "fork");
+			}, "fork", { forkCwdForIndex: () => targetCwd });
 
 			const childSessionFile = resolver.sessionFileForIndex(0);
 			assert.ok(childSessionFile);
 			assert.notEqual(childSessionFile, parentSessionFile);
 			assert.equal(fs.existsSync(childSessionFile), true);
+			const childEntries = fs.readFileSync(childSessionFile, "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+			assert.equal(childEntries[0].cwd, path.resolve(targetCwd));
+			assert.equal(childEntries[0].parentSession, parentSessionFile);
+			assert.deepEqual(childEntries.slice(1), parent.getEntries());
 		} finally {
 			fs.rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -213,7 +217,6 @@ describe("createForkContextResolver", () => {
 			const resolver = createForkContextResolver({
 				getSessionFile: () => parentSessionFile,
 				getLeafId: () => leafId,
-				getSessionDir: () => sessionDir,
 			}, "fork");
 
 			const childSessionFile = resolver.sessionFileForIndex(0);

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -6,6 +6,7 @@ import registerSubagentNotify, {
 	formatGroupedCompletion,
 	formatSingleCompletion,
 	parseSubagentNotifyContent,
+	SUBAGENT_NOTIFY_MESSAGE_TYPE,
 	type RegisterSubagentNotifyOptions,
 	type SubagentNotifyDetails,
 } from "../../src/runs/background/notify.ts";
@@ -151,6 +152,27 @@ describe("registerSubagentNotify", () => {
 		const { notifier, sent } = createPi("session-a");
 		assert.equal(await notifier.deliver(completionResult({ id: "direct-accepted" })), true);
 		assert.equal(sent.length, 1);
+	});
+
+	it("appends typed completion details alongside the display message", async () => {
+		const events = createEventBus();
+		const entries: Array<{ customType: string; data: unknown }> = [];
+		const pi = {
+			events,
+			sendMessage() {},
+			appendEntry(customType: string, data: unknown) {
+				entries.push({ customType, data });
+			},
+		};
+		const notifier = registerSubagentNotify(pi as never, { currentSessionId: "session-a", completionOwnerId: COMPLETION_OWNER_ID }, { batchConfig: { enabled: false } });
+		try {
+			assert.equal(await notifier.deliver(completionResult({ id: "journal-entry" })), true);
+			assert.equal(entries.length, 1);
+			assert.equal(entries[0]?.customType, SUBAGENT_NOTIFY_MESSAGE_TYPE);
+			assert.deepEqual(entries[0]?.data, { agent: "worker", status: "completed", resultPreview: "Done" });
+		} finally {
+			notifier.dispose();
+		}
 	});
 
 	it("rejects async completion delivery for a missing or different parent owner", async () => {

--- a/test/unit/steering-notices.test.ts
+++ b/test/unit/steering-notices.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { handleSubagentSteeringNotice } from "../../src/extension/steering-notices.ts";
+import { handleSubagentSteeringNotice, SUBAGENT_STEERING_MESSAGE_TYPE } from "../../src/extension/steering-notices.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
 
 function state(sessionId: string): SubagentState {
@@ -25,12 +25,18 @@ function state(sessionId: string): SubagentState {
 describe("steering notices", () => {
 	it("delivers a failure notice to the matching parent session", () => {
 		const messages: unknown[] = [];
+		const entries: string[] = [];
 		handleSubagentSteeringNotice({
-			pi: { sendMessage: (message: unknown) => messages.push(message) } as any,
+			pi: {
+				sendMessage: (message: unknown) => messages.push(message),
+				appendEntry: (customType: string) => entries.push(customType),
+			} as any,
 			state: state("session-1"),
 			details: { runId: "run", requestId: "request", state: "failed", message: "not delivered", currentSessionId: "session-1" },
 		});
 		assert.equal(messages.length, 1);
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0], SUBAGENT_STEERING_MESSAGE_TYPE);
 		assert.match(JSON.stringify(messages[0]), /not delivered/);
 	});
 

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -1450,6 +1450,8 @@ describe("subagent prompt runtime", () => {
 
 	it("rewrites the final child-visible prompt through before_agent_start", async () => {
 		let beforeAgentStart: ((event: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>) | undefined;
+		process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = "0";
+		process.env.PI_SUBAGENT_INHERIT_SKILLS = "0";
 		registerSubagentPromptRuntime({
 			on(event: string, handler: (payload: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>) {
 				if (event === "before_agent_start") beforeAgentStart = handler;
@@ -1458,9 +1460,6 @@ describe("subagent prompt runtime", () => {
 		} as { on(event: string, handler: (payload: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>): void; getAllTools(): Array<{ name: string }> });
 
 		assert.ok(beforeAgentStart, "expected before_agent_start handler");
-		process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = "0";
-		process.env.PI_SUBAGENT_INHERIT_SKILLS = "0";
-
 		const rewritten = await beforeAgentStart?.({ systemPrompt: BASE_PROMPT });
 		assert.ok(rewritten);
 		assert.ok(!rewritten.systemPrompt.includes("# Project Context"));
@@ -1470,16 +1469,15 @@ describe("subagent prompt runtime", () => {
 
 	it("uses the fanout boundary through before_agent_start when fanout env is set", async () => {
 		let beforeAgentStart: ((event: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>) | undefined;
+		process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = "1";
+		process.env.PI_SUBAGENT_INHERIT_SKILLS = "1";
+		process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
 		registerSubagentPromptRuntime({
 			on(event: string, handler: (payload: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>) {
 				if (event === "before_agent_start") beforeAgentStart = handler;
 			},
 			getAllTools: () => [{ name: "intercom" }, { name: "contact_supervisor" }],
 		} as { on(event: string, handler: (payload: { systemPrompt: string }) => Promise<{ systemPrompt: string } | undefined>): void; getAllTools(): Array<{ name: string }> });
-
-		process.env.PI_SUBAGENT_INHERIT_PROJECT_CONTEXT = "1";
-		process.env.PI_SUBAGENT_INHERIT_SKILLS = "1";
-		process.env[SUBAGENT_FANOUT_CHILD_ENV] = "1";
 
 		const rewritten = await beforeAgentStart?.({ systemPrompt: BASE_PROMPT });
 		assert.ok(rewritten);

--- a/test/unit/watchdog-render.test.ts
+++ b/test/unit/watchdog-render.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { formatWatchdogWarningRenderText } from "../../src/watchdog/render.ts";
-import { createWatchdogWarningMessage, formatWatchdogWarningContent } from "../../src/watchdog/warning-format.ts";
+import { createWatchdogWarningMessage, formatWatchdogWarningContent, sendWatchdogWarning } from "../../src/watchdog/warning-format.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE, type WatchdogWarningDetails } from "../../src/watchdog/types.ts";
 
 describe("watchdog warning formatting and rendering", () => {
@@ -45,6 +45,31 @@ describe("watchdog warning formatting and rendering", () => {
 		assert.equal(message.details.source, "main");
 		assert.match(message.content, /<summary>Missing focused test<\/summary>/);
 		assert.match(message.content, /<recommended_action>Add a parser regression test\.<\/recommended_action>/);
+	});
+
+	it("appends structured warning details to the session journal", () => {
+		const entries: Array<{ customType: string; data: unknown }> = [];
+		sendWatchdogWarning({
+			sendMessage() {},
+			appendEntry(customType: string, data: unknown) {
+				entries.push({ customType, data });
+			},
+		}, {
+			severity: "blocker",
+			summary: "Missing focused test",
+			evidence: "No test was run.",
+			recommendedAction: "Run the focused test.",
+		});
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0]?.customType, SUBAGENT_WATCHDOG_WARNING_TYPE);
+		assert.deepEqual(entries[0]?.data, {
+			severity: "blocker",
+			summary: "Missing focused test",
+			evidence: "No test was run.",
+			recommendedAction: "Run the focused test.",
+			category: "other",
+			source: "main",
+		});
 	});
 
 	it("renders concern, blocker, stale, failed, and stalemate states in text", () => {

--- a/test/unit/watchdog-runtime.test.ts
+++ b/test/unit/watchdog-runtime.test.ts
@@ -342,9 +342,8 @@ describe("main watchdog runtime", () => {
 		runtime.enqueueDelta(`Assistant:\n${"x".repeat(30_000)}`);
 		await runtime.handleAgentEnd({ type: "agent_end", messages: [] }, { cwd: "/tmp/project" });
 
-		assert.equal(reviewedDelta.length, 24_000, "head + marker + tail fill the cap exactly");
-		assert.match(reviewedDelta, /^Assistant:\nx+\n\n\[\.\.\. about \d+ characters omitted \.\.\.\]\n\nx+$/);
-		assert.equal(reviewedDelta.indexOf("\n\n[..."), 6_000, "the first 6,000 characters are kept as the head");
+		assert.ok(reviewedDelta.length <= 24_000, `bounded review input was ${reviewedDelta.length}`);
+		assert.match(reviewedDelta, /\n\n\[\.\.\. about \d+ characters omitted \.\.\.\]\n\n/);
 	});
 
 	it("does not record duplicate signatures for stale invalidated reviews", async () => {


### PR DESCRIPTION
Draft for #1837's single-PR commit sequence.

Completed so far as separate narrative commits:

1. `refactor: centralize child runtime hooks`
   - Adds typed child runtime config decoding and `createChildHooks(config)`.
   - Keeps print-mode subprocess behavior intact.
2. `refactor: reuse pi truncation helpers`
   - Uses pi truncate helpers for watchdog text caps where semantics are safe.
   - Leaves nested-event structural/JSON/character caps unchanged.
3. `refactor: journal subagent notices`
   - Appends typed custom journal entries for subagent notices and foreground history.
   - Restores selected-branch notices/history on reset and `session_tree`, with legacy fallback for old sessions.
4. `refactor: use session manager fork copies`
   - Uses `SessionManager.forkFrom` for full linear persisted fork histories.
   - Keeps branch-aware/pruned/fail-closed fallbacks.

Still draft because C1 foreground `createAgentSession` replacement is blocked on a host/runtime contract: `ExtensionContext` exposes `modelRegistry`, not the underlying `ModelRuntime` or a host-owned child-session factory needed for faithful parent provider/auth/runtime reuse. I am not removing foreground/background spawn until that contract is resolved.

Refs #1837.
