### PR TITLE
Suppress stale supervisor attention replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Replace collapsed async workflow role rollups with a compact lane view while keeping full details available when expanded (#1827). Thanks [@nicobailon](https://github.com/nicobailon).
 
 ### Fixed
+- Suppress stale async supervisor-request notices after the native request has already been answered (#1838). Thanks [@VladimirGVP](https://github.com/VladimirGVP).
 - Flush async workflow result assembly after session replacement when every child is already terminal, without permitting stale-context launches (#1833). Thanks [@redcomet168](https://github.com/redcomet168).
 - Accept calendar/platform `claude --version` output during Claude Code adapter preflight while retaining required launch-flag validation. Thanks [@drouhard](https://github.com/drouhard).
 - Show passive local command availability for external CLI agents in capability listings without replacing launch preflight (#1829). Thanks [@drouhard](https://github.com/drouhard).

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -546,6 +546,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const { ensurePoller, refreshWidget, handleStarted, handleComplete, resetJobs, restoreActiveJobs, dispose: disposeAsyncJobTracker } = createAsyncJobTracker(pi, state, DIRS.async, {
 		widgetEnabled: asyncWidgetEnabled,
 		onJobTerminal: () => refreshResultDelivery(),
+		supervisorRequestState: supervisorChannel.getSupervisorRequestState,
 	});
 	const resultWatcher = createResultWatcher(
 		pi,

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -12,7 +12,7 @@ import {
 	SUBAGENT_RUN_ID_ENV,
 	SUBAGENT_SUPERVISOR_CHANNEL_DIR_ENV,
 } from "../runs/shared/pi-args.ts";
-import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
+import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type ControlEvent, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
 import { shouldUseNativeFsWatch } from "../shared/watch-strategy.ts";
 
@@ -26,6 +26,10 @@ const CHANNEL_POLL_MS = Math.min(POLL_INTERVAL_MS, 500);
 const CHANNEL_SAFETY_POLL_MS = 5000;
 const STALE_EMPTY_CHANNEL_AGE_MS = 60 * 1000;
 const STALE_EMPTY_CHANNEL_CLEANUP_INTERVAL_MS = 60 * 1000;
+const MAX_SUPERVISOR_REQUEST_CORRELATIONS = 256;
+const SUPERVISOR_REQUEST_CORRELATION_RETENTION_MS = 10 * 60 * 1000;
+
+export type SupervisorRequestState = "pending" | "resolved" | "unknown";
 
 type SupervisorReason = "need_decision" | "interview_request" | "progress_update";
 
@@ -42,6 +46,7 @@ interface SupervisorRequest {
 	runId: string;
 	agent: string;
 	childIndex: number;
+	toolCallId?: string;
 	childTarget?: string;
 	interview?: unknown;
 }
@@ -49,6 +54,12 @@ interface SupervisorRequest {
 interface PendingSupervisorRequest extends SupervisorRequest {
 	channelDir: string;
 	requestFile: string;
+}
+
+interface SupervisorRequestCorrelation {
+	request: PendingSupervisorRequest;
+	state: Exclude<SupervisorRequestState, "unknown">;
+	updatedAt: number;
 }
 
 interface SupervisorReply {
@@ -231,7 +242,7 @@ async function waitForReply(channelDir: string, requestId: string, deadline: num
 	throw new Error("Timed out waiting for supervisor reply.");
 }
 
-async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: AbortSignal): Promise<AgentToolResult<Record<string, unknown>>> {
+async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: AbortSignal, toolCallId?: string): Promise<AgentToolResult<Record<string, unknown>>> {
 	const metadata = readChildMetadata();
 	if (!metadata) throw new Error("Native supervisor channel is not available for this subagent.");
 	if (params.reason !== "progress_update" && !params.message?.trim() && params.reason !== "interview_request") {
@@ -244,6 +255,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 	const replyDeadline = createdAt + askTimeoutMs();
 	const expiresAt = expectsReply ? replyDeadline : undefined;
 	const message = formatChildMessage({ ...metadata, reason: params.reason, message: params.message, interview: params.interview });
+	const requestToolCallId = typeof toolCallId === "string" && toolCallId.length > 0 ? toolCallId : undefined;
 	const request: SupervisorRequest = {
 		type: "subagent.supervisor.request",
 		id: requestId,
@@ -257,6 +269,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, signal?: A
 		runId: metadata.runId,
 		agent: metadata.agent,
 		childIndex: metadata.childIndex,
+		...(requestToolCallId ? { toolCallId: requestToolCallId } : {}),
 		...(metadata.childTarget ? { childTarget: metadata.childTarget } : {}),
 		...(params.interview !== undefined ? { interview: params.interview } : {}),
 	};
@@ -304,8 +317,8 @@ export function registerNativeSupervisorClient(pi: ExtensionAPI): void {
 		label: "Contact Supervisor",
 		description: "Contact the parent/supervisor session for a blocking decision, structured interview, or progress update.",
 		parameters: ContactSupervisorParamsSchema,
-		execute(_id, params, signal) {
-			return sendSupervisorRequest(params as ContactSupervisorParams, signal);
+		execute(id, params, signal) {
+			return sendSupervisorRequest(params as ContactSupervisorParams, signal, id);
 		},
 	};
 	pi.registerTool(tool);
@@ -319,7 +332,12 @@ function parseRequestFile(file: string, channelDir: string): PendingSupervisorRe
 		if (parsed.reason !== "need_decision" && parsed.reason !== "interview_request" && parsed.reason !== "progress_update") return undefined;
 		if (typeof parsed.message !== "string" || !parsed.message) return undefined;
 		if (typeof parsed.runId !== "string" || typeof parsed.agent !== "string" || typeof parsed.childIndex !== "number") return undefined;
-		return { ...parsed as SupervisorRequest, channelDir, requestFile: file };
+		return {
+			...parsed as SupervisorRequest,
+			...(typeof parsed.toolCallId === "string" && parsed.toolCallId.length > 0 ? { toolCallId: parsed.toolCallId } : { toolCallId: undefined }),
+			channelDir,
+			requestFile: file,
+		};
 	} catch {
 		return undefined;
 	}
@@ -483,6 +501,7 @@ function removeRequestFile(file: string): void {
 }
 
 type SupervisorRequestLifecycle = "pending" | "resolved" | "expired" | "inactive" | "missing" | "wrong-session";
+type SupervisorRequestLifecycleObserver = (request: PendingSupervisorRequest, lifecycle: SupervisorRequestLifecycle) => void;
 
 function requestExpiresAt(request: SupervisorRequest, now: number): number {
 	const expiresAt = (request as { expiresAt?: unknown }).expiresAt;
@@ -515,12 +534,13 @@ function cleanupRequestLifecycle(request: PendingSupervisorRequest, lifecycle: S
 	if (lifecycle === "resolved" || lifecycle === "expired" || lifecycle === "inactive") removeRequestFile(request.requestFile);
 }
 
-function refreshPendingRequests(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, ctx: ExtensionContext | undefined): void {
+function refreshPendingRequests(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, ctx: ExtensionContext | undefined, onLifecycle: SupervisorRequestLifecycleObserver): void {
 	const now = Date.now();
 	for (const request of pending.values()) {
 		const lifecycle = requestLifecycle(request, state, ctx, now);
 		if (lifecycle === "pending") continue;
 		pending.delete(request.id);
+		onLifecycle(request, lifecycle);
 		cleanupRequestLifecycle(request, lifecycle);
 	}
 }
@@ -583,14 +603,14 @@ function publicPendingRequests(pending: Map<string, PendingSupervisorRequest>): 
 	}));
 }
 
-function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest>, state: SubagentState): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
+function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
 	return {
 		name: NATIVE_SUPERVISOR_TOOL_NAME,
 		label: "Subagent Supervisor",
 		description: "Native pi-subagents supervisor channel. Use reply/pending/status to answer child subagent requests without overriding pi-intercom.",
 		parameters: IntercomParamsSchema,
 		async execute(_id, params) {
-			refreshPendingRequests(pending, state, state.lastUiContext ?? undefined);
+			refreshPendingRequests(pending, state, state.lastUiContext ?? undefined, onLifecycle);
 			const input = params as IntercomParams;
 			if (input.action === "status") {
 				return { content: [{ type: "text", text: `Native supervisor channel active. Pending replies: ${pending.size}.` }], details: { active: true, pending: pending.size, root: SUPERVISOR_CHANNEL_ROOT } };
@@ -602,6 +622,7 @@ function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest
 			if (input.action === "reply") {
 				const request = resolvePendingRequest(pending, input);
 				writeReply(request, input.message ?? "");
+				onLifecycle(request, "resolved");
 				pending.delete(request.id);
 				clearForegroundSupervisorAttention(request, pending, state);
 				return { content: [{ type: "text", text: `Replied to supervisor request ${request.id}.` }], details: { replyTo: request.id, runId: request.runId, agent: request.agent } };
@@ -614,10 +635,66 @@ function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest
 	};
 }
 
-export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentState, deps: NativeSupervisorChannelDeps = {}): { start: () => void; activateTransport: () => void; dispose: () => void; pending: Map<string, PendingSupervisorRequest> } {
+export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentState, deps: NativeSupervisorChannelDeps = {}): {
+	start: () => void;
+	activateTransport: () => void;
+	dispose: () => void;
+	pending: Map<string, PendingSupervisorRequest>;
+	getSupervisorRequestState: (event: ControlEvent) => SupervisorRequestState;
+} {
 	const watch = deps.watch ?? fs.watch;
 	const timers = deps.timers ?? globalThis;
 	const pending = new Map<string, PendingSupervisorRequest>();
+	const requestCorrelations = new Map<string, SupervisorRequestCorrelation>();
+	const correlationKey = (request: { runId: string; agent: string; childIndex: number; toolCallId?: string }): string | undefined => {
+		if (!request.toolCallId) return undefined;
+		return JSON.stringify([request.runId, request.agent, request.childIndex, request.toolCallId]);
+	};
+	const pruneRequestCorrelations = (now = Date.now()): void => {
+		for (const [key, correlation] of requestCorrelations) {
+			if (correlation.state === "resolved" && now - correlation.updatedAt > SUPERVISOR_REQUEST_CORRELATION_RETENTION_MS) requestCorrelations.delete(key);
+		}
+		while (requestCorrelations.size > MAX_SUPERVISOR_REQUEST_CORRELATIONS) {
+			const oldest = requestCorrelations.keys().next().value;
+			if (oldest === undefined) break;
+			requestCorrelations.delete(oldest);
+		}
+	};
+	const rememberPendingRequest = (request: PendingSupervisorRequest): void => {
+		const key = correlationKey(request);
+		if (!key || !request.expectsReply) return;
+		requestCorrelations.set(key, { request, state: "pending", updatedAt: Date.now() });
+		pruneRequestCorrelations();
+	};
+	const rememberResolvedRequest = (request: PendingSupervisorRequest): void => {
+		const key = correlationKey(request);
+		if (!key || !request.expectsReply) return;
+		requestCorrelations.set(key, { request, state: "resolved", updatedAt: Date.now() });
+		pruneRequestCorrelations();
+	};
+	const observeRequestLifecycle: SupervisorRequestLifecycleObserver = (request, lifecycle) => {
+		if (lifecycle !== "wrong-session") rememberResolvedRequest(request);
+	};
+	const getSupervisorRequestState = (event: ControlEvent): SupervisorRequestState => {
+		if (event.currentTool === "intercom" || event.index === undefined) return "unknown";
+		const toolCallId = typeof event.toolCallId === "string" && event.toolCallId.length > 0 ? event.toolCallId : undefined;
+		if (!toolCallId) return "unknown";
+		pruneRequestCorrelations();
+		const key = correlationKey({ runId: event.runId, agent: event.agent, childIndex: event.index, toolCallId });
+		if (!key) return "unknown";
+		const correlation = requestCorrelations.get(key);
+		if (!correlation) return "unknown";
+		if (correlation.state === "resolved") return "resolved";
+		const now = Date.now();
+		if (!fs.existsSync(correlation.request.requestFile)
+			|| fs.existsSync(replyPath(correlation.request.channelDir, correlation.request.id))
+			|| now > requestExpiresAt(correlation.request, now)
+			|| requestRunInactive(correlation.request, state)) {
+			rememberResolvedRequest(correlation.request);
+			return "resolved";
+		}
+		return "pending";
+	};
 	const seenFiles = new Set<string>();
 	const requestWatchers = new Map<string, fs.FSWatcher>();
 	let rootWatcher: fs.FSWatcher | undefined;
@@ -635,7 +712,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 
 	const registerParentTools = (): void => {
-		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pending, state));
+		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pending, state, observeRequestLifecycle));
 	};
 
 	const cleanupStaleChannelsIfDue = (): void => {
@@ -653,7 +730,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		cleanupStaleChannelsIfDue();
 		const ctx = state.lastUiContext;
 		if (!ctx) return;
-		refreshPendingRequests(pending, state, ctx);
+		refreshPendingRequests(pending, state, ctx, observeRequestLifecycle);
 		const now = Date.now();
 		for (const { channelDir, file } of listRequestFiles()) {
 			if (seenFiles.has(file)) continue;
@@ -662,11 +739,13 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			const lifecycle = requestLifecycle(request, state, undefined, now);
 			if (lifecycle !== "pending") {
 				seenFiles.add(file);
+				observeRequestLifecycle(request, lifecycle);
 				cleanupRequestLifecycle(request, lifecycle);
 				continue;
 			}
 			seenFiles.add(file);
 			if (request.expectsReply) {
+				rememberPendingRequest(request);
 				pending.set(request.id, request);
 				markForegroundSupervisorAttention(request, state);
 			}
@@ -805,8 +884,10 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			if (deferredWatcherRefresh) timers.clearImmediate(deferredWatcherRefresh);
 			deferredWatcherRefresh = undefined;
 			pending.clear();
+			requestCorrelations.clear();
 			seenFiles.clear();
 		},
 		pending,
+		getSupervisorRequestState,
 	};
 }

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -39,6 +39,8 @@ interface AsyncJobTrackerOptions {
 	watch?: typeof fs.watch;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	now?: () => number;
+	/** Resolve native supervisor requests without scanning supervisor mailboxes. */
+	supervisorRequestState?: (event: ControlEvent) => "pending" | "resolved" | "unknown";
 }
 
 const CONTROL_EVENT_READ_CHUNK_BYTES = 64 * 1024;
@@ -293,6 +295,15 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				if ((parsed as { type?: unknown }).type !== "subagent.control") return;
 				const record = parsed as { event?: ControlEvent; channels?: string[]; childIntercomTarget?: string; noticeText?: string; intercom?: { to?: string; message?: string } };
 				if (!record.event || !Array.isArray(record.channels)) return;
+				if (record.event.type === "needs_attention" && record.event.reason === "supervisor_request" && options.supervisorRequestState) {
+					let requestState: "pending" | "resolved" | "unknown" = "unknown";
+					try {
+						requestState = options.supervisorRequestState(record.event);
+					} catch (error) {
+						console.error(`Failed to resolve supervisor request state for async control event in '${job.asyncDir}':`, error);
+					}
+					if (requestState === "resolved") return;
+				}
 				const payload = {
 					event: record.event,
 					source: "async" as const,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -538,6 +538,7 @@ interface ChildEvent {
 	type?: string;
 	message?: ChildMessage;
 	toolName?: string;
+	toolCallId?: string;
 	args?: Record<string, unknown>;
 	willRetry?: unknown;
 }
@@ -3636,6 +3637,7 @@ async function runSubagent(
 					tokens: step.tokens?.total,
 					toolCount: step.toolCount,
 					currentTool: step.currentTool,
+					toolCallId: event.toolCallId,
 					currentToolDurationMs: 0,
 					currentPath: step.currentPath,
 				})));

--- a/src/runs/shared/subagent-control.ts
+++ b/src/runs/shared/subagent-control.ts
@@ -138,6 +138,7 @@ export function buildControlEvent(input: {
 	tokens?: number;
 	toolCount?: number;
 	currentTool?: string;
+	toolCallId?: string;
 	currentToolDurationMs?: number;
 	currentPath?: string;
 	elapsedMs?: number;
@@ -170,6 +171,7 @@ export function buildControlEvent(input: {
 		...(input.tokens !== undefined ? { tokens: input.tokens } : {}),
 		...(input.toolCount !== undefined ? { toolCount: input.toolCount } : {}),
 		...(input.currentTool ? { currentTool: input.currentTool } : {}),
+		...(input.toolCallId ? { toolCallId: input.toolCallId } : {}),
 		...(input.currentToolDurationMs !== undefined ? { currentToolDurationMs: input.currentToolDurationMs } : {}),
 		...(input.currentPath ? { currentPath: input.currentPath } : {}),
 		...(elapsedMs !== undefined ? { elapsedMs } : {}),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -369,6 +369,7 @@ export interface ControlEvent {
 	tokens?: number;
 	toolCount?: number;
 	currentTool?: string;
+	toolCallId?: string;
 	currentToolDurationMs?: number;
 	currentPath?: string;
 	elapsedMs?: number;

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -4,9 +4,10 @@ import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
 import { getArtifactsDir } from "../../src/shared/artifacts.ts";
-import { SUBAGENT_CHILD_STATUS_EVENT } from "../../src/shared/types.ts";
+import { SUBAGENT_CHILD_STATUS_EVENT, SUBAGENT_CONTROL_EVENT, type ControlEvent } from "../../src/shared/types.ts";
 import { ACTIVE_RUN_INDEX_DIR, updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
 import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR } from "../../src/runs/shared/external-job-bridge.ts";
+import { createNativeSupervisorChannel, ensureSupervisorChannelDir, resolveSupervisorChannelDir } from "../../src/intercom/native-supervisor-channel.ts";
 import { SubagentFleetComponent } from "../../src/tui/fleet.ts";
 import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
 import { createTempDir, removeTempDir, tryImport } from "../support/helpers.ts";
@@ -26,6 +27,7 @@ interface AsyncJobTrackerModule {
 			watch?: typeof fs.watch;
 			kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 			now?: () => number;
+			supervisorRequestState?: (event: ControlEvent) => "pending" | "resolved" | "unknown";
 		},
 	): {
 		ensurePoller(): void;
@@ -87,6 +89,84 @@ function createEventRecorder() {
 		},
 		events,
 	};
+}
+
+function writeSupervisorRequest(input: { sessionId: string; runId: string; toolCallId: string }): { channelDir: string; requestId: string } {
+	const channelDir = resolveSupervisorChannelDir(input.runId, "worker", 0);
+	ensureSupervisorChannelDir(channelDir);
+	const requestId = `request-${input.toolCallId}`;
+	fs.writeFileSync(path.join(channelDir, "requests", `${requestId}.json`), JSON.stringify({
+		type: "subagent.supervisor.request",
+		id: requestId,
+		createdAt: Date.now(),
+		reason: "need_decision",
+		message: "Need a decision",
+		expectsReply: true,
+		orchestratorSessionId: input.sessionId,
+		runId: input.runId,
+		agent: "worker",
+		childIndex: 0,
+		toolCallId: input.toolCallId,
+	}), "utf-8");
+	return { channelDir, requestId };
+}
+
+function writeControlRecord(runDir: string, event: ControlEvent): void {
+	fs.appendFileSync(path.join(runDir, "events.jsonl"), `${JSON.stringify({ type: "subagent.control", channels: ["event"], event })}\n`, "utf-8");
+}
+
+function supervisorControlEvent(runId: string, toolCallId: string, currentTool = "contact_supervisor"): ControlEvent {
+	return {
+		type: "needs_attention",
+		to: "needs_attention",
+		ts: Date.now(),
+		runId,
+		agent: "worker",
+		index: 0,
+		message: "worker is waiting for a supervisor reply",
+		reason: "supervisor_request",
+		currentTool,
+		toolCallId,
+	};
+}
+
+function writeRunningAsyncStatus(runDir: string, runId: string, sessionId: string): void {
+	fs.mkdirSync(runDir, { recursive: true });
+	fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+		runId,
+		mode: "single",
+		state: "running",
+		sessionId,
+		startedAt: Date.now(),
+		lastUpdate: Date.now(),
+		steps: [{ agent: "worker", status: "running" }],
+	}), "utf-8");
+}
+
+function createNativeSupervisorHarness(sessionId: string) {
+	const nativeState = createState();
+	(nativeState as { currentSessionId: string; lastUiContext: unknown }).currentSessionId = sessionId;
+	(nativeState as { currentSessionId: string; lastUiContext: unknown }).lastUiContext = {
+		hasUI: false,
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => null,
+			getEntries: () => [],
+		},
+	};
+	const tools = new Map<string, { execute: (id: string, params: Record<string, unknown>) => Promise<unknown> }>();
+	const sent: Array<{ customType?: string; options?: { triggerTurn?: boolean } }> = [];
+	const pi = {
+		getAllTools: () => [...tools.keys()].map((name) => ({ name })),
+		registerTool: (tool: { name: string; execute: (...args: unknown[]) => Promise<unknown> }) => {
+			tools.set(tool.name, { execute: (id, params) => tool.execute(id, params) });
+		},
+		sendMessage: (message: { customType?: string }, options?: { triggerTurn?: boolean }) => {
+			sent.push({ customType: message.customType, options });
+		},
+	};
+	const channel = createNativeSupervisorChannel(pi as never, nativeState as never, { platform: "win32" });
+	return { channel, tools, sent };
 }
 
 function pidGone(): never {
@@ -724,11 +804,16 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			}), "utf-8");
 			const state = createState();
 			const ui = createUiContext();
-			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, { pollIntervalMs: 10 });
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+				watch: (() => { throw new Error("native watcher disabled for test"); }) as never,
+			});
 			tracker.resetJobs(ui.ctx as never);
 			tracker.handleStarted({ id: "quiet-run", asyncDir: runDir, agent: "worker" });
 
+			const rendersAfterStart = ui.renderRequests;
 			await waitForCondition(() => state.asyncJobs.get("quiet-run")?.status === "running", "quiet running job refresh");
+			await waitForCondition(() => ui.renderRequests > rendersAfterStart, "quiet running widget redraw");
 			const renderRequests = ui.renderRequests;
 			await new Promise((resolve) => setTimeout(resolve, 120));
 
@@ -1468,6 +1553,135 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 			assert.equal(state.asyncJobs.get("run-recovered")?.status, "running");
 		} finally {
 			tracker?.resetJobs();
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("suppresses a resolved native supervisor notice before async replay", async () => {
+		const asyncRoot = createTempDir("pi-async-job-supervisor-replay-resolved-");
+		const sessionId = `session-${Date.now()}`;
+		const runId = `run-${Date.now()}`;
+		const toolCallId = `call-${Date.now()}`;
+		const { channel, tools, sent } = createNativeSupervisorHarness(sessionId);
+		const { channelDir, requestId } = writeSupervisorRequest({ sessionId, runId, toolCallId });
+		try {
+			const runDir = path.join(asyncRoot, runId);
+			writeRunningAsyncStatus(runDir, runId, sessionId);
+			const event = supervisorControlEvent(runId, toolCallId);
+			writeControlRecord(runDir, event);
+
+			channel.start();
+			assert.equal(channel.getSupervisorRequestState(event), "pending");
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+				supervisorRequestState: channel.getSupervisorRequestState,
+			});
+			tracker.handleStarted({ id: runId, asyncDir: runDir, agent: "worker", sessionId });
+			await tools.get("subagent_supervisor")!.execute("reply", { action: "reply", replyTo: requestId, message: "Approved" });
+			assert.equal(channel.getSupervisorRequestState(event), "resolved");
+			await waitForCondition(() => (state.asyncJobs.get(runId)?.controlEventCursor ?? 0) > 0, "resolved control event cursor");
+
+			assert.equal(recorder.events.some((entry) => entry.channel === SUBAGENT_CONTROL_EVENT), false);
+			assert.deepEqual(sent, [{ customType: "subagent_supervisor_request", options: { triggerTurn: true } }]);
+		} finally {
+			channel.dispose();
+			fs.rmSync(channelDir, { recursive: true, force: true });
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("delivers a native supervisor notice while its request is pending through replay", async () => {
+		const asyncRoot = createTempDir("pi-async-job-supervisor-replay-pending-");
+		const sessionId = `session-${Date.now()}`;
+		const runId = `run-${Date.now()}`;
+		const toolCallId = `call-${Date.now()}`;
+		const { channel, sent } = createNativeSupervisorHarness(sessionId);
+		const { channelDir } = writeSupervisorRequest({ sessionId, runId, toolCallId });
+		try {
+			const runDir = path.join(asyncRoot, runId);
+			writeRunningAsyncStatus(runDir, runId, sessionId);
+			const event = supervisorControlEvent(runId, toolCallId);
+			writeControlRecord(runDir, event);
+
+			channel.start();
+			assert.equal(channel.getSupervisorRequestState(event), "pending");
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+				supervisorRequestState: channel.getSupervisorRequestState,
+			});
+			tracker.handleStarted({ id: runId, asyncDir: runDir, agent: "worker", sessionId });
+			await waitForCondition(() => recorder.events.some((entry) => entry.channel === SUBAGENT_CONTROL_EVENT), "pending control event replay");
+
+			const payload = recorder.events.find((entry) => entry.channel === SUBAGENT_CONTROL_EVENT)?.data as { event?: ControlEvent } | undefined;
+			assert.equal(payload?.event?.toolCallId, toolCallId);
+			assert.deepEqual(sent.map((entry) => entry.customType), ["subagent_supervisor_request"]);
+		} finally {
+			channel.dispose();
+			fs.rmSync(channelDir, { recursive: true, force: true });
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("keeps the first native supervisor notice after resolution and suppresses later replay", async () => {
+		const asyncRoot = createTempDir("pi-async-job-supervisor-replay-late-");
+		const sessionId = `session-${Date.now()}`;
+		const runId = `run-${Date.now()}`;
+		const toolCallId = `call-${Date.now()}`;
+		const { channel, tools } = createNativeSupervisorHarness(sessionId);
+		const { channelDir, requestId } = writeSupervisorRequest({ sessionId, runId, toolCallId });
+		try {
+			const runDir = path.join(asyncRoot, runId);
+			writeRunningAsyncStatus(runDir, runId, sessionId);
+			const event = supervisorControlEvent(runId, toolCallId);
+			writeControlRecord(runDir, event);
+
+			channel.start();
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+				supervisorRequestState: channel.getSupervisorRequestState,
+			});
+			tracker.handleStarted({ id: runId, asyncDir: runDir, agent: "worker", sessionId });
+			await waitForCondition(() => recorder.events.filter((entry) => entry.channel === SUBAGENT_CONTROL_EVENT).length === 1, "first control event replay");
+
+			await tools.get("subagent_supervisor")!.execute("reply", { action: "reply", replyTo: requestId, message: "Approved" });
+			writeControlRecord(runDir, event);
+			const eventSize = fs.statSync(path.join(runDir, "events.jsonl")).size;
+			await waitForCondition(() => (state.asyncJobs.get(runId)?.controlEventCursor ?? 0) >= eventSize, "resolved replay cursor");
+			assert.equal(recorder.events.filter((entry) => entry.channel === SUBAGENT_CONTROL_EVENT).length, 1);
+		} finally {
+			channel.dispose();
+			fs.rmSync(channelDir, { recursive: true, force: true });
+			removeTempDir(asyncRoot);
+		}
+	});
+
+	it("delivers an external intercom ask with the native lifecycle lookup enabled", async () => {
+		const asyncRoot = createTempDir("pi-async-job-supervisor-replay-external-");
+		const sessionId = `session-${Date.now()}`;
+		const runId = `run-${Date.now()}`;
+		const { channel } = createNativeSupervisorHarness(sessionId);
+		try {
+			const runDir = path.join(asyncRoot, runId);
+			writeRunningAsyncStatus(runDir, runId, sessionId);
+			const event = supervisorControlEvent(runId, "external-call", "intercom");
+			writeControlRecord(runDir, event);
+			assert.equal(channel.getSupervisorRequestState(event), "unknown");
+			const state = createState();
+			const recorder = createEventRecorder();
+			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
+				pollIntervalMs: 10,
+				supervisorRequestState: channel.getSupervisorRequestState,
+			});
+			tracker.handleStarted({ id: runId, asyncDir: runDir, agent: "worker", sessionId });
+			await waitForCondition(() => recorder.events.some((entry) => entry.channel === SUBAGENT_CONTROL_EVENT), "external control event replay");
+		} finally {
+			channel.dispose();
 			removeTempDir(asyncRoot);
 		}
 	});


### PR DESCRIPTION
## Summary
- correlate native `contact_supervisor` requests and async supervisor control events by tool-call id
- suppress only confirmed resolved native supervisor-request replays before they become duplicate async notices
- keep pending supervisor notices, external intercom asks, cursor behavior, and other control events unchanged

Fixes #1838.

Thanks [@VladimirGVP](https://github.com/VladimirGVP) for the concrete stale-notice report and repro ordering.

## Validation
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/async-job-tracker.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/native-supervisor-channel.test.ts`
- `npm run typecheck`
- `git diff --check`
- conflict-marker scan
