### PR TITLE
Render native supervisor messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Include sanitized excluded model/provider/reason/expiry evidence when no usable subagent candidates remain. Thanks [@AlexKucera](https://github.com/AlexKucera) for #1841.
 
 ### Fixed
+- Show native supervisor requests and outbound replies as bounded TUI cards in parent sessions (#1845).
 - Suppress stale async supervisor-request notices after the native request has already been answered (#1838). Thanks [@VladimirGVP](https://github.com/VladimirGVP).
 - Flush async workflow result assembly after session replacement when every child is already terminal, without permitting stale-context launches (#1833). Thanks [@redcomet168](https://github.com/redcomet168).
 - Accept calendar/platform `claude --version` output during Claude Code adapter preflight while retaining required launch-flag validation. Thanks [@drouhard](https://github.com/drouhard).

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -46,6 +46,13 @@ import { registerPromptTemplateDelegationBridge } from "../slash/prompt-template
 import { registerMainWatchdog } from "../watchdog/register-main.ts";
 import { registerSlashSubagentBridge } from "../slash/slash-bridge.ts";
 import { createNativeSupervisorChannel } from "../intercom/native-supervisor-channel.ts";
+import {
+	renderSupervisorReply,
+	renderSupervisorRequest,
+	SUPERVISOR_REPLY_ENTRY_TYPE,
+	SUPERVISOR_REQUEST_MESSAGE_TYPE,
+	type SupervisorRequestMessageDetails,
+} from "../intercom/supervisor-ui.ts";
 import { registerHerdrStatusBridge, type HerdrStatusRun } from "../integrations/herdr-status.ts";
 import { listHerdrProjectPaneRoots, restoreHerdrProjectPaneSnapshots } from "../inspectors/herdr/project-panes.ts";
 import { registerSubagentRpcBridge } from "./rpc.ts";
@@ -602,6 +609,14 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		refreshResultDelivery: () => refreshResultDelivery(),
 	});
 	executorScheduled = executor.executeScheduled;
+
+	pi.registerMessageRenderer<SupervisorRequestMessageDetails>(SUPERVISOR_REQUEST_MESSAGE_TYPE, renderSupervisorRequest);
+	const registerEntryRenderer = (pi as unknown as {
+		registerEntryRenderer?: (customType: string, renderer: (entry: { data?: unknown }, options: { expanded: boolean }, theme: ExtensionContext["ui"]["theme"]) => Component | undefined) => void;
+	}).registerEntryRenderer;
+	if (typeof registerEntryRenderer === "function") {
+		registerEntryRenderer.call(pi, SUPERVISOR_REPLY_ENTRY_TYPE, renderSupervisorReply);
+	}
 
 	pi.registerMessageRenderer<SlashMessageDetails>(SLASH_RESULT_TYPE, (message, options, theme) => {
 		const details = resolveSlashMessageDetails(message.details);

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -8,6 +8,13 @@ import type { ChildSupervisorMetadata } from "../runs/shared/child-runtime-confi
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type ControlEvent, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
 import { writeAtomicJson } from "../shared/atomic-json.ts";
 import { shouldUseNativeFsWatch } from "../shared/watch-strategy.ts";
+import {
+	SUPERVISOR_REQUEST_MESSAGE_TYPE,
+	SUPERVISOR_REPLY_ENTRY_TYPE,
+	supervisorReplyHint,
+	type SupervisorReason,
+	type SupervisorReplyEntryData,
+} from "./supervisor-ui.ts";
 
 const SUPERVISOR_CHANNEL_ROOT = path.join(TEMP_ROOT_DIR, "supervisor-channels");
 const REQUESTS_DIR = "requests";
@@ -23,8 +30,6 @@ const MAX_SUPERVISOR_REQUEST_CORRELATIONS = 256;
 const SUPERVISOR_REQUEST_CORRELATION_RETENTION_MS = 10 * 60 * 1000;
 
 export type SupervisorRequestState = "pending" | "resolved" | "unknown";
-
-type SupervisorReason = "need_decision" | "interview_request" | "progress_update";
 
 interface SupervisorRequest {
 	type: "subagent.supervisor.request";
@@ -522,7 +527,7 @@ function requestVisibleText(request: PendingSupervisorRequest): string {
 	return lines.join("\n");
 }
 
-function writeReply(request: PendingSupervisorRequest, message: string): void {
+function writeReply(request: PendingSupervisorRequest, message: string): SupervisorReply {
 	if (!message.trim()) throw new Error("message is required for supervisor replies.");
 	const reply: SupervisorReply = {
 		type: "subagent.supervisor.reply",
@@ -532,6 +537,30 @@ function writeReply(request: PendingSupervisorRequest, message: string): void {
 	};
 	writeAtomicJson(replyPath(request.channelDir, request.id), reply);
 	removeRequestFile(request.requestFile);
+	return reply;
+}
+
+function appendSupervisorReplyEntry(pi: ExtensionAPI, request: PendingSupervisorRequest, reply: SupervisorReply): void {
+	const appendEntry = (pi as unknown as {
+		appendEntry?: (customType: string, data?: SupervisorReplyEntryData) => void;
+	}).appendEntry;
+	if (typeof appendEntry !== "function") return;
+	try {
+		appendEntry.call(pi, SUPERVISOR_REPLY_ENTRY_TYPE, {
+			requestId: request.id,
+			replyTo: request.id,
+			reason: request.reason,
+			runId: request.runId,
+			agent: request.agent,
+			childIndex: request.childIndex,
+			...(request.childTarget ? { childTarget: request.childTarget } : {}),
+			message: reply.message,
+			createdAt: reply.createdAt,
+		});
+	} catch (error) {
+		// The reply file is authoritative; a UI journal failure must not undo a delivered reply.
+		console.error("Failed to journal native supervisor reply:", error);
+	}
 }
 
 function resolvePendingRequest(pending: Map<string, PendingSupervisorRequest>, params: IntercomParams): PendingSupervisorRequest {
@@ -567,7 +596,7 @@ function publicPendingRequests(pending: Map<string, PendingSupervisorRequest>): 
 	}));
 }
 
-function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
+function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
 	return {
 		name: NATIVE_SUPERVISOR_TOOL_NAME,
 		label: "Subagent Supervisor",
@@ -585,7 +614,8 @@ function buildParentSupervisorTool(pending: Map<string, PendingSupervisorRequest
 			}
 			if (input.action === "reply") {
 				const request = resolvePendingRequest(pending, input);
-				writeReply(request, input.message ?? "");
+				const reply = writeReply(request, input.message ?? "");
+				appendSupervisorReplyEntry(pi, request, reply);
 				onLifecycle(request, "resolved");
 				pending.delete(request.id);
 				clearForegroundSupervisorAttention(request, pending, state);
@@ -676,7 +706,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 
 	const registerParentTools = (): void => {
-		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pending, state, observeRequestLifecycle));
+		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pi, pending, state, observeRequestLifecycle));
 	};
 
 	const cleanupStaleChannelsIfDue = (): void => {
@@ -717,16 +747,20 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 				removeRequestFile(request.requestFile);
 			}
 			pi.sendMessage({
-				customType: "subagent_supervisor_request",
+				customType: SUPERVISOR_REQUEST_MESSAGE_TYPE,
 				content: requestVisibleText(request),
 				display: true,
 				details: {
 					id: request.id,
+					requestId: request.id,
 					reason: request.reason,
 					expectsReply: request.expectsReply,
 					runId: request.runId,
 					agent: request.agent,
 					childIndex: request.childIndex,
+					...(request.childTarget ? { childTarget: request.childTarget } : {}),
+					...(request.interview !== undefined ? { interview: request.interview } : {}),
+					...(request.expectsReply ? { replyTo: request.id, replyHint: supervisorReplyHint(request.id) } : {}),
 				},
 			}, { triggerTurn: true });
 			if (request.expectsReply) {

--- a/src/intercom/supervisor-ui.ts
+++ b/src/intercom/supervisor-ui.ts
@@ -1,0 +1,216 @@
+import type { EntryRenderOptions, MessageRenderOptions, Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import { safeTerminalText } from "../shared/display-text.ts";
+
+export const SUPERVISOR_REQUEST_MESSAGE_TYPE = "subagent_supervisor_request";
+export const SUPERVISOR_REPLY_ENTRY_TYPE = "subagent_supervisor_reply";
+
+export type SupervisorReason = "need_decision" | "interview_request" | "progress_update";
+
+export interface SupervisorRequestMessageDetails {
+	id?: string;
+	requestId?: string;
+	reason?: SupervisorReason;
+	expectsReply?: boolean;
+	runId?: string;
+	agent?: string;
+	childIndex?: number;
+	childTarget?: string;
+	interview?: unknown;
+	replyTo?: string;
+	replyHint?: string;
+}
+
+export interface SupervisorReplyEntryData {
+	requestId: string;
+	replyTo: string;
+	reason?: SupervisorReason;
+	runId: string;
+	agent: string;
+	childIndex: number;
+	childTarget?: string;
+	message: string;
+	createdAt: number;
+}
+
+interface SupervisorMessageLike {
+	content: unknown;
+	details?: unknown;
+}
+
+interface SupervisorEntryLike {
+	data?: unknown;
+}
+
+const MAX_FIELD_CHARS = 512;
+const MAX_BODY_CHARS = 8_000;
+const MAX_INTERVIEW_CHARS = 4_000;
+const MAX_RENDER_LINES = 36;
+const TRUNCATION_MARKER = "[truncated]";
+
+export function supervisorReplyHint(requestId: string): string {
+	return `subagent_supervisor({ action: "reply", replyTo: "${requestId}", message: "..." })`;
+}
+
+function boundedText(value: string, maxChars: number): string {
+	const safe = safeTerminalText(value);
+	if (safe.length <= maxChars) return safe;
+	const prefixLength = Math.max(0, maxChars - TRUNCATION_MARKER.length - 1);
+	let prefix = "";
+	for (const character of safe) {
+		if (prefix.length + character.length > prefixLength) break;
+		prefix += character;
+	}
+	return `${prefix} ${TRUNCATION_MARKER}`;
+}
+
+function displayText(value: string, maxChars: number, expanded: boolean): string {
+	return expanded ? safeTerminalText(value) : boundedText(value, maxChars);
+}
+
+function boundedField(value: unknown, fallback = "unknown"): string {
+	return boundedText(typeof value === "string" ? value : value === undefined ? fallback : String(value), MAX_FIELD_CHARS);
+}
+
+function contentText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((part) => {
+			if (!part || typeof part !== "object") return "";
+			const text = (part as { text?: unknown }).text;
+			return typeof text === "string" ? text : "";
+		})
+		.filter(Boolean)
+		.join("\n");
+}
+
+function interviewText(interview: unknown, expanded: boolean): string {
+	let serialized: string;
+	try {
+		serialized = JSON.stringify(interview, null, 2) ?? String(interview);
+	} catch {
+		serialized = "[unavailable]";
+	}
+	return displayText(serialized, MAX_INTERVIEW_CHARS, expanded);
+}
+
+function requestDetails(value: unknown): SupervisorRequestMessageDetails | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	return value as SupervisorRequestMessageDetails;
+}
+
+function replyData(value: unknown): SupervisorReplyEntryData | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	return value as SupervisorReplyEntryData;
+}
+
+function withRequestId(details: SupervisorRequestMessageDetails): string {
+	return boundedField(details.requestId ?? details.id);
+}
+
+function requestHeading(reason: SupervisorReason | undefined): string {
+	if (reason === "interview_request") return "⚠ Supervisor interview request";
+	if (reason === "progress_update") return "ℹ Supervisor progress update";
+	return "⚠ Supervisor decision request";
+}
+
+function requestLines(message: SupervisorMessageLike, details: SupervisorRequestMessageDetails, expanded: boolean): string[] {
+	const requestId = withRequestId(details);
+	const lines = [
+		`Reason: ${boundedField(details.reason)}`,
+		`Run: ${boundedField(details.runId)}`,
+		`Agent: ${boundedField(details.agent)}`,
+		`Child index: ${boundedField(details.childIndex)}`,
+	];
+	if (details.childTarget) lines.push(`Child target: ${boundedField(details.childTarget)}`);
+	lines.push(`Request ID: ${requestId}`);
+	if (details.expectsReply) lines.push(`Reply with: ${displayText(details.replyHint ?? supervisorReplyHint(requestId), MAX_BODY_CHARS, expanded)}`);
+	lines.push("", "Request:", displayText(contentText(message.content) || "(no request body)", MAX_BODY_CHARS, expanded));
+	if (details.interview !== undefined) lines.push("", "Interview shape:", interviewText(details.interview, expanded));
+	return lines;
+}
+
+function replyLines(data: SupervisorReplyEntryData, expanded: boolean): string[] {
+	const requestId = boundedField(data.requestId || data.replyTo);
+	const lines = [
+		...(data.reason ? [`Reason: ${boundedField(data.reason)}`] : []),
+		`Run: ${boundedField(data.runId)}`,
+		`Agent: ${boundedField(data.agent)}`,
+		`Child index: ${boundedField(data.childIndex)}`,
+	];
+	if (data.childTarget) lines.push(`Child target: ${boundedField(data.childTarget)}`);
+	lines.push(`Reply to: ${requestId}`, "", "Reply:", displayText(data.message || "(empty reply)", MAX_BODY_CHARS, expanded));
+	return lines;
+}
+
+function renderCard(lines: string[], heading: string, theme: Theme, width: number, expanded: boolean): string[] {
+	const safeWidth = Math.max(0, Math.floor(width));
+	if (safeWidth < 3) return [truncateToWidth(heading, safeWidth, "")];
+	const bodyWidth = safeWidth - 2;
+	const headerText = truncateToWidth(` ${heading} `, bodyWidth, "");
+	const headerPadding = Math.max(0, bodyWidth - visibleWidth(headerText));
+	const border = (text: string) => theme.fg("accent", text);
+	const rendered = [border(`╭${headerText}${"─".repeat(headerPadding)}╮`)];
+	let hidden = false;
+	let interiorLines = 0;
+	for (const line of lines) {
+		const wrapped = wrapTextWithAnsi(line, Math.max(1, bodyWidth));
+		for (const wrappedLine of wrapped.length > 0 ? wrapped : [""]) {
+			if (!expanded && interiorLines >= MAX_RENDER_LINES) {
+				hidden = true;
+				break;
+			}
+			const text = truncateToWidth(wrappedLine, bodyWidth, "");
+			rendered.push(border(`│${text}${" ".repeat(Math.max(0, bodyWidth - visibleWidth(text)))}│`));
+			interiorLines++;
+		}
+		if (hidden) break;
+	}
+	if (hidden) {
+		const text = truncateToWidth(TRUNCATION_MARKER, bodyWidth, "");
+		rendered.push(border(`│${text}${" ".repeat(Math.max(0, bodyWidth - visibleWidth(text)))}│`));
+	}
+	rendered.push(border(`╰${"─".repeat(bodyWidth)}╯`));
+	return rendered;
+}
+
+class SupervisorCardComponent implements Component {
+	private readonly expanded: boolean;
+	private readonly heading: string;
+	private readonly lines: string[];
+	private readonly theme: Theme;
+
+	constructor(heading: string, lines: string[], theme: Theme, expanded: boolean) {
+		this.expanded = expanded;
+		this.heading = heading;
+		this.lines = lines;
+		this.theme = theme;
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return renderCard(this.lines, this.heading, this.theme, width, this.expanded);
+	}
+}
+
+export function renderSupervisorRequest(
+	message: SupervisorMessageLike,
+	options: MessageRenderOptions,
+	theme: Theme,
+): Component | undefined {
+	const details = requestDetails(message.details);
+	if (!details) return undefined;
+	return new SupervisorCardComponent(requestHeading(details.reason), requestLines(message, details, options.expanded), theme, options.expanded);
+}
+
+export function renderSupervisorReply(
+	entry: SupervisorEntryLike,
+	options: EntryRenderOptions,
+	theme: Theme,
+): Component | undefined {
+	const data = replyData(entry.data);
+	if (!data) return undefined;
+	return new SupervisorCardComponent("↩ Supervisor reply to child", replyLines(data, options.expanded), theme, options.expanded);
+}

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -1107,12 +1107,14 @@ describe("subagent extension child mode", () => {
 			const events = { on() { return () => {}; }, emit() {} };
 			const commands = [];
 			const renderers = [];
+			const entryRenderers = [];
 			const fakePi = new Proxy({
 				events,
 				registerTool() {},
 				registerCommand(name) { commands.push(name); },
 				registerShortcut() {},
 				registerMessageRenderer(type) { renderers.push(type); },
+				registerEntryRenderer(type) { entryRenderers.push(type); },
 				sendMessage() {},
 				getSessionName() { return undefined; },
 			}, {
@@ -1124,6 +1126,8 @@ describe("subagent extension child mode", () => {
 			registerSubagentExtension(fakePi);
 			if (!commands.includes("subagents-watchdog")) throw new Error("watchdog command not registered: " + commands.join(", "));
 			if (!renderers.includes("subagent_watchdog_warning")) throw new Error("watchdog renderer not registered: " + renderers.join(", "));
+			if (!renderers.includes("subagent_supervisor_request")) throw new Error("supervisor request renderer not registered: " + renderers.join(", "));
+			if (!entryRenderers.includes("subagent_supervisor_reply")) throw new Error("supervisor reply entry renderer not registered: " + entryRenderers.join(", "));
 		`;
 
 		execFileSync(

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -11,6 +11,7 @@ import {
 	registerNativeSupervisorClient,
 	resolveSupervisorChannelDir,
 } from "../../src/intercom/native-supervisor-channel.ts";
+import { SUPERVISOR_REPLY_ENTRY_TYPE, SUPERVISOR_REQUEST_MESSAGE_TYPE } from "../../src/intercom/supervisor-ui.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, type SubagentState } from "../../src/shared/types.ts";
 
 const createdChannels: string[] = [];
@@ -32,7 +33,7 @@ function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	};
 }
 
-function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; createdAt?: number; expiresAt?: number }): string {
+function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; reason?: "need_decision" | "interview_request" | "progress_update"; childTarget?: string; interview?: unknown; createdAt?: number; expiresAt?: number }): string {
 	const agent = input.agent ?? "worker";
 	const index = input.index ?? 0;
 	const channelDir = resolveSupervisorChannelDir(input.runId, agent, index);
@@ -44,14 +45,16 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 		id: requestId,
 		createdAt: input.createdAt ?? Date.now(),
 		...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
-		reason: "need_decision",
+		reason: input.reason ?? "need_decision",
 		message: input.message ?? "Need a decision",
-		expectsReply: true,
+		expectsReply: input.reason !== "progress_update",
 		orchestratorSessionId: input.sessionId,
 		orchestratorTarget: "shared-name",
 		runId: input.runId,
 		agent,
 		childIndex: index,
+		...(input.childTarget ? { childTarget: input.childTarget } : {}),
+		...(input.interview !== undefined ? { interview: input.interview } : {}),
 	}, null, "\t"));
 	return requestId;
 }
@@ -642,6 +645,94 @@ describe("native supervisor channel", () => {
 			assert.equal(reply.requestId, requestId);
 			assert.equal(reply.message, "Approved");
 			assert.equal(fs.existsSync(requestFile(runId, requestId)), false);
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("includes supervisor request metadata and journals a successful reply", async () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({
+			sessionId: currentSessionId,
+			runId,
+			agent: "worker",
+			index: 2,
+			message: "Should this change be applied?",
+			reason: "interview_request",
+			childTarget: "child-worker",
+			interview: { approved: "boolean", rationale: "string" },
+		});
+		const sent: Array<{ customType?: string; details?: Record<string, unknown> }> = [];
+		const entries: Array<{ customType: string; data?: Record<string, unknown> }> = [];
+		const journalState = { replyExistsAtAppend: false, requestExistsAtAppend: true };
+		const registeredTools = new Map<string, { execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<unknown> }>();
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const pi = {
+			getAllTools: () => [...registeredTools.keys()].map((name) => ({ name })),
+			registerTool: (tool: { name: string; execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<unknown> }) => {
+				registeredTools.set(tool.name, tool);
+			},
+			sendMessage: (message: { customType?: string; details?: Record<string, unknown> }) => { sent.push(message); },
+			appendEntry: (customType: string, data?: Record<string, unknown>) => {
+				journalState.replyExistsAtAppend = fs.existsSync(replyFile(runId, requestId, "worker", 2));
+				journalState.requestExistsAtAppend = fs.existsSync(requestFile(runId, requestId, "worker", 2));
+				entries.push({ customType, data });
+			},
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
+
+		try {
+			channel.start();
+			assert.equal(sent.length, 1);
+			assert.equal(sent[0]?.customType, SUPERVISOR_REQUEST_MESSAGE_TYPE);
+			assert.deepEqual(sent[0]?.details, {
+				id: requestId,
+				requestId,
+				reason: "interview_request",
+				expectsReply: true,
+				runId,
+				agent: "worker",
+				childIndex: 2,
+				childTarget: "child-worker",
+				interview: { approved: "boolean", rationale: "string" },
+				replyTo: requestId,
+				replyHint: `subagent_supervisor({ action: "reply", replyTo: "${requestId}", message: "..." })`,
+			});
+
+			await registeredTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", {
+				action: "reply",
+				replyTo: requestId,
+				message: "Approved with rationale",
+			});
+
+			assert.equal(entries.length, 1);
+			assert.equal(entries[0]?.customType, SUPERVISOR_REPLY_ENTRY_TYPE);
+			assert.deepEqual(journalState, { replyExistsAtAppend: true, requestExistsAtAppend: false });
+			assert.deepEqual({ ...entries[0]?.data, createdAt: undefined }, {
+				requestId,
+				replyTo: requestId,
+				reason: "interview_request",
+				runId,
+				agent: "worker",
+				childIndex: 2,
+				childTarget: "child-worker",
+				message: "Approved with rationale",
+				createdAt: undefined,
+			});
+			assert.equal(typeof entries[0]?.data?.createdAt, "number");
+			const reply = JSON.parse(fs.readFileSync(replyFile(runId, requestId, "worker", 2), "utf-8")) as { message?: string };
+			assert.equal(reply.message, "Approved with rationale");
+			assert.equal(fs.existsSync(requestFile(runId, requestId, "worker", 2)), false);
 		} finally {
 			channel.dispose();
 		}

--- a/test/unit/supervisor-ui.test.ts
+++ b/test/unit/supervisor-ui.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	renderSupervisorReply,
+	renderSupervisorRequest,
+	type SupervisorReplyEntryData,
+	type SupervisorRequestMessageDetails,
+} from "../../src/intercom/supervisor-ui.ts";
+
+const identityTheme = {
+	fg: (_color: string, text: string) => text,
+};
+
+function renderRequest(details: SupervisorRequestMessageDetails, content: string, width = 100, expanded = true): string[] {
+	const component = renderSupervisorRequest({ content, details }, { expanded }, identityTheme as never);
+	assert.ok(component);
+	return component.render(width);
+}
+
+function renderReply(data: SupervisorReplyEntryData, width = 100): string[] {
+	const component = renderSupervisorReply({ data }, { expanded: true }, identityTheme as never);
+	assert.ok(component);
+	return component.render(width);
+}
+
+describe("native supervisor UI", () => {
+	it("renders request metadata, interview shape, and an exact reply hint", () => {
+		const requestId = "request-123456";
+		const output = renderRequest({
+			id: requestId,
+			reason: "interview_request",
+			expectsReply: true,
+			runId: "run-1845",
+			agent: "worker",
+			childIndex: 2,
+			childTarget: "child-worker",
+			replyHint: `subagent_supervisor({ action: "reply", replyTo: "${requestId}", message: "..." })`,
+			interview: { approved: "boolean", rationale: "string" },
+		}, "Should this change be applied?");
+		const text = output.join("\n");
+
+		assert.match(text, /Supervisor interview request/);
+		assert.match(text, /Reason: interview_request/);
+		assert.match(text, /Run: run-1845/);
+		assert.match(text, /Agent: worker/);
+		assert.match(text, /Child index: 2/);
+		assert.match(text, /Child target: child-worker/);
+		assert.match(text, new RegExp(`Request ID: ${requestId}`));
+		assert.match(text, new RegExp(`replyTo: "${requestId}"`));
+		assert.match(text, /Interview shape:/);
+		assert.match(text, /approved/);
+		assert.match(text, /Should this change be applied/);
+	});
+
+	it("omits reply hints for progress updates and renders durable reply metadata", () => {
+		const requestOutput = renderRequest({
+			id: "progress-1",
+			reason: "progress_update",
+			expectsReply: false,
+			runId: "run-progress",
+			agent: "reviewer",
+			childIndex: 0,
+		}, "Progress is continuing.");
+		assert.equal(requestOutput.join("\n").includes("Reply with:"), false);
+
+		const replyOutput = renderReply({
+			requestId: "request-1",
+			replyTo: "request-1",
+			reason: "need_decision",
+			runId: "run-1",
+			agent: "worker",
+			childIndex: 1,
+			childTarget: "child-worker",
+			message: "Approved; continue.",
+			createdAt: 123,
+		});
+		const text = replyOutput.join("\n");
+		assert.match(text, /Supervisor reply to child/);
+		assert.match(text, /Reply to: request-1/);
+		assert.match(text, /Approved; continue\./);
+		assert.match(text, /child-worker/);
+	});
+
+	it("sanitizes and bounds collapsed untrusted content at narrow widths", () => {
+		const output = renderRequest({
+			id: "request-long",
+			reason: "need_decision",
+			expectsReply: true,
+			runId: "run-long",
+			agent: "worker",
+			childIndex: 0,
+		}, `\u0001${"untrusted ".repeat(400)}`, 24, false);
+		assert.ok(output.length <= 39, `expected bounded rows, got ${output.length}`);
+		for (const line of output) assert.ok(visibleWidth(line) <= 24, `line exceeds width: ${line}`);
+		const text = output.join("\n");
+		assert.match(text, /truncated/);
+		assert.equal(text.includes("\u0001"), false);
+		assert.match(text, /\[U\+0001\]/);
+	});
+
+	it("keeps long blocking requests visible when expanded", () => {
+		const content = `${Array.from({ length: 45 }, (_, index) => `decision line ${index + 1}`).join("\n")}\n${"body-detail ".repeat(800)}END_BODY`;
+		const output = renderRequest({
+			id: "request-expanded",
+			reason: "need_decision",
+			expectsReply: true,
+			runId: "run-expanded",
+			agent: "worker",
+			childIndex: 0,
+			interview: { questions: Array.from({ length: 12 }, (_, index) => ({ id: `q${index + 1}`, question: `${"Question detail ".repeat(40)}${index === 11 ? "END_INTERVIEW" : index + 1}` })) },
+		}, content, 120, true);
+		const text = output.join("\n");
+
+		assert.ok(output.length > 39, `expected expanded rows, got ${output.length}`);
+		assert.match(text, /decision line 45/);
+		assert.match(text, /END_BODY/);
+		assert.match(text, /END_INTERVIEW/);
+		assert.doesNotMatch(text, /\[truncated\]/);
+	});
+});


### PR DESCRIPTION
## Summary

- render native supervisor requests as bounded parent-session TUI cards
- append a visible outbound reply entry after the authoritative reply file is written
- cover request/reply rendering, metadata, registration, sanitization, and correlation

Closes #1845.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/supervisor-ui.test.ts test/unit/native-supervisor-channel.test.ts test/unit/index-child-registration.test.ts`
- `npm run typecheck`
- `git diff --check`
- conflict-marker scan
- fresh review: No issues found
