### PR TITLE
fix: refresh stale auth model exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Allow managed worktrees to start from a validated `baseRef` instead of always using `HEAD`. Thanks [@jaudiger](https://github.com/jaudiger) for #1842.
 
 ### Fixed
+- Ignore stale authentication-related model exclusions after Pi's `auth.json` is refreshed, while preserving quota, rate-limit, overload, and model-unavailable exclusions. Thanks [@wesleyfei1](https://github.com/wesleyfei1) for #1835.
 - Show native supervisor requests and outbound replies as bounded TUI cards in parent sessions (#1845).
 - Suppress stale async supervisor-request notices after the native request has already been answered (#1838). Thanks [@VladimirGVP](https://github.com/VladimirGVP).
 - Flush async workflow result assembly after session replacement when every child is already terminal, without permitting stale-context launches (#1833). Thanks [@redcomet168](https://github.com/redcomet168).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ Entries support `~` expansion. A single `*` path segment expands one directory l
 }
 ```
 
-Controls the duration, in milliseconds, for model exclusions. The default is `86400000` (24 hours), and the maximum is `8000000000000000` so generated expiry timestamps remain valid JavaScript dates. The extension applies this value when it starts or reloads. A lower configured value shortens active cached exclusions from their original `recordedAt`; it never extends an existing expiry. Launches also warn when a candidate is skipped, including the cached reason and expiry. `PI_MODEL_EXCLUSIONS_PATH` changes the exclusion-store path but does not change this TTL.
+Controls the duration, in milliseconds, for model exclusions. The default is `86400000` (24 hours), and the maximum is `8000000000000000` so generated expiry timestamps remain valid JavaScript dates. The extension applies this value when it starts or reloads. A lower configured value shortens active cached exclusions from their original `recordedAt`; it never extends an existing expiry. Authentication-related exclusions are ignored when Pi's `auth.json` was modified after the exclusion was recorded; other exclusion types are unaffected. Launches also warn when a candidate is skipped, including the cached reason and expiry. `PI_MODEL_EXCLUSIONS_PATH` changes the exclusion-store path but does not change this TTL.
 
 ## `toolDescriptionMode`
 

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { splitKnownThinkingSuffix } from "../../shared/model-info.ts";
 import { TEMP_ROOT_DIR } from "../../shared/types.ts";
+import { getAgentDir } from "../../shared/utils.ts";
 
 export const EXCLUSIONS_PATH_ENV = "PI_MODEL_EXCLUSIONS_PATH";
 
@@ -29,6 +30,43 @@ let defaultTTLMs = DEFAULT_MODEL_EXCLUSION_TTL_MS;
 let loadedTTLCeilingMs: number | undefined;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
 let persistSeq = 0;
+
+const AUTH_FAILURE_PATTERNS = [
+	/auth(?:entication)?/i,
+	/unauthori[sz]ed/i,
+	/forbidden/i,
+	/api key/i,
+	/token expired/i,
+	/invalid key/i,
+];
+
+function isAuthModelExclusion(entry: ModelExclusion): boolean {
+	const reason = entry.reason;
+	return typeof reason === "string" && AUTH_FAILURE_PATTERNS.some((pattern) => pattern.test(reason));
+}
+
+function getAuthStoreMtimeMs(): number | undefined {
+	const authStorePath = path.join(getAgentDir(), "auth.json");
+	try {
+		const stats = fs.statSync(authStorePath);
+		return stats.isFile() && Number.isFinite(stats.mtimeMs) ? stats.mtimeMs : undefined;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			console.error(`[model-exclusions] Failed to stat Pi auth store at ${authStorePath}; preserving auth-related exclusions:`, error);
+		}
+		return undefined;
+	}
+}
+
+function invalidateAuthExclusions(): void {
+	if (!exclusions.some(isAuthModelExclusion)) return;
+	const authStoreMtimeMs = getAuthStoreMtimeMs();
+	if (authStoreMtimeMs === undefined) return;
+	const retained = exclusions.filter((entry) => !isAuthModelExclusion(entry) || authStoreMtimeMs <= entry.recordedAt);
+	if (retained.length === exclusions.length) return;
+	exclusions = retained;
+	schedulePersist();
+}
 
 /**
  * Override the default TTL applied to newly recorded model exclusions.
@@ -112,6 +150,7 @@ function ensureLoaded(): void {
 			exclusions = deduplicate(exclusions);
 			if (shortened) schedulePersist();
 		}
+		invalidateAuthExclusions();
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 			console.error(`[model-exclusions] Failed to load exclusions from ${getExclusionsFilePath()}:`, error);
@@ -165,6 +204,7 @@ export function recordModelFailure(options: RecordModelFailureOptions): void {
  */
 export function clearExpiredExclusions(): void {
 	ensureLoaded();
+	invalidateAuthExclusions();
 	prune(exclusions, Date.now());
 	schedulePersist();
 }
@@ -202,6 +242,7 @@ function entryMatches(entry: ModelExclusion, candidateModelId: string, candidate
  */
 export function isExcluded(modelId: string, provider: string): boolean {
 	ensureLoaded();
+	invalidateAuthExclusions();
 	return exclusions.some((entry) => entryMatches(entry, modelId, provider, Date.now()));
 }
 
@@ -213,6 +254,7 @@ export function isExcluded(modelId: string, provider: string): boolean {
  */
 export function findModelExclusion(fullId: string, now = Date.now()): Readonly<ModelExclusion> | undefined {
 	ensureLoaded();
+	invalidateAuthExclusions();
 	const { provider, modelId } = parseModelKey(fullId);
 	return exclusions.find((entry) => entryMatches(entry, modelId, provider, now));
 }
@@ -252,6 +294,7 @@ export function filterFallbackCandidates(candidates: string[], opts?: {
 	onExcluded?: (candidate: string, exclusion: Readonly<ModelExclusion>) => void;
 }): string[] {
 	ensureLoaded();
+	invalidateAuthExclusions();
 	const timestamp = opts?.now ?? Date.now();
 	const seen = new Set<string>();
 	const filtered: string[] = [];

--- a/test/unit/model-exclusions.test.ts
+++ b/test/unit/model-exclusions.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
-import { afterEach, beforeEach, describe, it } from "node:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { after, afterEach, beforeEach, describe, it } from "node:test";
 import {
 	clearExclusions,
 	DEFAULT_MODEL_EXCLUSION_TTL_MS,
+	findModelExclusion,
 	filterFallbackCandidates,
 	flushPersist,
 	getExcludedCount,
@@ -17,15 +20,32 @@ import {
 	type ModelExclusion,
 } from "../../src/runs/shared/model-exclusions.ts";
 
+const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+const testAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-model-exclusions-auth-"));
+process.env.PI_CODING_AGENT_DIR = testAgentDir;
+const authPath = path.join(testAgentDir, "auth.json");
+
 // The exclusion store is a process-wide singleton persisted under TEMP_ROOT_DIR
 // (isolated per test run by test/support/isolated-temp-root.mjs). Clear it
 // before/after each test so cases don't leak state into each other.
 beforeEach(() => {
 	setDefaultTTL(DEFAULT_MODEL_EXCLUSION_TTL_MS);
 	fs.rmSync(getExclusionsFilePath(), { force: true });
+	fs.rmSync(authPath, { force: true });
 	clearExclusions();
 });
-afterEach(() => clearExclusions());
+afterEach(() => {
+	clearExclusions();
+	fs.rmSync(authPath, { force: true });
+});
+after(() => {
+	if (previousAgentDir === undefined) {
+		delete process.env.PI_CODING_AGENT_DIR;
+	} else {
+		process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
+	fs.rmSync(testAgentDir, { recursive: true, force: true });
+});
 
 describe("model exclusions — record & query", () => {
 	it("excludes a recorded model", () => {
@@ -165,6 +185,50 @@ describe("model exclusions — filtering fallback candidates", () => {
 });
 
 describe("model exclusions — persistence", () => {
+	it("keeps an auth exclusion after reload when auth.json is unchanged", () => {
+		fs.mkdirSync(path.dirname(authPath), { recursive: true });
+		fs.writeFileSync(authPath, JSON.stringify({ openai: { access: "credential-a" } }), "utf-8");
+		const authMtime = new Date(Date.now() - 1_000);
+		fs.utimesSync(authPath, authMtime, authMtime);
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "invalid oauth token" });
+		reloadFromDisk();
+		assert.equal(isExcluded("gpt-4", "openai"), true);
+	});
+
+	it("invalidates an auth exclusion after auth.json is modified", () => {
+		fs.mkdirSync(path.dirname(authPath), { recursive: true });
+		fs.writeFileSync(authPath, JSON.stringify({ openai: { access: "credential-a" } }), "utf-8");
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "invalid oauth token" });
+		const { recordedAt } = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")).exclusions[0] as ModelExclusion;
+		const newerAuthMtime = new Date(recordedAt + 1_000);
+		fs.utimesSync(authPath, newerAuthMtime, newerAuthMtime);
+		reloadFromDisk();
+		assert.equal(findModelExclusion("openai/gpt-4"), undefined);
+		assert.equal(isExcluded("gpt-4", "openai"), false);
+	});
+
+	it("keeps a non-auth exclusion after auth.json is modified", () => {
+		fs.mkdirSync(path.dirname(authPath), { recursive: true });
+		fs.writeFileSync(authPath, JSON.stringify({ openai: { access: "credential-a" } }), "utf-8");
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "quota exceeded" });
+		const { recordedAt } = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")).exclusions[0] as ModelExclusion;
+		const newerAuthMtime = new Date(recordedAt + 1_000);
+		fs.utimesSync(authPath, newerAuthMtime, newerAuthMtime);
+		reloadFromDisk();
+		assert.equal(isExcluded("gpt-4", "openai"), true);
+	});
+
+	it("does not persist credential contents in the exclusion store", () => {
+		const accessToken = "access-token-secret";
+		const refreshToken = "refresh-token-secret";
+		fs.mkdirSync(path.dirname(authPath), { recursive: true });
+		fs.writeFileSync(authPath, JSON.stringify({ openai: { access: accessToken, refresh: refreshToken } }), "utf-8");
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "invalid oauth token" });
+		const persisted = fs.readFileSync(getExclusionsFilePath(), "utf-8");
+		assert.equal(persisted.includes(accessToken), false);
+		assert.equal(persisted.includes(refreshToken), false);
+	});
+
 	it("survives a reload from disk", () => {
 		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "429" });
 		reloadFromDisk();


### PR DESCRIPTION
## Summary
- ignore authentication-related model exclusions when Pi's `auth.json` was modified after the exclusion was recorded
- keep quota, rate-limit, overload, and model-unavailable exclusions untouched
- document the reload behavior and credit @wesleyfei1 for the report

Closes #1835.

## Tests
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-exclusions.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-exclusions.test.ts test/unit/model-fallback.test.ts test/unit/pi-coding-agent-dir.test.ts test/unit/index-child-registration.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern "fails closed before spawn when cached exclusions leave zero launch candidates|does not retry a non-zero exit after tool activity" test/integration/single-execution.test.ts`
- `npm run test:unit`
- `npm run typecheck`
- `git diff --check`
