### PR TITLE
fix: fail closed for child model resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### Fixed
 - Drop only malformed persisted model-exclusion entries and rewrite the cleaned cache.
 - Stop live workflow children when a run-level stop targets an in-memory async workflow controller.
+- Fail closed when a fallback-only model configuration resolves no launch candidates. Thanks [@AdenosineTP](https://github.com/AdenosineTP) for #1853.
+- Resolve native child models after child extensions register provider models. Thanks [@mystery4f](https://github.com/mystery4f) for #1855.
 - Ignore stale authentication-related model exclusions after Pi's `auth.json` is refreshed, while preserving quota, rate-limit, overload, and model-unavailable exclusions. Thanks [@wesleyfei1](https://github.com/wesleyfei1) for #1835.
 - Show native supervisor requests and outbound replies as bounded TUI cards in parent sessions (#1845).
 - Suppress stale async supervisor-request notices after the native request has already been answered (#1838). Thanks [@VladimirGVP](https://github.com/VladimirGVP).

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -114,6 +114,19 @@ export interface DefaultChildSessionFactoryOptions {
 	shutdownTimeoutMs?: number;
 }
 
+type ModelRuntimeInstance = Awaited<ReturnType<PiCodingAgentModule["ModelRuntime"]["create"]>>;
+type QueuedProviderRegistration = { name: string; config: Parameters<ModelRuntimeInstance["registerProvider"]>[1]; extensionPath: string };
+type QueuedNativeProviderRegistration = { provider: Parameters<ModelRuntimeInstance["registerNativeProvider"]>[0]; extensionPath: string };
+
+interface LoaderWithExtensions {
+	getExtensions(): {
+		runtime: {
+			pendingProviderRegistrations: QueuedProviderRegistration[];
+			pendingNativeProviderRegistrations: QueuedNativeProviderRegistration[];
+		};
+	};
+}
+
 /** One launch at a time from env application through `session_start`, so parallel launches never observe each other's `processEnv` while their extensions load and start. */
 let loading: Promise<unknown> = Promise.resolve();
 
@@ -136,6 +149,27 @@ function applyProcessEnv(values: Record<string, string | undefined> | undefined)
 		if (value === undefined) delete process.env[name];
 		else process.env[name] = value;
 	}
+}
+
+function flushQueuedProviderRegistrations(loader: object, modelRuntime: ModelRuntimeInstance, onError: ((error: ChildSessionExtensionError) => void) | undefined): void {
+	if (!("getExtensions" in loader) || typeof loader.getExtensions !== "function") return;
+	const { runtime } = (loader as LoaderWithExtensions).getExtensions();
+	for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations) {
+		try {
+			modelRuntime.registerProvider(name, config);
+		} catch (error) {
+			onError?.({ extensionPath, event: "register_provider", error });
+		}
+	}
+	runtime.pendingProviderRegistrations = [];
+	for (const { provider, extensionPath } of runtime.pendingNativeProviderRegistrations) {
+		try {
+			modelRuntime.registerNativeProvider(provider);
+		} catch (error) {
+			onError?.({ extensionPath, event: "register_provider", error });
+		}
+	}
+	runtime.pendingNativeProviderRegistrations = [];
 }
 
 /**
@@ -180,6 +214,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 				applyProcessEnv(launch.processEnv);
 				if (!resetExtensionCacheOnReload(loader) && (launch.ambientExtensions || launch.extensionPaths.length)) launch.onExtensionError?.({ extensionPath: "<loader>", event: "load", error: new Error("pi's extension cache reset is unavailable; extensions loaded into this child share module state with other sessions in this process.") });
 				await loader.reload();
+				flushQueuedProviderRegistrations(loader, modelRuntime, launch.onExtensionError);
 				const sessionManager = launch.storage.kind === "file"
 					? pi.SessionManager.open(launch.storage.sessionFile, undefined, launch.cwd)
 					: launch.storage.kind === "dir"

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -464,6 +464,7 @@ export function buildModelCandidates(
 	const candidates: string[] = [];
 	const rawCandidates = [primaryModel, ...(fallbackModels ?? [])];
 	let skippedPrimary: string | undefined;
+	let skippedFallback: string | undefined;
 	for (let index = 0; index < rawCandidates.length; index++) {
 		const raw = rawCandidates[index];
 		if (!raw) continue;
@@ -473,7 +474,10 @@ export function buildModelCandidates(
 			: resolveSubagentModelCandidate(model, availableModels, preferredProvider);
 		if (!normalized) {
 			if (index === 0) skippedPrimary = model;
-			else console.warn(`[pi-subagents] Skipping fallback model '${model}' because it is unavailable in this environment.`);
+			else {
+				skippedFallback ??= model;
+				console.warn(`[pi-subagents] Skipping fallback model '${model}' because it is unavailable in this environment.`);
+			}
 			continue;
 		}
 		if (seen.has(normalized)) continue;
@@ -486,6 +490,7 @@ export function buildModelCandidates(
 	const resolved = filterFallbackCandidates(candidates, { onExcluded: warnCachedExclusion });
 	if (resolved.length === 0) {
 		if (skippedPrimary) resolveRequiredSubagentModelCandidate(skippedPrimary, availableModels, preferredProvider);
+		if (candidates.length === 0 && skippedFallback) resolveRequiredSubagentModelCandidate(skippedFallback, availableModels, preferredProvider);
 		if (candidates.length > 0) {
 			const shownExclusions = excludedCandidates;
 			const omittedExclusions = excludedCandidateCount - shownExclusions.length;

--- a/test/integration/async-execution.test.ts
+++ b/test/integration/async-execution.test.ts
@@ -861,6 +861,24 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 0);
 	});
 
+	it("rejects fallback-only configurations with no launch candidates before spawn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
+		mockPi.onCall({ output: "should not spawn" });
+		const launch = executeAsyncSingle(`async-fallback-only-zero-candidates-${Date.now().toString(36)}`, {
+			agent: "worker",
+			task: "Do work",
+			agentConfig: makeAgent("worker", { fallbackModels: ["does-not-exist"], completionGuard: false }),
+			availableModels: [{ provider: "mock", id: "fallback", fullId: "mock/fallback" }],
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			maxSubagentDepth: 2,
+			acceptance: false,
+		});
+		assert.equal(launch.isError, true);
+		assert.match(launch.content[0]?.text ?? "", /Unknown subagent model 'does-not-exist'/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
 	it("rejects an explicit non-strict out-of-scope model before spawn even when a fallback exists", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, () => {
 		mockPi.onCall({ output: "should not spawn" });
 		const launch = executeAsyncSingle(`async-explicit-scope-${Date.now().toString(36)}`, {

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -258,6 +258,36 @@ describe("default child session factory", () => {
 		assert.deepEqual(flags, [true, true]);
 	});
 
+	it("resolves models from providers queued during child extension loading", async () => {
+		const registeredProviders: string[] = [];
+		const registeredNativeProviders: string[] = [];
+		let pendingRuntime: { pendingProviderRegistrations: unknown[]; pendingNativeProviderRegistrations: unknown[] } | undefined;
+		const pi = stubPi();
+		pi.ModelRuntime = { create: async () => ({ registerProvider: (name: string) => { registeredProviders.push(name); }, registerNativeProvider: (provider: { id: string }) => { registeredNativeProviders.push(provider.id); } }) } as unknown as PiCodingAgentModule["ModelRuntime"];
+		pi.DefaultResourceLoader = class {
+			runtime = {
+				pendingProviderRegistrations: [{ name: "router", config: { models: [{ id: "mimo-v2.5" }] }, extensionPath: "/extensions/router.ts" }],
+				pendingNativeProviderRegistrations: [{ provider: { id: "native-router", models: [{ id: "native-model" }] }, extensionPath: "/extensions/native-router.ts" }],
+			};
+			async reload() { pendingRuntime = this.runtime; }
+			getExtensions() { return { extensions: [], errors: [], runtime: this.runtime }; }
+		} as unknown as PiCodingAgentModule["DefaultResourceLoader"];
+		pi.resolveCliModel = (({ cliModel }) => {
+			assert.equal(cliModel, "router/mimo-v2.5");
+			assert.deepEqual(registeredProviders, ["router"]);
+			assert.deepEqual(registeredNativeProviders, ["native-router"]);
+			return { model: { provider: "router", id: "mimo-v2.5" } };
+		}) as unknown as PiCodingAgentModule["resolveCliModel"];
+		pi.createAgentSession = (async ({ model }) => ({ session: { bindExtensions: async () => {}, dispose() {}, extensionRunner: { hasHandlers: () => false }, subscribe: () => () => {}, prompt: async () => {}, abort: async () => {}, steer: async () => {}, followUp: async () => {}, messages: [], sessionId: "s", model } })) as unknown as PiCodingAgentModule["createAgentSession"];
+
+		const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => pi });
+		const child = await factory.create({ ...stubLaunch, model: "router/mimo-v2.5" });
+
+		assert.equal(child.modelId, "router/mimo-v2.5");
+		assert.deepEqual(pendingRuntime?.pendingProviderRegistrations, []);
+		assert.deepEqual(pendingRuntime?.pendingNativeProviderRegistrations, []);
+	});
+
 	it("reports a missing extension cache reset when the child loads extension files", async () => {
 		const errors: string[] = [];
 		const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => stubPi() });

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -5919,6 +5919,21 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 0);
 	});
 
+	it("fails closed before spawn when fallback-only configuration resolves no launch candidates", async () => {
+		mockPi.onCall({ output: "should not spawn" });
+		const agents = [makeAgent("worker", { fallbackModels: ["does-not-exist"] })];
+
+		await assert.rejects(
+			runSync(tempDir, agents, "worker", "Do work", {
+				runId: "fallback-only-zero-candidates",
+				acceptance: false,
+				availableModels: [{ provider: "openai", id: "gpt-5-mini", fullId: "openai/gpt-5-mini" }],
+			}),
+			/Unknown subagent model 'does-not-exist'/,
+		);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
 	it("does not retry a non-zero exit after tool activity", async () => {
 		mockPi.onCall({ jsonl: [events.toolStart("read", { path: "package.json" })], exitCode: 1 });
 		mockPi.onCall({ output: "must not run" });

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -250,6 +250,19 @@ describe("model fallback helpers", () => {
 		assert.equal(warnings.some((warning) => warning.includes("Skipping primary model 'does-not-exist'")), false);
 	});
 
+	it("fails closed when fallback-only configuration resolves no candidates", () => {
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			assert.throws(
+				() => buildModelCandidates(undefined, ["does-not-exist"], availableModels),
+				/Unknown subagent model 'does-not-exist'/,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
 	it("keeps an explicit unknown primary strict even when fallbacks exist", () => {
 		assert.throws(
 			() => buildModelCandidates("does-not-exist", ["anthropic/claude-sonnet-4"], availableModels, undefined, { origin: "explicit" }),
@@ -295,6 +308,20 @@ describe("model fallback helpers", () => {
 					&& !message.includes("sk-secret-token-xyz");
 			},
 		);
+	});
+
+	it("keeps cached-exclusion diagnostics when an unrelated fallback is unavailable", () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "sk-secret-token-xyz" });
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			assert.throws(
+				() => buildModelCandidates("openai/gpt-5-mini", ["does-not-exist"], availableModels),
+				/No usable subagent models remain after registry, scope, and cached-exclusion filtering/,
+			);
+		} finally {
+			console.warn = originalWarn;
+		}
 	});
 
 	it("bounds and sanitizes excluded-candidate evidence", () => {


### PR DESCRIPTION
## Summary
- flush queued child extension provider registrations before native child model resolution
- fail closed when fallback-only model configs resolve no launch candidates
- add focused foreground, async, model-fallback, and in-process child regressions

Closes #1853.
Closes #1855.

Thanks @AdenosineTP for #1853 and @mystery4f for #1855.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'rejects fallback-only configurations with no launch candidates before spawn|rejects an explicit cached-excluded model before spawn even when a fallback exists' test/integration/async-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'fails closed before spawn when cached exclusions leave zero launch candidates|fails closed before spawn when fallback-only configuration resolves no launch candidates' test/integration/single-execution.test.ts`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/in-process-child.test.ts`
- `npm run typecheck`
- `git diff --check`
- conflict-marker scan
