### PR TITLE
fix: keep pi-web sessions alive for active subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add `contact_supervisor` to the bundled reviewer and scout tool allowlists without adding mutation tools (#1846).
 
 ### Fixed
+- Keep pi-web parent sessions alive while subagent work or completion delivery remains active. Thanks to [@vcing](https://github.com/vcing) for #1857.
 - Drop only malformed persisted model-exclusion entries and rewrite the cleaned cache.
 - Stop live workflow children when a run-level stop targets an in-memory async workflow controller.
 - Fail closed when a fallback-only model configuration resolves no launch candidates. Thanks [@AdenosineTP](https://github.com/AdenosineTP) for #1853.

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -414,6 +414,8 @@ Detached children do not stop when the session does. They are the host process's
 
 This matters because "is the parent busy?" is the wrong idle signal. A parent that launches a detached run and hands control back — which is what the async launch output tells it to do — is not prompting, streaming, compacting, or running a shell command. A host that reaps sessions on those signals alone will dispose exactly the session that was waiting to be woken.
 
+When pi-subagents runs inside a compatible pi-web host, it discovers the versioned `Symbol.for("@agegr/pi-web/session-liveness/v1")` registry and registers one provider for the current session. The provider reports live `queued`/`running` async jobs, active nested descendants (including foreground routes retained after their direct parent settles), foreground controls that still have a scheduling owner or active child, and completion notifications waiting for their batch-delivery timer. Retained terminal history, future schedules, and wait subscriptions do not make a session live by themselves. The registration is replaced on session changes and released during runtime shutdown or reload; other hosts remain unaffected.
+
 If your host reclaims idle sessions, keep a session alive while it still has live detached work:
 
 - Read run state from the status files under the async run directory rather than from event traffic. A long, quiet workflow sends almost nothing to the parent, so recent-activity heuristics conclude the wrong thing.
@@ -431,6 +433,7 @@ The main runtime files in this repository:
 | File | Purpose |
 |------|---------|
 | `src/extension/index.ts` | Extension registration, tool registration, message/render wiring. |
+| `src/integrations/pi-web-session-liveness.ts` | Optional pi-web idle-eviction liveness bridge. |
 | `src/agents/agents.ts` | Agent and chain discovery, frontmatter parsing. |
 | `src/runs/foreground/subagent-executor.ts` | Main execution routing for single, parallel, chain, management, status, interrupt, and doctor actions. |
 | `src/runs/foreground/execution.ts` | Core foreground `runSync` handling: drives one in-process child session per attempt. |

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -54,6 +54,8 @@ import {
 	type SupervisorRequestMessageDetails,
 } from "../intercom/supervisor-ui.ts";
 import { registerHerdrStatusBridge, type HerdrStatusRun } from "../integrations/herdr-status.ts";
+import { hasLiveSubagentWork, registerPiWebSessionLiveness } from "../integrations/pi-web-session-liveness.ts";
+import { createRetainedNestedRouteTracker } from "../runs/background/retained-nested-route-tracker.ts";
 import { listHerdrProjectPaneRoots, restoreHerdrProjectPaneSnapshots } from "../inspectors/herdr/project-panes.ts";
 import { registerSubagentRpcBridge } from "./rpc.ts";
 import { clearSlashSnapshots, getSlashRenderableSnapshot, resolveSlashMessageDetails, restoreSlashFinalSnapshots, type SlashMessageDetails } from "../slash/slash-live-state.ts";
@@ -467,6 +469,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		fleetJobs: new Map(),
 		foregroundRuns: new Map(),
 		foregroundControls: new Map(),
+		retainedForegroundNestedRoutes: new Map(),
 		lastForegroundControlId: null,
 		cleanupTimers: new Map(),
 		lastUiContext: null,
@@ -492,6 +495,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const mainWatchdog = registerMainWatchdog(pi);
 	const resultDeliveryOwnership = createResultDeliveryOwnership(state);
 	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch, ownership: resultDeliveryOwnership });
+	const retainedNestedRouteTracker = createRetainedNestedRouteTracker(state);
 	const fleetStatus = fleetViewEnabled
 		? new SubagentFleetStatus(state, async (itemKey) => {
 			const ctx = withLastUiContext((current) => current);
@@ -510,6 +514,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	let executorScheduled: ((id: string, params: SubagentParamsLike, signal: AbortSignal, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
 	let goalTurnId = 0;
 	let parentSessionEnvValue: string | null = null;
+	let releaseHostSessionLiveness = () => {};
 	const scheduledStoreRoot = config.scheduledRuns?.storeRoot === undefined ? undefined : resolveScheduledStoreRoot(config.scheduledRuns.storeRoot);
 	const scheduledRunManager = createScheduledRunManager({
 		config,
@@ -607,6 +612,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		discoverAgents: discoverAgentsForRuntime,
 		activateSupervisorTransport: () => supervisorChannel.activateTransport(),
 		refreshResultDelivery: () => refreshResultDelivery(),
+		trackRetainedNestedRoute: retainedNestedRouteTracker.track,
 	});
 	executorScheduled = executor.executeScheduled;
 
@@ -942,6 +948,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		cleanupSessionArtifacts(ctx);
 		logSlowPhase("session-artifact-cleanup", phaseStartedAt);
 		state.foregroundControls.clear();
+		retainedNestedRouteTracker.clear();
 		state.lastForegroundControlId = null;
 		phaseStartedAt = Date.now();
 		resetJobs(ctx);
@@ -978,6 +985,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			if (runtimeCleaned) return;
 			runtimeCleaned = true;
 			const shuttingDownParentSession = parentSessionEnvValue;
+			releaseHostSessionLiveness();
+			releaseHostSessionLiveness = () => {};
 			// Workflow continuations retain their launch context; abort them before
 			// teardown so a reload cannot launch through a stale context.
 			for (const controller of state.workflowControllers?.values() ?? []) {
@@ -1001,6 +1010,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			for (const timer of state.cleanupTimers.values()) clearTimeout(timer);
 			state.cleanupTimers.clear();
 			state.asyncJobs.clear();
+			retainedNestedRouteTracker.clear();
 			for (const unsubscribe of eventUnsubscribes) {
 				try {
 					unsubscribe();
@@ -1094,6 +1104,16 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		installRuntime(ctx);
 		const recovering = event.reason === "startup" || event.reason === "reload" || event.reason === "resume";
 		resetSessionState(ctx, recovering, event.previousSessionFile);
+		releaseHostSessionLiveness();
+		const sessionId = ctx.sessionManager.getSessionId();
+		const sessionFile = ctx.sessionManager.getSessionFile();
+		releaseHostSessionLiveness = sessionId
+			? registerPiWebSessionLiveness({
+				sessionId,
+				...(sessionFile ? { sessionFile } : {}),
+				isActive: () => hasLiveSubagentWork(state) || completionNotifier.hasPendingDelivery(),
+			})
+			: () => {};
 		herdrStatusBridge.sessionStarted({
 			hasUI: ctx.hasUI === true,
 			runs: activeHerdrRuns(),

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -469,7 +469,6 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		fleetJobs: new Map(),
 		foregroundRuns: new Map(),
 		foregroundControls: new Map(),
-		retainedForegroundNestedRoutes: new Map(),
 		lastForegroundControlId: null,
 		cleanupTimers: new Map(),
 		lastUiContext: null,
@@ -495,7 +494,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const mainWatchdog = registerMainWatchdog(pi);
 	const resultDeliveryOwnership = createResultDeliveryOwnership(state);
 	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch, ownership: resultDeliveryOwnership });
-	const retainedNestedRouteTracker = createRetainedNestedRouteTracker(state);
+	let retainedNestedRouteTracker: ReturnType<typeof createRetainedNestedRouteTracker> | undefined;
 	const fleetStatus = fleetViewEnabled
 		? new SubagentFleetStatus(state, async (itemKey) => {
 			const ctx = withLastUiContext((current) => current);
@@ -597,7 +596,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	}, ASYNC_RETENTION_DELAY_MS);
 	asyncRetentionTimer.unref?.();
 
-	const executor = createSubagentExecutor({
+	const executorDeps: Parameters<typeof createSubagentExecutor>[0] = {
 		pi,
 		state,
 		config,
@@ -612,8 +611,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		discoverAgents: discoverAgentsForRuntime,
 		activateSupervisorTransport: () => supervisorChannel.activateTransport(),
 		refreshResultDelivery: () => refreshResultDelivery(),
-		trackRetainedNestedRoute: retainedNestedRouteTracker.track,
-	});
+		trackRetainedNestedRoute: undefined,
+	};
+	const executor = createSubagentExecutor(executorDeps);
 	executorScheduled = executor.executeScheduled;
 
 	pi.registerMessageRenderer<SupervisorRequestMessageDetails>(SUPERVISOR_REQUEST_MESSAGE_TYPE, renderSupervisorRequest);
@@ -948,7 +948,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		cleanupSessionArtifacts(ctx);
 		logSlowPhase("session-artifact-cleanup", phaseStartedAt);
 		state.foregroundControls.clear();
-		retainedNestedRouteTracker.clear();
+		retainedNestedRouteTracker?.clear();
+		retainedNestedRouteTracker = undefined;
+		executorDeps.trackRetainedNestedRoute = undefined;
 		state.lastForegroundControlId = null;
 		phaseStartedAt = Date.now();
 		resetJobs(ctx);
@@ -1010,7 +1012,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			for (const timer of state.cleanupTimers.values()) clearTimeout(timer);
 			state.cleanupTimers.clear();
 			state.asyncJobs.clear();
-			retainedNestedRouteTracker.clear();
+			retainedNestedRouteTracker?.clear();
+			retainedNestedRouteTracker = undefined;
+			executorDeps.trackRetainedNestedRoute = undefined;
 			for (const unsubscribe of eventUnsubscribes) {
 				try {
 					unsubscribe();
@@ -1107,13 +1111,18 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		releaseHostSessionLiveness();
 		const sessionId = ctx.sessionManager.getSessionId();
 		const sessionFile = ctx.sessionManager.getSessionFile();
-		releaseHostSessionLiveness = sessionId
+		const liveness = sessionId
 			? registerPiWebSessionLiveness({
 				sessionId,
 				...(sessionFile ? { sessionFile } : {}),
 				isActive: () => hasLiveSubagentWork(state) || completionNotifier.hasPendingDelivery(),
 			})
-			: () => {};
+			: { registered: false, release: () => {} };
+		releaseHostSessionLiveness = liveness.release;
+		if (liveness.registered) {
+			retainedNestedRouteTracker = createRetainedNestedRouteTracker(state);
+			executorDeps.trackRetainedNestedRoute = retainedNestedRouteTracker.track;
+		}
 		herdrStatusBridge.sessionStarted({
 			hasUI: ctx.hasUI === true,
 			runs: activeHerdrRuns(),

--- a/src/integrations/pi-web-session-liveness.ts
+++ b/src/integrations/pi-web-session-liveness.ts
@@ -22,6 +22,12 @@ interface SessionLivenessRegistration {
 	isActive(): boolean;
 }
 
+export interface PiWebSessionLivenessHandle {
+	/** True only when the compatible host accepted the provider registration. */
+	registered: boolean;
+	release: () => void;
+}
+
 type LiveWorkState = Pick<SubagentState, "asyncJobs" | "foregroundControls" | "retainedForegroundNestedRoutes">;
 
 function resolveRegistry(): PiWebSessionLivenessRegistry | null {
@@ -55,9 +61,9 @@ export function hasLiveSubagentWork(state: LiveWorkState): boolean {
 	return false;
 }
 
-export function registerPiWebSessionLiveness(registration: SessionLivenessRegistration): () => void {
+export function registerPiWebSessionLiveness(registration: SessionLivenessRegistration): PiWebSessionLivenessHandle {
 	const registry = resolveRegistry();
-	if (!registry) return () => {};
+	if (!registry) return { registered: false, release: () => {} };
 	try {
 		const release = registry.register({
 			name: "pi-subagents",
@@ -65,10 +71,10 @@ export function registerPiWebSessionLiveness(registration: SessionLivenessRegist
 			...(registration.sessionFile ? { sessionFile: registration.sessionFile } : {}),
 			isActive: registration.isActive,
 		});
-		if (typeof release === "function") return release;
+		if (typeof release === "function") return { registered: true, release };
 		console.error("Failed to register pi-web session liveness: host registry returned no release function.");
 	} catch (error) {
 		console.error("Failed to register pi-web session liveness:", error);
 	}
-	return () => {};
+	return { registered: false, release: () => {} };
 }

--- a/src/integrations/pi-web-session-liveness.ts
+++ b/src/integrations/pi-web-session-liveness.ts
@@ -1,0 +1,74 @@
+import { hasLiveNestedDescendants, projectNestedEvents } from "../runs/shared/nested-events.ts";
+import type { NestedRouteInfo, SubagentState } from "../shared/types.ts";
+
+export const PI_WEB_SESSION_LIVENESS_REGISTRY_KEY = "@agegr/pi-web/session-liveness/v1";
+const PI_WEB_SESSION_LIVENESS_PROTOCOL_VERSION = 1;
+
+interface PiWebSessionLivenessProvider {
+	name: string;
+	sessionId: string;
+	sessionFile?: string;
+	isActive(): boolean;
+}
+
+interface PiWebSessionLivenessRegistry {
+	version: typeof PI_WEB_SESSION_LIVENESS_PROTOCOL_VERSION;
+	register(provider: PiWebSessionLivenessProvider): () => void;
+}
+
+interface SessionLivenessRegistration {
+	sessionId: string;
+	sessionFile?: string;
+	isActive(): boolean;
+}
+
+type LiveWorkState = Pick<SubagentState, "asyncJobs" | "foregroundControls" | "retainedForegroundNestedRoutes">;
+
+function resolveRegistry(): PiWebSessionLivenessRegistry | null {
+	const value = (globalThis as Record<PropertyKey, unknown>)[Symbol.for(PI_WEB_SESSION_LIVENESS_REGISTRY_KEY)];
+	if (!value || typeof value !== "object") return null;
+	const registry = value as Partial<PiWebSessionLivenessRegistry>;
+	if (registry.version !== PI_WEB_SESSION_LIVENESS_PROTOCOL_VERSION || typeof registry.register !== "function") return null;
+	return registry as PiWebSessionLivenessRegistry;
+}
+
+export function retainLiveForegroundNestedRoute(state: Pick<SubagentState, "retainedForegroundNestedRoutes">, route: NestedRouteInfo): boolean {
+	const nested = projectNestedEvents(route);
+	if (!hasLiveNestedDescendants(nested.children)) return false;
+	state.retainedForegroundNestedRoutes ??= new Map();
+	state.retainedForegroundNestedRoutes.set(route.rootRunId, { route, children: nested.children, awaitingFirstRefresh: true });
+	return true;
+}
+
+export function hasLiveSubagentWork(state: LiveWorkState): boolean {
+	for (const job of state.asyncJobs.values()) {
+		if (job.status === "queued" || job.status === "running" || hasLiveNestedDescendants(job.nestedChildren)) return true;
+	}
+	for (const control of state.foregroundControls.values()) {
+		if ((control.schedulingOwners ?? 0) > 0
+			|| (control.activeChildren?.size ?? 0) > 0
+			|| hasLiveNestedDescendants(control.nestedChildren)) return true;
+	}
+	for (const retained of state.retainedForegroundNestedRoutes?.values() ?? []) {
+		if (retained.awaitingFirstRefresh || hasLiveNestedDescendants(retained.children)) return true;
+	}
+	return false;
+}
+
+export function registerPiWebSessionLiveness(registration: SessionLivenessRegistration): () => void {
+	const registry = resolveRegistry();
+	if (!registry) return () => {};
+	try {
+		const release = registry.register({
+			name: "pi-subagents",
+			sessionId: registration.sessionId,
+			...(registration.sessionFile ? { sessionFile: registration.sessionFile } : {}),
+			isActive: registration.isActive,
+		});
+		if (typeof release === "function") return release;
+		console.error("Failed to register pi-web session liveness: host registry returned no release function.");
+	} catch (error) {
+		console.error("Failed to register pi-web session liveness:", error);
+	}
+	return () => {};
+}

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -123,6 +123,7 @@ export interface RegisterSubagentNotifyOptions {
 
 export interface CompletionNotifier {
 	deliver(result: CompletionNotification): Promise<boolean>;
+	hasPendingDelivery(): boolean;
 	dispose(): void;
 }
 
@@ -628,6 +629,7 @@ export default function registerSubagentNotify(
 
 	return {
 		deliver,
+		hasPendingDelivery: () => pending.size > 0,
 		dispose() {
 			if (disposed) return;
 			disposed = true;

--- a/src/runs/background/retained-nested-route-tracker.ts
+++ b/src/runs/background/retained-nested-route-tracker.ts
@@ -1,0 +1,98 @@
+import * as fs from "node:fs";
+import type { SubagentState } from "../../shared/types.ts";
+import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
+import { hasLiveNestedDescendants, projectNestedEvents } from "../shared/nested-events.ts";
+
+interface RetainedNestedRouteTrackerOptions {
+	pollIntervalMs?: number;
+	platform?: NodeJS.Platform;
+	watch?: typeof fs.watch;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const REFRESH_DEBOUNCE_MS = 25;
+
+export function createRetainedNestedRouteTracker(
+	state: Pick<SubagentState, "retainedForegroundNestedRoutes">,
+	options: RetainedNestedRouteTrackerOptions = {},
+): { track: (rootRunId: string) => void; clear: () => void } {
+	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	const watch = options.watch ?? fs.watch;
+	const watchers = new Map<string, fs.FSWatcher>();
+	const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	let poller: ReturnType<typeof setInterval> | undefined;
+
+	const close = (rootRunId: string): void => {
+		watchers.get(rootRunId)?.close();
+		watchers.delete(rootRunId);
+		const timer = refreshTimers.get(rootRunId);
+		if (timer) clearTimeout(timer);
+		refreshTimers.delete(rootRunId);
+	};
+
+	const refresh = (rootRunId: string): void => {
+		const retained = state.retainedForegroundNestedRoutes?.get(rootRunId);
+		if (!retained) {
+			close(rootRunId);
+			return;
+		}
+		try {
+			retained.children = projectNestedEvents(retained.route).children;
+			retained.awaitingFirstRefresh = false;
+			if (hasLiveNestedDescendants(retained.children)) return;
+			state.retainedForegroundNestedRoutes?.delete(rootRunId);
+			close(rootRunId);
+		} catch (error) {
+			console.error(`Failed to refresh retained nested descendants for foreground run '${rootRunId}':`, error);
+		}
+	};
+
+	const scheduleRefresh = (rootRunId: string): void => {
+		if (refreshTimers.has(rootRunId)) return;
+		const timer = setTimeout(() => {
+			refreshTimers.delete(rootRunId);
+			refresh(rootRunId);
+		}, REFRESH_DEBOUNCE_MS);
+		timer.unref?.();
+		refreshTimers.set(rootRunId, timer);
+	};
+
+	const ensurePoller = (): void => {
+		if (poller || (state.retainedForegroundNestedRoutes?.size ?? 0) === 0) return;
+		poller = setInterval(() => {
+			for (const rootRunId of state.retainedForegroundNestedRoutes?.keys() ?? []) refresh(rootRunId);
+			if ((state.retainedForegroundNestedRoutes?.size ?? 0) > 0) return;
+			if (poller) clearInterval(poller);
+			poller = undefined;
+		}, pollIntervalMs);
+		poller.unref?.();
+	};
+
+	const track = (rootRunId: string): void => {
+		const retained = state.retainedForegroundNestedRoutes?.get(rootRunId);
+		if (!retained) return;
+		if (shouldUseNativeFsWatch("retained-nested-route-tracker", options.platform) && !watchers.has(rootRunId)) {
+			try {
+				const watcher = watch(retained.route.eventSink, () => scheduleRefresh(rootRunId));
+				watcher.on("error", () => close(rootRunId));
+				watcher.unref?.();
+				watchers.set(rootRunId, watcher);
+			} catch {
+				// The bounded safety poll below covers unsupported or failed watchers.
+			}
+		}
+		scheduleRefresh(rootRunId);
+		ensurePoller();
+	};
+
+	const clear = (): void => {
+		if (poller) clearInterval(poller);
+		poller = undefined;
+		for (const rootRunId of watchers.keys()) close(rootRunId);
+		for (const timer of refreshTimers.values()) clearTimeout(timer);
+		refreshTimers.clear();
+		state.retainedForegroundNestedRoutes?.clear();
+	};
+
+	return { track, clear };
+}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -60,6 +60,7 @@ import { applyIntercomBridgeToAgent, INTERCOM_BRIDGE_MARKER, resolveIntercomBrid
 import { formatControlIntercomMessage, formatControlNoticeMessage, resolveControlConfig, shouldNotifyControlEvent } from "../shared/subagent-control.ts";
 import { formatSpawnBudget, getSpawnBudgetSnapshot, grantSpawnBudget, preflightSpawnBudget, preflightSpawnBudgetGrant, reserveSpawnBudget } from "../shared/spawn-budget.ts";
 import { claimRunFanoutBatch, claimRunFanoutBatchWithCommit, createRunFanoutBudget, formatRunFanoutBudget, getRunFanoutBudgetSnapshot, readRunFanoutBudgetDescriptor, RunFanoutLimitError, writeRunFanoutBudgetDescriptor } from "../shared/run-fanout-budget.ts";
+import { retainLiveForegroundNestedRoute } from "../../integrations/pi-web-session-liveness.ts";
 import { validateToolBudgetConfig } from "../shared/tool-budget.ts";
 import { usageBudgetExceededMessage, usageBudgetState, validateUsageBudgetConfig } from "../shared/usage-budget.ts";
 import { intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling, type ResolvedSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
@@ -438,6 +439,7 @@ interface ExecutorDeps {
 	allowMutatingManagementActions?: boolean;
 	activateSupervisorTransport?: () => void;
 	refreshResultDelivery?: () => void;
+	trackRetainedNestedRoute?: (rootRunId: string) => void;
 	kill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
 	/** Set when this executor runs inside a child session; carries the runtime settings the host passes instead of environment variables. */
 	childRuntime?: ChildRuntimeConfig;
@@ -526,9 +528,16 @@ function loadWorkflowScriptPath(params: SubagentParamsLike, runtimeCwd: string):
 	return { params: { ...rest, workflowScript } };
 }
 
-function removeForegroundControlIfIdle(state: SubagentState, runId: string): boolean {
+export function removeForegroundControlIfIdle(state: SubagentState, runId: string, trackRetainedNestedRoute?: (rootRunId: string) => void): boolean {
 	const control = state.foregroundControls.get(runId);
 	if (control && (!foregroundSchedulingSettled(control) || (control.activeChildren?.size ?? 0) > 0)) return false;
+	if (control?.nestedRoute) {
+		try {
+			if (retainLiveForegroundNestedRoute(state, control.nestedRoute)) trackRetainedNestedRoute?.(runId);
+		} catch (error) {
+			console.error(`Failed to retain live nested descendants for foreground run '${runId}':`, error);
+		}
+	}
 	state.foregroundControls.delete(runId);
 	if (state.lastForegroundControlId === runId) state.lastForegroundControlId = null;
 	return true;
@@ -3911,7 +3920,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 						try {
 							if (foregroundControl) finishForegroundChild(foregroundControl, 0);
 						} finally {
-							removeForegroundControlIfIdle(deps.state, runId);
+							removeForegroundControlIfIdle(deps.state, runId, deps.trackRetainedNestedRoute);
 						}
 					}
 				}
@@ -6904,7 +6913,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			if (activeAsyncCapacity && !activeAsyncCapacity.owner.runnerStartedAt) activeAsyncCapacity.rollback();
 			if (foregroundControl) {
 				settleForegroundSchedulingOwner(foregroundControl);
-				removeForegroundControlIfIdle(deps.state, runId);
+				removeForegroundControlIfIdle(deps.state, runId, deps.trackRetainedNestedRoute);
 			}
 		}
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -531,9 +531,9 @@ function loadWorkflowScriptPath(params: SubagentParamsLike, runtimeCwd: string):
 export function removeForegroundControlIfIdle(state: SubagentState, runId: string, trackRetainedNestedRoute?: (rootRunId: string) => void): boolean {
 	const control = state.foregroundControls.get(runId);
 	if (control && (!foregroundSchedulingSettled(control) || (control.activeChildren?.size ?? 0) > 0)) return false;
-	if (control?.nestedRoute) {
+	if (control?.nestedRoute && trackRetainedNestedRoute) {
 		try {
-			if (retainLiveForegroundNestedRoute(state, control.nestedRoute)) trackRetainedNestedRoute?.(runId);
+			if (retainLiveForegroundNestedRoute(state, control.nestedRoute)) trackRetainedNestedRoute(runId);
 		} catch (error) {
 			console.error(`Failed to retain live nested descendants for foreground run '${runId}':`, error);
 		}

--- a/src/runs/shared/nested-events.ts
+++ b/src/runs/shared/nested-events.ts
@@ -286,7 +286,7 @@ function sanitizeTurnBudget(value: unknown): TurnBudgetState | undefined {
 }
 
 function sanitizeState(value: unknown, fallback: NestedRunState): NestedRunState {
-	return value === "queued" || value === "running" || value === "complete" || value === "failed" || value === "partial" || value === "paused" || value === "stopped"
+	return value === "queued" || value === "running" || value === "complete" || value === "failed" || value === "partial" || value === "paused" || value === "stopped" || value === "rejected"
 		? value
 		: fallback;
 }
@@ -296,7 +296,7 @@ function sanitizeStep(input: unknown, depth: number): NestedStepSummary | undefi
 	const raw = input as Record<string, unknown>;
 	const agent = stringValue(raw.agent, 128);
 	if (!agent) return undefined;
-	const status = raw.status === "pending" || raw.status === "running" || raw.status === "complete" || raw.status === "completed" || raw.status === "failed" || raw.status === "paused" || raw.status === "stopped"
+	const status = raw.status === "pending" || raw.status === "running" || raw.status === "complete" || raw.status === "completed" || raw.status === "failed" || raw.status === "partial" || raw.status === "paused" || raw.status === "stopped" || raw.status === "rejected"
 		? raw.status
 		: "pending";
 	const model = stringValue(raw.model);
@@ -438,7 +438,7 @@ export function parseNestedEventRecords(content: string, route: NestedRoute): Ne
 }
 
 function terminal(state: NestedRunState): boolean {
-	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "stopped";
+	return state === "complete" || state === "failed" || state === "partial" || state === "paused" || state === "rejected" || state === "stopped";
 }
 
 function mergeBoundedChildren(existing: NestedRunSummary[] | undefined, incoming: NestedRunSummary[] | undefined): NestedRunSummary[] | undefined {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2201,6 +2201,13 @@ export interface SubagentState {
 	trustedSessionFileRoot?: string;
 	/** Live async session roots created by this parent executor, keyed by run id. */
 	liveAsyncSessionRoots?: Map<string, string>;
+	/** Foreground nested routes retained after their direct parent settles, keyed by root run id. */
+	retainedForegroundNestedRoutes?: Map<string, {
+		route: NestedRouteInfo;
+		children: NestedRunSummary[];
+		/** Conservative guard until the tracker observes a post-registration refresh. */
+		awaitingFirstRefresh: boolean;
+	}>;
 	/** Last valid parent session model observed for this session; used when continuation contexts omit ctx.model. */
 	lastParentModel?: { provider: string; id: string };
 	subagentInProgress?: boolean;

--- a/src/shared/watch-strategy.ts
+++ b/src/shared/watch-strategy.ts
@@ -7,5 +7,6 @@ export type FileWatchPurpose =
 	| "child-steering-inbox";
 
 export function shouldUseNativeFsWatch(_purpose: FileWatchPurpose, platform: NodeJS.Platform = process.platform): boolean {
+	if (_purpose === "retained-nested-route-tracker" && platform === "win32") return false;
 	return platform !== "darwin";
 }

--- a/src/shared/watch-strategy.ts
+++ b/src/shared/watch-strategy.ts
@@ -2,6 +2,7 @@ export type FileWatchPurpose =
 	| "result-delivery"
 	| "supervisor-channel"
 	| "async-job-tracker"
+	| "retained-nested-route-tracker"
 	| "runner-control-inbox"
 	| "child-steering-inbox";
 

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -675,6 +675,68 @@ describe("subagent extension child mode", () => {
 		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
 	});
 
+	it("registers pi-web liveness for the current session and releases it on shutdown", () => {
+		const script = String.raw`
+			import registerSubagentExtension from "./index.ts";
+			import { currentCompletionOwnerId } from "./src/shared/completion-owner.ts";
+			const handlers = new Map();
+			const listeners = new Map();
+			const events = {
+				on(channel, handler) {
+					let set = listeners.get(channel);
+					if (!set) listeners.set(channel, set = new Set());
+					set.add(handler);
+					return () => set.delete(handler);
+				},
+				emit(channel, payload) {
+					for (const handler of [...(listeners.get(channel) ?? [])]) handler(payload);
+				},
+			};
+			const pi = new Proxy({
+				events,
+				on(channel, handler) { handlers.set(channel, handler); },
+				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
+				sendMessage() {}, getSessionName() { return undefined; },
+			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
+			const sessionId = "liveness-" + crypto.randomUUID();
+			const sessionFile = "/tmp/" + sessionId + ".jsonl";
+			let provider;
+			let released = 0;
+			const registryKey = Symbol.for("@agegr/pi-web/session-liveness/v1");
+			globalThis[registryKey] = {
+				version: 1,
+				register(value) {
+					provider = value;
+					return () => { released += 1; };
+				},
+			};
+			const ctx = {
+				cwd: process.cwd(), hasUI: false,
+				ui: { setWidget() {}, requestRender() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } },
+				sessionManager: { getSessionId() { return sessionId; }, getSessionFile() { return sessionFile; }, getEntries() { return []; } },
+				modelRegistry: { getAvailable() { return []; } },
+			};
+			registerSubagentExtension(pi);
+			handlers.get("session_start")({ reason: "startup" }, ctx);
+			if (provider?.name !== "pi-subagents" || provider?.sessionId !== sessionId || provider?.sessionFile !== sessionFile) {
+				throw new Error("liveness provider did not preserve exact session identity: " + JSON.stringify(provider));
+			}
+			if (provider.isActive()) throw new Error("idle runtime reported live work");
+			const completionOwnerId = currentCompletionOwnerId();
+			events.emit("subagent:async-started", { id: "run-1", sessionId: sessionFile, completionOwnerId, mode: "single", agent: "worker", asyncDir: "/tmp/" + sessionId + "-run" });
+			if (!provider.isActive()) throw new Error("queued async work was not reported live");
+			events.emit("subagent:async-complete", { id: "run-1", sessionId: sessionFile, completionOwnerId, success: true, summary: "done" });
+			if (!provider.isActive()) throw new Error("pending completion delivery was not reported live");
+			const deliveryDeadline = Date.now() + 2000;
+			while (provider.isActive() && Date.now() < deliveryDeadline) await new Promise((resolve) => setTimeout(resolve, 10));
+			if (provider.isActive()) throw new Error("retained terminal work was reported live after delivery");
+			await handlers.get("session_shutdown")({ reason: "quit" });
+			if (released !== 1) throw new Error("liveness registration was not released exactly once: " + released);
+			delete globalThis[registryKey];
+		`;
+		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: projectRoot, env: parentToolEnv(), stdio: "pipe" });
+	});
+
 	it("keeps independent extension runtimes active in one process", () => {
 		const script = String.raw`
 			import registerSubagentExtension from "./index.ts";

--- a/test/unit/nested-events.test.ts
+++ b/test/unit/nested-events.test.ts
@@ -45,7 +45,7 @@ function trackRoute(rootRunId = "root-run") {
 	return route;
 }
 
-function child(id: string, state: "queued" | "running" | "complete" | "failed" | "paused", ts: number, parentRunId = "root-run") {
+function child(id: string, state: "queued" | "running" | "complete" | "failed" | "paused" | "rejected", ts: number, parentRunId = "root-run") {
 	return {
 		id,
 		parentRunId,
@@ -308,6 +308,27 @@ describe("nested event parsing and projection", () => {
 				}],
 			}],
 		}]), true);
+	});
+
+	it("preserves rejected nested states across the event and registry boundary", () => {
+		const route = trackRoute("rejected-root");
+		writeNestedEvent(route, {
+			type: "subagent.nested.completed",
+			ts: 300,
+			parentRunId: route.rootRunId,
+			parentStepIndex: 0,
+			child: {
+				...child("rejected-child", "rejected", 300, route.rootRunId),
+				parentStepIndex: 0,
+				path: [{ runId: route.rootRunId, stepIndex: 0 }],
+				steps: [{ agent: "leaf", status: "rejected" }],
+			},
+		});
+
+		const registry = projectNestedEvents(route);
+		assert.equal(registry.children[0]?.state, "rejected");
+		assert.equal(registry.children[0]?.steps?.[0]?.status, "rejected");
+		assert.equal(hasLiveNestedDescendants(registry.children), false);
 	});
 
 	it("accepts only complete numeric token usage at the nested event boundary", () => {

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -192,9 +192,11 @@ describe("registerSubagentNotify", () => {
 		});
 		try {
 			const pending = notifier.deliver(completionResult({ id: "delayed-unclaimed" }));
+			assert.equal(notifier.hasPendingDelivery(), true);
 			state.currentSessionId = "session-b";
 			clock.advance(150);
 			assert.equal(await pending, false);
+			assert.equal(notifier.hasPendingDelivery(), false);
 			assert.equal(sent.length, 0);
 		} finally {
 			notifier.dispose();
@@ -217,8 +219,10 @@ describe("registerSubagentNotify", () => {
 		const clock = createFakeClock();
 		const { notifier, sent } = createBatchingPi(clock);
 		const pending = notifier.deliver(completionResult({ id: "dispose-pending" }));
+		assert.equal(notifier.hasPendingDelivery(), true);
 		notifier.dispose();
 		assert.equal(await pending, false);
+		assert.equal(notifier.hasPendingDelivery(), false);
 		clock.advance(1000);
 		assert.equal(sent.length, 0);
 	});

--- a/test/unit/pi-web-session-liveness.test.ts
+++ b/test/unit/pi-web-session-liveness.test.ts
@@ -9,6 +9,7 @@ import {
 	retainLiveForegroundNestedRoute,
 } from "../../src/integrations/pi-web-session-liveness.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
+import { createRetainedNestedRouteTracker } from "../../src/runs/background/retained-nested-route-tracker.ts";
 import { removeForegroundControlIfIdle } from "../../src/runs/foreground/subagent-executor.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
 
@@ -108,6 +109,60 @@ describe("pi-web session liveness integration", () => {
 		assert.equal(hasLiveSubagentWork(state), true, "the synchronous probe reads only its cached projection");
 	});
 
+	it("does not retain foreground nested routes without a host registration", () => {
+		const state = makeState() as SubagentState;
+		const route = nestedRoute("unregistered-foreground-root");
+		writeNestedState(route, "running", 100);
+		state.foregroundControls.set(route.rootRunId, {
+			runId: route.rootRunId,
+			mode: "single",
+			startedAt: 1,
+			updatedAt: 1,
+			schedulingOwners: 0,
+			activeChildren: new Map(),
+			nestedRoute: route,
+		});
+
+		const liveness = registerPiWebSessionLiveness({ sessionId: "session-a", isActive: () => true });
+		assert.equal(liveness.registered, false);
+		assert.equal(removeForegroundControlIfIdle(state, route.rootRunId), true);
+		assert.equal(state.retainedForegroundNestedRoutes, undefined);
+	});
+
+	it("retains and tracks foreground nested routes after host registration", () => {
+		const state = makeState() as SubagentState;
+		const route = nestedRoute("registered-foreground-root");
+		writeNestedState(route, "running", 100);
+		state.foregroundControls.set(route.rootRunId, {
+			runId: route.rootRunId,
+			mode: "single",
+			startedAt: 1,
+			updatedAt: 1,
+			schedulingOwners: 0,
+			activeChildren: new Map(),
+			nestedRoute: route,
+		});
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(PI_WEB_SESSION_LIVENESS_REGISTRY_KEY)] = {
+			version: 1,
+			register() {
+				return () => {};
+			},
+		};
+		const liveness = registerPiWebSessionLiveness({ sessionId: "session-a", isActive: () => true });
+		const tracker = liveness.registered
+			? createRetainedNestedRouteTracker(state, { platform: "win32", pollIntervalMs: 60_000 })
+			: undefined;
+		try {
+			assert.equal(liveness.registered, true);
+			assert.ok(tracker);
+			assert.equal(removeForegroundControlIfIdle(state, route.rootRunId, tracker.track), true);
+			assert.equal(state.retainedForegroundNestedRoutes?.has(route.rootRunId), true);
+		} finally {
+			tracker?.clear();
+			liveness.release();
+		}
+	});
+
 	it("transfers a live nested route before removing its settled foreground control", () => {
 		const state = makeState() as SubagentState;
 		const route = nestedRoute("settled-foreground-root");
@@ -143,8 +198,8 @@ describe("pi-web session liveness integration", () => {
 			sessionId: "session-a",
 			isActive: () => true,
 		});
-		releaseWithoutHost();
-
+		assert.equal(releaseWithoutHost.registered, false);
+		releaseWithoutHost.release();
 		let registered = false;
 		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(PI_WEB_SESSION_LIVENESS_REGISTRY_KEY)] = {
 			version: 2,
@@ -153,7 +208,8 @@ describe("pi-web session liveness integration", () => {
 				return () => {};
 			},
 		};
-		registerPiWebSessionLiveness({ sessionId: "session-a", isActive: () => true });
+		const incompatible = registerPiWebSessionLiveness({ sessionId: "session-a", isActive: () => true });
+		assert.equal(incompatible.registered, false);
 		assert.equal(registered, false);
 	});
 
@@ -174,6 +230,7 @@ describe("pi-web session liveness integration", () => {
 			sessionFile: "/tmp/session-a.jsonl",
 			isActive: () => active,
 		});
+		assert.equal(release.registered, true);
 		assert.equal(provider?.name, "pi-subagents");
 		assert.equal(provider?.sessionId, "session-a");
 		assert.equal(provider?.sessionFile, "/tmp/session-a.jsonl");
@@ -181,7 +238,7 @@ describe("pi-web session liveness integration", () => {
 		active = false;
 		assert.equal(provider?.isActive(), false);
 
-		release();
+		release.release();
 		assert.equal(released, 1);
 	});
 });

--- a/test/unit/pi-web-session-liveness.test.ts
+++ b/test/unit/pi-web-session-liveness.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+	hasLiveSubagentWork,
+	PI_WEB_SESSION_LIVENESS_REGISTRY_KEY,
+	registerPiWebSessionLiveness,
+	retainLiveForegroundNestedRoute,
+} from "../../src/integrations/pi-web-session-liveness.ts";
+import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
+import { removeForegroundControlIfIdle } from "../../src/runs/foreground/subagent-executor.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+function clearRegistry(): void {
+	delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(PI_WEB_SESSION_LIVENESS_REGISTRY_KEY)];
+}
+
+const routeRoots: string[] = [];
+
+afterEach(() => {
+	clearRegistry();
+	for (const root of routeRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function nestedRoute(rootRunId: string) {
+	const route = createNestedRoute(rootRunId);
+	routeRoots.push(path.dirname(route.eventSink));
+	return route;
+}
+
+function writeNestedState(route: ReturnType<typeof nestedRoute>, state: "running" | "complete", ts: number): void {
+	writeNestedEvent(route, {
+		type: state === "running" ? "subagent.nested.updated" : "subagent.nested.completed",
+		ts,
+		parentRunId: route.rootRunId,
+		parentStepIndex: 0,
+		child: {
+			id: "nested-child",
+			parentRunId: route.rootRunId,
+			parentStepIndex: 0,
+			depth: 1,
+			path: [{ runId: route.rootRunId, stepIndex: 0 }],
+			state,
+			agent: "worker",
+			lastUpdate: ts,
+		},
+	});
+}
+
+function makeState(): Pick<SubagentState, "asyncJobs" | "foregroundControls"> {
+	return {
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+	};
+}
+
+describe("pi-web session liveness integration", () => {
+	it("reports only queued or running async jobs as live", () => {
+		const state = makeState();
+		state.asyncJobs.set("retained", { status: "complete" } as never);
+		assert.equal(hasLiveSubagentWork(state), false);
+
+		state.asyncJobs.set("queued", { status: "queued" } as never);
+		assert.equal(hasLiveSubagentWork(state), true);
+		state.asyncJobs.delete("queued");
+
+		state.asyncJobs.set("running", { status: "running" } as never);
+		assert.equal(hasLiveSubagentWork(state), true);
+	});
+
+	it("keeps a terminal parent live while a nested descendant is active", () => {
+		const state = makeState();
+		const nestedChild = { state: "running" };
+		state.asyncJobs.set("parent", {
+			status: "complete",
+			nestedChildren: [{ state: "complete", children: [nestedChild] }],
+		} as never);
+		assert.equal(hasLiveSubagentWork(state), true);
+
+		nestedChild.state = "complete";
+		assert.equal(hasLiveSubagentWork(state), false);
+	});
+
+	it("reports foreground scheduling or active children as live", () => {
+		const state = makeState();
+		state.foregroundControls.set("settled", { schedulingOwners: 0, activeChildren: new Map() } as never);
+		assert.equal(hasLiveSubagentWork(state), false);
+
+		state.foregroundControls.set("scheduling", { schedulingOwners: 1, activeChildren: new Map() } as never);
+		assert.equal(hasLiveSubagentWork(state), true);
+		state.foregroundControls.delete("scheduling");
+
+		state.foregroundControls.set("child", { schedulingOwners: 0, activeChildren: new Map([[0, {}]]) } as never);
+		assert.equal(hasLiveSubagentWork(state), true);
+	});
+
+	it("retains a foreground nested route until its async descendant finishes", () => {
+		const state = makeState();
+		const route = nestedRoute("foreground-root");
+		writeNestedState(route, "running", 100);
+
+		assert.equal(retainLiveForegroundNestedRoute(state, route), true);
+		assert.equal(state.retainedForegroundNestedRoutes?.has(route.rootRunId), true);
+		assert.equal(hasLiveSubagentWork(state), true);
+
+		writeNestedState(route, "complete", 200);
+		assert.equal(hasLiveSubagentWork(state), true, "the synchronous probe reads only its cached projection");
+	});
+
+	it("transfers a live nested route before removing its settled foreground control", () => {
+		const state = makeState() as SubagentState;
+		const route = nestedRoute("settled-foreground-root");
+		writeNestedState(route, "running", 100);
+		state.foregroundControls.set(route.rootRunId, {
+			runId: route.rootRunId,
+			mode: "single",
+			startedAt: 1,
+			updatedAt: 1,
+			schedulingOwners: 0,
+			activeChildren: new Map(),
+			nestedRoute: route,
+		});
+		let tracked: string | undefined;
+
+		assert.equal(removeForegroundControlIfIdle(state, route.rootRunId, (rootRunId) => { tracked = rootRunId; }), true);
+		assert.equal(state.foregroundControls.has(route.rootRunId), false);
+		assert.equal(state.retainedForegroundNestedRoutes?.has(route.rootRunId), true);
+		assert.equal(tracked, route.rootRunId);
+	});
+
+	it("does not retain foreground routes without live descendants", () => {
+		const state = makeState();
+		const route = nestedRoute("terminal-foreground-root");
+		writeNestedState(route, "complete", 100);
+
+		assert.equal(retainLiveForegroundNestedRoute(state, route), false);
+		assert.equal(state.retainedForegroundNestedRoutes, undefined);
+	});
+
+	it("is a no-op outside pi-web or with an incompatible protocol", () => {
+		const releaseWithoutHost = registerPiWebSessionLiveness({
+			sessionId: "session-a",
+			isActive: () => true,
+		});
+		releaseWithoutHost();
+
+		let registered = false;
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(PI_WEB_SESSION_LIVENESS_REGISTRY_KEY)] = {
+			version: 2,
+			register() {
+				registered = true;
+				return () => {};
+			},
+		};
+		registerPiWebSessionLiveness({ sessionId: "session-a", isActive: () => true });
+		assert.equal(registered, false);
+	});
+
+	it("registers exact session aliases and returns the host release function", () => {
+		let provider: { name: string; sessionId: string; sessionFile?: string; isActive(): boolean } | undefined;
+		let released = 0;
+		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(PI_WEB_SESSION_LIVENESS_REGISTRY_KEY)] = {
+			version: 1,
+			register(value: typeof provider) {
+				provider = value;
+				return () => { released += 1; };
+			},
+		};
+
+		let active = true;
+		const release = registerPiWebSessionLiveness({
+			sessionId: "session-a",
+			sessionFile: "/tmp/session-a.jsonl",
+			isActive: () => active,
+		});
+		assert.equal(provider?.name, "pi-subagents");
+		assert.equal(provider?.sessionId, "session-a");
+		assert.equal(provider?.sessionFile, "/tmp/session-a.jsonl");
+		assert.equal(provider?.isActive(), true);
+		active = false;
+		assert.equal(provider?.isActive(), false);
+
+		release();
+		assert.equal(released, 1);
+	});
+});

--- a/test/unit/retained-nested-route-tracker.test.ts
+++ b/test/unit/retained-nested-route-tracker.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { retainLiveForegroundNestedRoute } from "../../src/integrations/pi-web-session-liveness.ts";
+import { createRetainedNestedRouteTracker } from "../../src/runs/background/retained-nested-route-tracker.ts";
+import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
+import type { SubagentState } from "../../src/shared/types.ts";
+
+const routeRoots: string[] = [];
+
+function route(rootRunId: string) {
+	const value = createNestedRoute(rootRunId);
+	routeRoots.push(path.dirname(value.eventSink));
+	return value;
+}
+
+function writeState(value: ReturnType<typeof route>, state: "running" | "complete", ts: number): void {
+	writeNestedEvent(value, {
+		type: state === "running" ? "subagent.nested.updated" : "subagent.nested.completed",
+		ts,
+		parentRunId: value.rootRunId,
+		child: {
+			id: "nested-child",
+			parentRunId: value.rootRunId,
+			depth: 1,
+			path: [{ runId: value.rootRunId }],
+			state,
+			agent: "worker",
+			lastUpdate: ts,
+		},
+	});
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!check() && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+	assert.equal(check(), true, "condition did not become true before timeout");
+}
+
+afterEach(() => {
+	for (const root of routeRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("retained foreground nested route tracker", () => {
+	it("releases retained liveness after the nested descendant completes", async () => {
+		const state: Pick<SubagentState, "retainedForegroundNestedRoutes"> = {};
+		const nestedRoute = route("retained-root");
+		writeState(nestedRoute, "running", 100);
+		assert.equal(retainLiveForegroundNestedRoute(state, nestedRoute), true);
+
+		const tracker = createRetainedNestedRouteTracker(state, { platform: "win32", pollIntervalMs: 10 });
+		try {
+			tracker.track(nestedRoute.rootRunId);
+			writeState(nestedRoute, "complete", 200);
+			await waitFor(() => !state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId));
+		} finally {
+			tracker.clear();
+		}
+	});
+
+	it("keeps the route through the handoff race until the first tracker refresh", async () => {
+		const state: Pick<SubagentState, "retainedForegroundNestedRoutes"> = {};
+		const nestedRoute = route("handoff-root");
+		writeState(nestedRoute, "running", 100);
+		assert.equal(retainLiveForegroundNestedRoute(state, nestedRoute), true);
+		writeState(nestedRoute, "complete", 200);
+
+		const retained = state.retainedForegroundNestedRoutes?.get(nestedRoute.rootRunId);
+		assert.equal(retained?.awaitingFirstRefresh, true);
+
+		const tracker = createRetainedNestedRouteTracker(state, { platform: "win32", pollIntervalMs: 60_000 });
+		try {
+			tracker.track(nestedRoute.rootRunId);
+			assert.equal(state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId), true);
+			await waitFor(() => !state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId));
+		} finally {
+			tracker.clear();
+		}
+	});
+
+	it("keeps polling after a native watcher error", async () => {
+		const state: Pick<SubagentState, "retainedForegroundNestedRoutes"> = {};
+		const nestedRoute = route("watch-error-root");
+		writeState(nestedRoute, "running", 100);
+		assert.equal(retainLiveForegroundNestedRoute(state, nestedRoute), true);
+
+		let watcherError: (() => void) | undefined;
+		const tracker = createRetainedNestedRouteTracker(state, {
+			platform: "linux",
+			pollIntervalMs: 10,
+			watch: (() => ({
+				close: () => undefined,
+				on: (event: string, listener: () => void) => {
+					if (event === "error") watcherError = listener;
+					return undefined;
+				},
+				unref: () => undefined,
+			} as unknown as fs.FSWatcher)) as typeof fs.watch,
+		});
+		try {
+			tracker.track(nestedRoute.rootRunId);
+			watcherError?.();
+			writeState(nestedRoute, "complete", 200);
+			await waitFor(() => !state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId));
+		} finally {
+			tracker.clear();
+		}
+	});
+
+	it("refreshes every retained route instead of stopping at the first live one", async () => {
+		const state: Pick<SubagentState, "retainedForegroundNestedRoutes"> = {};
+		const liveRoute = route("multi-live-root");
+		const terminalRoute = route("multi-terminal-root");
+		writeState(liveRoute, "running", 100);
+		writeState(terminalRoute, "running", 100);
+		assert.equal(retainLiveForegroundNestedRoute(state, liveRoute), true);
+		assert.equal(retainLiveForegroundNestedRoute(state, terminalRoute), true);
+
+		const tracker = createRetainedNestedRouteTracker(state, { platform: "win32", pollIntervalMs: 10 });
+		try {
+			tracker.track(liveRoute.rootRunId);
+			tracker.track(terminalRoute.rootRunId);
+			writeState(terminalRoute, "complete", 200);
+			await waitFor(() => !state.retainedForegroundNestedRoutes?.has(terminalRoute.rootRunId));
+			assert.equal(state.retainedForegroundNestedRoutes?.has(liveRoute.rootRunId), true);
+		} finally {
+			tracker.clear();
+		}
+	});
+
+	it("refreshes promptly from native watch events", async () => {
+		const state: Pick<SubagentState, "retainedForegroundNestedRoutes"> = {};
+		const nestedRoute = route("watched-root");
+		writeState(nestedRoute, "running", 100);
+		assert.equal(retainLiveForegroundNestedRoute(state, nestedRoute), true);
+
+		let notify: (() => void) | undefined;
+		let closed = 0;
+		const tracker = createRetainedNestedRouteTracker(state, {
+			platform: "linux",
+			pollIntervalMs: 60_000,
+			watch: ((_path: fs.PathLike, listener: fs.WatchListener<string>) => {
+				notify = () => listener("rename", "event.json");
+				return {
+					close: () => { closed += 1; },
+					on: () => undefined,
+					unref: () => undefined,
+				} as unknown as fs.FSWatcher;
+			}) as typeof fs.watch,
+		});
+		try {
+			tracker.track(nestedRoute.rootRunId);
+			writeState(nestedRoute, "complete", 200);
+			notify?.();
+			await waitFor(() => !state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId));
+			assert.equal(closed, 1);
+		} finally {
+			tracker.clear();
+		}
+	});
+
+	it("clears every retained route during session teardown", () => {
+		const state: Pick<SubagentState, "retainedForegroundNestedRoutes"> = {};
+		const nestedRoute = route("cleared-root");
+		writeState(nestedRoute, "running", 100);
+		assert.equal(retainLiveForegroundNestedRoute(state, nestedRoute), true);
+
+		const tracker = createRetainedNestedRouteTracker(state, { platform: "win32", pollIntervalMs: 60_000 });
+		tracker.track(nestedRoute.rootRunId);
+		tracker.clear();
+
+		assert.equal(state.retainedForegroundNestedRoutes?.size, 0);
+	});
+});


### PR DESCRIPTION
## Summary

- register an optional exact-session liveness provider when running inside a compatible pi-web host
- keep the parent session alive for live async/nested/foreground work and for completion notifications awaiting batched delivery
- retain foreground nested routes after their direct parent settles, then release them when descendants become terminal
- release all liveness state on session replacement, reload, and shutdown; remain a no-op in other hosts

## Problem

A detached subagent can remain active after the parent turn has returned. Pi Web's automatic idle eviction currently sees only foreground `AgentSession` activity, so it can dispose the parent session and its extension runtime while subagent work is still running. The detached runner may finish, but the parent-side notifier that should wake the conversation has already been removed.

This PR implements the pi-subagents side of the optional host protocol proposed in agegr/pi-web#705.

## Behavior

The provider reports a session as live while any of the following is true:

- an async job is `queued` or `running`
- an async or foreground run has an active nested descendant
- a foreground control still has a scheduling owner or active child
- a foreground nested route remains live after its direct parent has settled
- a completion notification is waiting for its batch-delivery timer

Retained terminal history, future schedules, and wait subscriptions do not keep a session alive by themselves.

The adapter discovers `Symbol.for("@agegr/pi-web/session-liveness/v1")`, checks the protocol version, and otherwise returns a no-op release function. Registration uses the exact Pi session id and optional session file. The previous registration is released on session changes and runtime cleanup.

The host-facing `isActive()` probe reads only in-memory projections. Foreground nested routes are projected once before their control is removed, then refreshed outside the probe through filesystem events where supported and a 5-second safety poll. They are discarded as soon as no live descendants remain and cleared on session teardown.

The patch also preserves existing `rejected` nested run and step states through the sanitizer and classifies rejected descendants as terminal; otherwise they degrade to running/pending and can keep a session alive indefinitely.

## Validation

- `npm run typecheck`
- focused liveness, retained-route, nested-state tests — 33 passed
- focused notifier and extension lifecycle tests — 66 passed
- full unit attempt — 2,795 passed, 2 unrelated high-load timing tests failed, 3 skipped; the Orca timing test passed on isolated rerun, while the watchdog LSP timing test remains locally sensitive to its 50ms timeout
- earlier full integration attempt — 915 passed, 1 unrelated async-result wait timed out, 6 skipped; the timed-out test passed on isolated rerun
- cross-repository protocol handshake test
- independent exact-diff review found no remaining P0/P1/P2 issue
- `git diff --check`

## Dependency

Depends on agegr/pi-web#705. The adapter is optional and version-checked, so this remains inert in hosts that do not expose the protocol.
