### PR TITLE
fix: key explicit sessionDir by child run ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
-- Key subagent children launched under an explicit `sessionDir` by their run id so concurrent children resolve distinct session files instead of sharing `run-0`.
+- Key subagent children launched under an explicit `sessionDir` by their run id so concurrent children resolve distinct session files instead of sharing `run-0`. Thanks to [@dat9uy](https://github.com/dat9uy) for #1859 and #1858.
 
 ## [0.65.0] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
+- Key subagent children launched under an explicit `sessionDir` by their run id so concurrent children resolve distinct session files instead of sharing `run-0`.
 
 ## [0.65.0] - 2026-09-04
 

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -73,6 +73,7 @@ export interface SubagentLaunchContractInput {
 	/** Current parent leaf required before an implicit `defaultContext: fork` stays `fork`. */
 	parentLeafId?: string | null;
 	sessionRoot?: string;
+	/** Caller directory used as a root keyed by the child run id ("preflight" placeholder when runId is omitted). */
 	sessionDir?: string;
 	runId?: string;
 	/** Root run id supplied by a host when projecting nested async lifecycle paths. */
@@ -380,7 +381,10 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	const artifactsDir = artifactsEnabled ? getArtifactsDir(input.parentSessionFile ?? null, effectiveCwd, input.artifactDir) : undefined;
 	const artifactPaths = artifactsDir ? getArtifactPaths(artifactsDir, runId, agent.name, 0) : undefined;
 	const outputPath = resolveSingleOutputPath(behavior.output, effectiveCwd, effectiveCwd, artifactsDir ? path.join(artifactsDir, "outputs", runId) : undefined);
-	const sessionRoot = input.sessionDir ? path.resolve(input.sessionDir) : input.sessionRoot ? path.join(path.resolve(input.sessionRoot), runId) : undefined;
+	// An explicit sessionDir is a root keyed by the child run id, matching the
+	// sibling sessionRoot derivation; hosts omitting runId get the documented
+	// deterministic "preflight" placeholder.
+	const sessionRoot = input.sessionDir ? path.join(path.resolve(input.sessionDir), runId) : input.sessionRoot ? path.join(path.resolve(input.sessionRoot), runId) : undefined;
 	const sessionDir = sessionRoot ? path.join(sessionRoot, "run-0") : undefined;
 	const lifecycleAsyncDir = input.nestedRootRunId
 		? path.join(TEMP_ROOT_DIR, "nested-subagent-runs", input.nestedRootRunId, runId)

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -6551,7 +6551,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 
 		let sessionRoot: string;
 		if (effectiveParams.sessionDir) {
-			sessionRoot = path.resolve(deps.expandTilde(effectiveParams.sessionDir));
+			// An explicit sessionDir is a root keyed by this launch's run id so
+			// concurrent children resolve distinct per-child session files.
+			sessionRoot = path.join(path.resolve(deps.expandTilde(effectiveParams.sessionDir)), runId);
 		} else {
 			const baseSessionRoot = deps.config.defaultSessionDir
 				? path.resolve(deps.expandTilde(deps.config.defaultSessionDir))

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -2734,6 +2734,53 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(fs.readFileSync(path.join(tempDir, "workflow-report.monitor.md"), "utf-8"), "second report");
 	});
 
+	it("keys concurrent workflow children under distinct run-id session roots for an explicit sessionDir", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "first child" });
+		mockPi.onCall({ output: "second child" });
+		const sessionDir = path.join(tempDir, "fanout-sessions");
+		const executor = makeExecutor([makeAgent("echo")]);
+
+		const result = await executor.execute(
+			"workflow-session-dir-fanout",
+			{
+				async: false,
+				sessionDir,
+				workflowScript: `
+					const children = await runs.all([
+						{ key: "first", agent: "echo", task: "First" },
+						{ key: "second", agent: "echo", task: "Second" }
+					]);
+					return children.map(({ key }) => key);
+				`,
+			},
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		const sessionArgs = readAllCallArgs(true)
+			.map((args) => {
+				const index = args.indexOf("--session");
+				return index >= 0 ? args[index + 1] : undefined;
+			})
+			.filter((value): value is string => value !== undefined);
+		assert.equal(sessionArgs.length, 2, `expected two --session child args, got ${JSON.stringify(sessionArgs)}`);
+		const [firstSession, secondSession] = sessionArgs;
+		assert.notEqual(firstSession, secondSession);
+		for (const sessionFile of sessionArgs) {
+			const relative = path.relative(sessionDir, sessionFile);
+			const segments = relative.split(path.sep);
+			assert.match(segments[0]!, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+			assert.deepEqual(segments.slice(1), ["run-0", "session.jsonl"]);
+		}
+		const runIdDirs = fs.readdirSync(sessionDir).sort();
+		assert.equal(runIdDirs.length, 2);
+		for (const runIdDir of runIdDirs) {
+			assert.deepEqual(fs.readdirSync(path.join(sessionDir, runIdDir)), ["run-0"]);
+		}
+	});
+
 	it("maps a task-requested report path to the workflow-saved child output", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "review report" });
 		const requestedReport = path.join(tempDir, "requested-review.md");

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -157,6 +157,43 @@ Project prompt.
 		}
 	});
 
+	it("projects concurrent children under distinct run-id roots for an explicit sessionDir", async () => {
+		const cwd = path.join(tempDir, "repo-session-dir-keying");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "worker.md"), `---\nname: worker\ndescription: Project worker\n---\nWorker.\n`);
+		const sessionDir = path.join(tempDir, "caller-sessions");
+		const runIds = ["run-123", "run-456"];
+
+		const projected = await Promise.all(runIds.map((runId) => resolveSubagentLaunchContract({
+			agent: "worker",
+			cwd,
+			task: "Inspect the repo",
+			runId,
+			sessionDir,
+		})));
+		assert.ok(projected.every((result) => result.ok));
+		for (const [index, result] of projected.entries()) {
+			if (!result.ok) continue;
+			const runId = runIds[index]!;
+			assert.equal(result.contract.roots.sessionFile, path.join(sessionDir, runId, "run-0", "session.jsonl"));
+			assert.equal(result.contract.roots.sessionDir, path.join(sessionDir, runId, "run-0"));
+			assert.equal(result.contract.roots.sessionRoot, path.join(sessionDir, runId));
+		}
+		assert.notEqual(projected[0]!.contract?.roots.sessionFile, projected[1]!.contract?.roots.sessionFile);
+
+		const withoutRunId = await resolveSubagentLaunchContract({
+			agent: "worker",
+			cwd,
+			task: "Inspect the repo",
+			sessionDir,
+		});
+		assert.equal(withoutRunId.ok, true);
+		if (withoutRunId.ok) {
+			assert.equal(withoutRunId.contract.roots.sessionFile, path.join(sessionDir, "preflight", "run-0", "session.jsonl"));
+			assert.equal(withoutRunId.contract.roots.sessionDir, path.join(sessionDir, "preflight", "run-0"));
+		}
+	});
+
 	it("binds canonical extension metadata into public preflight provenance", async () => {
 		const cwd = path.join(tempDir, "bindings-repo");
 		fs.mkdirSync(cwd, { recursive: true });


### PR DESCRIPTION
## Summary

- Treat an explicit `sessionDir` as a caller-owned root and append each child launch’s run id before `run-<idx>`.
- Keep public preflight projections aligned with runtime allocation, including the documented `preflight` placeholder when no run id is supplied.
- Preserve the async workflow `workflowSessionRoot` as the transcript-trust umbrella for its sibling child run directories.
- Add unit and integration coverage for distinct concurrent child session files and document the fix under `[Unreleased]`.

Fixes #1858

## Validation

- Red proof against `upstream/main` (`6e440285`), with the test-only patch:
  - `test/unit/preflight.test.ts` failed because both explicit projections resolved under the unkeyed root.
  - `test/integration/single-execution.test.ts` failed because both `runs.all` children received the same `run-0/session.jsonl`.
- Focused unit test: pass.
- Focused integration test: pass.
- `npm run test:integration` — pass (917 passed, 6 skipped).
- `npm run typecheck` — pass.
- `git diff --check upstream/main...HEAD` — pass.
- `npm run test:all` — 2,785 passed, 3 skipped, 1 failed at `test/unit/host-peer-runtime-imports.test.ts` (`resolveCompileFromPackageRoot loads typebox/compile from a fake Pi host package root`). The same focused failure reproduces on unchanged `upstream/main` in this environment; integration was then run separately as above.
- Live run-and-discard probe: two fresh two-child fan-outs under one explicit root completed all four children and produced four distinct `<sessionDir>/<uuid>/run-0/session.jsonl` paths; the original package pins were restored and probe files removed.
