### PR TITLE
fix: lazy-load prompt audit optional peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
+
 ## [0.65.0] - 2026-09-04
 
 ### Highlights

--- a/src/runs/foreground/prompt-audit.ts
+++ b/src/runs/foreground/prompt-audit.ts
@@ -1,6 +1,5 @@
-import { Agent, type StreamFn, type ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { streamSimple } from "@earendil-works/pi-ai/compat";
+import type { Agent, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Model, ProviderHeaders } from "@earendil-works/pi-ai";
 import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
 import type { ForegroundRunControl } from "../../shared/types.ts";
@@ -64,6 +63,11 @@ export async function rewritePromptWithGuidance(input: {
 }): Promise<string> {
 	const model = input.ctx.model;
 	if (!model) throw new Error("Prompt redo needs the current session model to rewrite the authored task.");
+	const [{ Agent }, { convertToLlm }, { streamSimple }] = await Promise.all([
+		import("@earendil-works/pi-agent-core"),
+		import("@earendil-works/pi-coding-agent"),
+		import("@earendil-works/pi-ai/compat"),
+	]);
 	const auth = await resolveRewriteAuth(input.ctx, model);
 	const registeredProvider = (input.ctx.modelRegistry as {
 		getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;

--- a/test/unit/prompt-audit-optional-peers.test.ts
+++ b/test/unit/prompt-audit-optional-peers.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+test("ordinary prompt audit works without optional Pi peers", async () => {
+	const isolatedRoot = await mkdtemp(join(tmpdir(), "pi-subagents-prompt-audit-"));
+	const promptAuditPath = join(isolatedRoot, "src/runs/foreground/prompt-audit.ts");
+	const streamOptionsPath = join(isolatedRoot, "src/shared/agent-stream-options.ts");
+
+	try {
+		await mkdir(dirname(promptAuditPath), { recursive: true });
+		await mkdir(dirname(streamOptionsPath), { recursive: true });
+		await writeFile(
+			promptAuditPath,
+			await readFile(join(repositoryRoot, "src/runs/foreground/prompt-audit.ts"), "utf8"),
+		);
+		await writeFile(
+			streamOptionsPath,
+			await readFile(join(repositoryRoot, "src/shared/agent-stream-options.ts"), "utf8"),
+		);
+
+		const promptAudit = await import(pathToFileURL(promptAuditPath).href);
+		const control = {};
+		promptAudit.registerLivePromptAudit(control, 0, "authored", "before authored after");
+		assert.deepEqual(promptAudit.getLivePromptAudit(control, 0), {
+			authoredTask: "authored",
+			runtimeAdditions: "before\n\nafter",
+			finalEffectivePrompt: "before authored after",
+		});
+
+		promptAudit.updateLiveEffectivePrompt(control, 0, "next authored tail");
+		assert.equal(promptAudit.getLivePromptAudit(control, 0)?.runtimeAdditions, "next\n\ntail");
+		promptAudit.removeLivePromptAudit(control, 0);
+		assert.equal(promptAudit.getLivePromptAudit(control, 0), undefined);
+	} finally {
+		await rm(isolatedRoot, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary
- keep optional Pi peer imports type-only during ordinary prompt-audit module loading
- lazy-load rewrite-only runtime peers inside `rewritePromptWithGuidance`
- add an isolated regression that exercises prompt-audit registration with peers unavailable

## Validation
- `npm run typecheck` — pass
- focused optional-peer regression — 1/1 pass
- integration — 915 pass, 1 unrelated shared Orca observer-numbering failure; the failing test passes in isolation on untouched upstream
- unit — focused regression passes; full upstream suite has pre-existing package-agent discovery failures reproduced on untouched upstream HEAD
- LSP/pi-lens — zero findings in changed files

Exactly two files are changed.
