### PR TITLE
fix: treat acceptance:false as omitted with gate and echo conflicting fields

### DIFF
--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -387,7 +387,7 @@ const SubagentParamProperties = {
 	outputSchema: Type.Optional(JsonSchemaObject),
 	agentContract: Type.Optional(AgentContractOverride),
 	acceptance: Type.Optional(AcceptanceOverride),
-	gate: Type.Optional(Type.String({ minLength: 1, description: "Host gate command. Cannot be combined with acceptance." })),
+	gate: Type.Optional(Type.String({ minLength: 1, description: "Host gate command. Cannot be combined with acceptance; an explicit acceptance of false is treated as omitted." })),
 };
 
 const SubagentParamsSchema = Type.Object(SubagentParamProperties);

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -202,8 +202,28 @@ export function normalizeGateAcceptance(gate: unknown, acceptance: AcceptanceInp
 		return normalized.error ? { ok: false, error: normalized.error } : { ok: true, acceptance: normalized.value as AcceptanceInput };
 	}
 	if (typeof gate !== "string" || !gate.trim()) return { ok: false, error: "gate must be a non-empty command string." };
-	if (acceptance !== undefined) return { ok: false, error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." };
+	// `acceptance: false` is the deprecated "disable acceptance" shorthand. It carries no
+	// verification intent that could conflict with a gate, so the gate wins instead of erroring:
+	// a caller that disables acceptance policy and asks for a gate command wants the gate.
+	if (acceptance === false) return { ok: true, acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
+	if (acceptance !== undefined) return { ok: false, error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." + describeGateAcceptanceConflict(gate, acceptance) };
 	return { ok: true, acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
+}
+
+// Renders the offending gate and acceptance values, bounded, so a rejected call can be
+// diagnosed from the error alone. Without this, a caller that keeps sending both fields
+// cannot see from the message what it actually sent.
+export function describeGateAcceptanceConflict(gate: unknown, acceptance: unknown): string {
+	const render = (value: unknown): string => {
+		let encoded: string;
+		try {
+			encoded = JSON.stringify(value) ?? String(value);
+		} catch {
+			encoded = String(value);
+		}
+		return encoded.length > 120 ? `${encoded.slice(0, 120)}...` : encoded;
+	};
+	return ` Both fields were present: gate=${render(gate)} acceptance=${render(acceptance)}.`;
 }
 
 function explicitAcceptanceCanDisable(explicit: AcceptanceConfig): boolean {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -5,6 +5,7 @@ import { Worker } from "node:worker_threads";
 import { DEFAULT_GLOBAL_CONCURRENCY_LIMIT, Semaphore } from "../runs/shared/parallel-utils.ts";
 import { HOST_STEP_MAX_COUNT } from "../runs/shared/host-step-status.ts";
 import { classifyTaskMutationIntent } from "../runs/shared/task-intent.ts";
+import { describeGateAcceptanceConflict } from "../runs/shared/acceptance.ts";
 import type { AcceptanceRecoveryMetadata, HostStepNodeV1, SingleResult } from "../shared/types.ts";
 import { normalizeWorkflowHostCommandParams, type WorkflowHostCommandParams, type WorkflowHostCommandResult } from "./host-command.ts";
 
@@ -614,6 +615,19 @@ function validateLaneMetadata(value, label, workflowKey) {
   }
 }
 
+function describeGateAcceptanceConflict(gate, acceptance) {
+  const render = (value) => {
+    let encoded;
+    try {
+      encoded = JSON.stringify(value) ?? String(value);
+    } catch {
+      encoded = String(value);
+    }
+    return encoded.length > 120 ? encoded.slice(0, 120) + "..." : encoded;
+  };
+  return " Both fields were present: gate=" + render(gate) + " acceptance=" + render(acceptance) + ".";
+}
+
 function validateRunCall(key, params, label, fingerprints) {
   if (typeof key !== "string" || !runKeyPattern.test(key)) throw new Error(label + " has an invalid key.");
   if (hostKeys.has(key)) throw new Error("Workflow key '" + key + "' is already used by runs.host.");
@@ -627,7 +641,7 @@ function validateRunCall(key, params, label, fingerprints) {
   if (params.baseRef !== undefined && (typeof params.baseRef !== "string" || !validGitRef(params.baseRef))) throw new Error(label + " baseRef must be a valid Git ref.");
   validateLaneMetadata(params.lane, label + " lane", key);
   if (params.gate !== undefined && (typeof params.gate !== "string" || !params.gate.trim())) throw new Error(label + " gate must be a non-empty command string.");
-  if (params.gate !== undefined && params.acceptance !== undefined) throw new Error(label + " gate cannot be combined with acceptance; use one gate command or acceptance.verify.");
+  if (params.gate !== undefined && params.acceptance !== undefined && params.acceptance !== false) throw new Error(label + " gate cannot be combined with acceptance; use one gate command or acceptance.verify." + describeGateAcceptanceConflict(params.gate, params.acceptance));
   if (params.gate !== undefined && params.resume !== undefined) throw new Error(label + " gate is not supported with retained resume.");
   if (params.extensionBindings !== undefined && params.resume !== undefined) throw new Error(label + " extensionBindings is not supported with retained resume; resume uses the original retained child binding.");
   if (params.resume !== undefined && typeof params.resume !== "string") {
@@ -2109,8 +2123,8 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 			if (params.gate !== undefined && (typeof params.gate !== "string" || !params.gate.trim())) {
 				return respond(Promise.reject(new Error(`runs.run('${key}') gate must be a non-empty command string.`)));
 			}
-			if (params.gate !== undefined && params.acceptance !== undefined) {
-				return respond(Promise.reject(new Error(`runs.run('${key}') gate cannot be combined with acceptance; use one gate command or acceptance.verify.`)));
+			if (params.gate !== undefined && params.acceptance !== undefined && params.acceptance !== false) {
+				return respond(Promise.reject(new Error(`runs.run('${key}') gate cannot be combined with acceptance; use one gate command or acceptance.verify.` + describeGateAcceptanceConflict(params.gate, params.acceptance))));
 			}
 			if (params.gate !== undefined && params.resume !== undefined) {
 				return respond(Promise.reject(new Error(`runs.run('${key}') gate is not supported with retained resume.`)));

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -75,6 +75,12 @@ function stableRunJson(value) {
   return JSON.stringify(value) ?? "undefined";
 }
 
+function canonicalRunParams(params) {
+  if (params.gate === undefined || params.acceptance !== false) return params;
+  const { acceptance: _acceptance, ...withoutAcceptance } = params;
+  return withoutAcceptance;
+}
+
 function isDirectWorkflowScriptPromiseHandlerCall() {
   const stack = new Error().stack;
   if (typeof stack !== "string") return false;
@@ -446,7 +452,7 @@ function validateLaneSpecs(laneSpecs) {
       validateLaneStageBounds(validationParams, stageLabel);
       validateRunCall(generatedKey, validationParams, stageLabel, validationFingerprints);
       const existingFingerprint = runFingerprints.get(generatedKey);
-      if (existingFingerprint !== undefined && (resume === "previous" || existingFingerprint !== stableRunJson(params))) {
+      if (existingFingerprint !== undefined && (resume === "previous" || existingFingerprint !== stableRunJson(canonicalRunParams(params)))) {
         throw new Error("runs.lanes generated child key '" + generatedKey + "' is already used with incompatible launch params.");
       }
       stages.push({ key: stageKey, generatedKey, resume, params });
@@ -658,7 +664,7 @@ function validateRunCall(key, params, label, fingerprints) {
   if (params.resume !== undefined && (typeof params.task !== "string" || !params.task.trim())) throw new Error(label + " resume requires a non-empty task follow-up.");
   validateExtensionBindings(params.extensionBindings, label);
   assertJsonValue(params, label + " params");
-  const fingerprint = stableRunJson(params);
+  const fingerprint = stableRunJson(canonicalRunParams(params));
   const existing = fingerprints.get(key);
   if (existing !== undefined && existing !== fingerprint) throw new Error("Duplicate workflow key '" + key + "' used with incompatible launch params.");
   fingerprints.set(key, fingerprint);
@@ -1384,6 +1390,12 @@ function stableJson(value: unknown): string {
 	return JSON.stringify(value) ?? "undefined";
 }
 
+function canonicalRunParams(params: Record<string, unknown>): Record<string, unknown> {
+	if (params.gate === undefined || params.acceptance !== false) return params;
+	const { acceptance: _acceptance, ...withoutAcceptance } = params;
+	return withoutAcceptance;
+}
+
 function validateKey(value: unknown, owner = "runs.run"): string {
 	if (typeof value !== "string" || !KEY_PATTERN.test(value)) {
 		throw new Error(`${owner} key must be 1-128 characters using letters, numbers, '.', '_' or '-', and start with a letter or number.`);
@@ -2096,7 +2108,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 					}
 					return result;
 				});
-			const fingerprint = stableJson(params);
+			const fingerprint = stableJson(canonicalRunParams(params));
 			const existing = launches.get(key);
 			if (existing) {
 				if (existing.fingerprint !== fingerprint) return respond(Promise.reject(new Error(`Duplicate workflow key '${key}' used with incompatible launch params.`)));

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -1238,7 +1238,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				{
 					workflowScript: `return await runs.run("gated", { agent: "worker", task: "run", gate: "npm test" });`,
 					async: true,
-					acceptance: false,
+					acceptance: "checked",
 				},
 				new AbortController().signal,
 				undefined,

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1312,6 +1312,16 @@ describe("acceptance gates", () => {
 		const conflictingGate = normalizeGateAcceptance("npm test", "checked");
 		assert.equal(conflictingGate.ok, false);
 		assert.match(conflictingGate.error, /cannot be combined with acceptance/);
+		assert.match(conflictingGate.error, /Both fields were present: gate="npm test" acceptance="checked"/);
+		const oversizedAcceptance = normalizeGateAcceptance("npm test", { level: "checked", evidence: ["a".repeat(200)] });
+		assert.equal(oversizedAcceptance.ok, false);
+		assert.match(oversizedAcceptance.error || "", /Both fields were present/);
+		assert.ok(!(oversizedAcceptance.error || "").includes("a".repeat(200)));
+		const disabledAcceptance = normalizeGateAcceptance("npm test", false);
+		assert.deepEqual(disabledAcceptance, {
+			ok: true,
+			acceptance: { level: "verified", verify: [{ id: "gate", command: "npm test" }] },
+		});
 	});
 
 	it("keeps explicit acceptance.verify arrays as existing verified acceptance", async () => {

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -768,6 +768,13 @@ describe("scripted workflow runtime", () => {
 			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
 		});
 		assert.equal(launches[0]?.gate, "npm test");
+		await runWorkflowScript({
+			script: `return runs.run("gated-disabled", { agent: "worker", gate: "npm test", acceptance: false });`,
+			async launch(key, params) { launches.push(params); return { key, ok: true, output: "done", artifactPaths: [] }; },
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		assert.equal(launches[1]?.gate, "npm test");
+		assert.equal(launches[1]?.acceptance, false);
 		await assert.rejects(
 			runWorkflowScript({
 				script: `return runs.run("invalid", { agent: "worker", gate: "npm test", acceptance: "checked" });`,

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -785,6 +785,26 @@ describe("scripted workflow runtime", () => {
 		);
 	});
 
+	it("reuses a gated key when acceptance false is explicit", async () => {
+		const launches: string[] = [];
+		const result = await runWorkflowScript({
+			script: `
+				const first = await runs.run("g", { agent: "worker", gate: "npm test" });
+				const second = await runs.run("g", { agent: "worker", gate: "npm test", acceptance: false });
+				return { first: first.key, second: second.key };
+			`,
+			timeoutMs: 2_000,
+			async launch(key) {
+				launches.push(key);
+				return { key, ok: true, output: "ok", artifactPaths: [], results: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+
+		assert.deepEqual(result.value, { first: "g", second: "g" });
+		assert.deepEqual(launches, ["g"]);
+	});
+
 	it("rejects retained resume with gate", async () => {
 		await assert.rejects(
 			runWorkflowScript({


### PR DESCRIPTION
# fix: treat acceptance:false as omitted with gate and echo conflicting fields

## Problem

A call that sets both `gate` and `acceptance` fails with `gate cannot be combined with acceptance; use one gate command or acceptance.verify.` The check is a **presence** check, so the deprecated `acceptance: false` disable shorthand also trips it — including indirectly, when a workflow sets `acceptance: false` at the top level and one of its children carries a `gate`. A caller that disables acceptance policy and supplies a gate command wants the gate, not an error.

Separately, the conflict error carries no detail about what was actually sent. A caller that keeps sending both fields cannot diagnose its own payload from the message, which makes this particular rejection unusually hard to recover from in long agent sessions.

## Changes

- `normalizeGateAcceptance` treats `acceptance: false` as omitted when a gate is present: the gate carries the verification intent, so it wins. Applied consistently at the top level (`normalizeGateParams`), in workflow child validation (`validateRunCall`), and in the `runs.run` runtime check.
- Gate/acceptance conflict errors now echo the offending values, bounded to 120 characters per field:

  ```
  gate cannot be combined with acceptance; use one gate command or acceptance.verify. Both fields were present: gate="npm test" acceptance="checked".
  ```

- The workflowScript worker source is a self-contained `String.raw` eval string and cannot import shared modules, so it carries a plain-JS copy of the conflict formatter.
- The `gate` tool-schema description documents the `false` exception.

## Tests

- `acceptance.test.ts`: `false` + gate normalizes to the gate acceptance; the conflict message names both sent values; an oversized acceptance payload is truncated in the message.
- `scripted-workflow.test.ts`: `{ gate, acceptance: false }` passes child validation and reaches the launch with the gate intact; `{ gate, acceptance: "checked" }` still rejects.
- `intercom-result-delivery.test.ts`: the capacity-release-on-failure integration test now uses `acceptance: "checked"` so it still exercises the conflict path.
