### PR TITLE
fix: initialize pi's theme before child sessions bind extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Configure proxy-aware HTTP dispatch in detached background runners. Thanks to [@jasonrale](https://github.com/jasonrale) for #1867/#1866.
 - Ignore stale model-not-found exclusions once the active model registry contains that model again. Thanks [@x1prog](https://github.com/x1prog) for #1862.
 - Alias `@earendil-works/pi-agent-core/node` to Pi's exact `./node` export for detached runners. Thanks [@plopezlpz](https://github.com/plopezlpz) for #1871.
+- Initialize Pi's global theme before child sessions bind their extensions, so extensions reading `ctx.ui.theme` no longer throw "Theme not initialized. Call initTheme() first." in subagent runs (detached background runners in particular). Thanks [@danielmarbach](https://github.com/danielmarbach) for #1865.
 
 ## [0.65.0] - 2026-09-04
 

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -196,6 +196,16 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 			const modelRuntime = await sharedRuntime(pi);
 			const agentDir = getAgentDir();
 			const settingsManager = pi.SettingsManager.create(launch.cwd, agentDir);
+			// Headless child processes (the detached async runner in particular)
+			// never run pi's main-mode startup, so the global theme registry stays
+			// uninitialized and any extension reading `ctx.ui.theme` throws
+			// "Theme not initialized. Call initTheme() first." on every event it
+			// handles. Initialize the theme from the configured settings here,
+			// mirroring the `initTheme(settingsManager.getTheme(), ...)` call
+			// main-mode makes in main.js. Re-initializing in a process where main
+			// already initialized is idempotent (same theme name), and load errors
+			// fall back to the built-in dark theme exactly like main-mode.
+			if (typeof pi.initTheme === "function") pi.initTheme(settingsManager.getTheme());
 			const loader = new pi.DefaultResourceLoader({
 				cwd: launch.cwd,
 				agentDir,

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -296,6 +296,24 @@ describe("default child session factory", () => {
 		assert.deepEqual(errors, ["<loader>"]);
 	});
 
+	it("initializes the theme from settings before each child session", async () => {
+		const themed: Array<string | undefined> = [];
+		const pi = stubPi();
+		pi.initTheme = ((themeName?: string) => { themed.push(themeName); }) as PiCodingAgentModule["initTheme"];
+		pi.SettingsManager = { create: () => ({ getTheme: () => "solarized-dark" }) } as unknown as PiCodingAgentModule["SettingsManager"];
+		const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => pi });
+		await factory.create(stubLaunch);
+		await factory.create(stubLaunch);
+		assert.deepEqual(themed, ["solarized-dark", "solarized-dark"]);
+	});
+
+	it("skips theme initialization when the pi module has no initTheme export", async () => {
+		const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => stubPi() });
+		await factory.create(stubLaunch);
+		// Reaching here without throwing is the assertion: `settingsManager.getTheme()`
+		// must not be evaluated when `initTheme` is unavailable.
+	});
+
 	it("disposes the session when bindExtensions rejects", async () => {
 		let disposed = 0;
 		const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => stubPi({ bindExtensions: async () => { throw new Error("bind failed"); }, dispose: () => { disposed += 1; } }) });


### PR DESCRIPTION
## Problem

Extensions that read `ctx.ui.theme` throw `Theme not initialized. Call initTheme() first.` on **every event they handle** in subagent runs. The parent session shows it as a stream of `Extension error (.../index.ts, message_update)` entries per child.

Root cause: since #1844 subagents run as native `AgentSession`s instead of spawned `pi` processes. Foreground children run in the parent process (where `main.js` already called `initTheme`), but **detached background children run in the runner process, which never runs pi's main-mode startup** — so the global theme registry stays uninitialized. The `ctx.ui.theme` proxy then throws on first property access, every `message_update`.

Reproduced with a bare-node smoke test:

```
before initTheme -> throws: true | Theme not initialized. Call initTheme() first.
after  initTheme -> styled length: 28
```

## Fix

In `createDefaultChildSessionFactory().create()` (the path both foreground and detached background children use), initialize the theme from the configured settings before extensions load:

```ts
if (typeof pi.initTheme === "function") pi.initTheme(settingsManager.getTheme());
```

This mirrors the exact call main-mode makes in `main.js`. It's idempotent in processes where main already initialized (same theme name), gives detached runners a usable theme, and load errors fall back to the built-in dark theme exactly like main-mode. Guarded on `typeof` so older pi packages without the export keep working.

## Verification

- `npm run typecheck` — clean
- `npm test` — 2785 pass / 0 fail
- New tests cover both the init call (with the configured theme name) and the no-`initTheme`-export fallback
