### PR TITLE
fix: configure proxy-aware HTTP dispatcher in detached runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
 - Key subagent children launched under an explicit `sessionDir` by their run id so concurrent children resolve distinct session files instead of sharing `run-0`. Thanks to [@dat9uy](https://github.com/dat9uy) for #1859 and #1858.
+- Configure proxy-aware HTTP dispatch in detached background runners. Thanks to [@jasonrale](https://github.com/jasonrale) for #1867/#1866.
 
 ## [0.65.0] - 2026-09-04
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "acorn": "8.18.0",
         "jiti": "2.7.0",
         "typebox": "1.1.38",
+        "undici": "8.10.0",
         "yaml": "2.8.3"
       },
       "bin": {
@@ -666,7 +667,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1790,6 +1790,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -1850,7 +1859,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "acorn": "8.18.0",
     "jiti": "2.7.0",
     "typebox": "1.1.38",
+    "undici": "8.10.0",
     "yaml": "2.8.3"
   },
   "devDependencies": {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1,8 +1,49 @@
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
+
+/**
+ * Detached runners bypass pi's CLI entry points, so pi core's
+ * configureHttpDispatcher() never runs here and the global fetch keeps Node's
+ * default dispatcher, which silently ignores *_proxy (once observed as
+ * deterministic upstream 403s on a region-gated model). Mirror the host setup
+ * with the locally resolvable undici copy; every step is best-effort and falls
+ * back to previous behavior instead of breaking startup.
+ */
+const requireFromRunner = createRequire(import.meta.url);
+function ensureProxyAwareHttpDispatcher(): void {
+	try {
+		const undici = requireFromRunner("undici") as {
+			EnvHttpProxyAgent?: new (opts?: Record<string, unknown>) => unknown;
+			setGlobalDispatcher?: (dispatcher: unknown) => void;
+			install?: () => void;
+		};
+		if (typeof undici?.EnvHttpProxyAgent !== "function") return;
+		const dispatcher = new undici.EnvHttpProxyAgent({ allowH2: false });
+		try {
+			const { EventEmitter } = requireFromRunner("node:events") as {
+				EventEmitter: new (...args: unknown[]) => { on(event: string, listener: () => void): unknown };
+			};
+			if (dispatcher instanceof EventEmitter) dispatcher.on("error", () => {});
+		} catch {
+			// Error-listener hardening is best-effort only.
+		}
+		undici.setGlobalDispatcher?.(dispatcher);
+		// Route pi-ai's global-fetch calls through this dispatcher (parity with host).
+		undici.install?.();
+	} catch (error) {
+		// Fall back to previous behavior, but leave a breadcrumb for next time.
+		try {
+			console.error(`[pi-subagents] proxy-aware HTTP dispatcher not installed: ${error instanceof Error ? error.message : String(error)}`);
+		} catch {
+			// Logging must never break runner startup.
+		}
+	}
+}
+ensureProxyAwareHttpDispatcher();
 import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { writeAsyncResultFile, writePendingAsyncResultFile } from "./result-files.ts";
 import { createFileCoalescer } from "../../shared/file-coalescer.ts";


### PR DESCRIPTION
Fixes #1866.

   Background runners never go through pi CLI entries, so the global fetch keeps Node's default
 dispatcher and silently ignores proxy env. This mirrors the host setup (EnvHttpProxyAgent +
 setGlobalDispatcher + install) with the locally resolvable undici copy, all best-effort with fallback.

   Verified live: background delegate on a region-gated model went from deterministic 403 to OK;
 foreground/main untouched (separate process).