### PR TITLE
fix: ignore stale model-missing exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
 - Key subagent children launched under an explicit `sessionDir` by their run id so concurrent children resolve distinct session files instead of sharing `run-0`. Thanks to [@dat9uy](https://github.com/dat9uy) for #1859 and #1858.
 - Configure proxy-aware HTTP dispatch in detached background runners. Thanks to [@jasonrale](https://github.com/jasonrale) for #1867/#1866.
+- Ignore stale model-not-found exclusions once the active model registry contains that model again. Thanks [@x1prog](https://github.com/x1prog) for #1862.
 
 ## [0.65.0] - 2026-09-04
 

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -317,6 +317,7 @@ export function parseModelKey(fullId: string): { provider?: string; modelId: str
 export function filterFallbackCandidates(candidates: string[], opts?: {
 	now?: number;
 	onExcluded?: (candidate: string, exclusion: Readonly<ModelExclusion>) => void;
+	ignoreExclusion?: (candidate: string, exclusion: Readonly<ModelExclusion>) => boolean;
 }): string[] {
 	ensureLoaded();
 	invalidateAuthExclusions();
@@ -326,7 +327,7 @@ export function filterFallbackCandidates(candidates: string[], opts?: {
 	for (const raw of candidates) {
 		if (!raw || seen.has(raw)) continue;
 		const { provider: candidateProvider, modelId: candidateModelId } = parseModelKey(raw);
-		const exclusion = exclusions.find((entry) => entryMatches(entry, candidateModelId, candidateProvider, timestamp));
+		const exclusion = exclusions.find((entry) => entryMatches(entry, candidateModelId, candidateProvider, timestamp) && opts?.ignoreExclusion?.(raw, entry) !== true);
 		if (exclusion) {
 			opts?.onExcluded?.(raw, exclusion);
 			continue;

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -309,6 +309,24 @@ function formatExcludedCandidateEvidence(candidate: string, exclusion: NonNullab
 	return `${displayCandidate} — model: ${displayModel}; provider: ${displayProvider}; reason: ${reason}; expires: ${formatModelExclusionExpiry(exclusion.expiresAt)}`;
 }
 
+const MODEL_UNAVAILABLE_EXCLUSION_PATTERNS = [
+	/model.*not found/i,
+	/unknown model/i,
+	/model.*unavailable/i,
+	/model.*disabled/i,
+];
+
+function isCurrentRegistryModel(candidate: string, availableModels: AvailableModelInfo[] | undefined): boolean {
+	if (!availableModels || availableModels.length === 0) return false;
+	const { baseModel } = splitThinkingSuffix(candidate);
+	return availableModels.some((entry) => entry.fullId === baseModel);
+}
+
+function ignoreStaleModelUnavailableExclusion(candidate: string, exclusion: NonNullable<ReturnType<typeof findModelExclusion>>, availableModels: AvailableModelInfo[] | undefined): boolean {
+	const reason = exclusion.reason ?? "";
+	return MODEL_UNAVAILABLE_EXCLUSION_PATTERNS.some((pattern) => pattern.test(reason)) && isCurrentRegistryModel(candidate, availableModels);
+}
+
 function throwForExplicitModelExclusion(model: string): void {
 	const exclusion = findModelExclusion(model);
 	if (!exclusion) return;
@@ -487,7 +505,10 @@ export function buildModelCandidates(
 		seen.add(normalized);
 		candidates.push(normalized);
 	}
-	const resolved = filterFallbackCandidates(candidates, { onExcluded: warnCachedExclusion });
+	const resolved = filterFallbackCandidates(candidates, {
+		onExcluded: warnCachedExclusion,
+		ignoreExclusion: (candidate, exclusion) => ignoreStaleModelUnavailableExclusion(candidate, exclusion, availableModels),
+	});
 	if (resolved.length === 0) {
 		if (skippedPrimary) resolveRequiredSubagentModelCandidate(skippedPrimary, availableModels, preferredProvider);
 		if (candidates.length === 0 && skippedFallback) resolveRequiredSubagentModelCandidate(skippedFallback, availableModels, preferredProvider);

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -277,6 +277,40 @@ describe("model fallback helpers", () => {
 		);
 	});
 
+	it("ignores stale model-not-found exclusions when the model is back in the registry", () => {
+		recordModelFailure({
+			modelId: "gpt-5-mini",
+			provider: "openai",
+			reason: 'Model "openai/gpt-5-mini" not found. Use --list-models to see available models.',
+		});
+		assert.deepEqual(buildModelCandidates("openai/gpt-5-mini", undefined, availableModels), ["openai/gpt-5-mini"]);
+	});
+
+	it("keeps provider-wide exclusions when ignoring a stale model-not-found entry", () => {
+		recordModelFailure({ provider: "openai", reason: "quota exceeded" });
+		recordModelFailure({
+			modelId: "gpt-5-mini",
+			provider: "openai",
+			reason: 'Model "openai/gpt-5-mini" not found. Use --list-models to see available models.',
+		});
+		assert.throws(
+			() => buildModelCandidates("openai/gpt-5-mini", undefined, availableModels),
+			/No usable subagent models remain after registry, scope, and cached-exclusion filtering/,
+		);
+	});
+
+	it("keeps explicit stale model-not-found exclusions strict", () => {
+		recordModelFailure({
+			modelId: "gpt-5-mini",
+			provider: "openai",
+			reason: 'Model "openai/gpt-5-mini" not found. Use --list-models to see available models.',
+		});
+		assert.throws(
+			() => buildModelCandidates("openai/gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels, undefined, { origin: "explicit" }),
+			/Requested subagent model 'openai\/gpt-5-mini' is excluded and cannot be replaced by a fallback/,
+		);
+	});
+
 	it("keeps an explicit cached-excluded primary strict even when fallbacks exist", () => {
 		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "sk-secret-token-xyz" });
 		assert.throws(


### PR DESCRIPTION
Fixes #1862.

This keeps cached model exclusions fail-closed for quota/auth/rate-limit/provider-wide failures, but ignores stale model-not-found exclusions when the active Pi model registry now contains that exact model again.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test --test-name-pattern='stale model-not-found|provider-wide exclusions|explicit stale model-not-found|cached exclusions leave zero candidates|explicit cached-excluded' test/unit/model-fallback.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts test/unit/model-exclusions.test.ts`
- `npm run typecheck`
- `git diff --check`

Fresh review: `No issues found` in `issue-1862-model-exclusion-review-2.md`.
