### PR TITLE
fix: validate managed worktree patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Ignore stale model-not-found exclusions once the active model registry contains that model again. Thanks [@x1prog](https://github.com/x1prog) for #1862.
 - Alias `@earendil-works/pi-agent-core/node` to Pi's exact `./node` export for detached runners. Thanks [@plopezlpz](https://github.com/plopezlpz) for #1871.
 - Initialize Pi's global theme before child sessions bind their extensions, so extensions reading `ctx.ui.theme` no longer throw "Theme not initialized. Call initTheme() first." in subagent runs (detached background runners in particular). Thanks [@danielmarbach](https://github.com/danielmarbach) for #1865.
+- Capture managed-worktree handoff patches with machine-safe diff settings and validate them before cleanup. Thanks [@jeanduplessis](https://github.com/jeanduplessis) for #1868.
 
 ## [0.65.0] - 2026-09-04
 

--- a/src/runs/shared/worktree-cleanup-plan.ts
+++ b/src/runs/shared/worktree-cleanup-plan.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../shared/types.ts";
 import { getAgentDir } from "../../shared/utils.ts";
 import { isTerminalParallelHandoffChildStatus } from "./parallel-handoff.ts";
+import { MACHINE_DIFF_OPTIONS, validateWorktreePatchRepresentsCurrentWorktree } from "./worktree.ts";
 
 export const WORKTREE_CLEANUP_PLAN_VERSION = 1 as const;
 export const WORKTREE_CLEANUP_PLAN_TTL_MS = 30 * 60 * 1000;
@@ -572,7 +573,7 @@ function resolveBranchTip(repoRoot: string, branch: string): { value?: string; e
 	return { value: result.stdout.trim() };
 }
 
-function isPatchCaptured(record: ManifestMetadataRecord, worktreePath: string): { path?: string; error?: string } {
+function isPatchCaptured(record: ManifestMetadataRecord, worktreePath: string, baseCommit: string): { path?: string; error?: string } {
 	const patchPath = metadataPatchPath(record);
 	if (!patchPath || record.child.patch?.error !== undefined || record.child.patch?.changed !== true) return {};
 	const inspection = inspectPath(patchPath);
@@ -587,6 +588,8 @@ function isPatchCaptured(record: ManifestMetadataRecord, worktreePath: string): 
 	if (!patchStat.isFile()) return { error: "captured handoff patch is not a file" };
 	if (pathInside(worktreePath, inspection.realpath)) return { error: "durable handoff patch lives inside the worktree" };
 	if (patchStat.size <= 0) return { error: "captured handoff patch is empty" };
+	const validationError = validateWorktreePatchRepresentsCurrentWorktree(worktreePath, baseCommit, patchPath);
+	if (validationError) return { error: `captured handoff patch failed validation: ${validationError}` };
 	return { path: patchPath };
 }
 
@@ -665,14 +668,14 @@ function buildManagedEntry(input: {
 	entry.preconditions.statusDigest = status.digest;
 	if (status.output && status.output.trim()) return blockedEntry(entry, "dirty", "keep", "worktree has uncommitted or untracked changes");
 
-	const diff = runGit(worktreePath, ["diff", "--quiet", resolvedBase.value, "--"]);
+	const diff = runGit(worktreePath, ["diff", "--quiet", ...MACHINE_DIFF_OPTIONS, resolvedBase.value, "--"]);
 	if (diff.status !== 0 && diff.status !== 1) return blockedEntry(entry, "unknown", "unknown", `git diff safety check failed: ${gitFailure(diff, "git diff")}`);
 	const ancestor = runGit(repoRoot, ["merge-base", "--is-ancestor", git.head, targetHead]);
 	if (ancestor.status !== 0 && ancestor.status !== 1) return blockedEntry(entry, "unknown", "unknown", `local merge safety check failed: ${gitFailure(ancestor, "git merge-base --is-ancestor")}`);
 	const branchTipIsAncestor = ancestor.status === 0;
 	let divergenceSafe = diff.status === 0;
 	if (!divergenceSafe) {
-		const captured = isPatchCaptured(record, worktreePath);
+		const captured = isPatchCaptured(record, worktreePath, resolvedBase.value);
 		if (captured.error) return blockedEntry(entry, "ineligible", "keep", captured.error);
 		if (captured.path) {
 			entry.patchPath = captured.path;

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -17,6 +17,9 @@ const WORKTREE_NAMING_COMPONENT_MAX_BYTES = 96;
 const WORKTREE_NAMING_LABEL_MAX_BYTES = 256;
 const WORKTREE_NAMING_BRANCH_MAX_BYTES = 256;
 const WORKTREE_COMMAND_OUTPUT_MAX_BYTES = 128 * 1024;
+export const MACHINE_DIFF_OPTIONS = ["--no-color", "--no-ext-diff", "--no-textconv", "--default-prefix", "--line-prefix=", "--no-relative"] as const;
+const MACHINE_PATCH_OPTIONS = [...MACHINE_DIFF_OPTIONS, "--binary"] as const;
+const PATCH_VALIDATION_OPTIONS = ["apply", "--check", "--cached", "--reverse", "--binary", "--whitespace=nowarn"] as const;
 
 export interface WorktreeNamingInput {
 	runId: string;
@@ -168,8 +171,8 @@ interface RepoState {
 
 const DEFAULT_WORKTREE_SETUP_HOOK_TIMEOUT_MS = 30000;
 
-function runGit(cwd: string, args: string[]): GitResult {
-	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", windowsHide: true, shell: false });
+function runGit(cwd: string, args: string[], env?: NodeJS.ProcessEnv): GitResult {
+	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", windowsHide: true, shell: false, ...(env ? { env: { ...process.env, ...env } } : {}) });
 	return {
 		stdout: result.stdout ?? "",
 		stderr: result.stderr ?? "",
@@ -185,6 +188,53 @@ function runGitChecked(cwd: string, args: string[]): string {
 		throw new Error(message);
 	}
 	return result.stdout;
+}
+
+/** Validate a captured patch against the worktree index without changing either. */
+export function validateWorktreePatch(worktreePath: string, patchPath: string): string | undefined {
+	const result = runGit(worktreePath, [...PATCH_VALIDATION_OPTIONS, patchPath]);
+	if (result.status === 0) return undefined;
+	return result.stderr.trim() || result.stdout.trim() || `git -C ${worktreePath} apply --check failed`;
+}
+
+function currentWorktreePatch(worktreePath: string, baseCommit: string): { patch?: string; error?: string } {
+	let tempDir: string;
+	try {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-index-"));
+	} catch (error) {
+		return { error: error instanceof Error ? error.message : String(error) };
+	}
+	const env = { GIT_INDEX_FILE: path.join(tempDir, "index") };
+	try {
+		const readTree = runGit(worktreePath, ["read-tree", "HEAD"], env);
+		if (readTree.status !== 0) return { error: readTree.stderr.trim() || readTree.stdout.trim() || "git read-tree failed" };
+		const add = runGit(worktreePath, ["add", "-A"], env);
+		if (add.status !== 0) return { error: add.stderr.trim() || add.stdout.trim() || "git add failed" };
+		const diff = runGit(worktreePath, ["diff", "--cached", ...MACHINE_PATCH_OPTIONS, baseCommit], env);
+		if (diff.status !== 0) return { error: diff.stderr.trim() || diff.stdout.trim() || "git diff failed" };
+		return { patch: diff.stdout };
+	} finally {
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// Cleanup safety depends on preserving the worktree, not on best-effort temp-index deletion.
+		}
+	}
+}
+
+export function validateWorktreePatchRepresentsCurrentWorktree(worktreePath: string, baseCommit: string, patchPath: string): string | undefined {
+	const validationError = validateWorktreePatch(worktreePath, patchPath);
+	if (validationError) return validationError;
+	let capturedPatch: string;
+	try {
+		capturedPatch = fs.readFileSync(patchPath, "utf-8");
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+	const current = currentWorktreePatch(worktreePath, baseCommit);
+	if (current.error) return current.error;
+	if (capturedPatch !== current.patch) return "captured handoff patch does not match current worktree changes";
+	return undefined;
 }
 
 function findGitWorktreePath(cwd: string, branch: string): string | undefined {
@@ -957,14 +1007,17 @@ function captureWorktreeDiff(
 ): WorktreeDiff {
 	removeSyntheticPathsBeforeDiff(worktree);
 	runGitChecked(worktree.path, ["add", "-A"]);
-	const diffStat = runGitChecked(worktree.path, ["diff", "--cached", "--stat", setup.baseCommit]).trim();
-	const patch = runGitChecked(worktree.path, ["diff", "--cached", setup.baseCommit]);
-	const numstat = runGitChecked(worktree.path, ["diff", "--cached", "--numstat", setup.baseCommit]);
+	const diffStat = runGitChecked(worktree.path, ["diff", "--cached", ...MACHINE_DIFF_OPTIONS, "--stat", setup.baseCommit]).trim();
+	const patch = runGitChecked(worktree.path, ["diff", "--cached", ...MACHINE_PATCH_OPTIONS, setup.baseCommit]);
+	const numstat = runGitChecked(worktree.path, ["diff", "--cached", ...MACHINE_DIFF_OPTIONS, "--numstat", setup.baseCommit]);
 	fs.writeFileSync(patchPath, patch, "utf-8");
 
 	if (!patch.trim()) {
 		return emptyDiff(worktree.index, agent, worktree.branch, patchPath);
 	}
+
+	const validationError = validateWorktreePatch(worktree.path, patchPath);
+	if (validationError) throw new Error(`captured worktree patch is not machine-applyable: ${validationError}`);
 
 	const parsed = parseNumstat(numstat);
 	return {
@@ -1034,7 +1087,7 @@ function cleanupSingleWorktree(
 			errors.push(`synthetic path cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
 		}
 		const status = runGit(worktree.path, ["status", "--porcelain"]);
-		const baseDiff = runGit(worktree.path, ["diff", "--quiet", setup.baseCommit, "--"]);
+		const baseDiff = runGit(worktree.path, ["diff", "--quiet", ...MACHINE_DIFF_OPTIONS, setup.baseCommit, "--"]);
 		if (status.status !== 0 || (baseDiff.status !== 0 && baseDiff.status !== 1)) {
 			const reason = status.status !== 0
 				? status.stderr.trim() || status.stdout.trim() || "git status failed"
@@ -1055,13 +1108,25 @@ function cleanupSingleWorktree(
 		const hasWork = status.stdout.trim().length > 0 || baseDiff.status === 1;
 		if (hasWork && intent.kind === "preserve") {
 			const captured = (intent.capturedDiffs ?? setup.capturedDiffs)?.find((diff) => diff.index === worktree.index);
-			const patchCaptured = captured !== undefined
+			let patchValidationError: string | undefined;
+			let patchCaptured = false;
+			if (captured !== undefined
 				&& captured.error === undefined
 				&& fs.existsSync(captured.patchPath)
-				&& fs.statSync(captured.patchPath).size > 0
-				&& handoffRecordsPatch(intent.handoffManifestPath, captured.patchPath);
+				&& handoffRecordsPatch(intent.handoffManifestPath, captured.patchPath)) {
+				try {
+					if (fs.statSync(captured.patchPath).size > 0) {
+						patchValidationError = validateWorktreePatchRepresentsCurrentWorktree(worktree.path, setup.baseCommit, captured.patchPath);
+						patchCaptured = patchValidationError === undefined;
+					}
+				} catch (error) {
+					patchValidationError = error instanceof Error ? error.message : String(error);
+				}
+			}
 			if (!patchCaptured) {
-				const reason = "worktree contains changes that are not represented by a captured handoff patch";
+				const reason = patchValidationError
+					? `captured handoff patch failed validation: ${patchValidationError}`
+					: "worktree contains changes that are not represented by a captured handoff patch";
 				return {
 					index: worktree.index,
 					path: worktree.path,

--- a/test/unit/worktree-cleanup-plan.test.ts
+++ b/test/unit/worktree-cleanup-plan.test.ts
@@ -30,6 +30,18 @@ function createRepo(prefix: string): string {
 	return repo;
 }
 
+function createHookScript(fileName: string, source: string): string {
+	const hooksDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-hook-script-"));
+	const hookPath = path.join(hooksDir, fileName);
+	fs.writeFileSync(hookPath, `#!/usr/bin/env node\n${source}\n`, "utf-8");
+	fs.chmodSync(hookPath, 0o755);
+	return hookPath;
+}
+
+const hookScriptSkip = process.platform === "win32"
+	? "Hook script execution differs on Windows CI environments."
+	: undefined;
+
 function removeGeneratedWorktrees(repo: string, setup: WorktreeSetup | undefined): void {
 	for (const worktree of setup?.worktrees ?? []) {
 		try { execFileSync("git", ["-C", repo, "worktree", "remove", "--force", worktree.path], { stdio: "ignore" }); } catch {}
@@ -101,7 +113,7 @@ function writeManifest(input: {
 			},
 		}],
 	}, null, 2), "utf-8");
-	if (patch.changed) fs.writeFileSync(patch.path, "captured patch\n", "utf-8");
+	if (patch.changed) fs.writeFileSync(patch.path, execFileSync("git", ["-C", worktree.path, "diff", "--binary", baseCommit, "HEAD"], { encoding: "utf-8" }), "utf-8");
 }
 
 function entriesByPath(plan: WorktreeCleanupPlan): Map<string, WorktreeCleanupPlan["entries"][number]> {
@@ -287,6 +299,33 @@ describe("worktree cleanup plan", () => {
 			assert.equal(captured.entries[0]?.decision, "remove");
 			assert.equal(captured.entries[0]?.state, "safe");
 			assert.equal(captured.entries[0]?.willDeleteBranch, false);
+		} finally {
+			removeGeneratedWorktrees(repo, setup);
+			fs.rmSync(repo, { recursive: true, force: true });
+			fs.rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not let trusted external diff hide cleanup-plan divergence", { skip: hookScriptSkip }, () => {
+		const repo = createRepo("pi-cleanup-plan-external-diff-");
+		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
+		const externalDiffPath = createHookScript("external-diff-plan.mjs", "process.exit(0);");
+		let setup: WorktreeSetup | undefined;
+		try {
+			setup = createWorktrees(repo, "external-diff", 1, { baseDir });
+			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
+			writeManifest({ repo, manifestPath, setup });
+			const worktree = setup.worktrees[0]!;
+			fs.writeFileSync(path.join(worktree.path, "unmerged.txt"), "unmerged\n", "utf-8");
+			git(worktree.path, ["add", "unmerged.txt"]);
+			git(worktree.path, ["commit", "-m", "unmerged"]);
+			git(repo, ["config", "diff.external", externalDiffPath]);
+			git(repo, ["config", "diff.trustExitCode", "true"]);
+
+			const plan = buildPlan({ repo, worktreeBaseDir: baseDir, now: 40_000, planId: "external-diff-plan" });
+			assert.equal(plan.entries[0]?.decision, "keep");
+			assert.equal(plan.entries[0]?.state, "ineligible");
+			assert.match(plan.entries[0]?.reasons.join(" ") ?? "", /neither preserved.*nor merged/i);
 		} finally {
 			removeGeneratedWorktrees(repo, setup);
 			fs.rmSync(repo, { recursive: true, force: true });

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -705,6 +705,53 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 		}
 	});
 
+	it("captures applyable patches despite external diffs and display configuration", { skip: hookScriptSkip }, () => {
+		const repoDir = createRepo("pi-worktree-diff-external-");
+		const externalDiffPath = createHookScript(repoDir, "external-diff.mjs", `
+process.stdout.write("corrupt external diff output\\n");
+`);
+		let setup: WorktreeSetup | undefined;
+		try {
+			git(repoDir, ["config", "diff.external", externalDiffPath]);
+			git(repoDir, ["config", "color.ui", "always"]);
+			git(repoDir, ["config", "diff.noprefix", "true"]);
+			git(repoDir, ["config", "diff.linePrefix", "corrupt display prefix "]);
+			git(repoDir, ["config", "diff.relative", "true"]);
+			setup = createWorktrees(repoDir, "diff-external", 1);
+			const worktree = setup.worktrees[0]!;
+			fs.writeFileSync(path.join(worktree.path, "tracked.txt"), "external-safe\n", "utf-8");
+
+			const diffs = diffWorktrees(setup, ["worker"], path.join(repoDir, "artifacts", "external"));
+			assert.equal(diffs[0]?.error, undefined);
+			const patch = fs.readFileSync(diffs[0]!.patchPath, "utf-8");
+			assert.match(patch, /^diff --git a\/tracked\.txt b\/tracked\.txt/m);
+			assert.doesNotMatch(patch, /corrupt external diff output|corrupt display prefix|\u001b/);
+			assert.equal(git(worktree.path, ["apply", "--check", "--cached", "--reverse", diffs[0]!.patchPath]), "");
+		} finally {
+			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupRepo(repoDir);
+		}
+	});
+
+	it("includes binary data in captured patches", () => {
+		const repoDir = createRepo("pi-worktree-diff-binary-");
+		let setup: WorktreeSetup | undefined;
+		try {
+			setup = createWorktrees(repoDir, "diff-binary", 1);
+			const worktree = setup.worktrees[0]!;
+			fs.writeFileSync(path.join(worktree.path, "binary.dat"), Buffer.from([0, 1, 2, 255, 0, 3]));
+
+			const diffs = diffWorktrees(setup, ["worker"], path.join(repoDir, "artifacts", "binary"));
+			assert.equal(diffs[0]?.error, undefined);
+			const patch = fs.readFileSync(diffs[0]!.patchPath, "utf-8");
+			assert.match(patch, /GIT binary patch/);
+			assert.equal(git(worktree.path, ["apply", "--check", "--cached", "--reverse", diffs[0]!.patchPath]), "");
+		} finally {
+			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupRepo(repoDir);
+		}
+	});
+
 	it("cleanupWorktrees removes worktrees and branches", () => {
 		const repoDir = createRepo("pi-worktree-cleanup-");
 		let setup: WorktreeSetup | undefined;
@@ -783,6 +830,31 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 		}
 	});
 
+	it("does not let trusted external diff hide uncaptured committed work during cleanup", { skip: hookScriptSkip }, () => {
+		const repoDir = createRepo("pi-worktree-cleanup-external-diff-");
+		const externalDiffPath = createHookScript(repoDir, "external-diff-clean.mjs", "process.exit(0);");
+		let setup: WorktreeSetup | undefined;
+		try {
+			git(repoDir, ["config", "diff.external", externalDiffPath]);
+			git(repoDir, ["config", "diff.trustExitCode", "true"]);
+			setup = createWorktrees(repoDir, "cleanup-external-diff", 1);
+			const worktree = setup.worktrees[0]!;
+			fs.writeFileSync(path.join(worktree.path, "committed.txt"), "unlanded work\n", "utf-8");
+			git(worktree.path, ["add", "committed.txt"]);
+			git(worktree.path, ["commit", "-m", "unlanded work"]);
+
+			const cleanup = cleanupWorktrees(setup);
+			assert.equal(cleanup.state, "partial");
+			assert.equal(cleanup.tasks[0]?.preserved, true);
+			assert.match(cleanup.tasks[0]?.reason ?? "", /not represented by a captured handoff patch/);
+			assert.equal(fs.existsSync(worktree.path), true);
+			assert.notEqual(git(repoDir, ["branch", "--list", worktree.branch]), "");
+		} finally {
+			if (setup) cleanupWorktrees(setup, { kind: "setup-rollback" });
+			cleanupRepo(repoDir);
+		}
+	});
+
 	it("removes dirty worktrees only after their captured patch is recorded in the handoff manifest", () => {
 		const repoDir = createRepo("pi-worktree-captured-");
 		let setup: WorktreeSetup | undefined;
@@ -803,7 +875,21 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 				version: 1,
 				groups: [{ children: [{ patch: { path: diffs[0]!.patchPath } }] }],
 			}), "utf-8");
-			const cleanup = cleanupWorktrees(setup, { kind: "preserve", capturedDiffs: diffs, handoffManifestPath });
+			fs.writeFileSync(diffs[0]!.patchPath, "corrupt patch\n", "utf-8");
+			const invalidPatch = cleanupWorktrees(setup, { kind: "preserve", capturedDiffs: diffs, handoffManifestPath });
+			assert.equal(invalidPatch.state, "partial");
+			assert.match(invalidPatch.tasks[0]?.reason ?? "", /failed validation/);
+			assert.equal(fs.existsSync(worktreePath), true);
+
+			const validatedDiffs = diffWorktrees(setup, ["worker"], path.join(repoDir, "artifacts", "captured"));
+			fs.writeFileSync(path.join(worktreePath, "late.txt"), "late\n", "utf-8");
+			const stalePatch = cleanupWorktrees(setup, { kind: "preserve", capturedDiffs: validatedDiffs, handoffManifestPath });
+			assert.equal(stalePatch.state, "partial");
+			assert.match(stalePatch.tasks[0]?.reason ?? "", /does not match current worktree changes/);
+			assert.equal(fs.existsSync(worktreePath), true);
+
+			const currentDiffs = diffWorktrees(setup, ["worker"], path.join(repoDir, "artifacts", "captured"));
+			const cleanup = cleanupWorktrees(setup, { kind: "preserve", capturedDiffs: currentDiffs, handoffManifestPath });
 			assert.equal(cleanup.state, "complete");
 			assert.equal(fs.existsSync(worktreePath), false);
 			setup = undefined;


### PR DESCRIPTION
Fixes #1868.

This makes managed-worktree handoff patch capture immune to user diff configuration by using machine-safe diff options, including binary patches, and validating captured patches before cleanup can remove a preserved worktree.

The cleanup path now verifies that the recorded patch still exactly represents the current worktree changes, so stale-but-applyable patches cannot delete later work.