### PR TITLE
fix: alias pi-agent-core node export in detached runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Key subagent children launched under an explicit `sessionDir` by their run id so concurrent children resolve distinct session files instead of sharing `run-0`. Thanks to [@dat9uy](https://github.com/dat9uy) for #1859 and #1858.
 - Configure proxy-aware HTTP dispatch in detached background runners. Thanks to [@jasonrale](https://github.com/jasonrale) for #1867/#1866.
 - Ignore stale model-not-found exclusions once the active model registry contains that model again. Thanks [@x1prog](https://github.com/x1prog) for #1862.
+- Alias `@earendil-works/pi-agent-core/node` to Pi's exact `./node` export for detached runners. Thanks [@plopezlpz](https://github.com/plopezlpz) for #1871.
 
 ## [0.65.0] - 2026-09-04
 

--- a/src/runs/background/runner-aliases.ts
+++ b/src/runs/background/runner-aliases.ts
@@ -19,6 +19,7 @@ export const JITI_ALIAS_ENV = "JITI_ALIAS";
 export const HOST_PEER_ALIASES: ReadonlyArray<{ specifier: string; pkg: string; subpath: string }> = [
 	{ specifier: "@earendil-works/pi-coding-agent", pkg: "@earendil-works/pi-coding-agent", subpath: "." },
 	{ specifier: "@earendil-works/pi-agent-core", pkg: "@earendil-works/pi-agent-core", subpath: "." },
+	{ specifier: "@earendil-works/pi-agent-core/node", pkg: "@earendil-works/pi-agent-core", subpath: "./node" },
 	{ specifier: "@earendil-works/pi-tui", pkg: "@earendil-works/pi-tui", subpath: "." },
 	{ specifier: "@earendil-works/pi-ai", pkg: "@earendil-works/pi-ai", subpath: "./compat" },
 	{ specifier: "@earendil-works/pi-ai/compat", pkg: "@earendil-works/pi-ai", subpath: "./compat" },

--- a/test/unit/host-peer-runtime-imports.test.ts
+++ b/test/unit/host-peer-runtime-imports.test.ts
@@ -98,6 +98,32 @@ test("every host peer package the detached async runner imports is aliased to th
 	for (const specifier of aliased) assert.ok(fs.existsSync(resolved.aliases[specifier]!), `alias target for ${specifier} exists`);
 });
 
+test("resolves pi-agent-core/node to its exact package export instead of appending to the root alias", () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-agent-core-node-alias-"));
+	const packageDir = path.join(root, "node_modules", "@earendil-works", "pi-agent-core");
+	const distDir = path.join(packageDir, "dist");
+	try {
+		fs.mkdirSync(distDir, { recursive: true });
+		fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({
+			name: "@earendil-works/pi-agent-core",
+			version: "0.85.0-test",
+			exports: {
+				".": "./dist/index.js",
+				"./node": "./dist/node.js",
+			},
+		}), "utf-8");
+		fs.writeFileSync(path.join(distDir, "index.js"), "export {};\n", "utf-8");
+		fs.writeFileSync(path.join(distDir, "node.js"), "export {};\n", "utf-8");
+
+		const resolved = resolveHostPeerAliases(root);
+		assert.equal(resolved.aliases["@earendil-works/pi-agent-core"], path.join(distDir, "index.js"));
+		assert.equal(resolved.aliases["@earendil-works/pi-agent-core/node"], path.join(distDir, "node.js"));
+		assert.notEqual(resolved.aliases["@earendil-works/pi-agent-core/node"], path.join(distDir, "index.js", "node"));
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
 function writeFakeTypeboxPackage(typeboxDir: string): void {
 	fs.mkdirSync(typeboxDir, { recursive: true });
 	fs.writeFileSync(


### PR DESCRIPTION
## Summary

- add an exact detached-runner alias for `@earendil-works/pi-agent-core/node`
- verify it resolves to the package's `node.js` export

Without the exact alias, Jiti applies the existing package-root alias as a prefix and looks for `dist/index.js/node` on Pi 0.85.

Fixes #1871.

## Validation

- `npm run typecheck`
- `npm run test:unit` (2,788 passed, 3 skipped)
- Pi 0.85 smoke: generated the patched alias map and loaded both `NodeExecutionEnv` and `SessionManager` through Jiti successfully

## Upstream note

A clean Pi 0.85 install also needs the separate missing `@earendil-works/pi-server` dependency fixed upstream: earendil-works/pi#9132. The smoke installed that package explicitly so this PR's alias fix could be tested independently.
