### PR TITLE
fix: lazy-load llm-intent-arbiter optional Pi peers

### DIFF
--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
-import { Agent, type AgentTool, type StreamFn } from "@earendil-works/pi-agent-core";
-import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { streamSimple } from "@earendil-works/pi-ai/compat";
+import type { Agent, AgentTool, StreamFn } from "@earendil-works/pi-agent-core";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
 import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
@@ -52,7 +51,10 @@ export function mapArbiterDecision(
 
 interface ArbiterRuntime {
 	model: NonNullable<RegistryModel>;
-	baseStreamFn: StreamFn;
+	/** Explicit override or the registered provider's own stream fn; `undefined` falls back to the compat `streamSimple`. */
+	baseStreamFn?: StreamFn;
+	/** The api the registered stream fn belongs to, for the api match at use time. */
+	registeredApi?: string;
 	timeoutMs: number;
 }
 
@@ -71,6 +73,10 @@ export interface TaskMutationArbiterOptions {
 }
 
 const DEFAULT_ARBITER_TIMEOUT_MS = 10_000;
+
+function registeredApiMatches(registeredApi: string | undefined, modelApi: string | undefined): boolean {
+	return registeredApi !== undefined && registeredApi === modelApi;
+}
 
 type RegistryModel = ReturnType<NonNullable<ExtensionContext["modelRegistry"]["find"]>>;
 
@@ -103,15 +109,11 @@ function resolveArbiterRuntime(
 	const registry = ctx.modelRegistry as {
 		getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
 	};
-	const modelApi = (model as { api?: string }).api;
 	const registered = registry.getRegisteredProviderConfig?.(model.provider);
-	const baseStreamFn = options?.streamFn
-		?? (registered?.streamSimple && registered.api === modelApi
-			? registered.streamSimple
-			: streamSimple);
 	return {
 		model,
-		baseStreamFn,
+		baseStreamFn: options?.streamFn ?? registered?.streamSimple,
+		registeredApi: registered?.api,
 		timeoutMs: options?.timeoutMs ?? DEFAULT_ARBITER_TIMEOUT_MS,
 	};
 }
@@ -164,6 +166,20 @@ async function runArbitration(
 	auth: ArbiterAuth,
 	task: string,
 ): Promise<TaskMutationVerdict> {
+	// The detached runner cannot resolve the optional Pi peers statically
+	// (same shape as the prompt-audit fix), and the arbiter only runs in the
+	// parent when a completion-guard rescue needs it, so load them here.
+	const [{ Agent }, { convertToLlm }, { streamSimple }] = await Promise.all([
+		import("@earendil-works/pi-agent-core"),
+		import("@earendil-works/pi-coding-agent"),
+		import("@earendil-works/pi-ai/compat"),
+	]);
+	const baseStreamFn: StreamFn = runtime.baseStreamFn ?? streamSimple;
+	const modelApi = (runtime.model as { api?: string }).api;
+	const streamFn: StreamFn =
+		runtime.baseStreamFn !== undefined || registeredApiMatches(runtime.registeredApi, modelApi)
+			? baseStreamFn
+			: streamSimple;
 	let decision: DecisionParams | undefined;
 	const tool: AgentTool<typeof DecisionParams, { recorded: boolean }> = {
 		name: "task_mutation_decision",
@@ -190,7 +206,7 @@ async function runArbitration(
 			tools: [tool],
 		},
 		convertToLlm,
-		...agentStreamOptions(authWrappedStreamFn(runtime.baseStreamFn, auth)),
+		...agentStreamOptions(authWrappedStreamFn(streamFn, auth)),
 		getApiKey: (providerName) =>
 			providerName === runtime.model.provider ? auth.apiKey : undefined,
 		beforeToolCall: async ({ toolCall }) =>


### PR DESCRIPTION
## Problem

Background subagents crash on boot with `MODULE_NOT_FOUND` before any agent runs. The failing chain (from a real crash log):

```
jiti-cli.mjs
└─ src/runs/background/subagent-runner.ts
   └─ src/runs/shared/child-launch.ts:35
      └─ src/extension/fanout-child.ts:7
         └─ src/runs/foreground/subagent-executor.ts:27
            └─ src/runs/foreground/execution.ts:61
               └─ src/runs/shared/llm-intent-arbiter.ts:3   ← crash
                  import { convertToLlm } from "@earendil-works/pi-coding-agent"
```

The detached runner is a plain Node process started through jiti. The Pi peer packages (`@earendil-works/pi-coding-agent`, `pi-agent-core`, `pi-ai/compat`) are peers that live inside the installed pi package, not next to this extension, so a *static* import of them cannot resolve in the runner's module graph. When jiti falls back to its own resolver it dies (in some installs with a mangled path like `dist/index.js/node`, because the host re-exports an `exports`-subpath import of `pi-agent-core/node` that jiti's fallback resolution mangles).

The completion guard's `subagent-executor.ts:72 → createTaskMutationArbiter` pull made this module load on **every** background launch, taking background children down with it.

## Fix

Same shape as 8adcb1f ("lazy-load prompt audit optional peers"), which fixed the identical bug in `prompt-audit.ts` but missed this module:

- `llm-intent-arbiter.ts` keeps `pi-agent-core` / `pi-coding-agent` / `pi-ai/compat` as **type-only** imports.
- `runArbitration` loads them with `await Promise.all([import(...), ...])` at call time. It only executes in the **parent** process, and only when a completion-guard rescue actually needs the model — the runner boot path never touches them.

The stream-fn selection moves to call time so the fallback to compat `streamSimple` still applies when no registered provider stream fn matches the model's api, preserving the old `options?.streamFn ?? (registered && api-match ? registered : streamSimple)` semantics.

## Verification

- `npx tsc --noEmit` clean.
- `npm test`: 2790 pass / 15 fail — the **same 15 fail on clean `main`** in this environment (agent-management ENOENTs; name-for-name identical diff, timings only). No new failures.
- Real-world repro: with pi-coding-agent@0.85.0 installed and the extension loaded, every `subagent` dispatch died at runner boot with the stack above. After this change the runner boots through full TS evaluation (272 jiti module ops, zero resolution errors) and reaches its config wait.
- Follows the pattern the maintainer already accepted in 8adcb1f, including the changelog credit convention.