### PR TITLE
fix: lazy-load intent arbiter peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Bound foreground workflow run identities to filesystem-safe segments across progress, child, and receipt records. Thanks [@jstillwa](https://github.com/jstillwa) for #1875.
 - Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
+- Use registered provider streams for intent arbitration only when their API matches the model. Thanks [@pwguler](https://github.com/pwguler) for #1874.
 - Key subagent children launched under an explicit `sessionDir` by their run id so concurrent children resolve distinct session files instead of sharing `run-0`. Thanks to [@dat9uy](https://github.com/dat9uy) for #1859 and #1858.
 - Configure proxy-aware HTTP dispatch in detached background runners. Thanks to [@jasonrale](https://github.com/jasonrale) for #1867/#1866.
 - Ignore stale model-not-found exclusions once the active model registry contains that model again. Thanks [@x1prog](https://github.com/x1prog) for #1862.

--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
-import { Agent, type AgentTool, type StreamFn } from "@earendil-works/pi-agent-core";
-import { convertToLlm, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { streamSimple } from "@earendil-works/pi-ai/compat";
+import type { Agent, AgentTool, StreamFn } from "@earendil-works/pi-agent-core";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
 import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
@@ -52,7 +51,11 @@ export function mapArbiterDecision(
 
 interface ArbiterRuntime {
 	model: NonNullable<RegistryModel>;
-	baseStreamFn: StreamFn;
+	/** Explicit override; it always wins over a registered provider stream. */
+	explicitStreamFn?: StreamFn;
+	/** Registered provider stream, usable only when its api matches the model. */
+	registeredStreamFn?: StreamFn;
+	registeredApi?: string;
 	timeoutMs: number;
 }
 
@@ -71,6 +74,10 @@ export interface TaskMutationArbiterOptions {
 }
 
 const DEFAULT_ARBITER_TIMEOUT_MS = 10_000;
+
+function registeredApiMatches(registeredApi: string | undefined, modelApi: string | undefined): boolean {
+	return registeredApi !== undefined && registeredApi === modelApi;
+}
 
 type RegistryModel = ReturnType<NonNullable<ExtensionContext["modelRegistry"]["find"]>>;
 
@@ -103,15 +110,12 @@ function resolveArbiterRuntime(
 	const registry = ctx.modelRegistry as {
 		getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
 	};
-	const modelApi = (model as { api?: string }).api;
 	const registered = registry.getRegisteredProviderConfig?.(model.provider);
-	const baseStreamFn = options?.streamFn
-		?? (registered?.streamSimple && registered.api === modelApi
-			? registered.streamSimple
-			: streamSimple);
 	return {
 		model,
-		baseStreamFn,
+		explicitStreamFn: options?.streamFn,
+		registeredStreamFn: registered?.streamSimple,
+		registeredApi: registered?.api,
 		timeoutMs: options?.timeoutMs ?? DEFAULT_ARBITER_TIMEOUT_MS,
 	};
 }
@@ -164,6 +168,18 @@ async function runArbitration(
 	auth: ArbiterAuth,
 	task: string,
 ): Promise<TaskMutationVerdict> {
+	// The detached runner cannot resolve the optional Pi peers statically
+	// (same shape as the prompt-audit fix), and the arbiter only runs in the
+	// parent when a completion-guard rescue needs it, so load them here.
+	const [{ Agent }, { convertToLlm }, { streamSimple }] = await Promise.all([
+		import("@earendil-works/pi-agent-core"),
+		import("@earendil-works/pi-coding-agent"),
+		import("@earendil-works/pi-ai/compat"),
+	]);
+	const modelApi = (runtime.model as { api?: string }).api;
+	const streamFn: StreamFn = runtime.explicitStreamFn
+		?? (registeredApiMatches(runtime.registeredApi, modelApi) ? runtime.registeredStreamFn : undefined)
+		?? streamSimple;
 	let decision: DecisionParams | undefined;
 	const tool: AgentTool<typeof DecisionParams, { recorded: boolean }> = {
 		name: "task_mutation_decision",
@@ -190,7 +206,7 @@ async function runArbitration(
 			tools: [tool],
 		},
 		convertToLlm,
-		...agentStreamOptions(authWrappedStreamFn(runtime.baseStreamFn, auth)),
+		...agentStreamOptions(authWrappedStreamFn(streamFn, auth)),
 		getApiKey: (providerName) =>
 			providerName === runtime.model.provider ? auth.apiKey : undefined,
 		beforeToolCall: async ({ toolCall }) =>

--- a/test/unit/llm-intent-arbiter.test.ts
+++ b/test/unit/llm-intent-arbiter.test.ts
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import {
+	createAssistantMessageEventStream,
+	fauxAssistantMessage,
+	fauxToolCall,
+	type AssistantMessage,
+} from "@earendil-works/pi-ai";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import {
 	arbitrateCompletionGuardRescue,
 	createTaskMutationArbiter,
@@ -12,15 +20,43 @@ import {
 const GUARD_ERROR =
 	"Subagent completed without making edits for an implementation task.\nIt appears to have returned planning or scratchpad output instead of applying changes.";
 
-function fakeCtx(overrides: { models?: Array<{ provider?: string; id?: string; api?: string }> } = {}) {
+function fakeCtx(overrides: {
+	models?: Array<{ provider?: string; id?: string; api?: string }>;
+	providerConfig?: { api?: string; streamSimple?: StreamFn };
+} = {}) {
 	const models = overrides.models ?? [{ provider: "test", id: "model-1", api: "test-api" }];
 	return {
 		model: models[0],
 		modelRegistry: {
 			getAvailable: () => models,
-			getRegisteredProviderConfig: () => undefined,
+			getRegisteredProviderConfig: () => overrides.providerConfig,
 		},
 	} as never;
+}
+
+function responseStream(message: AssistantMessage) {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => stream.push({ type: "done", reason: message.stopReason, message }));
+	return stream;
+}
+
+function decisionResponses(source: string): AssistantMessage[] {
+	return [
+		fauxAssistantMessage(fauxToolCall("task_mutation_decision", {
+			classification: "read_only",
+			confidence: "high",
+			reason: `${source} stream selected`,
+		}), { stopReason: "toolUse" }),
+		fauxAssistantMessage("done", { stopReason: "stop" }),
+	];
+}
+
+function decisionStream(source: string, calls: string[]): StreamFn {
+	const responses = decisionResponses(source);
+	return () => {
+		calls.push(source);
+		return responseStream(responses.shift() ?? fauxAssistantMessage("done", { stopReason: "stop" }));
+	};
 }
 
 function stubArbiter(verdict: "read-only" | "implementation" | "unavailable" | "throw"): TaskMutationArbiter {
@@ -163,6 +199,54 @@ describe("maybeRescueCompletionGuardFailure", () => {
 		const rescued = await maybeRescueCompletionGuardFailure(result, "task", stubArbiter("read-only"));
 		assert.equal(rescued, false);
 		assert.equal(result.exitCode, 1);
+	});
+});
+
+describe("arbiter stream selection", () => {
+	it("uses a registered provider stream when its API matches the model", async () => {
+		const calls: string[] = [];
+		const arbiter = createTaskMutationArbiter(fakeCtx({
+			models: [{ provider: "registered", id: "model-1", api: "registered-api" }],
+			providerConfig: { api: "registered-api", streamSimple: decisionStream("registered", calls) },
+		}))!;
+
+		assert.equal(await arbiter("task"), "read-only");
+		assert.deepEqual(calls, ["registered", "registered"]);
+	});
+
+	it("lets an explicit stream override a mismatched registered provider", async () => {
+		const calls: string[] = [];
+		const registeredCalls: string[] = [];
+		const arbiter = createTaskMutationArbiter(fakeCtx({
+			models: [{ provider: "registered", id: "model-1", api: "model-api" }],
+			providerConfig: { api: "registered-api", streamSimple: decisionStream("registered", registeredCalls) },
+		}), { streamFn: decisionStream("explicit", calls) })!;
+
+		assert.equal(await arbiter("task"), "read-only");
+		assert.deepEqual(calls, ["explicit", "explicit"]);
+		assert.deepEqual(registeredCalls, []);
+	});
+
+	it("falls back to compat streamSimple for a mismatched registered provider", async () => {
+		const compat = registerFauxProvider({
+			api: "llm-intent-arbiter-compat-test",
+			provider: "compat-provider",
+			models: [{ id: "model-1", reasoning: false }],
+		});
+		try {
+			compat.setResponses(decisionResponses("compat"));
+			const registeredCalls: string[] = [];
+			const arbiter = createTaskMutationArbiter(fakeCtx({
+				models: [{ provider: "registered", id: "model-1", api: compat.api }],
+				providerConfig: { api: "registered-api", streamSimple: decisionStream("registered", registeredCalls) },
+			}))!;
+
+			assert.equal(await arbiter("task"), "read-only");
+			assert.deepEqual(registeredCalls, []);
+			assert.equal(compat.state.callCount, 2);
+		} finally {
+			compat.unregister();
+		}
 	});
 });
 


### PR DESCRIPTION
Replacement for contributor PR #1874.

This preserves @pwguler's lazy optional-peer import fix while addressing Greptile's stream-selection blocker:

- keep optional Pi runtime peers as type-only imports at module load
- dynamically import `Agent`, `convertToLlm`, and compat `streamSimple` only when arbitration runs
- preserve stream precedence: explicit override, API-compatible registered stream, compat fallback
- add focused stream-selection regression coverage
- add Unreleased changelog credit for [@pwguler](https://github.com/pwguler)

Validation:
- `git diff --check`
- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/llm-intent-arbiter.test.ts`

Fresh review: no issues found in `pr-1874-final-review.md`.
