### PR TITLE
fix: eliminate startup-time PowerShell process probe on Windows

### DIFF
--- a/src/missions/workflow-state.ts
+++ b/src/missions/workflow-state.ts
@@ -66,13 +66,25 @@ function windowsProcessStartKey(pid: number): string | undefined {
 	}
 }
 
+const processStartKeyCache = new Map<number, string | undefined>();
+
 function processStartKey(pid: number): string | undefined {
-	if (process.platform === "linux") return linuxProcessStartKey(pid) ?? psProcessStartKey(pid);
-	if (process.platform === "win32") return windowsProcessStartKey(pid);
-	return undefined;
+	const cached = processStartKeyCache.get(pid);
+	if (processStartKeyCache.has(pid)) return cached;
+	let value: string | undefined;
+	if (process.platform === "linux") value = linuxProcessStartKey(pid) ?? psProcessStartKey(pid);
+	else if (process.platform === "win32") value = windowsProcessStartKey(pid);
+	processStartKeyCache.set(pid, value);
+	return value;
 }
 
-const CURRENT_PROCESS_KEY = processStartKey(process.pid);
+let currentProcessKey: string | undefined | null = null;
+
+/** Lazily resolve the current process start key; a process start time never changes, so it is memoized. */
+function currentProcessStartKey(): string | undefined {
+	if (currentProcessKey === null) currentProcessKey = processStartKey(process.pid);
+	return currentProcessKey;
+}
 
 function readStateLockOwner(lockPath: string): StateLockOwner | undefined {
 	try {
@@ -96,7 +108,7 @@ function stateLockIsStale(lockPath: string, now = Date.now()): boolean {
 	if (owner) {
 		if (!isProcessAlive(owner.pid)) return true;
 		if (owner.processKey) {
-			const currentProcessKey = owner.pid === process.pid ? CURRENT_PROCESS_KEY : processStartKey(owner.pid);
+			const currentProcessKey = owner.pid === process.pid ? currentProcessStartKey() : processStartKey(owner.pid);
 			if (currentProcessKey) return owner.processKey !== currentProcessKey;
 			if (owner.pid === process.pid) return true;
 		}
@@ -181,7 +193,8 @@ function withStateFileLock<T>(filePath: string, operation: () => T): T {
 			waitForStateLock(DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS[attempt], lockPath);
 			continue;
 		}
-		owner = { pid: process.pid, token: randomUUID(), createdAt: Date.now(), ...(CURRENT_PROCESS_KEY ? { processKey: CURRENT_PROCESS_KEY } : {}) };
+		const key = currentProcessStartKey();
+		owner = { pid: process.pid, token: randomUUID(), createdAt: Date.now(), ...(key ? { processKey: key } : {}) };
 		try {
 			fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify(owner), { encoding: "utf-8", mode: 0o600 });
 		} catch (error) {

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -320,7 +320,17 @@ function readCursor(root: string): RetentionCursor {
 	return value?.version === 1 ? value as unknown as RetentionCursor : { version: 1 };
 }
 
+const processStartIdentityCache = new Map<number, string | undefined>();
+
 function processStartIdentity(pid: number): string | undefined {
+	const cached = processStartIdentityCache.get(pid);
+	if (processStartIdentityCache.has(pid)) return cached;
+	const value = computeProcessStartIdentity(pid);
+	processStartIdentityCache.set(pid, value);
+	return value;
+}
+
+function computeProcessStartIdentity(pid: number): string | undefined {
 	if (process.platform === "linux") {
 		try {
 			const stat = fs.readFileSync(`/proc/${pid}/stat`).toString("utf8");


### PR DESCRIPTION
# Fix: eliminate startup-time PowerShell process probe on Windows

## Problem

Since installing the extension, pi startup on Windows was noticeably slower (~0.5s of extra CPU-bound startup work per process, more visible with cold jiti caches). Tracing child-process creation during startup showed repeated PowerShell invocations:

```
powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter \"ProcessId=<pid>\").CreationDate"
```

A CPU profile of `pi` startup (headless, Windows) pinned the cost:

| | unpatched | patched |
|---|---|---|
| `spawnSync` self-time during startup | ~471 ms | ~46 ms |
| PowerShell `Win32_Process` probe at module load | ~429 ms | eliminated |

## Root cause

`src/missions/workflow-state.ts` resolved the current process start key **at module load time**:

```ts
const CURRENT_PROCESS_KEY = processStartKey(process.pid);
```

On Windows, `processStartKey()` synchronously spawns `powershell.exe` to query
`Get-CimInstance Win32_Process`, which costs ~430–450 ms per call. Because this
was a module-level constant, **every** pi process (main session, headless runs,
background runners, each subagent child) paid this cost during extension load.

The same unmemoized probe was also invoked:

- once per lock-owner check in `stateLockIsStale()` — many locks ⇒ many PowerShell spawns,
- in `src/runs/background/async-retention.ts` (`processStartIdentity()`), same pattern, per retention-lock owner.

## Fix

- Resolve the current process start key **lazily** on first use (most sessions that never contend on a state lock never need it).
- **Memoize `processStartKey()` / `processStartIdentity()` per PID.** A process's start time is immutable, and both call sites only consult the key for PIDs already confirmed alive via `process.kill(pid, 0)`, so the cache is safe.

## Local measurements (Windows 11, Node v24.14.0, NVMe SSD, warm jiti cache)

All numbers measured on the reporter's machine with CPU profiles (`node --cpu-prof`) during headless `pi` startup, plus direct timing of the probe itself.

### 1. The probe itself is expensive

```
$ time powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter \"ProcessId=<pid>\").CreationDate"
real  0m0.431s   (second run: 0m0.415s)
```

### 2. A/B CPU profile of pi startup (same machine, same commands)

| measurement | unpatched | patched |
|---|---|---|
| `execFileSync` → PowerShell `Win32_Process` probe (`workflow-state.ts:60`) | **429 ms** | **eliminated** |
| `runGit` watchdog diff baseline (`watchdog/diff-tool.ts:22`) | 43 ms | 45 ms |
| total `spawnSync` self-time during startup | **471 ms** | **46 ms** |
| headless pi startup wall time (3 runs, median) | ~7.0 s | **3.5 s** |

Cold-cache comparison (first run after clearing the jiti TS cache): unpatched ~14.4 s vs patched ~7.9 s wall time, with the same ~470 ms → ~45 ms spawnSync CPU delta.

### 3. Repeated spawns observed live

A 60 ms-resolution `Win32_Process` creation poller around a `pi` launch captured the extension spawning exactly this command during startup:

```
powershell.exe -NoProfile -Command "(Get-CimInstance Win32_Process -Filter \"ProcessId=21364\").CreationDate"
```

and the module-level `CURRENT_PROCESS_KEY` pattern means every pi process (main session, headless runs, background runners, each subagent child) repeats it.

## Verification

- `npm run typecheck` passes.
- `test/unit/async-retention.test.ts` and all mission-state related unit tests pass (44/44). The only failing test on this machine (`subagent-wait.test.ts`) fails on `main` too — it requires Windows symlink privileges (`EPERM` creating a symlink), unrelated to this change.
- Measured A/B on Windows with CPU profiles: PowerShell probe eliminated from startup; total CPU spawn cost reduced by ~425 ms per process, and child processes no longer pay it at load time (detailed numbers in the *Local measurements* section above).
