### PR TITLE
fix: lazy process identity lookup for locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Clarify that subagent lane infrastructure failures require an explicit owner-approved execution-mode fallback, with exact state and worktree evidence checks before retrying (#1879).
+- Resolve workflow and async-retention process identities lazily without memoizing foreign PIDs. Thanks to [@ducaoya](https://github.com/ducaoya) for #1878.
 - Bound foreground workflow run identities to filesystem-safe segments across progress, child, and receipt records. Thanks [@jstillwa](https://github.com/jstillwa) for #1875.
 - Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
 - Use registered provider streams for intent arbitration only when their API matches the model. Thanks [@pwguler](https://github.com/pwguler) for #1874.

--- a/src/missions/workflow-state.ts
+++ b/src/missions/workflow-state.ts
@@ -18,6 +18,12 @@ export interface MissionWorkflowState {
 	set(key: string, value: unknown): void;
 }
 
+export interface MissionWorkflowStateOptions {
+	isProcessAlive?: (pid: number) => boolean;
+	getProcessStartKey?: (pid: number) => string | undefined;
+	retryDelaysMs?: readonly number[];
+}
+
 export function missionStatePath(location: MissionStoreLocation, missionId: string): string {
 	return path.join(location.missionDir, validateMissionId(missionId), "state.json");
 }
@@ -66,13 +72,26 @@ function windowsProcessStartKey(pid: number): string | undefined {
 	}
 }
 
+let currentProcessKey: string | undefined | null = null;
+
 function processStartKey(pid: number): string | undefined {
+	// Foreign PIDs can be reused while this process lives, so resolve them afresh.
+	if (pid !== process.pid) return computeProcessStartKey(pid);
+	if (currentProcessKey === null) currentProcessKey = computeProcessStartKey(pid);
+	return currentProcessKey;
+}
+
+function computeProcessStartKey(pid: number): string | undefined {
 	if (process.platform === "linux") return linuxProcessStartKey(pid) ?? psProcessStartKey(pid);
 	if (process.platform === "win32") return windowsProcessStartKey(pid);
 	return undefined;
 }
 
-const CURRENT_PROCESS_KEY = processStartKey(process.pid);
+interface StateLockOptions {
+	isProcessAlive: (pid: number) => boolean;
+	getProcessStartKey: (pid: number) => string | undefined;
+	retryDelaysMs: readonly number[];
+}
 
 function readStateLockOwner(lockPath: string): StateLockOwner | undefined {
 	try {
@@ -91,13 +110,13 @@ function readStateLockOwner(lockPath: string): StateLockOwner | undefined {
 	return undefined;
 }
 
-function stateLockIsStale(lockPath: string, now = Date.now()): boolean {
+function stateLockIsStale(lockPath: string, options: StateLockOptions, now = Date.now()): boolean {
 	const owner = readStateLockOwner(lockPath);
 	if (owner) {
-		if (!isProcessAlive(owner.pid)) return true;
+		if (!options.isProcessAlive(owner.pid)) return true;
 		if (owner.processKey) {
-			const currentProcessKey = owner.pid === process.pid ? CURRENT_PROCESS_KEY : processStartKey(owner.pid);
-			if (currentProcessKey) return owner.processKey !== currentProcessKey;
+			const observedProcessKey = options.getProcessStartKey(owner.pid);
+			if (observedProcessKey) return owner.processKey !== observedProcessKey;
 			if (owner.pid === process.pid) return true;
 		}
 		return false;
@@ -140,11 +159,11 @@ function waitForStateLock(delayMs: number | undefined, lockPath: string): void {
 	waitForFileSystemRetry(delayMs);
 }
 
-function reclaimStaleStateLock(lockPath: string, reclaimPath: string): boolean {
-	if (!stateLockIsStale(lockPath)) return false;
+function reclaimStaleStateLock(lockPath: string, reclaimPath: string, options: StateLockOptions): boolean {
+	if (!stateLockIsStale(lockPath, options)) return false;
 	if (!tryMakeDirectory(reclaimPath, 0o700)) return false;
 	try {
-		if (!stateLockIsStale(lockPath)) return false;
+		if (!stateLockIsStale(lockPath, options)) return false;
 		fs.rmSync(lockPath, { recursive: true, force: true });
 		return true;
 	} finally {
@@ -152,7 +171,7 @@ function reclaimStaleStateLock(lockPath: string, reclaimPath: string): boolean {
 	}
 }
 
-function withStateFileLock<T>(filePath: string, operation: () => T): T {
+function withStateFileLock<T>(filePath: string, operation: () => T, options: StateLockOptions): T {
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
 	const lockPath = `${filePath}.lock`;
 	const reclaimPath = `${lockPath}.reclaim`;
@@ -163,7 +182,7 @@ function withStateFileLock<T>(filePath: string, operation: () => T): T {
 				fs.rmSync(reclaimPath, { recursive: true, force: true });
 				continue;
 			}
-			waitForStateLock(DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS[attempt], lockPath);
+			waitForStateLock(options.retryDelaysMs[attempt], lockPath);
 			continue;
 		}
 		let acquired = false;
@@ -171,17 +190,18 @@ function withStateFileLock<T>(filePath: string, operation: () => T): T {
 			acquired = tryMakeDirectory(lockPath, 0o700);
 		} catch (error) {
 			if (isRetryableFileSystemError(error)) {
-				waitForStateLock(DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS[attempt], lockPath);
+				waitForStateLock(options.retryDelaysMs[attempt], lockPath);
 				continue;
 			}
 			throw new Error(`Failed to acquire mission state lock '${lockPath}': ${error instanceof Error ? error.message : String(error)}`);
 		}
 		if (!acquired) {
-			if (reclaimStaleStateLock(lockPath, reclaimPath)) continue;
-			waitForStateLock(DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS[attempt], lockPath);
+			if (reclaimStaleStateLock(lockPath, reclaimPath, options)) continue;
+			waitForStateLock(options.retryDelaysMs[attempt], lockPath);
 			continue;
 		}
-		owner = { pid: process.pid, token: randomUUID(), createdAt: Date.now(), ...(CURRENT_PROCESS_KEY ? { processKey: CURRENT_PROCESS_KEY } : {}) };
+		const key = options.getProcessStartKey(process.pid);
+		owner = { pid: process.pid, token: randomUUID(), createdAt: Date.now(), ...(key ? { processKey: key } : {}) };
 		try {
 			fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify(owner), { encoding: "utf-8", mode: 0o600 });
 		} catch (error) {
@@ -205,8 +225,14 @@ function validateStateKey(value: unknown): string {
 	return value;
 }
 
-export function createMissionWorkflowState(location: MissionStoreLocation, missionId: string): MissionWorkflowState {
+export function createMissionWorkflowState(location: MissionStoreLocation, missionId: string, options: MissionWorkflowStateOptions = {}): MissionWorkflowState {
 	const filePath = missionStatePath(location, missionId);
+	const getProcessStartKey = options.getProcessStartKey ?? processStartKey;
+	const lockOptions: StateLockOptions = {
+		isProcessAlive: options.isProcessAlive ?? isProcessAlive,
+		getProcessStartKey,
+		retryDelaysMs: options.retryDelaysMs ?? DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS,
+	};
 	let loaded = false;
 	let values: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
 
@@ -254,7 +280,7 @@ export function createMissionWorkflowState(location: MissionStoreLocation, missi
 				writePrivateAtomicJson(filePath, next);
 				values = next;
 				loaded = true;
-			});
+			}, lockOptions);
 		},
 	};
 }

--- a/src/runs/background/async-retention.ts
+++ b/src/runs/background/async-retention.ts
@@ -320,7 +320,16 @@ function readCursor(root: string): RetentionCursor {
 	return value?.version === 1 ? value as unknown as RetentionCursor : { version: 1 };
 }
 
+let currentProcessStartIdentity: string | undefined | null = null;
+
 function processStartIdentity(pid: number): string | undefined {
+	// Foreign PIDs can be reused while this process lives, so resolve them afresh.
+	if (pid !== process.pid) return computeProcessStartIdentity(pid);
+	if (currentProcessStartIdentity === null) currentProcessStartIdentity = computeProcessStartIdentity(pid);
+	return currentProcessStartIdentity;
+}
+
+function computeProcessStartIdentity(pid: number): string | undefined {
 	if (process.platform === "linux") {
 		try {
 			const stat = fs.readFileSync(`/proc/${pid}/stat`).toString("utf8");

--- a/test/unit/async-retention.test.ts
+++ b/test/unit/async-retention.test.ts
@@ -287,6 +287,54 @@ describe("async retention cleanup", () => {
 		}
 	});
 
+	it("does not reclaim a live replacement owner after a reused pid identity changes", async () => {
+		const roots = makeRoots();
+		try {
+			const reusedPid = process.pid + 100_000;
+			const lockDir = path.join(roots.root, ".async-retention.lock");
+			const ownerPath = path.join(lockDir, "owner.json");
+			const replacementOwner = {
+				version: 1,
+				token: "replacement-token",
+				pid: reusedPid,
+				hostname: "test-host",
+				processStartIdentity: "replacement-process",
+				startedAt: NOW,
+			};
+			fs.mkdirSync(lockDir);
+			fs.writeFileSync(ownerPath, JSON.stringify({
+				version: 1,
+				token: "old-token",
+				pid: reusedPid,
+				hostname: "test-host",
+				processStartIdentity: "old-process",
+				startedAt: NOW,
+			}));
+
+			let currentIdentity = "old-process";
+			const options = {
+				...cleanupOptions(roots),
+				hostname: "test-host",
+				processStartIdentity: "cleaner-process",
+				isProcessAlive: (pid: number) => pid === reusedPid || pid === process.pid,
+				getProcessStartIdentity: (pid: number) => pid === reusedPid ? currentIdentity : "cleaner-process",
+			};
+			const first = await cleanupAsyncRetention(options);
+			assert.equal(first.acquired, false);
+			assert.equal(first.skipped["lock-busy"], 1);
+
+			fs.writeFileSync(ownerPath, JSON.stringify(replacementOwner));
+			currentIdentity = "replacement-process";
+			const second = await cleanupAsyncRetention(options);
+
+			assert.equal(second.acquired, false);
+			assert.equal(second.skipped["lock-busy"], 1);
+			assert.deepEqual(JSON.parse(fs.readFileSync(ownerPath, "utf-8")), replacementOwner);
+		} finally {
+			fs.rmSync(roots.root, { recursive: true, force: true });
+		}
+	});
+
 	it("limits result candidates to the cleanup batch", async () => {
 		const roots = makeRoots();
 		try {

--- a/test/unit/mission-store.test.ts
+++ b/test/unit/mission-store.test.ts
@@ -298,6 +298,36 @@ describe("mission store", () => {
 		}
 	});
 
+	it("does not reclaim a live replacement owner after observing a reused pid identity", () => {
+		const test = fixture();
+		try {
+			const mission = createMission(test.location, { title: "Replacement owner", objective: "Keep a reused pid lock safe" });
+			const statePath = missionStatePath(test.location, mission.id);
+			const lockPath = `${statePath}.lock`;
+			const ownerPath = path.join(lockPath, "owner.json");
+			const reusedPid = process.pid + 100_000;
+			const replacementOwner = { pid: reusedPid, token: "replacement", createdAt: Date.now(), processKey: "replacement-process" };
+			fs.mkdirSync(lockPath, { recursive: true });
+			fs.writeFileSync(ownerPath, JSON.stringify({ pid: reusedPid, token: "old", createdAt: Date.now(), processKey: "old-process" }), "utf-8");
+
+			let currentIdentity = "old-process";
+			const state = createMissionWorkflowState(test.location, mission.id, {
+				isProcessAlive: (pid) => pid === reusedPid,
+				getProcessStartKey: (pid) => pid === reusedPid ? currentIdentity : "current-process",
+				retryDelaysMs: [],
+			});
+
+			assert.throws(() => state.set("reviewer", "ready"), /Timed out acquiring mission state lock/);
+			fs.writeFileSync(ownerPath, JSON.stringify(replacementOwner), "utf-8");
+			currentIdentity = "replacement-process";
+			assert.throws(() => state.set("reviewer", "ready"), /Timed out acquiring mission state lock/);
+			assert.deepEqual(JSON.parse(fs.readFileSync(ownerPath, "utf-8")), replacementOwner);
+			assert.equal(fs.existsSync(statePath), false);
+		} finally {
+			fs.rmSync(test.root, { recursive: true, force: true });
+		}
+	});
+
 	it("serializes competing abandoned-lock recovery", async () => {
 		const test = fixture();
 		try {


### PR DESCRIPTION
## Summary

Replacement for #1878.

Preserves @ducaoya's startup fix while addressing the review blocker: process identity lookup is lazy for the current process, but stale-lock checks resolve foreign PID identities fresh so PID reuse cannot cause a live lock owner to be reclaimed.

Adds focused coverage for workflow-state and async-retention reused-PID lock safety, plus changelog credit for #1878.

## Validation

- `git diff --check`
- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/mission-store.test.ts test/unit/async-retention.test.ts`
- `npm run test:unit`
- Fresh read-only review: no issues found
