### PR TITLE
fix: refresh child session provider registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Clarify that subagent lane infrastructure failures require an explicit owner-approved execution-mode fallback, with exact state and worktree evidence checks before retrying (#1879).
 - Resolve workflow and async-retention process identities lazily without memoizing foreign PIDs. Thanks to [@ducaoya](https://github.com/ducaoya) for #1878.
+- Refresh child session models after loading extension-registered providers and tolerate Pi runtimes without native provider queues. Thanks [@kevinkirkup](https://github.com/kevinkirkup) for #1885.
 - Bound foreground workflow run identities to filesystem-safe segments across progress, child, and receipt records. Thanks [@jstillwa](https://github.com/jstillwa) for #1875.
 - Lazy-load prompt audit optional Pi peers. Thanks [@VladimirGVP](https://github.com/VladimirGVP) for #1860.
 - Use registered provider streams for intent arbitration only when their API matches the model. Thanks [@pwguler](https://github.com/pwguler) for #1874.

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -121,8 +121,8 @@ type QueuedNativeProviderRegistration = { provider: Parameters<ModelRuntimeInsta
 interface LoaderWithExtensions {
 	getExtensions(): {
 		runtime: {
-			pendingProviderRegistrations: QueuedProviderRegistration[];
-			pendingNativeProviderRegistrations: QueuedNativeProviderRegistration[];
+			pendingProviderRegistrations?: QueuedProviderRegistration[];
+			pendingNativeProviderRegistrations?: QueuedNativeProviderRegistration[];
 		};
 	};
 }
@@ -151,25 +151,29 @@ function applyProcessEnv(values: Record<string, string | undefined> | undefined)
 	}
 }
 
-function flushQueuedProviderRegistrations(loader: object, modelRuntime: ModelRuntimeInstance, onError: ((error: ChildSessionExtensionError) => void) | undefined): void {
+async function flushQueuedProviderRegistrations(loader: object, modelRuntime: ModelRuntimeInstance, onError: ((error: ChildSessionExtensionError) => void) | undefined): Promise<void> {
 	if (!("getExtensions" in loader) || typeof loader.getExtensions !== "function") return;
 	const { runtime } = (loader as LoaderWithExtensions).getExtensions();
-	for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations) {
+	let registered = false;
+	for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations ?? []) {
 		try {
 			modelRuntime.registerProvider(name, config);
+			registered = true;
 		} catch (error) {
 			onError?.({ extensionPath, event: "register_provider", error });
 		}
 	}
-	runtime.pendingProviderRegistrations = [];
-	for (const { provider, extensionPath } of runtime.pendingNativeProviderRegistrations) {
+	if (Array.isArray(runtime.pendingProviderRegistrations)) runtime.pendingProviderRegistrations = [];
+	for (const { provider, extensionPath } of runtime.pendingNativeProviderRegistrations ?? []) {
 		try {
 			modelRuntime.registerNativeProvider(provider);
+			registered = true;
 		} catch (error) {
 			onError?.({ extensionPath, event: "register_provider", error });
 		}
 	}
-	runtime.pendingNativeProviderRegistrations = [];
+	if (Array.isArray(runtime.pendingNativeProviderRegistrations)) runtime.pendingNativeProviderRegistrations = [];
+	if (registered) await modelRuntime.refresh({ allowNetwork: false });
 }
 
 /**
@@ -224,7 +228,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 				applyProcessEnv(launch.processEnv);
 				if (!resetExtensionCacheOnReload(loader) && (launch.ambientExtensions || launch.extensionPaths.length)) launch.onExtensionError?.({ extensionPath: "<loader>", event: "load", error: new Error("pi's extension cache reset is unavailable; extensions loaded into this child share module state with other sessions in this process.") });
 				await loader.reload();
-				flushQueuedProviderRegistrations(loader, modelRuntime, launch.onExtensionError);
+				await flushQueuedProviderRegistrations(loader, modelRuntime, launch.onExtensionError);
 				const sessionManager = launch.storage.kind === "file"
 					? pi.SessionManager.open(launch.storage.sessionFile, undefined, launch.cwd)
 					: launch.storage.kind === "dir"

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -261,9 +261,10 @@ describe("default child session factory", () => {
 	it("resolves models from providers queued during child extension loading", async () => {
 		const registeredProviders: string[] = [];
 		const registeredNativeProviders: string[] = [];
+		let refreshed = false;
 		let pendingRuntime: { pendingProviderRegistrations: unknown[]; pendingNativeProviderRegistrations: unknown[] } | undefined;
 		const pi = stubPi();
-		pi.ModelRuntime = { create: async () => ({ registerProvider: (name: string) => { registeredProviders.push(name); }, registerNativeProvider: (provider: { id: string }) => { registeredNativeProviders.push(provider.id); } }) } as unknown as PiCodingAgentModule["ModelRuntime"];
+		pi.ModelRuntime = { create: async () => ({ registerProvider: (name: string) => { registeredProviders.push(name); }, registerNativeProvider: (provider: { id: string }) => { registeredNativeProviders.push(provider.id); }, refresh: async () => { refreshed = true; } }) } as unknown as PiCodingAgentModule["ModelRuntime"];
 		pi.DefaultResourceLoader = class {
 			runtime = {
 				pendingProviderRegistrations: [{ name: "router", config: { models: [{ id: "mimo-v2.5" }] }, extensionPath: "/extensions/router.ts" }],
@@ -276,6 +277,7 @@ describe("default child session factory", () => {
 			assert.equal(cliModel, "router/mimo-v2.5");
 			assert.deepEqual(registeredProviders, ["router"]);
 			assert.deepEqual(registeredNativeProviders, ["native-router"]);
+			assert.equal(refreshed, true);
 			return { model: { provider: "router", id: "mimo-v2.5" } };
 		}) as unknown as PiCodingAgentModule["resolveCliModel"];
 		pi.createAgentSession = (async ({ model }) => ({ session: { bindExtensions: async () => {}, dispose() {}, extensionRunner: { hasHandlers: () => false }, subscribe: () => () => {}, prompt: async () => {}, abort: async () => {}, steer: async () => {}, followUp: async () => {}, messages: [], sessionId: "s", model } })) as unknown as PiCodingAgentModule["createAgentSession"];
@@ -286,6 +288,34 @@ describe("default child session factory", () => {
 		assert.equal(child.modelId, "router/mimo-v2.5");
 		assert.deepEqual(pendingRuntime?.pendingProviderRegistrations, []);
 		assert.deepEqual(pendingRuntime?.pendingNativeProviderRegistrations, []);
+	});
+
+	it("resolves queued providers when the loader has no native provider queue", async () => {
+		const registeredProviders: string[] = [];
+		let refreshed = false;
+		let pendingRuntime: { pendingProviderRegistrations?: unknown[] } | undefined;
+		const pi = stubPi();
+		pi.ModelRuntime = { create: async () => ({ registerProvider: (name: string) => { registeredProviders.push(name); }, registerNativeProvider: () => {}, refresh: async () => { refreshed = true; } }) } as unknown as PiCodingAgentModule["ModelRuntime"];
+		pi.DefaultResourceLoader = class {
+			runtime = {
+				pendingProviderRegistrations: [{ name: "router", config: { models: [{ id: "mimo-v2.5" }] }, extensionPath: "/extensions/router.ts" }],
+			};
+			async reload() { pendingRuntime = this.runtime; }
+			getExtensions() { return { extensions: [], errors: [], runtime: this.runtime }; }
+		} as unknown as PiCodingAgentModule["DefaultResourceLoader"];
+		pi.resolveCliModel = (({ cliModel }) => {
+			assert.equal(cliModel, "router/mimo-v2.5");
+			assert.deepEqual(registeredProviders, ["router"]);
+			assert.equal(refreshed, true);
+			return { model: { provider: "router", id: "mimo-v2.5" } };
+		}) as unknown as PiCodingAgentModule["resolveCliModel"];
+		pi.createAgentSession = (async ({ model }) => ({ session: { bindExtensions: async () => {}, dispose() {}, extensionRunner: { hasHandlers: () => false }, subscribe: () => () => {}, prompt: async () => {}, abort: async () => {}, steer: async () => {}, followUp: async () => {}, messages: [], sessionId: "s", model } })) as unknown as PiCodingAgentModule["createAgentSession"];
+
+		const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => pi });
+		const child = await factory.create({ ...stubLaunch, model: "router/mimo-v2.5" });
+
+		assert.equal(child.modelId, "router/mimo-v2.5");
+		assert.deepEqual(pendingRuntime?.pendingProviderRegistrations, []);
 	});
 
 	it("reports a missing extension cache reset when the child loads extension files", async () => {


### PR DESCRIPTION
## Summary

Closes #1885.

Keeps in-process child sessions compatible with extension-registered providers on newer Pi runtimes:

- tolerate Pi loaders that do not expose a native-provider pending queue
- flush queued extension providers before child model resolution
- await a local model-runtime refresh after applying queued provider registrations

## Validation

- `git diff --check`
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/in-process-child.test.ts`
- `npm run typecheck`
- Fresh read-only review: no issues found
