### PR TITLE
refactor: simplify unreleased runtime changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+- Simplify retained-route liveness, dispatcher setup, and internal types without changing launch or cleanup contracts.
+
 ### Fixed
+- Keep pi-web parent sessions alive while subagent work or completion delivery remains active. Thanks to [@vcing](https://github.com/vcing) for #1857.
 - Clarify that subagent lane infrastructure failures require an explicit owner-approved execution-mode fallback, with exact state and worktree evidence checks before retrying (#1879).
 - Resolve workflow and async-retention process identities lazily without memoizing foreign PIDs. Thanks to [@ducaoya](https://github.com/ducaoya) for #1878.
 - Refresh child session models after loading extension-registered providers and tolerate Pi runtimes without native provider queues. Thanks [@kevinkirkup](https://github.com/kevinkirkup) for #1885.
@@ -14,7 +18,7 @@
 - Ignore stale model-not-found exclusions once the active model registry contains that model again. Thanks [@x1prog](https://github.com/x1prog) for #1862.
 - Alias `@earendil-works/pi-agent-core/node` to Pi's exact `./node` export for detached runners. Thanks [@plopezlpz](https://github.com/plopezlpz) for #1871.
 - Alias host peer subpath imports for detached runners. Thanks to [@pwguler](https://github.com/pwguler) for #1880.
-- Initialize Pi's global theme before child sessions bind their extensions, so extensions reading `ctx.ui.theme` no longer throw "Theme not initialized. Call initTheme() first." in subagent runs (detached background runners in particular). Thanks [@danielmarbach](https://github.com/danielmarbach) for #1865.
+- Initialize Pi's global theme before child extensions access `ctx.ui.theme`, including in detached runners. Thanks [@danielmarbach](https://github.com/danielmarbach) for #1865.
 - Capture managed-worktree handoff patches with machine-safe diff settings and validate them before cleanup. Thanks [@jeanduplessis](https://github.com/jeanduplessis) for #1868.
 
 ## [0.65.0] - 2026-09-04
@@ -38,7 +42,6 @@
 - Add `contact_supervisor` to the bundled reviewer and scout tool allowlists without adding mutation tools (#1846).
 
 ### Fixed
-- Keep pi-web parent sessions alive while subagent work or completion delivery remains active. Thanks to [@vcing](https://github.com/vcing) for #1857.
 - Drop only malformed persisted model-exclusion entries and rewrite the cleaned cache.
 - Stop live workflow children when a run-level stop targets an in-memory async workflow controller.
 - Fail closed when a fallback-only model configuration resolves no launch candidates. Thanks [@AdenosineTP](https://github.com/AdenosineTP) for #1853.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -120,7 +120,7 @@ The complete plain-JSON inventory is validated before the first launch (maximum 
 | `share` | boolean | false | Upload session export to GitHub Gist. |
 | `sessionDir` | string | derived | Override session log directory. |
 | `acceptance` | string/object/false | inferred | Configure evidence gates. See [Acceptance gates](#acceptance-gates). |
-| `gate` | string | - | One host-run verification command, shorthand for `acceptance: { level: "verified", verify: [{ id: "gate", command }] }`. Also valid on individual `runs.run`/`runs.all` items. Cannot be combined with `acceptance`, and is rejected with retained `resume`. |
+| `gate` | string | - | One host-run verification command, shorthand for `acceptance: { level: "verified", verify: [{ id: "gate", command }] }`. Also valid on individual `runs.run`/`runs.all` items. Rejects `acceptance` except `false` (treated as omitted), and rejects retained `resume`. |
 
 ### Budget guidance for writers
 
@@ -391,7 +391,7 @@ When one host-run command is the entire verification contract, use the `gate` sh
 { workflowScript: `return runs.run("impl", { agent: "worker", task: "Implement the fix", gate: "npm test" })` }
 ```
 
-`gate` normalizes to verified acceptance with that single command, so the runtime executes it on the host and records the result as evidence. Verification results are memoized per tracked workspace state and effective environment, so an unchanged tree does not rerun the same command. Use explicit `acceptance.verify` when you need multiple commands, timeouts, or custom criteria. `gate` cannot be combined with `acceptance` and is rejected on retained `resume` items. With `worktree: true`, the gate runs inside the child's managed worktree.
+`gate` normalizes to verified acceptance with that single command, so the runtime executes it on the host and records the result as evidence. Verification results are memoized per tracked workspace state and effective environment, so an unchanged tree does not rerun the same command. Use explicit `acceptance.verify` when you need multiple commands, timeouts, or custom criteria. `gate` rejects `acceptance` except `false` (treated as omitted), and rejects retained `resume` items. With `worktree: true`, the gate runs inside the child's managed worktree.
 
 ### Levels and inference
 

--- a/src/integrations/pi-web-session-liveness.ts
+++ b/src/integrations/pi-web-session-liveness.ts
@@ -16,11 +16,7 @@ interface PiWebSessionLivenessRegistry {
 	register(provider: PiWebSessionLivenessProvider): () => void;
 }
 
-interface SessionLivenessRegistration {
-	sessionId: string;
-	sessionFile?: string;
-	isActive(): boolean;
-}
+type SessionLivenessRegistration = Omit<PiWebSessionLivenessProvider, "name">;
 
 export interface PiWebSessionLivenessHandle {
 	/** True only when the compatible host accepted the provider registration. */
@@ -42,7 +38,7 @@ export function retainLiveForegroundNestedRoute(state: Pick<SubagentState, "reta
 	const nested = projectNestedEvents(route);
 	if (!hasLiveNestedDescendants(nested.children)) return false;
 	state.retainedForegroundNestedRoutes ??= new Map();
-	state.retainedForegroundNestedRoutes.set(route.rootRunId, { route, children: nested.children, awaitingFirstRefresh: true });
+	state.retainedForegroundNestedRoutes.set(route.rootRunId, route);
 	return true;
 }
 
@@ -55,10 +51,7 @@ export function hasLiveSubagentWork(state: LiveWorkState): boolean {
 			|| (control.activeChildren?.size ?? 0) > 0
 			|| hasLiveNestedDescendants(control.nestedChildren)) return true;
 	}
-	for (const retained of state.retainedForegroundNestedRoutes?.values() ?? []) {
-		if (retained.awaitingFirstRefresh || hasLiveNestedDescendants(retained.children)) return true;
-	}
-	return false;
+	return (state.retainedForegroundNestedRoutes?.size ?? 0) > 0;
 }
 
 export function registerPiWebSessionLiveness(registration: SessionLivenessRegistration): PiWebSessionLivenessHandle {

--- a/src/missions/workflow-state.ts
+++ b/src/missions/workflow-state.ts
@@ -87,11 +87,7 @@ function computeProcessStartKey(pid: number): string | undefined {
 	return undefined;
 }
 
-interface StateLockOptions {
-	isProcessAlive: (pid: number) => boolean;
-	getProcessStartKey: (pid: number) => string | undefined;
-	retryDelaysMs: readonly number[];
-}
+type StateLockOptions = Required<MissionWorkflowStateOptions>;
 
 function readStateLockOwner(lockPath: string): StateLockOwner | undefined {
 	try {
@@ -227,10 +223,9 @@ function validateStateKey(value: unknown): string {
 
 export function createMissionWorkflowState(location: MissionStoreLocation, missionId: string, options: MissionWorkflowStateOptions = {}): MissionWorkflowState {
 	const filePath = missionStatePath(location, missionId);
-	const getProcessStartKey = options.getProcessStartKey ?? processStartKey;
 	const lockOptions: StateLockOptions = {
 		isProcessAlive: options.isProcessAlive ?? isProcessAlive,
-		getProcessStartKey,
+		getProcessStartKey: options.getProcessStartKey ?? processStartKey,
 		retryDelaysMs: options.retryDelaysMs ?? DEFAULT_FILE_SYSTEM_RETRY_DELAYS_MS,
 	};
 	let loaded = false;

--- a/src/runs/background/retained-nested-route-tracker.ts
+++ b/src/runs/background/retained-nested-route-tracker.ts
@@ -37,9 +37,7 @@ export function createRetainedNestedRouteTracker(
 			return;
 		}
 		try {
-			retained.children = projectNestedEvents(retained.route).children;
-			retained.awaitingFirstRefresh = false;
-			if (hasLiveNestedDescendants(retained.children)) return;
+			if (hasLiveNestedDescendants(projectNestedEvents(retained).children)) return;
 			state.retainedForegroundNestedRoutes?.delete(rootRunId);
 			close(rootRunId);
 		} catch (error) {
@@ -73,7 +71,7 @@ export function createRetainedNestedRouteTracker(
 		if (!retained) return;
 		if (shouldUseNativeFsWatch("retained-nested-route-tracker", options.platform) && !watchers.has(rootRunId)) {
 			try {
-				const watcher = watch(retained.route.eventSink, () => scheduleRefresh(rootRunId));
+				const watcher = watch(retained.eventSink, () => scheduleRefresh(rootRunId));
 				watcher.on("error", () => close(rootRunId));
 				watcher.unref?.();
 				watchers.set(rootRunId, watcher);

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1,46 +1,23 @@
 import { spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 
-/**
- * Detached runners bypass pi's CLI entry points, so pi core's
- * configureHttpDispatcher() never runs here and the global fetch keeps Node's
- * default dispatcher, which silently ignores *_proxy (once observed as
- * deterministic upstream 403s on a region-gated model). Mirror the host setup
- * with the locally resolvable undici copy; every step is best-effort and falls
- * back to previous behavior instead of breaking startup.
- */
-const requireFromRunner = createRequire(import.meta.url);
+// Detached runners skip Pi's CLI proxy setup. Keep fetch on the same Undici dispatcher.
 function ensureProxyAwareHttpDispatcher(): void {
 	try {
-		const undici = requireFromRunner("undici") as {
-			EnvHttpProxyAgent?: new (opts?: Record<string, unknown>) => unknown;
-			setGlobalDispatcher?: (dispatcher: unknown) => void;
-			install?: () => void;
-		};
-		if (typeof undici?.EnvHttpProxyAgent !== "function") return;
+		// SAFETY: require loads the pinned direct dependency described by these types.
+		const undici = createRequire(import.meta.url)("undici") as typeof import("undici");
 		const dispatcher = new undici.EnvHttpProxyAgent({ allowH2: false });
-		try {
-			const { EventEmitter } = requireFromRunner("node:events") as {
-				EventEmitter: new (...args: unknown[]) => { on(event: string, listener: () => void): unknown };
-			};
-			if (dispatcher instanceof EventEmitter) dispatcher.on("error", () => {});
-		} catch {
-			// Error-listener hardening is best-effort only.
-		}
-		undici.setGlobalDispatcher?.(dispatcher);
-		// Route pi-ai's global-fetch calls through this dispatcher (parity with host).
-		undici.install?.();
+		// Fetch rejects stream errors; the listener prevents an unhandled EventEmitter error.
+		EventEmitter.prototype.on.call(dispatcher, "error", () => {});
+		undici.setGlobalDispatcher(dispatcher);
+		undici.install();
 	} catch (error) {
-		// Fall back to previous behavior, but leave a breadcrumb for next time.
-		try {
-			console.error(`[pi-subagents] proxy-aware HTTP dispatcher not installed: ${error instanceof Error ? error.message : String(error)}`);
-		} catch {
-			// Logging must never break runner startup.
-		}
+		console.error(`[pi-subagents] proxy-aware HTTP dispatcher not installed: ${error instanceof Error ? error.message : String(error)}`);
 	}
 }
 ensureProxyAwareHttpDispatcher();

--- a/src/runs/foreground/prompt-audit.ts
+++ b/src/runs/foreground/prompt-audit.ts
@@ -1,6 +1,6 @@
 import type { Agent, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { Model, ProviderHeaders } from "@earendil-works/pi-ai";
+import type { ProviderHeaders } from "@earendil-works/pi-ai";
 import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
 import type { ForegroundRunControl } from "../../shared/types.ts";
 export type PromptAuditView = "authored" | "runtime" | "effective";
@@ -20,7 +20,7 @@ export interface LivePromptAudit {
 
 const livePrompts = new WeakMap<ForegroundRunControl, Map<number, LivePromptAudit>>();
 
-type RegistryModel = Model<any>;
+type RegistryModel = NonNullable<ExtensionContext["model"]>;
 
 function fullModelId(model: Pick<RegistryModel, "provider" | "id">): string {
 	return `${model.provider}/${model.id}`;

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -202,17 +202,10 @@ export function normalizeGateAcceptance(gate: unknown, acceptance: AcceptanceInp
 		return normalized.error ? { ok: false, error: normalized.error } : { ok: true, acceptance: normalized.value as AcceptanceInput };
 	}
 	if (typeof gate !== "string" || !gate.trim()) return { ok: false, error: "gate must be a non-empty command string." };
-	// `acceptance: false` is the deprecated "disable acceptance" shorthand. It carries no
-	// verification intent that could conflict with a gate, so the gate wins instead of erroring:
-	// a caller that disables acceptance policy and asks for a gate command wants the gate.
-	if (acceptance === false) return { ok: true, acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
-	if (acceptance !== undefined) return { ok: false, error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." + describeGateAcceptanceConflict(gate, acceptance) };
+	if (acceptance !== undefined && acceptance !== false) return { ok: false, error: "gate cannot be combined with acceptance; use one gate command or acceptance.verify." + describeGateAcceptanceConflict(gate, acceptance) };
 	return { ok: true, acceptance: { level: "verified", verify: [{ id: "gate", command: gate.trim() }] } };
 }
 
-// Renders the offending gate and acceptance values, bounded, so a rejected call can be
-// diagnosed from the error alone. Without this, a caller that keeps sending both fields
-// cannot see from the message what it actually sent.
 export function describeGateAcceptanceConflict(gate: unknown, acceptance: unknown): string {
 	const render = (value: unknown): string => {
 		let encoded: string;

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -115,17 +115,6 @@ export interface DefaultChildSessionFactoryOptions {
 }
 
 type ModelRuntimeInstance = Awaited<ReturnType<PiCodingAgentModule["ModelRuntime"]["create"]>>;
-type QueuedProviderRegistration = { name: string; config: Parameters<ModelRuntimeInstance["registerProvider"]>[1]; extensionPath: string };
-type QueuedNativeProviderRegistration = { provider: Parameters<ModelRuntimeInstance["registerNativeProvider"]>[0]; extensionPath: string };
-
-interface LoaderWithExtensions {
-	getExtensions(): {
-		runtime: {
-			pendingProviderRegistrations?: QueuedProviderRegistration[];
-			pendingNativeProviderRegistrations?: QueuedNativeProviderRegistration[];
-		};
-	};
-}
 
 /** One launch at a time from env application through `session_start`, so parallel launches never observe each other's `processEnv` while their extensions load and start. */
 let loading: Promise<unknown> = Promise.resolve();
@@ -151,9 +140,9 @@ function applyProcessEnv(values: Record<string, string | undefined> | undefined)
 	}
 }
 
-async function flushQueuedProviderRegistrations(loader: object, modelRuntime: ModelRuntimeInstance, onError: ((error: ChildSessionExtensionError) => void) | undefined): Promise<void> {
+async function flushQueuedProviderRegistrations(loader: InstanceType<PiCodingAgentModule["DefaultResourceLoader"]>, modelRuntime: ModelRuntimeInstance, onError: ((error: ChildSessionExtensionError) => void) | undefined): Promise<void> {
 	if (!("getExtensions" in loader) || typeof loader.getExtensions !== "function") return;
-	const { runtime } = (loader as LoaderWithExtensions).getExtensions();
+	const { runtime } = loader.getExtensions();
 	let registered = false;
 	for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations ?? []) {
 		try {
@@ -200,15 +189,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 			const modelRuntime = await sharedRuntime(pi);
 			const agentDir = getAgentDir();
 			const settingsManager = pi.SettingsManager.create(launch.cwd, agentDir);
-			// Headless child processes (the detached async runner in particular)
-			// never run pi's main-mode startup, so the global theme registry stays
-			// uninitialized and any extension reading `ctx.ui.theme` throws
-			// "Theme not initialized. Call initTheme() first." on every event it
-			// handles. Initialize the theme from the configured settings here,
-			// mirroring the `initTheme(settingsManager.getTheme(), ...)` call
-			// main-mode makes in main.js. Re-initializing in a process where main
-			// already initialized is idempotent (same theme name), and load errors
-			// fall back to the built-in dark theme exactly like main-mode.
+			// Headless sessions skip Pi's CLI theme setup; extensions still need ctx.ui.theme.
 			if (typeof pi.initTheme === "function") pi.initTheme(settingsManager.getTheme());
 			const loader = new pi.DefaultResourceLoader({
 				cwd: launch.cwd,

--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -75,10 +75,6 @@ export interface TaskMutationArbiterOptions {
 
 const DEFAULT_ARBITER_TIMEOUT_MS = 10_000;
 
-function registeredApiMatches(registeredApi: string | undefined, modelApi: string | undefined): boolean {
-	return registeredApi !== undefined && registeredApi === modelApi;
-}
-
 type RegistryModel = ReturnType<NonNullable<ExtensionContext["modelRegistry"]["find"]>>;
 
 function resolveArbiterModel(
@@ -168,17 +164,14 @@ async function runArbitration(
 	auth: ArbiterAuth,
 	task: string,
 ): Promise<TaskMutationVerdict> {
-	// The detached runner cannot resolve the optional Pi peers statically
-	// (same shape as the prompt-audit fix), and the arbiter only runs in the
-	// parent when a completion-guard rescue needs it, so load them here.
+	// Keep optional Pi peers out of the detached runner's static import graph.
 	const [{ Agent }, { convertToLlm }, { streamSimple }] = await Promise.all([
 		import("@earendil-works/pi-agent-core"),
 		import("@earendil-works/pi-coding-agent"),
 		import("@earendil-works/pi-ai/compat"),
 	]);
-	const modelApi = (runtime.model as { api?: string }).api;
 	const streamFn: StreamFn = runtime.explicitStreamFn
-		?? (registeredApiMatches(runtime.registeredApi, modelApi) ? runtime.registeredStreamFn : undefined)
+		?? (runtime.registeredApi !== undefined && runtime.registeredApi === runtime.model.api ? runtime.registeredStreamFn : undefined)
 		?? streamSimple;
 	let decision: DecisionParams | undefined;
 	const tool: AgentTool<typeof DecisionParams, { recorded: boolean }> = {

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -197,7 +197,7 @@ export function validateWorktreePatch(worktreePath: string, patchPath: string): 
 	return result.stderr.trim() || result.stdout.trim() || `git -C ${worktreePath} apply --check failed`;
 }
 
-function currentWorktreePatch(worktreePath: string, baseCommit: string): { patch?: string; error?: string } {
+function currentWorktreePatch(worktreePath: string, baseCommit: string): { patch: string } | { error: string } {
 	let tempDir: string;
 	try {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-index-"));
@@ -232,7 +232,7 @@ export function validateWorktreePatchRepresentsCurrentWorktree(worktreePath: str
 		return error instanceof Error ? error.message : String(error);
 	}
 	const current = currentWorktreePatch(worktreePath, baseCommit);
-	if (current.error) return current.error;
+	if ("error" in current) return current.error || "failed to capture current worktree patch";
 	if (capturedPatch !== current.patch) return "captured handoff patch does not match current worktree changes";
 	return undefined;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2202,12 +2202,7 @@ export interface SubagentState {
 	/** Live async session roots created by this parent executor, keyed by run id. */
 	liveAsyncSessionRoots?: Map<string, string>;
 	/** Foreground nested routes retained after their direct parent settles, keyed by root run id. */
-	retainedForegroundNestedRoutes?: Map<string, {
-		route: NestedRouteInfo;
-		children: NestedRunSummary[];
-		/** Conservative guard until the tracker observes a post-registration refresh. */
-		awaitingFirstRefresh: boolean;
-	}>;
+	retainedForegroundNestedRoutes?: Map<string, NestedRouteInfo>;
 	/** Last valid parent session model observed for this session; used when continuation contexts omit ctx.model. */
 	lastParentModel?: { provider: string; id: string };
 	subagentInProgress?: boolean;

--- a/test/unit/pi-web-session-liveness.test.ts
+++ b/test/unit/pi-web-session-liveness.test.ts
@@ -9,7 +9,6 @@ import {
 	retainLiveForegroundNestedRoute,
 } from "../../src/integrations/pi-web-session-liveness.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
-import { createRetainedNestedRouteTracker } from "../../src/runs/background/retained-nested-route-tracker.ts";
 import { removeForegroundControlIfIdle } from "../../src/runs/foreground/subagent-executor.ts";
 import type { SubagentState } from "../../src/shared/types.ts";
 
@@ -49,7 +48,7 @@ function writeNestedState(route: ReturnType<typeof nestedRoute>, state: "running
 	});
 }
 
-function makeState(): Pick<SubagentState, "asyncJobs" | "foregroundControls"> {
+function makeState(): Parameters<typeof hasLiveSubagentWork>[0] {
 	return {
 		asyncJobs: new Map(),
 		foregroundControls: new Map(),
@@ -127,40 +126,6 @@ describe("pi-web session liveness integration", () => {
 		assert.equal(liveness.registered, false);
 		assert.equal(removeForegroundControlIfIdle(state, route.rootRunId), true);
 		assert.equal(state.retainedForegroundNestedRoutes, undefined);
-	});
-
-	it("retains and tracks foreground nested routes after host registration", () => {
-		const state = makeState() as SubagentState;
-		const route = nestedRoute("registered-foreground-root");
-		writeNestedState(route, "running", 100);
-		state.foregroundControls.set(route.rootRunId, {
-			runId: route.rootRunId,
-			mode: "single",
-			startedAt: 1,
-			updatedAt: 1,
-			schedulingOwners: 0,
-			activeChildren: new Map(),
-			nestedRoute: route,
-		});
-		(globalThis as Record<PropertyKey, unknown>)[Symbol.for(PI_WEB_SESSION_LIVENESS_REGISTRY_KEY)] = {
-			version: 1,
-			register() {
-				return () => {};
-			},
-		};
-		const liveness = registerPiWebSessionLiveness({ sessionId: "session-a", isActive: () => true });
-		const tracker = liveness.registered
-			? createRetainedNestedRouteTracker(state, { platform: "win32", pollIntervalMs: 60_000 })
-			: undefined;
-		try {
-			assert.equal(liveness.registered, true);
-			assert.ok(tracker);
-			assert.equal(removeForegroundControlIfIdle(state, route.rootRunId, tracker.track), true);
-			assert.equal(state.retainedForegroundNestedRoutes?.has(route.rootRunId), true);
-		} finally {
-			tracker?.clear();
-			liveness.release();
-		}
 	});
 
 	it("transfers a live nested route before removing its settled foreground control", () => {

--- a/test/unit/retained-nested-route-tracker.test.ts
+++ b/test/unit/retained-nested-route-tracker.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -8,6 +9,12 @@ import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/neste
 import type { SubagentState } from "../../src/shared/types.ts";
 
 const routeRoots: string[] = [];
+
+class Watcher extends EventEmitter implements fs.FSWatcher {
+	close() { this.emit("close"); }
+	ref() { return this; }
+	unref() { return this; }
+}
 
 function route(rootRunId: string) {
 	const value = createNestedRoute(rootRunId);
@@ -66,9 +73,6 @@ describe("retained foreground nested route tracker", () => {
 		assert.equal(retainLiveForegroundNestedRoute(state, nestedRoute), true);
 		writeState(nestedRoute, "complete", 200);
 
-		const retained = state.retainedForegroundNestedRoutes?.get(nestedRoute.rootRunId);
-		assert.equal(retained?.awaitingFirstRefresh, true);
-
 		const tracker = createRetainedNestedRouteTracker(state, { platform: "win32", pollIntervalMs: 60_000 });
 		try {
 			tracker.track(nestedRoute.rootRunId);
@@ -85,22 +89,15 @@ describe("retained foreground nested route tracker", () => {
 		writeState(nestedRoute, "running", 100);
 		assert.equal(retainLiveForegroundNestedRoute(state, nestedRoute), true);
 
-		let watcherError: (() => void) | undefined;
+		const watcher = new Watcher();
 		const tracker = createRetainedNestedRouteTracker(state, {
 			platform: "linux",
 			pollIntervalMs: 10,
-			watch: (() => ({
-				close: () => undefined,
-				on: (event: string, listener: () => void) => {
-					if (event === "error") watcherError = listener;
-					return undefined;
-				},
-				unref: () => undefined,
-			} as unknown as fs.FSWatcher)) as typeof fs.watch,
+			watch: () => watcher,
 		});
 		try {
 			tracker.track(nestedRoute.rootRunId);
-			watcherError?.();
+			watcher.emit("error", new Error("watch failed"));
 			writeState(nestedRoute, "complete", 200);
 			await waitFor(() => !state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId));
 		} finally {
@@ -129,7 +126,8 @@ describe("retained foreground nested route tracker", () => {
 		}
 	});
 
-	it("refreshes promptly from native watch events", async () => {
+	it("refreshes promptly from native watch events", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
 		const state: Pick<SubagentState, "retainedForegroundNestedRoutes"> = {};
 		const nestedRoute = route("watched-root");
 		writeState(nestedRoute, "running", 100);
@@ -137,23 +135,25 @@ describe("retained foreground nested route tracker", () => {
 
 		let notify: (() => void) | undefined;
 		let closed = 0;
+		const watcher = new Watcher();
+		watcher.on("close", () => { closed += 1; });
 		const tracker = createRetainedNestedRouteTracker(state, {
 			platform: "linux",
 			pollIntervalMs: 60_000,
+			// SAFETY: the tracker uses only fs.watch(path, listener), not the options overloads.
 			watch: ((_path: fs.PathLike, listener: fs.WatchListener<string>) => {
 				notify = () => listener("rename", "event.json");
-				return {
-					close: () => { closed += 1; },
-					on: () => undefined,
-					unref: () => undefined,
-				} as unknown as fs.FSWatcher;
+				return watcher;
 			}) as typeof fs.watch,
 		});
 		try {
 			tracker.track(nestedRoute.rootRunId);
+			t.mock.timers.tick(25);
+			assert.equal(state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId), true);
 			writeState(nestedRoute, "complete", 200);
 			notify?.();
-			await waitFor(() => !state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId));
+			t.mock.timers.tick(25);
+			assert.equal(state.retainedForegroundNestedRoutes?.has(nestedRoute.rootRunId), false);
 			assert.equal(closed, 1);
 		} finally {
 			tracker.clear();


### PR DESCRIPTION
## Summary

Reduce the unreleased implementation by 107 lines across 14 files, without changing launch or cleanup contracts.

- Use retained-route membership as the liveness source of truth instead of duplicating a child tree and refresh flag.
- Derive loader, model, lock, and registration types; simplify dispatcher setup and gate normalization.
- Remove redundant test wiring and make the native-watcher test require a watcher event after the initial refresh.
- Trim comments, document the `acceptance: false` gate exception, and move the post-release pi-web fix into Unreleased while preserving contributor credit.

Keep optional-host checks, proxy startup diagnostics, polling fallback, model stream compatibility, and both worktree patch safety checks.

## Validation

- Typecheck and focused runtime tests.
- Direct/proxied fetch and invalid-proxy fallback probe using the runner's actual setup code.
- Fresh TypeScript and conciseness reviews with no unresolved findings.
- Full suite: 2,823 unit tests and 920 integration tests passed (3 and 6 skipped).
- `npm pack --dry-run` passed.

All seven deslop categories reviewed. Anti-slop is already configured; no dependency or lint configuration changes.
