### PR TITLE
fix: preserve workflow child execution semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Hide the idle `Async runs 0/∞` Fleet summary while preserving finite and occupied capacity meters. Thanks to [@youssefsiam38](https://github.com/youssefsiam38) for #1892.
 - Supply Pi 0.85.0’s missing server dependency for background children, including extensions importing the public SDK, while preserving host-provided packages.
 - Avoid repeating structured metadata and reply instructions in native supervisor request cards. Thanks to [@youssefsiam38](https://github.com/youssefsiam38) for #1893.
+- Fail foreground children before provider work when required tools are unavailable, honor omitted workflow child async defaults while awaiting completion, and avoid duplicate workflow failure diagnostics. Thanks to [@youssefsiam38](https://github.com/youssefsiam38) for #1891.
 
 ## [0.65.1] - 2026-09-04
 

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -983,6 +983,20 @@ async function runSingleAttempt(
 				compactionStartedReceived = false;
 				afterCompactionSettlement = false;
 			}
+			if (evt.type === "agent_start") {
+				const diagnostic = capture.toolDiagnostic();
+				if (diagnostic) {
+					const message = formatChildToolDiagnostic(diagnostic, { host: "parent" });
+					toolAvailabilityError = message;
+					result.error = message;
+					result.finalOutput = message;
+					progress.status = "failed";
+					progress.error = message;
+					fireUpdate();
+					abortChild();
+					return;
+				}
+			}
 			const lifecycleAction = projectChildLifecycle(evt, false, childLifecycleState);
 			if (evt.type === "agent_settled" && lifecycleAction === "start-drain") {
 				agentSettledReceived = true;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4150,9 +4150,13 @@ function workflowChildResult(
 		? result.details.results[0].finalOutput
 		: receiptOutput;
 	const childError = result.details.results.map((child) => child.error).find((error): error is string => Boolean(error));
-	const failureError = childError && receiptOutput && receiptOutput !== childError
-		? `${childError}\n\n${receiptOutput}`
+	const failureErrorBase = childError && receiptOutput
+		? receiptOutput.includes(childError) ? receiptOutput : `${childError}\n\n${receiptOutput}`
 		: childError || receiptOutput || output || "Child run failed.";
+	const savedOutputEvidence = [...new Set(result.details.results.map((child) => child.savedOutputPath).filter((value): value is string => Boolean(value)))]
+		.filter((savedOutputPath) => !failureErrorBase.includes(savedOutputPath))
+		.map((savedOutputPath) => `Saved output: ${savedOutputPath}`);
+	const failureError = [failureErrorBase, ...savedOutputEvidence].join("\n");
 	const detached = result.details.results.some((child) => child.detached);
 	const interrupted = result.details.results.some((child) => child.interrupted);
 	const stopped = result.details.results.some((child) => child.stopped);
@@ -4524,12 +4528,13 @@ export function prepareWorkflowLaunchParams(
 		};
 	}
 	const control = mergeWorkflowControlOverrides(workflowDefaults.control, childParams.control as ControlConfig | undefined);
+	const asyncOmitted = childParams.async === undefined && workflowDefaults.async === undefined;
 	const launchParams = {
 		...workflowDefaults,
-		async: options.externalAsyncRequired === true && childParams.async === undefined && workflowDefaults.async === undefined ? true : false,
+		...(options.externalAsyncRequired === true && asyncOmitted ? { async: true } : {}),
 		...childParams,
 		...(control !== undefined ? { control } : {}),
-		...(options.externalAsyncRequired === true && childParams.async === undefined && workflowDefaults.async === undefined ? { workflowAwaitAsync: true } : {}),
+		...(asyncOmitted ? { workflowAwaitAsync: true } : {}),
 		...(options.missionDetached ? { mission: false } : {}),
 		workflowParentRunId: parentWorkflowRunId,
 		workflowKey,
@@ -5370,7 +5375,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								if (child.runId) workflowChildRunIds.set(key, child.runId);
 								const step = status.steps?.find((candidate) => candidate.workflowKey === key);
 								if (step) {
-									step.async = Boolean(result.details.asyncId || result.details.asyncDir);
+									step.async = step.async === true || Boolean(result.details.asyncId || result.details.asyncDir);
 									if (child.runId) step.runId = child.runId;
 									if (child.lane) step.lane = child.lane;
 								}
@@ -5558,7 +5563,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						let preparedChildParams: SubagentParamsLike | undefined;
 						const result = await runMissionWorkflowChild(missionBinding, foregroundWorkflowRunId, key, childPhase, () => {
 							const childRequest = bindMissionWorkflowChildAsyncLaunch(
-								{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams, parentWorkflowRunId: foregroundWorkflowRunId, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), outputClaimPath: childOutputClaimPaths.get(key), options: { missionDetached: detachWorkflowChildMissions, suppressRoutineResultIntercom: chatProgress.mode === "live-card", runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt, capabilityCeiling: workflowCapabilityCeiling } }), runFanoutAdmitted: admission.admitted },
+								{ ...prepareWorkflowChildLaunchParams({ workflowDefaults: workflowChildDefaults, childParams: delegatedWorkflowPermit ? { ...childParams, async: false } : childParams, parentWorkflowRunId: foregroundWorkflowRunId, workflowKey: key, ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, outputOverride: childOutputOverrides.get(key), outputClaimPath: childOutputClaimPaths.get(key), options: { missionDetached: detachWorkflowChildMissions, suppressRoutineResultIntercom: chatProgress.mode === "live-card", runFanoutBudget: workflowFanoutBudget, parentDeadlineAt: workflowDeadlineAt, capabilityCeiling: workflowCapabilityCeiling } }), runFanoutAdmitted: admission.admitted },
 								missionBinding,
 								deps.asyncByDefault,
 							);

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1284,7 +1284,7 @@ function workflowChecklistItemPriority(state: WorkflowChecklistState): number {
 	return 6;
 }
 
-function workflowChecklistItemLine(item: WorkflowChecklistItem, theme: Theme, indent: string, frame?: number): string {
+function workflowChecklistItemLine(item: WorkflowChecklistItem, theme: Theme, indent: string, frame: number | undefined, includeError: boolean): string {
 	const identity = [item.label, item.agent && item.agent !== item.label ? item.agent : undefined].filter(Boolean).join(" · ");
 	const context = contextModeBadge(theme, item.context);
 	const state = item.state === "complete" ? "" : ` ${theme.fg("dim", `· ${workflowChecklistStateLabel(item.state)}`)}`;
@@ -1294,15 +1294,26 @@ function workflowChecklistItemLine(item: WorkflowChecklistItem, theme: Theme, in
 		!item.currentTool && item.durationMs !== undefined ? formatDuration(item.durationMs) : undefined,
 		item.toolCount !== undefined ? `${item.toolCount} tools` : undefined,
 		item.outputName ? `out:${item.outputName}` : undefined,
-		item.error ? `error:${oneLine(item.error)}` : undefined,
+		includeError && item.error ? `error:${oneLine(item.error)}` : undefined,
 	].filter(Boolean).join(" · ");
 	return `${indent}${workflowChecklistGlyph(item, theme, frame)} ${theme.bold(identity || item.key)}${context}${state}${details ? ` ${theme.fg("dim", `· ${details}`)}` : ""}`;
 }
 
 const COLLAPSED_WORKFLOW_PHASE_LIMIT = 4;
 
-function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | undefined, theme: Theme, indent: string, expanded: boolean, frame?: number, includeSummary = true, limitPhases = !expanded, includeBottleneckOutput = expanded): string[] {
+interface WorkflowChecklistWidgetOptions {
+	includeSummary?: boolean;
+	limitPhases?: boolean;
+	includeBottleneckOutput?: boolean;
+	includeItemErrors?: boolean;
+}
+
+function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | undefined, theme: Theme, indent: string, expanded: boolean, frame?: number, options: WorkflowChecklistWidgetOptions = {}): string[] {
 	if (!checklist?.total) return [];
+	const includeSummary = options.includeSummary ?? true;
+	const limitPhases = options.limitPhases ?? !expanded;
+	const includeBottleneckOutput = options.includeBottleneckOutput ?? expanded;
+	const includeItemErrors = options.includeItemErrors ?? true;
 	const lines = includeSummary ? [`${indent}${theme.fg("dim", `Checklist ${formatWorkflowChecklistSummary(checklist)}`)}`] : [];
 	const phases = !limitPhases || checklist.phases.length <= COLLAPSED_WORKFLOW_PHASE_LIMIT
 		? checklist.phases
@@ -1326,11 +1337,11 @@ function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | u
 		lines.push(`${indent}${glyph} ${theme.bold(formatWorkflowChecklistPhase(phase))}`);
 		if (expanded) {
 			for (const item of [...phase.items].sort((left, right) => workflowChecklistItemPriority(left.state) - workflowChecklistItemPriority(right.state))) {
-				lines.push(workflowChecklistItemLine(item, theme, `${indent}  `, frame));
+				lines.push(workflowChecklistItemLine(item, theme, `${indent}  `, frame, includeItemErrors));
 			}
 		}
 	}
-	const bottleneck = formatWorkflowChecklistBottleneck(checklist.bottleneck, { includeOutput: includeBottleneckOutput });
+	const bottleneck = formatWorkflowChecklistBottleneck(checklist.bottleneck, { includeOutput: includeBottleneckOutput, includeError: !expanded });
 	if (bottleneck) {
 		const tone = checklist.bottleneck?.state === "blocked" || checklist.bottleneck?.state === "failed" ? "error" : checklist.bottleneck?.state === "running" ? "accent" : "warning";
 		lines.push(`${indent}${theme.fg(tone, `bottleneck · ${bottleneck}`)}`);
@@ -2371,7 +2382,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
 	const lines: string[] = [
 		...(expanded ? workflowPreflightLines(job) : []),
-		...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
+		...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame, { includeItemErrors: !expanded }),
 	];
 	const group = activeParallelWidgetGroup(job);
 	if (group) {
@@ -2767,7 +2778,7 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 			: [
 				`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
 				...widgetLaneDetailLines(job, theme, projection),
-				...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
+				...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame, { includeItemErrors: !expanded || !job.steps?.length }),
 				...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 			];
 		items.push([
@@ -2991,7 +3002,7 @@ function renderWorkflowChatProgress(d: Details, result: AgentToolResult<Details>
 	if (d.preflight) c.addChild(new Text(truncLine(theme.fg("dim", formatWorkflowPreflightPlanSummary(d.preflight, { indent: rowIndent })), width), 0, 0));
 	if (phase) c.addChild(new Text(truncLine(theme.fg("dim", `${rowIndent}Phase  ${phase}`), width), 0, 0));
 	const checklist = projectWorkflowChecklist({ hostSteps: workflow?.receipt?.hostSteps, preflight: d.preflight, trace: workflow?.trace, now: Date.now() });
-	for (const line of workflowChecklistWidgetLines(checklist, theme, rowIndent, false, frame, true, !expanded, expanded)) {
+	for (const line of workflowChecklistWidgetLines(checklist, theme, rowIndent, false, frame, { limitPhases: !expanded, includeBottleneckOutput: expanded })) {
 		c.addChild(new Text(truncLine(line, width), 0, 0));
 	}
 	if (rows.length === 0) {
@@ -3073,7 +3084,7 @@ function renderMultiCompact(d: Details, theme: Theme, layout: MainWindowRenderLa
 	const detailIndent = mainWindowIndent(layout, 2);
 	c.addChild(new Text(truncLine(`${glyph} ${theme.fg("toolTitle", theme.bold(d.mode))}${contextBadge}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`, width), 0, 0));
 	if (checklistPrimary) {
-		for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, rowIndent, false, frame, false)) {
+		for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, rowIndent, false, frame, { includeSummary: false })) {
 			c.addChild(new Text(truncLine(line, width), 0, 0));
 		}
 		if (hasRunning || workflowChecklist.running > 0) c.addChild(new Text(truncLine(theme.fg("accent", `${rowIndent}${liveDetailHintText()}`), width), 0, 0));
@@ -3424,7 +3435,7 @@ export function renderSubagentResult(
 		c.addChild(new Text(fit(`  ${chainVis}`), 0, 0));
 	}
 	const workflowChecklist = foregroundWorkflowChecklist(d);
-	for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, "  ", true, frame)) {
+	for (const line of workflowChecklistWidgetLines(workflowChecklist, theme, "  ", true, frame, { includeItemErrors: false })) {
 		c.addChild(new Text(fit(line), 0, 0));
 	}
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1337,7 +1337,7 @@ function workflowChecklistWidgetLines(checklist: WorkflowChecklistProjection | u
 		lines.push(`${indent}${glyph} ${theme.bold(formatWorkflowChecklistPhase(phase))}`);
 		if (expanded) {
 			for (const item of [...phase.items].sort((left, right) => workflowChecklistItemPriority(left.state) - workflowChecklistItemPriority(right.state))) {
-				lines.push(workflowChecklistItemLine(item, theme, `${indent}  `, frame, includeItemErrors));
+				lines.push(workflowChecklistItemLine(item, theme, `${indent}  `, frame, includeItemErrors || item.kind === "host"));
 			}
 		}
 	}

--- a/src/workflows/workflow-checklist.ts
+++ b/src/workflows/workflow-checklist.ts
@@ -402,11 +402,12 @@ export function formatWorkflowChecklistPhase(phase: WorkflowChecklistPhase): str
 	return counts.length ? `${phase.label} ${counts.join(" · ")}` : phase.label;
 }
 
-export function formatWorkflowChecklistBottleneck(item: WorkflowChecklistItem | undefined, options: { includeOutput?: boolean } = {}): string | undefined {
+export function formatWorkflowChecklistBottleneck(item: WorkflowChecklistItem | undefined, options: { includeOutput?: boolean; includeError?: boolean } = {}): string | undefined {
 	if (!item) return undefined;
 	const identity = [item.label, item.agent && item.agent !== item.label ? item.agent : undefined].filter((value): value is string => Boolean(value)).join(" · ") || item.key;
 	const includeOutput = options.includeOutput ?? true;
-	const details = [item.context ? `(${item.context})` : undefined, item.currentTool ? `${item.currentTool}${item.durationMs !== undefined ? ` ${formatDurationText(item.durationMs)}` : ""}` : undefined, !item.currentTool && item.currentPath ? item.currentPath : undefined, !item.currentTool && item.durationMs !== undefined ? formatDurationText(item.durationMs) : undefined, item.toolCount !== undefined ? `${item.toolCount} tools` : undefined, includeOutput && item.outputName ? `out:${item.outputName}` : undefined, item.error ? `error:${item.error.replace(/\bOutput:/g, "output:")}` : undefined].filter((value): value is string => Boolean(value));
+	const includeError = options.includeError ?? true;
+	const details = [item.context ? `(${item.context})` : undefined, item.currentTool ? `${item.currentTool}${item.durationMs !== undefined ? ` ${formatDurationText(item.durationMs)}` : ""}` : undefined, !item.currentTool && item.currentPath ? item.currentPath : undefined, !item.currentTool && item.durationMs !== undefined ? formatDurationText(item.durationMs) : undefined, item.toolCount !== undefined ? `${item.toolCount} tools` : undefined, includeOutput && item.outputName ? `out:${item.outputName}` : undefined, includeError && item.error ? `error:${item.error.replace(/\bOutput:/g, "output:")}` : undefined].filter((value): value is string => Boolean(value));
 	return [identity, ...details].join(" · ");
 }
 
@@ -433,7 +434,7 @@ export function formatWorkflowChecklistText(projection: WorkflowChecklistProject
 			lines.push(`${indent}    ${marker} ${formatWorkflowChecklistItem(item)}`);
 		}
 	}
-	const bottleneck = formatWorkflowChecklistBottleneck(projection.bottleneck);
+	const bottleneck = formatWorkflowChecklistBottleneck(projection.bottleneck, { includeError: options.includeItems === false });
 	if (bottleneck) lines.push(`${indent}  bottleneck · ${bottleneck}`);
 	return lines;
 }

--- a/test/integration/render-fork-badge.test.ts
+++ b/test/integration/render-fork-badge.test.ts
@@ -696,6 +696,47 @@ describe("renderSubagentResult fork indicator", () => {
 		assert.match(expanded, /✓ five · completed/);
 	});
 
+	it("keeps mixed workflow host diagnostics visible once while deduplicating child errors", () => {
+		const hostError = "CI command failed: executable not found";
+		const childError = "Child review failed";
+		for (const childFailed of [false, true]) {
+			const result = {
+				content: [{ type: "text" as const, text: "workflow failed" }],
+				isError: true,
+				details: {
+					mode: "workflow" as const,
+					results: [{
+						agent: "reviewer",
+						task: "Review changes",
+						exitCode: childFailed ? 1 : 0,
+						error: childFailed ? childError : undefined,
+						finalOutput: childFailed ? "" : "Review complete",
+						messages: [],
+						usage: emptyUsage,
+					}],
+					workflow: {
+						value: "workflow finished",
+						trace: [],
+						emits: [],
+						console: [],
+						receipt: {
+							hostSteps: [{
+								version: 1, kind: "host-step", monitorKind: "command",
+								id: "ci", label: "CI", state: "error", detail: hostError,
+								exitCode: 127, updatedAt: 1,
+							}],
+						},
+					},
+				},
+			};
+			for (const expanded of childFailed ? [true] : [false, true]) {
+				const text = withTerminalWidth(220, () => renderSubagentResult!(result, { expanded }, theme).render(220).join("\n"));
+				assert.equal(text.split(hostError).length - 1, 1, text);
+				if (expanded) assert.equal(text.split(childError).length - 1, childFailed ? 1 : 0, text);
+			}
+		}
+	});
+
 	it("renders a stale-running interrupted aggregate as paused", () => {
 		const result = {
 			content: [{ type: "text" as const, text: "paused" }],

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -379,6 +379,19 @@ describe("subagent async widget rendering", () => {
 		assert.doesNotMatch(text, /bottleneck · paused-first/);
 	});
 
+	it("renders a workflow failure detail once in expanded checklist output", () => {
+		const detail = "review failed with one canonical diagnostic";
+		const text = buildWidgetLines([{
+			asyncId: "workflow-error-dedup",
+			asyncDir: "/tmp/workflow-error-dedup",
+			status: "failed",
+			mode: "workflow",
+			steps: [{ index: 0, workflowKey: "review", agent: "reviewer", status: "failed", error: detail }],
+		}], theme, 180, true).join("\n");
+
+		assert.equal(text.match(new RegExp(detail, "g"))?.length, 1, text);
+	});
+
 	it("keeps simple one-off async rows on the existing fallback projection", () => {
 		const job = {
 			asyncId: "simple-run",

--- a/test/integration/single-execution.test.ts
+++ b/test/integration/single-execution.test.ts
@@ -1277,7 +1277,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 	it("starts workflow scripts asynchronously with a portable internal run id", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		mockPi.onCall({ output: "async child done" });
 		const asyncJobs: SubagentState["asyncJobs"] = new Map();
-		const executor = makeExecutor([makeAgent("echo", { aliases: ["helper"] })], { missions: { globalIndex: false } }, false, undefined, true, asyncJobs);
+		const executor = makeExecutor([makeAgent("echo", { aliases: ["helper"], defaultAsync: true })], { missions: { globalIndex: false } }, false, undefined, true, asyncJobs);
 		const workflowCwd = path.join(tempDir, "workflow-cwd");
 		fs.mkdirSync(workflowCwd);
 		const toolCallId = "call_demo|fc_demo";
@@ -1316,8 +1316,8 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.content[0]?.text ?? "", /Preflight: v1 · complete · 1 lane/);
 		assert.match(result.content[0]?.text ?? "", /Async workflow/);
 		const statusPath = path.join(result.details.asyncDir!, "status.json");
-		let status: { runId?: string; toolCallId?: string; cwd?: string; sessionRoot?: string; state?: string; preflight?: unknown; steps?: Array<{ agent?: string; sessionName?: string; label?: string; phase?: string; workflowKey?: string; parentWorkflowRunId?: string }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; agent?: string; label?: string; phase?: string; state?: string }> } } = {};
-		for (let attempt = 0; attempt < 100; attempt++) {
+		let status: { runId?: string; toolCallId?: string; cwd?: string; sessionRoot?: string; state?: string; preflight?: unknown; steps?: Array<{ agent?: string; sessionName?: string; label?: string; phase?: string; workflowKey?: string; parentWorkflowRunId?: string; async?: boolean }>; workflow?: { value?: unknown; emits?: unknown[]; trace?: Array<{ key?: string; agent?: string; label?: string; phase?: string; state?: string }> } } = {};
+		for (let attempt = 0; attempt < 300; attempt++) {
 			status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
 			if (status.state === "complete" || status.state === "failed") break;
 			await new Promise((resolve) => setTimeout(resolve, 20));
@@ -1343,6 +1343,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			{ agent: "echo", sessionName: "echo: Async work", label: "Run async child", phase: "Execution", workflowKey: "work" },
 		]);
 		assert.ok(status.steps?.every((step) => step.parentWorkflowRunId === workflowRunId));
+		assert.equal(status.steps?.[0]?.async, true);
 		assert.deepEqual(status.workflow?.value, { answer: 42 });
 		assert.deepEqual(status.workflow?.emits, ["starting"]);
 		assert.equal(mockPi.callCount(), 1);
@@ -1379,13 +1380,15 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(persistedResult.workflowReceipt?.receipt?.entries?.work?.key, "work");
 		assert.equal(persistedResult.workflowReceipt?.receipt?.entries?.work?.agent, "echo");
 		assert.equal(persistedResult.workflowReceipt?.receipt?.entries?.work?.latestRunId, persistedResult.results?.[0]?.runId);
-		assert.equal(fs.existsSync(path.join(DIRS.async, persistedResult.results?.[0]?.runId ?? "missing")), false);
+		const childAsyncDir = path.join(DIRS.async, persistedResult.results?.[0]?.runId ?? "missing");
+		assert.equal(fs.existsSync(childAsyncDir), true);
 		assert.deepEqual(persistedResult.workflowReceipt?.receipt?.entries?.work?.continuation?.runIds, [persistedResult.results?.[0]?.runId]);
 		assert.deepEqual(persistedResult.workflowReceipt?.receipt?.entries?.work?.resumability, { state: "resumable" });
 		assert.deepEqual(JSON.parse(fs.readFileSync(persistedResult.workflowReceipt!.path!, "utf-8")), persistedResult.workflowReceipt?.receipt);
 		assert.equal(fs.existsSync(path.join(DIRS.results, `${toolCallId}.json`)), false);
 		fs.rmSync(result.details.asyncDir!, { recursive: true, force: true });
 		fs.rmSync(resultPath, { force: true });
+		fs.rmSync(childAsyncDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 	});
 
 	it("flushes async workflow assembly after cleanup once children are terminal", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
@@ -2070,6 +2073,28 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(mockPi.callCount(), 0);
 		fs.rmSync(started.details.asyncDir!, { recursive: true, force: true });
 		fs.rmSync(resultPath, { force: true });
+	});
+
+	it("honors an omitted agent async default while awaiting the workflow child result", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "default async child done" });
+		const executor = makeExecutor([makeAgent("echo", { defaultAsync: true })], {}, false);
+		const result = await executor.execute(
+			`scripted-workflow-agent-async-default-${Date.now()}`,
+			{ workflowScript: `return await runs.run("background", { agent: "echo", task: "Async child" });`, async: false },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		const child = result.details.workflow?.value as { ok?: boolean; output?: string; runId?: string } | undefined;
+		assert.equal(child?.ok, true);
+		assert.equal(child?.output, "default async child done");
+		assert.ok(child?.runId);
+		assert.equal(result.details.results[0]?.finalOutput, "default async child done");
+		assert.equal(fs.existsSync(path.join(DIRS.async, child.runId)), true);
+		fs.rmSync(path.join(DIRS.async, child.runId), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+		fs.rmSync(path.join(DIRS.results, `${child.runId}.json`), { force: true });
 	});
 
 	it("keeps ordinary async workflow child results in the watcher-owned path", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
@@ -3368,6 +3393,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		const failed = value.find(({ ok }) => !ok);
 		const succeeded = value.find(({ ok }) => ok);
 		assert.match(failed?.error ?? "", /first child failed/);
+		assert.equal(failed?.error?.match(/first child failed/g)?.length, 1);
 		assert.equal(succeeded?.error, undefined);
 		assert.deepEqual(result.details.workflow?.trace.filter((entry) => entry.state !== "started").map(({ state }) => state).sort(), ["completed", "failed"]);
 	});
@@ -7801,6 +7827,9 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.match(result.error ?? "", /must run as background children \(`async: true`\)/);
 		assert.match(result.error ?? "", /subagentOnlyExtensions/);
 		assert.match(result.error ?? "", /strict allowlist/);
+		assert.doesNotMatch(result.finalOutput ?? "", /Model incorrectly claimed success/);
+		assert.equal(result.messages?.length, 0);
+		assert.equal(result.usage.turns, 0);
 		assert.equal(result.modelAttempts?.length, 1);
 	});
 

--- a/test/unit/workflow-checklist.test.ts
+++ b/test/unit/workflow-checklist.test.ts
@@ -81,6 +81,20 @@ test("workflow checklist preserves explicit host monitor verdicts and trace lane
 	assert.match(formatWorkflowChecklistBottleneck(projection.bottleneck) ?? "", /CI/);
 });
 
+test("workflow checklist renders a failed item error only once when item details are included", () => {
+	const projection = projectWorkflowChecklist({
+		steps: [{ workflowKey: "review", agent: "reviewer", status: "failed", error: "review failed with details" }],
+	});
+
+	const expanded = formatWorkflowChecklistText(projection).join("\n");
+	assert.equal(expanded.match(/review failed with details/g)?.length, 1);
+	assert.doesNotMatch(expanded, /bottleneck .*error:review failed with details/);
+
+	const collapsed = formatWorkflowChecklistText(projection, "", { includeItems: false }).join("\n");
+	assert.equal(collapsed.match(/review failed with details/g)?.length, 1);
+	assert.match(collapsed, /bottleneck .*error:review failed with details/);
+});
+
 test("workflow checklist counts one host monitor when host status and trace share an id", () => {
 	const host: HostStepNodeV1 = {
 		version: 1,

--- a/test/unit/workflow-launch-params.test.ts
+++ b/test/unit/workflow-launch-params.test.ts
@@ -4,7 +4,7 @@ import { prepareWorkflowLaunchParams, promptAuditRedoParams, resolveRevivalContr
 import { resolveControlConfig } from "../../src/runs/shared/subagent-control.ts";
 
 describe("workflow launch params", () => {
-	it("keeps omitted workflow child async foreground", () => {
+	it("preserves omitted workflow child async defaults and awaits background resolution", () => {
 		assert.deepEqual(
 			prepareWorkflowLaunchParams(
 				{},
@@ -15,7 +15,7 @@ describe("workflow launch params", () => {
 			{
 				agent: "worker",
 				task: "Run",
-				async: false,
+				workflowAwaitAsync: true,
 				workflowParentRunId: "workflow-run",
 				workflowKey: "run",
 			},
@@ -131,7 +131,8 @@ describe("workflow launch params", () => {
 			"run",
 			{ parentDeadlineAt },
 		);
-		assert.equal(params.async, false);
+		assert.equal(params.async, undefined);
+		assert.equal(params.workflowAwaitAsync, true);
 		assert.equal(params.timeoutMs, undefined);
 		assert.equal(params.workflowParentDeadlineAt, parentDeadlineAt);
 	});
@@ -238,7 +239,7 @@ describe("workflow launch params", () => {
 				agent: "worker",
 				task: "Run",
 				intercomBridge: { mode: "off" },
-				async: false,
+				workflowAwaitAsync: true,
 				workflowParentRunId: "workflow-run",
 				workflowKey: "isolated",
 			},
@@ -265,7 +266,7 @@ describe("workflow launch params", () => {
 				agent: "worker",
 				task: "Implement",
 				worktree: true,
-				async: false,
+				workflowAwaitAsync: true,
 				workflowParentRunId: "workflow-run",
 				workflowKey: "gated",
 				acceptance: { level: "verified", verify: [{ id: "gate", command: "npm test" }] },


### PR DESCRIPTION
## Summary

- stop foreground children as soon as startup reports unavailable required tools, before provider work can continue
- preserve omitted workflow-child `async` values so agent/global defaults apply, while awaiting background completion inside the workflow
- keep one canonical workflow failure diagnostic while preserving saved-output evidence
- avoid repeating expanded failure details in workflow checklist bottlenecks
- add focused unit/integration coverage and document the fixes under `[Unreleased]`

Explicit `async: true` and `async: false` behavior is unchanged. Host-only workflow child permits remain foreground. No public schema or parameter was added.

## Validation

- Red proof against `origin/main` (`71843d1`), with the test-only patch:
  - omitted workflow children were forced to `async: false`
  - a missing-tool child still exposed the model's success output
  - child failure text appeared twice in `runs.all` results and three times in expanded workflow rendering
- `npm run typecheck` — pass
- `npm run test:all` — pass
  - unit: 2,823 passed, 4 skipped
  - integration: 922 passed, 6 skipped
- focused test-only patch fails against upstream and passes on this branch
- `git diff --check` — pass
