### PR TITLE
fix: deduplicate native supervisor request cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Hide the idle `Async runs 0/∞` Fleet summary while preserving finite and occupied capacity meters. Thanks to [@youssefsiam38](https://github.com/youssefsiam38) for #1892.
 - Supply Pi 0.85.0’s missing server dependency for background children, including extensions importing the public SDK, while preserving host-provided packages.
+- Avoid repeating structured metadata and reply instructions in native supervisor request cards. Thanks to [@youssefsiam38](https://github.com/youssefsiam38) for #1893.
 
 ## [0.65.1] - 2026-09-04
 

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -128,8 +128,6 @@ function reasonHeading(reason: SupervisorReason): string {
 	return "Subagent needs a supervisor decision.";
 }
 
-const STRUCTURED_REPLY_INSTRUCTION = "Structured response requested. Reply with JSON, optionally fenced in ```json, matching the requested interview shape.";
-
 function parseStructuredReply(message: string): { value?: unknown; error?: string } {
 	const trimmed = message.trim();
 	const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)?.[1]?.trim();
@@ -493,32 +491,7 @@ function formatPendingLine(request: PendingSupervisorRequest): string {
 	return `- ${request.id}: ${request.agent} [${request.runId}#${request.childIndex}] ${request.reason}.${replyHint}`;
 }
 
-function legacyRequestBody(request: PendingSupervisorRequest): string | undefined {
-	const prefix = [
-		reasonHeading(request.reason),
-		`Run: ${request.runId}`,
-		`Agent: ${request.agent}`,
-		`Child index: ${request.childIndex}`,
-		...(request.childTarget ? [`Child intercom target: ${request.childTarget}`] : []),
-	].join("\n");
-	if (request.message !== prefix && !request.message.startsWith(`${prefix}\n`)) return undefined;
-	let body = request.message.slice(prefix.length).replace(/^\n+/, "");
-	if (request.reason === "interview_request") {
-		const suffix = [STRUCTURED_REPLY_INSTRUCTION, ...(request.interview !== undefined ? [JSON.stringify(request.interview, null, "\t")] : [])].join("\n");
-		if (body === suffix) return "";
-		const marker = `\n\n${suffix}`;
-		if (body.endsWith(marker)) body = body.slice(0, -marker.length);
-	}
-	return body.trim();
-}
-
 function requestVisibleText(request: PendingSupervisorRequest): string {
-	const legacyBody = legacyRequestBody(request);
-	if (legacyBody !== undefined) {
-		const lines = [request.message];
-		if (request.expectsReply) lines.push("", `Reply with: ${supervisorReplyHint(request.id)}`);
-		return lines.join("\n").trimEnd();
-	}
 	const lines = [
 		reasonHeading(request.reason),
 		`Run: ${request.runId}`,
@@ -531,7 +504,7 @@ function requestVisibleText(request: PendingSupervisorRequest): string {
 	if (request.reason === "interview_request") {
 		lines.push(
 			"",
-			STRUCTURED_REPLY_INSTRUCTION,
+			"Structured response requested. Reply with JSON, optionally fenced in ```json, matching the requested interview shape.",
 		);
 		if (request.interview !== undefined) lines.push(JSON.stringify(request.interview, null, "\t"));
 	}
@@ -771,7 +744,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 					childIndex: request.childIndex,
 					...(request.childTarget ? { childTarget: request.childTarget } : {}),
 					...(request.interview !== undefined ? { interview: request.interview } : {}),
-					requestBody: legacyRequestBody(request) ?? request.message,
+					requestBody: request.message,
 					...(request.expectsReply ? { replyHint: supervisorReplyHint(request.id) } : {}),
 				},
 			}, { triggerTurn: true });

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -128,33 +128,7 @@ function reasonHeading(reason: SupervisorReason): string {
 	return "Subagent needs a supervisor decision.";
 }
 
-function formatChildMessage(input: {
-	reason: SupervisorReason;
-	message?: string;
-	interview?: unknown;
-	runId: string;
-	agent: string;
-	childIndex: number;
-	childTarget?: string;
-}): string {
-	const lines = [
-		reasonHeading(input.reason),
-		`Run: ${input.runId}`,
-		`Agent: ${input.agent}`,
-		`Child index: ${input.childIndex}`,
-	];
-	if (input.childTarget) lines.push(`Child intercom target: ${input.childTarget}`);
-	lines.push("");
-	if (input.message?.trim()) lines.push(input.message.trim());
-	if (input.reason === "interview_request") {
-		lines.push(
-			"",
-			"Structured response requested. Reply with JSON, optionally fenced in ```json, matching the requested interview shape.",
-		);
-		if (input.interview !== undefined) lines.push(JSON.stringify(input.interview, null, "\t"));
-	}
-	return lines.join("\n").trimEnd();
-}
+const STRUCTURED_REPLY_INSTRUCTION = "Structured response requested. Reply with JSON, optionally fenced in ```json, matching the requested interview shape.";
 
 function parseStructuredReply(message: string): { value?: unknown; error?: string } {
 	const trimmed = message.trim();
@@ -210,8 +184,8 @@ async function waitForReply(channelDir: string, requestId: string, deadline: num
 }
 
 async function sendSupervisorRequest(params: ContactSupervisorParams, metadata: ChildSupervisorMetadata, signal?: AbortSignal, toolCallId?: string): Promise<AgentToolResult<Record<string, unknown>>> {
-	if (params.reason !== "progress_update" && !params.message?.trim() && params.reason !== "interview_request") {
-		throw new Error("message is required for supervisor decisions.");
+	if (!params.message?.trim() && params.reason !== "interview_request") {
+		throw new Error("message is required for supervisor decisions and progress updates.");
 	}
 	ensureSupervisorChannelDir(metadata.channelDir);
 	const requestId = randomUUID();
@@ -219,7 +193,7 @@ async function sendSupervisorRequest(params: ContactSupervisorParams, metadata: 
 	const createdAt = Date.now();
 	const replyDeadline = createdAt + askTimeoutMs();
 	const expiresAt = expectsReply ? replyDeadline : undefined;
-	const message = formatChildMessage({ ...metadata, reason: params.reason, message: params.message, interview: params.interview });
+	const message = params.message?.trim() ?? "";
 	const requestToolCallId = typeof toolCallId === "string" && toolCallId.length > 0 ? toolCallId : undefined;
 	const request: SupervisorRequest = {
 		type: "subagent.supervisor.request",
@@ -299,7 +273,7 @@ function parseRequestFile(file: string, channelDir: string): PendingSupervisorRe
 		if (parsed.type !== "subagent.supervisor.request") return undefined;
 		if (typeof parsed.id !== "string" || !parsed.id) return undefined;
 		if (parsed.reason !== "need_decision" && parsed.reason !== "interview_request" && parsed.reason !== "progress_update") return undefined;
-		if (typeof parsed.message !== "string" || !parsed.message) return undefined;
+		if (typeof parsed.message !== "string" || (!parsed.message.trim() && parsed.reason !== "interview_request")) return undefined;
 		if (typeof parsed.runId !== "string" || typeof parsed.agent !== "string" || typeof parsed.childIndex !== "number") return undefined;
 		return {
 			...parsed as SupervisorRequest,
@@ -519,12 +493,50 @@ function formatPendingLine(request: PendingSupervisorRequest): string {
 	return `- ${request.id}: ${request.agent} [${request.runId}#${request.childIndex}] ${request.reason}.${replyHint}`;
 }
 
-function requestVisibleText(request: PendingSupervisorRequest): string {
-	const lines = [request.message];
-	if (request.expectsReply) {
-		lines.push("", `Reply with: ${supervisorReplyHint(request.id)}`);
+function legacyRequestBody(request: PendingSupervisorRequest): string | undefined {
+	const prefix = [
+		reasonHeading(request.reason),
+		`Run: ${request.runId}`,
+		`Agent: ${request.agent}`,
+		`Child index: ${request.childIndex}`,
+		...(request.childTarget ? [`Child intercom target: ${request.childTarget}`] : []),
+	].join("\n");
+	if (request.message !== prefix && !request.message.startsWith(`${prefix}\n`)) return undefined;
+	let body = request.message.slice(prefix.length).replace(/^\n+/, "");
+	if (request.reason === "interview_request") {
+		const suffix = [STRUCTURED_REPLY_INSTRUCTION, ...(request.interview !== undefined ? [JSON.stringify(request.interview, null, "\t")] : [])].join("\n");
+		if (body === suffix) return "";
+		const marker = `\n\n${suffix}`;
+		if (body.endsWith(marker)) body = body.slice(0, -marker.length);
 	}
-	return lines.join("\n");
+	return body.trim();
+}
+
+function requestVisibleText(request: PendingSupervisorRequest): string {
+	const legacyBody = legacyRequestBody(request);
+	if (legacyBody !== undefined) {
+		const lines = [request.message];
+		if (request.expectsReply) lines.push("", `Reply with: ${supervisorReplyHint(request.id)}`);
+		return lines.join("\n").trimEnd();
+	}
+	const lines = [
+		reasonHeading(request.reason),
+		`Run: ${request.runId}`,
+		`Agent: ${request.agent}`,
+		`Child index: ${request.childIndex}`,
+	];
+	if (request.childTarget) lines.push(`Child intercom target: ${request.childTarget}`);
+	lines.push("");
+	if (request.message) lines.push(request.message);
+	if (request.reason === "interview_request") {
+		lines.push(
+			"",
+			STRUCTURED_REPLY_INSTRUCTION,
+		);
+		if (request.interview !== undefined) lines.push(JSON.stringify(request.interview, null, "\t"));
+	}
+	if (request.expectsReply) lines.push("", `Reply with: ${supervisorReplyHint(request.id)}`);
+	return lines.join("\n").trimEnd();
 }
 
 function writeReply(request: PendingSupervisorRequest, message: string): SupervisorReply {
@@ -759,6 +771,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 					childIndex: request.childIndex,
 					...(request.childTarget ? { childTarget: request.childTarget } : {}),
 					...(request.interview !== undefined ? { interview: request.interview } : {}),
+					requestBody: legacyRequestBody(request) ?? request.message,
 					...(request.expectsReply ? { replyHint: supervisorReplyHint(request.id) } : {}),
 				},
 			}, { triggerTurn: true });

--- a/src/intercom/supervisor-ui.ts
+++ b/src/intercom/supervisor-ui.ts
@@ -17,6 +17,7 @@ export interface SupervisorRequestMessageDetails {
 	childIndex?: number;
 	childTarget?: string;
 	interview?: unknown;
+	requestBody?: string;
 	replyHint?: string;
 }
 
@@ -107,7 +108,7 @@ function optionalString(value: unknown): boolean {
 
 function requestDetails(value: unknown): SupervisorRequestMessageDetails | undefined {
 	if (!isRecord(value)) return undefined;
-	if (!optionalString(value.id) || !optionalString(value.requestId) || !optionalString(value.replyHint) || !optionalString(value.runId) || !optionalString(value.agent) || !optionalString(value.childTarget)) return undefined;
+	if (!optionalString(value.id) || !optionalString(value.requestId) || !optionalString(value.replyHint) || !optionalString(value.requestBody) || !optionalString(value.runId) || !optionalString(value.agent) || !optionalString(value.childTarget)) return undefined;
 	if (value.reason !== undefined && !isSupervisorReason(value.reason)) return undefined;
 	if (value.expectsReply !== undefined && typeof value.expectsReply !== "boolean") return undefined;
 	if (value.childIndex !== undefined && (typeof value.childIndex !== "number" || !Number.isFinite(value.childIndex))) return undefined;
@@ -153,7 +154,7 @@ function requestLines(message: SupervisorMessageLike, details: SupervisorRequest
 	if (details.childTarget) lines.push(`Child target: ${boundedField(details.childTarget)}`);
 	lines.push(`Request ID: ${requestId}`);
 	if (details.expectsReply) lines.push(`Reply with: ${displayText(details.replyHint ?? supervisorReplyHint(requestId), MAX_BODY_CHARS, expanded)}`);
-	lines.push("", "Request:", displayText(contentText(message.content) || "(no request body)", MAX_BODY_CHARS, expanded));
+	lines.push("", "Request:", displayText((details.requestBody ?? contentText(message.content)) || "(no request body)", MAX_BODY_CHARS, expanded));
 	if (details.interview !== undefined) lines.push("", "Interview shape:", interviewText(details.interview, expanded));
 	return lines;
 }

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -772,41 +772,6 @@ describe("native supervisor channel", () => {
 		assert.equal(sent[0]?.details?.requestBody, "");
 	});
 
-	it("normalizes pending legacy request bodies without duplicating model metadata", () => {
-		const currentSessionId = `session-${randomUUID()}`;
-		const runId = `run-${randomUUID()}`;
-		const legacyMessage = [
-			"Subagent needs a supervisor decision.",
-			`Run: ${runId}`,
-			"Agent: worker",
-			"Child index: 0",
-			"",
-			"Choose the safer option.",
-		].join("\n");
-		writeRequest({ sessionId: currentSessionId, runId, reason: "need_decision", message: legacyMessage });
-		const sent: Array<{ content?: string; details?: Record<string, unknown> }> = [];
-		const ctx = {
-			cwd: process.cwd(),
-			hasUI: false,
-			sessionManager: { getSessionId: () => currentSessionId, getSessionFile: () => null, getEntries: () => [] },
-		};
-		const pi = {
-			getAllTools: () => [],
-			registerTool: () => {},
-			sendMessage: (message: { content?: string; details?: Record<string, unknown> }) => { sent.push(message); },
-			getSessionName: () => "shared-name",
-		};
-		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
-
-		channel.start();
-		channel.dispose();
-
-		assert.equal(sent.length, 1);
-		assert.equal(sent[0]?.content?.match(new RegExp(`Run: ${runId}`, "g"))?.length, 1);
-		assert.equal(sent[0]?.content?.match(/Agent: worker/g)?.length, 1);
-		assert.equal(sent[0]?.details?.requestBody, "Choose the safer option.");
-	});
-
 	it("suppresses resolved, expired, and inactive requests before displaying them", () => {
 		const currentSessionId = `session-${randomUUID()}`;
 		const resolvedRunId = `run-${randomUUID()}`;

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -663,7 +663,7 @@ describe("native supervisor channel", () => {
 			childTarget: "child-worker",
 			interview: { approved: "boolean", rationale: "string" },
 		});
-		const sent: Array<{ customType?: string; details?: Record<string, unknown> }> = [];
+		const sent: Array<{ customType?: string; content?: string; details?: Record<string, unknown> }> = [];
 		const entries: Array<{ customType: string; data?: Record<string, unknown> }> = [];
 		const journalState = { replyExistsAtAppend: false, requestExistsAtAppend: true };
 		const registeredTools = new Map<string, { execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<unknown> }>();
@@ -681,7 +681,7 @@ describe("native supervisor channel", () => {
 			registerTool: (tool: { name: string; execute: (_id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<unknown> }) => {
 				registeredTools.set(tool.name, tool);
 			},
-			sendMessage: (message: { customType?: string; details?: Record<string, unknown> }) => { sent.push(message); },
+			sendMessage: (message: { customType?: string; content?: string; details?: Record<string, unknown> }) => { sent.push(message); },
 			appendEntry: (customType: string, data?: Record<string, unknown>) => {
 				journalState.replyExistsAtAppend = fs.existsSync(replyFile(runId, requestId, "worker", 2));
 				journalState.requestExistsAtAppend = fs.existsSync(requestFile(runId, requestId, "worker", 2));
@@ -695,6 +695,9 @@ describe("native supervisor channel", () => {
 			channel.start();
 			assert.equal(sent.length, 1);
 			assert.equal(sent[0]?.customType, SUPERVISOR_REQUEST_MESSAGE_TYPE);
+			assert.match(sent[0]?.content ?? "", /Subagent requests a structured supervisor interview\./);
+			assert.match(sent[0]?.content ?? "", /Should this change be applied\?/);
+			assert.match(sent[0]?.content ?? "", /Reply with: subagent_supervisor/);
 			assert.deepEqual(sent[0]?.details, {
 				id: requestId,
 				requestId,
@@ -705,6 +708,7 @@ describe("native supervisor channel", () => {
 				childIndex: 2,
 				childTarget: "child-worker",
 				interview: { approved: "boolean", rationale: "string" },
+				requestBody: "Should this change be applied?",
 				replyHint: `subagent_supervisor({ action: "reply", replyTo: "${requestId}", message: "..." })`,
 			});
 
@@ -734,6 +738,73 @@ describe("native supervisor channel", () => {
 		} finally {
 			channel.dispose();
 		}
+	});
+
+	it("keeps message-less interview metadata visible to the parent model", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId: currentSessionId, runId, reason: "interview_request", message: "", interview: { approved: "boolean" } });
+		const sent: Array<{ content?: string; details?: Record<string, unknown> }> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: {
+				getSessionId: () => currentSessionId,
+				getSessionFile: () => null,
+				getEntries: () => [],
+			},
+		};
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: (message: { content?: string; details?: Record<string, unknown> }) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
+
+		channel.start();
+		channel.dispose();
+
+		assert.equal(sent.length, 1);
+		assert.match(sent[0]?.content ?? "", /Structured response requested/);
+		assert.match(sent[0]?.content ?? "", /"approved": "boolean"/);
+		assert.match(sent[0]?.content ?? "", new RegExp(`replyTo: "${requestId}"`));
+		assert.equal(sent[0]?.details?.requestBody, "");
+	});
+
+	it("normalizes pending legacy request bodies without duplicating model metadata", () => {
+		const currentSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const legacyMessage = [
+			"Subagent needs a supervisor decision.",
+			`Run: ${runId}`,
+			"Agent: worker",
+			"Child index: 0",
+			"",
+			"Choose the safer option.",
+		].join("\n");
+		writeRequest({ sessionId: currentSessionId, runId, reason: "need_decision", message: legacyMessage });
+		const sent: Array<{ content?: string; details?: Record<string, unknown> }> = [];
+		const ctx = {
+			cwd: process.cwd(),
+			hasUI: false,
+			sessionManager: { getSessionId: () => currentSessionId, getSessionFile: () => null, getEntries: () => [] },
+		};
+		const pi = {
+			getAllTools: () => [],
+			registerTool: () => {},
+			sendMessage: (message: { content?: string; details?: Record<string, unknown> }) => { sent.push(message); },
+			getSessionName: () => "shared-name",
+		};
+		const channel = createNativeSupervisorChannel(pi as never, makeState(currentSessionId, ctx));
+
+		channel.start();
+		channel.dispose();
+
+		assert.equal(sent.length, 1);
+		assert.equal(sent[0]?.content?.match(new RegExp(`Run: ${runId}`, "g"))?.length, 1);
+		assert.equal(sent[0]?.content?.match(/Agent: worker/g)?.length, 1);
+		assert.equal(sent[0]?.details?.requestBody, "Choose the safer option.");
 	});
 
 	it("suppresses resolved, expired, and inactive requests before displaying them", () => {
@@ -828,6 +899,43 @@ describe("native supervisor channel", () => {
 		} finally {
 			channel.dispose();
 		}
+	});
+
+	it("stores only the child-authored supervisor message in the request body", async () => {
+		const runId = `run-${randomUUID()}`;
+		const channelDir = resolveSupervisorChannelDir(runId, "worker", 3);
+		createdChannels.push(channelDir);
+		const registeredTools = new Map<string, { execute: (_id: string, params: { reason: string; message?: string }) => Promise<unknown> | unknown }>();
+		const pi = {
+			getAllTools: () => [...registeredTools.keys()].map((name) => ({ name })),
+			registerTool: (tool: { name: string; execute: (_id: string, params: { reason: string; message?: string }) => Promise<unknown> | unknown }) => {
+				registeredTools.set(tool.name, tool);
+			},
+		};
+		registerNativeSupervisorClient(pi as never, {
+			channelDir,
+			runId,
+			agent: "worker",
+			childIndex: 3,
+			orchestratorTarget: "shared-name",
+			orchestratorSessionId: "session-parent",
+		});
+
+		await assert.rejects(
+			() => registeredTools.get("contact_supervisor")!.execute("blank-progress", { reason: "progress_update" }),
+			/message is required for supervisor decisions and progress updates/,
+		);
+		await registeredTools.get("contact_supervisor")!.execute("contact", {
+			reason: "progress_update",
+			message: "  Finished the first review pass.  ",
+		});
+
+		const [file] = fs.readdirSync(path.join(channelDir, "requests"));
+		const request = JSON.parse(fs.readFileSync(path.join(channelDir, "requests", file!), "utf-8")) as { message?: string; runId?: string; agent?: string; childIndex?: number };
+		assert.equal(request.message, "Finished the first review pass.");
+		assert.equal(request.runId, runId);
+		assert.equal(request.agent, "worker");
+		assert.equal(request.childIndex, 3);
 	});
 
 	it("removes the request file when a child supervisor ask is cancelled", async () => {

--- a/test/unit/supervisor-ui.test.ts
+++ b/test/unit/supervisor-ui.test.ts
@@ -37,7 +37,15 @@ describe("native supervisor UI", () => {
 			childTarget: "child-worker",
 			replyHint: `subagent_supervisor({ action: "reply", replyTo: "${requestId}", message: "..." })`,
 			interview: { approved: "boolean", rationale: "string" },
-		}, "Should this change be applied?");
+			requestBody: "Should this change be applied?",
+		}, [
+			"Subagent requests a structured supervisor interview.",
+			"Run: run-1845",
+			"Agent: worker",
+			"Child index: 2",
+			"Should this change be applied?",
+			`Reply with: subagent_supervisor({ action: "reply", replyTo: "${requestId}", message: "..." })`,
+		].join("\n"));
 		const text = output.join("\n");
 
 		assert.match(text, /Supervisor interview request/);
@@ -51,6 +59,10 @@ describe("native supervisor UI", () => {
 		assert.match(text, /Interview shape:/);
 		assert.match(text, /approved/);
 		assert.match(text, /Should this change be applied/);
+		assert.equal(text.match(/Run: run-1845/g)?.length, 1);
+		assert.equal(text.match(/Agent: worker/g)?.length, 1);
+		assert.equal(text.match(/Child index: 2/g)?.length, 1);
+		assert.equal(text.match(/Reply with:/g)?.length, 1);
 	});
 
 	it("omits reply hints for progress updates and renders durable reply metadata", () => {


### PR DESCRIPTION
## Summary

- persist native supervisor request bodies as only the child-authored message
- preserve complete model-visible run metadata, interview shape, and reply guidance in parent delivery
- render metadata/reply guidance once from structured details and render only the child-authored request body in the card
- reject empty progress updates while continuing to support message-less structured interview requests
- add focused transport/rendering coverage and document the fix under `[Unreleased]`

## Validation

- Red proof against `origin/main` (`71843d1`), with the test-only patch:
  - rendered cards repeated metadata/reply guidance
  - persisted request bodies repeated generated metadata
  - message-less interviews were not delivered from a plain request body
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/native-supervisor-channel.test.ts test/unit/supervisor-ui.test.ts` — 25 passed
- `npm run typecheck` — pass
- `git diff --check` — pass
