### PR TITLE
test: capture runner terminal evidence for shared-cwd regression

### DIFF
--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -22,7 +22,7 @@ import {
 	createSubagentExecutor, escapeRegExp, createRepo, writePackageSkill,
 	waitForAsyncResultFile, waitForAsyncEvent, waitForAsyncState, waitForMockPiCall,
 	readLastMockPiArgs, readMockPiArgs, readMockPiArgsMatching, tempDir, mockPi,
-	makeAsyncExecutor, readAsyncPayload,
+	makeAsyncExecutor, readAsyncPayload, observeSharedCwdRunner,
 } from "../support/async-execution-fixture.ts";
 
 describe("async execution utilities", { skip: !available ? "pi packages not available" : undefined }, () => {
@@ -717,7 +717,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.doesNotMatch(eventsText, /Interrupt:/);
 	});
 
-	it("does not use shared-cwd sibling tracked edits as parallel completion-guard proof", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+	it("does not use shared-cwd sibling tracked edits as parallel completion-guard proof", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async (t) => {
 		mockPi.onCall({
 			matchArgIncludes: "Edit tracked file",
 			delay: 50,
@@ -735,8 +735,17 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const repo = createRepo("pi-subagents-shared-cwd-mutation-guard-");
 		const id = `async-parallel-shared-cwd-mutation-${Date.now().toString(36)}`;
 		let runnerStarted = false;
+		const observer = observeSharedCwdRunner(id);
+		const failures: unknown[] = [];
+		let reported = false;
+		const reportFailure = () => {
+			if (reported) return;
+			reported = true;
+			try { t.diagnostic(`#1906 ${JSON.stringify({ ...observer.summary(), snapshot: observer.snapshot() })}`); }
+			catch { t.diagnostic("#1906 failure snapshot unavailable (contents withheld)"); }
+		};
 		try {
-			const launch = executeAsyncChain(id, {
+			const launch = observer.launch(() => executeAsyncChain(id, {
 				chain: [{
 					parallel: [
 						{ agent: "first", task: "Edit tracked file" },
@@ -746,24 +755,47 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 				}],
 				resultMode: "parallel",
 				agents: [makeAgent("first"), makeAgent("second")],
-				ctx: { pi: { events: { emit() {} } }, cwd: repo, currentSessionId: "session-1" },
+				ctx: { pi: { events: { emit: observer.emit } }, cwd: repo, currentSessionId: "session-1" },
 				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
 				shareEnabled: false,
 				maxSubagentDepth: 2,
-			});
+			}));
 			runnerStarted = !launch.isError;
 
 			const payload = await readAsyncPayload(id);
+			observer.marks.payloadReadAt = Date.now();
 			assert.equal(payload.results[0]?.success, true);
 			assert.equal(payload.results[0]?.effects?.fileMutation?.status, "observed");
 			assert.equal(payload.results[1]?.success, false);
 			assert.equal(payload.results[1]?.effects?.fileMutation?.status, "missing");
 			assert.equal(payload.results[1]?.effects?.fileMutation?.attempted, false);
 			assert.match(payload.results[1]?.error ?? "", /completed without making edits/);
+			observer.marks.assertionsCompletedAt = Date.now();
+		} catch (error) {
+			failures.push(error);
 		} finally {
-			if (runnerStarted) await waitForAsyncEvent(id, "subagent.run.process_terminal");
-			fs.rmSync(repo, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+			try {
+				if (runnerStarted) {
+					observer.marks.waitStartedAt = Date.now();
+					try { await waitForAsyncEvent(id, "subagent.run.process_terminal"); }
+					finally { observer.marks.waitFinishedAt = Date.now(); }
+				}
+				if (failures.length) reportFailure();
+				fs.rmSync(repo, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+				// Validate channel support/correlation without reading artifacts on success.
+				const summary = observer.summary();
+				t.diagnostic(`#1906 observer ${JSON.stringify(summary)}`);
+				if (runnerStarted) {
+					assert.equal(summary.correlatedProcesses, 1, "diagnostic channel must capture the started-event runner PID");
+					for (const type of ["spawn", "exit", "close"]) assert.ok(summary.processEvents.flat().some((event) => (event as { type: string }).type === type), `diagnostic runner ${type} must be observed`);
+				}
+			} catch (error) {
+				failures.push(error);
+				reportFailure();
+			} finally { observer.dispose(); }
 		}
+		if (failures.length === 1) throw failures[0];
+		if (failures.length > 1) throw new AggregateError(failures, "Primary execution and cleanup/diagnostic failures", { cause: failures[0] });
 	});
 
 	it("background implementation challenges keep explicit no-change reports successful", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/support/async-execution-fixture.ts
+++ b/test/support/async-execution-fixture.ts
@@ -9,7 +9,8 @@
 
 import { after, afterEach, before, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { ChildProcess, spawnSync } from "node:child_process";
+import { channel } from "node:diagnostics_channel";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -377,6 +378,106 @@ async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<s
 		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
 	return resultPath;
+}
+
+// #1906 only: observation, never a terminality predicate or process controller.
+export function observeSharedCwdRunner(id: string) {
+	const number = (value: unknown) => typeof value === "number" && Number.isFinite(value) ? value : undefined;
+	const known = (value: unknown, values: string[]) => typeof value === "string" && values.includes(value) ? value : undefined;
+	const record = (value: unknown): Record<string, unknown> => value !== null && typeof value === "object" ? value as Record<string, unknown> : {};
+	const errorCode = (error: unknown) => known(record(error).code, ["ENOENT", "EACCES", "EPERM", "EBUSY", "EIO", "EMFILE", "ENFILE", "ENOSPC"]) ?? "other";
+	const project = (value: unknown) => {
+		const raw = record(value);
+		return {
+			runMatches: (raw.runId ?? raw.id) === id,
+			runnerProcessInstanceId: typeof raw.runnerProcessInstanceId === "string" && /^[a-zA-Z0-9:-]{1,128}$/.test(raw.runnerProcessInstanceId) ? raw.runnerProcessInstanceId : undefined,
+			state: known(raw.state, ["pending", "running", "complete", "failed", "cancelled", "observed", "unknown", "not-started"]),
+			reason: known(raw.reason, ["observer-unavailable", "runner-candidate-missing", "runner-instance-mismatch", "writer-close-unverified", "process-tree-unverified", "canonical-session-unavailable", "canonical-session-lease-active", "canonical-session-release-unverified", "proof-write-failed", "stale-repair"]),
+			pid: number(raw.pid), ts: number(raw.ts), timestamp: number(raw.timestamp),
+			startedAt: number(raw.startedAt), endedAt: number(raw.endedAt), observedAt: number(raw.observedAt),
+			exitCode: number(raw.exitCode), success: typeof raw.success === "boolean" ? raw.success : undefined,
+		};
+	};
+	const marks: Record<string, number | boolean> = {};
+	const notifications: unknown[] = [];
+	const processes: Array<{ proc: ChildProcess; events: unknown[]; dispose: () => void }> = [];
+	let pid: number | undefined;
+	const diagnosticChannel = channel("child_process");
+	const onProcess = (message: unknown) => {
+		const proc = record(message).process;
+		if (!(proc instanceof ChildProcess) || processes.length >= 8) return;
+		const events: unknown[] = [];
+		const add = (type: string, code?: unknown, signal?: unknown) => events.push({ type, at: Date.now(), pid: proc.pid, code: number(code) ?? (code === null ? null : undefined), signal: known(signal, ["SIGTERM", "SIGKILL", "SIGINT", "SIGABRT", "SIGSEGV"]) });
+		const spawn = () => add("spawn");
+		const error = (err: Error) => events.push({ type: "error", at: Date.now(), code: errorCode(err) });
+		const exit = (code: number | null, signal: NodeJS.Signals | null) => add("exit", code, signal);
+		const close = (code: number | null, signal: NodeJS.Signals | null) => add("close", code, signal);
+		proc.once("spawn", spawn).once("error", error).once("exit", exit).once("close", close);
+		processes.push({ proc, events, dispose: () => { proc.off("spawn", spawn).off("error", error).off("exit", exit).off("close", close); } });
+	};
+	return {
+		marks,
+		emit(type: string, value: unknown) {
+			const raw = record(value);
+			if (type === "subagent:async-started" && raw.id === id) pid = number(raw.pid);
+			else if (type !== "subagent:process-terminal" || raw.runId !== id) return;
+			if (notifications.length < 8) notifications.push({ type, at: Date.now(), ...project(raw) });
+		},
+		launch(run: () => AsyncExecutionResult) {
+			diagnosticChannel.subscribe(onProcess);
+			try {
+				const receipt = run();
+				marks.launchReturnedAt = Date.now();
+				marks.launchIsError = receipt.isError === true;
+				marks.launchIdMatches = receipt.details.asyncId === id;
+				return receipt;
+			} finally {
+				diagnosticChannel.unsubscribe(onProcess);
+				for (const entry of processes) if (pid === undefined || entry.proc.pid !== pid) entry.dispose();
+			}
+		},
+		summary() {
+			const matched = processes.filter(({ proc }) => pid !== undefined && proc.pid === pid);
+			return { id, pid, marks, notifications, capturedProcesses: processes.length, correlatedProcesses: matched.length, processEvents: matched.map(({ events }) => events) };
+		},
+		// One bounded read per known file, only after failure. No arbitrary text escapes.
+		snapshot() {
+			const snapshotAt = Date.now();
+			const files = ["process-terminal.json", "process-terminal-candidate.json", "status.json", "result", "events.jsonl", "runner.stdout.log", "runner.stderr.log"].map((name) => {
+				const file = name === "result" ? path.join(RESULTS_DIR, `${id}.json`) : path.join(ASYNC_DIR, id, name);
+				let fd: number | undefined;
+				const readAt = Date.now();
+				try {
+					fd = fs.openSync(file, "r");
+					const size = fs.fstatSync(fd).size;
+					const tail = name === "events.jsonl" || name.endsWith(".log");
+					const limit = name.endsWith(".log") ? 8192 : 65536;
+					if (!tail && size > limit) return { name, readAt, size, state: "oversized; not parsed" };
+					const offset = tail ? Math.max(0, size - limit) : 0;
+					const buffer = Buffer.alloc(Math.min(size, limit));
+					const text = buffer.subarray(0, fs.readSync(fd, buffer, 0, buffer.length, offset)).toString("utf-8");
+					const base = { name, readAt, size, truncated: offset > 0 };
+					if (name.endsWith(".log")) return { ...base, markers: ["ENOENT", "EACCES", "EPERM", "EBUSY", "ENOSPC", "SyntaxError", "TypeError", "UnhandledPromiseRejection"].filter((marker) => text.includes(marker)) };
+					if (name === "events.jsonl") {
+						let parseErrors = 0;
+						const lifecycle = [];
+						for (const line of text.split("\n").slice(offset > 0 ? 1 : 0).filter(Boolean)) {
+							try {
+								const event = record(JSON.parse(line));
+								if (["subagent.run.started", "subagent.run.completed", "subagent.run.process_terminal"].includes(String(event.type))) lifecycle.push({ type: event.type, ...project(event), proof: project(event.processTerminal) });
+							} catch { parseErrors++; }
+						}
+						return { ...base, parseErrors, lifecycle: lifecycle.slice(-16), terminalPresentInRead: lifecycle.some((event) => event.type === "subagent.run.process_terminal") };
+					}
+					const raw = record(JSON.parse(text));
+					return { ...base, ...project(raw), proof: project(raw.processTerminal), writers: ["0", "1"].map((index) => ({ index, count: Array.isArray(record(raw.writers)[index]) ? (record(raw.writers)[index] as unknown[]).length : undefined, expected: number(record(raw.expectedWriters)[index]) })) };
+				} catch (error) { return { name, readAt, state: error instanceof SyntaxError ? "invalid-json" : errorCode(error) }; }
+				finally { if (fd !== undefined) fs.closeSync(fd); }
+			});
+			return { snapshotAt, finishedAt: Date.now(), waitElapsedMs: typeof marks.waitStartedAt === "number" ? snapshotAt - marks.waitStartedAt : undefined, files };
+		},
+		dispose() { for (const entry of processes) entry.dispose(); },
+	};
 }
 
 async function waitForAsyncEvent(id: string, type: string, timeoutMs = 10_000): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary
Add bounded diagnostic evidence to the shared-cwd completion-guard regression so a recurrence of #1906 can distinguish runner exit/close, durable terminal proof, event publication and observation timing.

- Correlate the test's runner with its started-event PID and observe spawn/exit/close without controlling the process.
- On failure, capture bounded, allowlisted lifecycle metadata and log markers. Do not print arbitrary payloads or log contents.
- Preserve primary failures alongside cleanup failures.

The original payload assertions, 10-second terminal-event deadline, polling cadence and wait-before-removal safety predicate remain unchanged. No production code changes, retries, sleeps or timeout increases.

## Validation
- Focused shared-cwd regression, typecheck and diagnostic-sanitization smoke passed on the pre-rebase candidate.
- Rebase onto `3304d23bf2e764984e19049b181c73f38dd7b972` is patch-equivalent; both changed test files are byte-identical.
- Dedicated simplification and fresh exact-head review found no issues. Diff hygiene passed.
- Full cross-platform checks are deferred to this PR's exact-head CI, including Windows at the existing suite concurrency.

## Scope
Related to #1906; **does not close it**. Root cause remains unproven. Passing CI alone is not evidence that the intermittent failure is fixed. These sequential snapshots are bounded and non-atomic; they are diagnostic evidence, not a replacement terminality predicate.

No user-facing behavior or release surface changes; no changelog entry required for this test-only instrumentation.
