### PR TITLE
fix: keep managed-worktree setup responsive and cancellable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Keep background streaming status updates batched during long-running and attention states while publishing child activity transitions immediately (#1901).
 - Honor distinct output paths on retained workflow follow-ups, preserving the original report and returning the saved output references (#1903).
+- Keep worktree setup responsive and cancellable while preserving uncertain allocations for manual reconciliation (#1902).
 
 ## [0.65.1] - 2026-09-04
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -437,6 +437,10 @@ Set `worktree` to `true` to make managed worktree isolation the default for laun
 
 The hook runs once per created worktree. Paths must be absolute, `~/...`, or repo-relative; bare command names are rejected.
 
+Setup command waits are nonblocking and cancellable through existing run controls. Existing run deadlines and the hook timeout still apply; there is no new setup timeout or configuration.
+
+Setup commands, including Git hooks, must be finite and await all descendants before reporting success; do not start background services. Exit zero, natural pipe closure, complete bounded output, and valid JSON/path metadata are trusted completion for launch and cleanup—not observed process-tree proof. Violations are unsupported: protection against deleting a worktree with an undisclosed live descendant is not guaranteed. No additional Windows containment guarantee is provided.
+
 stdin is a JSON object with `repoRoot`, `worktreePath`, `agentCwd`, `branch`, `index`, `runId`, and `baseCommit`. stdout must be one JSON object, for example:
 
 ```json

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -381,6 +381,8 @@ Use `baseRef` to branch managed worktrees from a named commit or branch instead 
 
 Configure the worktree provider, native path layout, base directory, and setup hook in [configuration.md](configuration.md).
 
+Setup waits remain nonblocking and cancellable. Normal cleanup, including detached foreground finalization, waits for the same in-process setup turn rather than retaining worktrees merely because another setup is active. This is not a cross-process lock. Hooks must follow the [finite setup contract](configuration.md#worktreesetuphook).
+
 ### Lane metadata lifecycle
 
 Workflow children may declare a bounded `lane` object (`version`, `key`, optional
@@ -402,11 +404,13 @@ Older runs without lane metadata remain readable and retain their existing
 handoff/cleanup behavior. Missing lane, receipt, or handoff metadata is
 unknown—not eligible for destructive cleanup.
 
-For managed worktree launches, the runner writes the pending handoff and the
-display-only status path/branch from the deterministic setup plan before the
-first `git worktree add`. If setup then fails or is interrupted, that pending
-ownership record remains preserved evidence; cleanup still rechecks the actual
-worktree state before any removal.
+Managed setup records actual allocation attempts in the handoff; only validated
+allocations become cleanup tasks and display-only status paths/branches. On
+cancellation or failure with unknown settlement, it retains actual/attempted
+ownership evidence and artifacts for manual reconciliation, blocking further
+unsafe setup and cleanup in that process. An allocator interrupted before
+reporting its path may leave branch-only diagnostics, never an invented path.
+Inspect the handoff before reconciliation; cleanup still requires fresh checks.
 
 ## Supervisor coordination (child asks parent)
 

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -107,7 +107,7 @@ import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelSt
 import { claimRunFanoutBatch, getRunFanoutBudgetSnapshot } from "../shared/run-fanout-budget.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent } from "../shared/nested-events.ts";
 import { formatModelAttemptNote, formatSubagentModelVerificationError, isContextOverflow, isRetryableModelFailureAttempt, recordRetryableModelFailure } from "../shared/model-fallback.ts";
-import { markProcessTerminalCandidateLeaseRelease, writeProcessTerminalCandidate, type ProcessTerminalCandidate } from "./process-terminal.ts";
+import { markProcessTerminalCandidateLeaseRelease, processTerminalPath, writeProcessTerminalCandidate, type ProcessTerminalCandidate } from "./process-terminal.ts";
 import { createSteeringStatus, recordSteeringRequest, steeringStatus, terminalSteeringNoticeState, updateSteeringTarget } from "./steering.ts";
 import { PROMPT_REDACTED, detectSubagentError, extractTextFromContent, extractToolArgsPreview, formatEmptyTerminalAssistantResponseError, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
 import { evaluateCompletionMutationGuard, expectsImplementationMutation, hasMutationToolCapability, validateImplementationToolContract } from "../shared/completion-guard.ts";
@@ -129,6 +129,9 @@ import type { TokenUsage } from "../../shared/types.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
+	withWorktreeTransaction,
+	WorktreeSetupError,
+	type WorktreeSetupProgress,
 	diffWorktrees,
 	findWorktreeTaskCwdConflict,
 	formatWorktreeDiffSummary,
@@ -150,7 +153,7 @@ import { asyncStatusChildIdentity } from "../shared/child-identity.ts";
 import { initialToolBudgetState, toolBudgetState } from "../shared/tool-budget.ts";
 import { effectiveToolTimeoutMs, formatToolTimeoutMessage, toolTimeoutCallKey } from "../shared/tool-timeout.ts";
 import { usageBudgetExceededMessage, usageBudgetState } from "../shared/usage-budget.ts";
-import { formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup, writePendingParallelHandoff } from "../shared/parallel-handoff.ts";
+import { formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup, writeWorktreeSetupHandoff } from "../shared/parallel-handoff.ts";
 import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
@@ -1657,12 +1660,15 @@ function markParallelGroupSetupFailure(input: {
 		const statusStep = requiredStatusStep(input.statusPayload, flatTaskIndex);
 		const task = input.group.parallel[taskIndex];
 		if (!task) throw new Error(`Missing parallel task at index ${taskIndex}`);
-		statusStep.status = "failed";
+		const stopped = statusStep.stopped || statusStep.stopRequested || input.statusPayload.stopped;
+		const paused = !stopped && input.statusPayload.state === "paused";
+		statusStep.status = stopped ? "stopped" : paused ? "paused" : "failed";
 		statusStep.startedAt = input.failedAt;
 		statusStep.endedAt = input.failedAt;
 		statusStep.durationMs = 0;
-		statusStep.exitCode = 1;
-		input.results.push(omitUndefinedProperties({ agent: task.agent, context: task.context, output: input.setupError, success: false, exitCode: 1, sessionFile: task.sessionFile }));
+		statusStep.exitCode = paused ? 0 : 1;
+		statusStep.error ??= input.setupError;
+		input.results.push(omitUndefinedProperties({ agent: task.agent, context: task.context, output: input.setupError, error: input.setupError, success: false, exitCode: paused ? 0 : 1, sessionFile: task.sessionFile, stopped: stopped || undefined, interrupted: paused || undefined, timedOut: input.statusPayload.timedOut || undefined }));
 	}
 	input.statusPayload.currentStep = input.groupStartFlatIndex;
 	input.statusPayload.lastUpdate = input.failedAt;
@@ -1894,6 +1900,8 @@ async function runSubagent(
 	const stopMessage = "Subagent stopped by user.";
 	const timeoutAbortController = new AbortController();
 	const stopAbortController = new AbortController();
+	const setupInterruptController = new AbortController();
+	const setupSignal = AbortSignal.any([timeoutAbortController.signal, stopAbortController.signal, setupInterruptController.signal]);
 	let previousCumulativeTokens: TokenUsage = { input: 0, output: 0, total: 0 };
 	let latestSessionFile: string | undefined;
 
@@ -3106,10 +3114,55 @@ async function runSubagent(
 		activityTimer.unref?.();
 	}
 
+	const publishSetupUnknown = (progress: WorktreeSetupProgress): void => {
+		if (!progress.unknown) return;
+		const proof = {
+			version: 1 as const, state: "unknown" as const, runId: id,
+			runnerProcessInstanceId: config.runnerProcessInstanceId ?? "unknown",
+			reason: "process-tree-unverified" as const,
+			diagnostic: `Worktree setup settlement unknown: ${progress.unknown}; manual reconciliation required; ${parallelHandoffPath(asyncDir)}`,
+		};
+		statusPayload.processTerminal = proof;
+		// Publish the sticky proof independently of in-process child writer counts.
+		writeAtomicJson(processTerminalPath(asyncDir), proof);
+	};
+	const finalizeWorktree = async (setup: WorktreeSetup, stepIndex: number, flatStartIndex: number, action: () => void, deadlineAt?: number): Promise<void> => {
+		let admitted = false;
+		try { await withWorktreeTransaction(() => {
+			if (deadlineAt !== undefined && Date.now() >= deadlineAt) throw new Error("Run deadline expired before worktree cleanup");
+			admitted = true;
+			action();
+		}); }
+		catch (error) {
+			if (admitted) throw error;
+			const reason = `Worktree finalization retained; manual reconciliation required: ${error instanceof Error ? error.message : String(error)}`;
+			statusPayload.parallelHandoff = writeParallelHandoffGroup({
+				manifestPath: parallelHandoffPath(asyncDir), runId: id,
+				mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" : (config.resultMode ?? statusPayload.mode) === "single" ? "single" : "chain",
+				source: "async", cwd, stepIndex, flatStartIndex, setup, diffs: [], results: [],
+				cleanup: { state: "partial", pruned: false, errors: [reason], tasks: setup.worktrees.map((worktree) => ({
+					index: worktree.index, path: worktree.path, branch: worktree.branch, provider: worktree.provider, naming: worktree.naming,
+					worktreeRemoved: false, branchRemoved: false, preserved: true, reason,
+				})) },
+			});
+			previousOutput = [previousOutput, reason, formatParallelHandoffReference(statusPayload.parallelHandoff)].filter(Boolean).join("\n\n");
+			writeStatusPayload();
+		}
+	};
+	const cleanupRemainingWorktree = (setup: WorktreeSetup, stepIndex: number, flatStartIndex: number) => finalizeWorktree(setup, stepIndex, flatStartIndex, () => {
+		const cleanup = cleanupWorktrees(setup);
+		statusPayload.parallelHandoff = writeParallelHandoffGroup({
+			manifestPath: parallelHandoffPath(asyncDir), runId: id,
+			mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" : (config.resultMode ?? statusPayload.mode) === "single" ? "single" : "chain",
+			source: "async", cwd, stepIndex, flatStartIndex, setup, diffs: [], results: [], cleanup,
+		});
+		writeStatusPayload();
+	}, config.deadlineAt);
 	const interruptRunner = () => {
 		consumeInterruptRequest(asyncDir);
 		if (interrupted || statusPayload.state !== "running") return;
 		interrupted = true;
+		setupInterruptController.abort();
 		const now = Date.now();
 		statusPayload.state = "paused";
 		currentActivityState = undefined;
@@ -3798,7 +3851,9 @@ async function runSubagent(
 					break;
 				}
 				try {
-					worktreeSetup = createWorktrees(cwd, `${id}-s${stepIndex}`, group.parallel.length, omitUndefinedProperties({
+					worktreeSetup = await createWorktrees(cwd, `${id}-s${stepIndex}`, group.parallel.length, omitUndefinedProperties({
+						signal: setupSignal,
+						deadlineAt: config.deadlineAt,
 						agents: group.parallel.map((task) => task.agent),
 						labels: group.parallel.map((task) => task.lane?.key ?? config.workflowKey ?? task.outputName ?? task.label),
 						tasks: group.parallel.map((task) => task.task),
@@ -3809,9 +3864,10 @@ async function runSubagent(
 							? omitUndefinedProperties({ hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs })
 							: undefined,
 						baseDir: config.worktreeBaseDir,
-						beforeCreate: (plannedSetup) => {
-							for (const worktree of plannedSetup.worktrees) setStatusWorktreeReference(requiredStatusStep(statusPayload, groupStartFlatIndex + worktree.index), worktree);
-							const pendingHandoff = writePendingParallelHandoff({
+						onProgress: (progress) => {
+							publishSetupUnknown(progress);
+							for (const worktree of progress.setup.worktrees) setStatusWorktreeReference(requiredStatusStep(statusPayload, groupStartFlatIndex + worktree.index), worktree);
+							const pendingHandoff = writeWorktreeSetupHandoff({
 								manifestPath: parallelHandoffPath(asyncDir),
 								runId: id,
 								mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" : "chain",
@@ -3819,16 +3875,25 @@ async function runSubagent(
 								cwd,
 								stepIndex,
 								flatStartIndex: groupStartFlatIndex,
-								setup: plannedSetup,
+								progress,
 								laneBindings: handoffWorkflowKey || config.lane ? [{ index: groupStartFlatIndex, taskIndex: 0, ...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}), ...(handoffChildRunId ? { runId: handoffChildRunId } : {}), ...(config.lane ? { lane: config.lane } : {}) }] : undefined,
 							});
+							if (!pendingHandoff) return;
 							statusPayload.parallelHandoff = pendingHandoff;
 							statusPayload.lastUpdate = Date.now();
 							writeStatusPayload();
 						},
 					}));
+					if (config.deadlineAt !== undefined && Date.now() >= config.deadlineAt) timeoutRunner();
+					if (setupSignal.aborted) throw new Error(stopped ? stopMessage : timedOut ? timeoutMessage ?? "Subagent timed out." : "Subagent paused during worktree setup.");
 				} catch (error) {
+					if (worktreeSetup) await cleanupRemainingWorktree(worktreeSetup, stepIndex, groupStartFlatIndex);
+					if (config.deadlineAt !== undefined && Date.now() >= config.deadlineAt) timeoutRunner();
 					const setupError = error instanceof Error ? error.message : String(error);
+					if (error instanceof WorktreeSetupError) publishSetupUnknown(error.snapshot);
+					for (let index = groupStartFlatIndex; index < groupStartFlatIndex + group.parallel.length; index++) {
+						if (childStopRequests.has(index)) markChildStopped(index);
+					}
 					const failedAt = Date.now();
 					markParallelGroupSetupFailure({
 						statusPayload,
@@ -4142,47 +4207,50 @@ async function runSubagent(
 					})),
 				);
 				if (worktreeSetup) {
-					const captured = captureParallelWorktreeDiffs(worktreeSetup, asyncDir, stepIndex, group);
-					if (captured.summary) previousOutput = `${previousOutput}\n\n${captured.summary}`;
+					const setup = worktreeSetup;
 					worktreeFinalized = true;
-					const manifestPath = parallelHandoffPath(asyncDir);
-					const handoff = {
-						manifestPath,
-						runId: id,
-						mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" as const : "chain" as const,
-						source: "async" as const,
-						cwd,
-						stepIndex,
-						flatStartIndex: groupStartFlatIndex,
-						setup: worktreeSetup,
-						diffs: captured.diffs,
-						results: parallelResults.map((result) => ({
-							agent: result.agent,
-							...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}),
-							...(handoffChildRunId ? { runId: handoffChildRunId } : {}),
-							...(config.lane ? { lane: config.lane } : {}),
-							status: result.stopped || (result.exitCode !== 0 && isUnexplainedProcessSignal(omitUndefinedProperties({
-								processSignal: result.processSignal,
-								interrupted: result.interrupted,
-								timedOut: result.timedOut,
-								stopped: result.stopped,
-							}))) ? "stopped" as const : result.interrupted ? "paused" as const : result.exitCode === 0 ? "completed" as const : "failed" as const,
-							summary: result.output || result.error || "(no output)",
-							...(result.artifactPaths?.outputPath ? { outputPath: result.artifactPaths.outputPath } : {}),
-							...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
-							...(result.structuredOutputPath ? { structuredOutputPath: result.structuredOutputPath } : {}),
-							...(result.sessionFile ? { sessionPath: result.sessionFile } : {}),
-						})),
-					};
-					try {
-						writeParallelHandoffGroup(handoff);
-						const cleanup = cleanupWorktrees(worktreeSetup, { kind: "preserve", capturedDiffs: captured.diffs, handoffManifestPath: manifestPath });
-						statusPayload.parallelHandoff = writeParallelHandoffGroup({ ...handoff, cleanup });
-						previousOutput = `${previousOutput}\n\n${formatParallelHandoffReference(statusPayload.parallelHandoff)}`;
-					} catch (error) {
-						previousOutput = `${previousOutput}\n\n${formatParallelHandoffError(error)}`;
-					}
-					writeStatusPayload();
+					await finalizeWorktree(setup, stepIndex, groupStartFlatIndex, () => {
+						const captured = captureParallelWorktreeDiffs(setup, asyncDir, stepIndex, group);
+						if (captured.summary) previousOutput = `${previousOutput}\n\n${captured.summary}`;
+						const manifestPath = parallelHandoffPath(asyncDir);
+						const handoff = {
+							manifestPath,
+							runId: id,
+							mode: (config.resultMode ?? statusPayload.mode) === "parallel" ? "parallel" as const : "chain" as const,
+							source: "async" as const,
+							cwd,
+							stepIndex,
+							flatStartIndex: groupStartFlatIndex,
+							setup,
+							diffs: captured.diffs,
+							results: parallelResults.map((result) => ({
+								agent: result.agent,
+								...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}),
+								...(handoffChildRunId ? { runId: handoffChildRunId } : {}),
+								...(config.lane ? { lane: config.lane } : {}),
+								status: result.stopped || (result.exitCode !== 0 && isUnexplainedProcessSignal(omitUndefinedProperties({
+									processSignal: result.processSignal,
+									interrupted: result.interrupted,
+									timedOut: result.timedOut,
+									stopped: result.stopped,
+								}))) ? "stopped" as const : result.interrupted ? "paused" as const : result.exitCode === 0 ? "completed" as const : "failed" as const,
+								summary: result.output || result.error || "(no output)",
+								...(result.artifactPaths?.outputPath ? { outputPath: result.artifactPaths.outputPath } : {}),
+								...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+								...(result.structuredOutputPath ? { structuredOutputPath: result.structuredOutputPath } : {}),
+								...(result.sessionFile ? { sessionPath: result.sessionFile } : {}),
+							})),
+						};
+						try {
+							writeParallelHandoffGroup(handoff);
+							const cleanup = cleanupWorktrees(setup, { kind: "preserve", capturedDiffs: captured.diffs, handoffManifestPath: manifestPath });
+							statusPayload.parallelHandoff = writeParallelHandoffGroup({ ...handoff, cleanup });
+							previousOutput = `${previousOutput}\n\n${formatParallelHandoffReference(statusPayload.parallelHandoff)}`;
+						} catch (error) {
+							previousOutput = `${previousOutput}\n\n${formatParallelHandoffError(error)}`;
+						}
+						writeStatusPayload();
+					});
 				}
 
 				appendJsonl(eventsPath, JSON.stringify({
@@ -4206,7 +4274,7 @@ async function runSubagent(
 					break;
 				}
 			} finally {
-				if (worktreeSetup && !worktreeFinalized) cleanupWorktrees(worktreeSetup);
+				if (worktreeSetup && !worktreeFinalized) await cleanupRemainingWorktree(worktreeSetup, stepIndex, groupStartFlatIndex);
 			}
 		} else {
 			const seqStep = step as SubagentStep;
@@ -4233,7 +4301,9 @@ async function runSubagent(
 			let singleWorktreeSetup: WorktreeSetup | undefined;
 			if (seqStep.worktree) {
 				try {
-					singleWorktreeSetup = createWorktrees(cwd, `${id}-s${stepIndex}`, 1, omitUndefinedProperties({
+					singleWorktreeSetup = await createWorktrees(cwd, `${id}-s${stepIndex}`, 1, omitUndefinedProperties({
+						signal: setupSignal,
+						deadlineAt: config.deadlineAt,
 						agents: [seqStep.agent],
 						labels: [seqStep.lane?.key ?? config.workflowKey ?? seqStep.outputName ?? seqStep.label],
 						tasks: [seqStep.task],
@@ -4244,12 +4314,13 @@ async function runSubagent(
 							? omitUndefinedProperties({ hookPath: config.worktreeSetupHook, timeoutMs: config.worktreeSetupHookTimeoutMs })
 							: undefined,
 						baseDir: config.worktreeBaseDir,
-						beforeCreate: (plannedSetup) => {
-							const worktree = plannedSetup.worktrees[0];
+						onProgress: (progress) => {
+							publishSetupUnknown(progress);
+							const worktree = progress.setup.worktrees[0];
 							if (worktree) {
 								setStatusWorktreeReference(requiredStatusStep(statusPayload, flatIndex), worktree);
 							}
-							const pendingHandoff = writePendingParallelHandoff({
+							const pendingHandoff = writeWorktreeSetupHandoff({
 								manifestPath: parallelHandoffPath(asyncDir),
 								runId: id,
 								mode: "single",
@@ -4257,18 +4328,46 @@ async function runSubagent(
 								cwd,
 								stepIndex,
 								flatStartIndex: flatIndex,
-								setup: plannedSetup,
+								progress,
 								laneBindings: handoffWorkflowKey || config.lane ? [{ index: flatIndex, taskIndex: 0, ...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}), ...(handoffChildRunId ? { runId: handoffChildRunId } : {}), ...(config.lane ? { lane: config.lane } : {}) }] : undefined,
 							});
+							if (!pendingHandoff) return;
 							statusPayload.parallelHandoff = pendingHandoff;
 							statusPayload.lastUpdate = Date.now();
 							writeStatusPayload();
 						},
 					}));
 				} catch (error) {
-					if (singleWorktreeSetup) cleanupWorktrees(singleWorktreeSetup);
-					throw error;
+					if (error instanceof WorktreeSetupError) publishSetupUnknown(error.snapshot);
+					if (config.deadlineAt !== undefined && Date.now() >= config.deadlineAt) timeoutRunner();
+					const message = error instanceof Error ? error.message : String(error);
+					if (childStopRequests.has(flatIndex)) markChildStopped(flatIndex);
+					const statusStep = requiredStatusStep(statusPayload, flatIndex);
+					statusStep.status = stopped || childStopRequests.has(flatIndex) ? "stopped" : interrupted ? "paused" : "failed";
+					statusStep.error ??= message;
+					statusStep.exitCode = interrupted ? 0 : 1;
+					statusStep.endedAt = Date.now();
+					results.push(stopped ? stoppedStepResult(seqStep.agent, seqStep.context, seqStep.sessionName)
+						: childStopRequests.has(flatIndex) ? childStopResult(flatIndex, seqStep.agent, seqStep.context)
+						: timedOut ? timedOutStepResult(seqStep.agent, seqStep.context, seqStep.sessionName)
+						: interrupted ? pausedStepResult(seqStep.agent, seqStep.context, seqStep.sessionName)
+						: { agent: seqStep.agent, output: message, error: message, exitCode: 1, success: false });
+					statusPayload.error ??= message;
+					writeStatusPayload();
+					flatIndex++;
+					break;
 				}
+			}
+			if (singleWorktreeSetup && config.deadlineAt !== undefined && Date.now() >= config.deadlineAt) timeoutRunner();
+			if (singleWorktreeSetup && (timedOut || stopped || interrupted || childStopRequests.has(flatIndex))) {
+				await cleanupRemainingWorktree(singleWorktreeSetup, stepIndex, flatIndex);
+				results.push(stopped ? stoppedStepResult(seqStep.agent, seqStep.context, seqStep.sessionName)
+					: childStopRequests.has(flatIndex) ? childStopResult(flatIndex, seqStep.agent, seqStep.context)
+					: timedOut ? timedOutStepResult(seqStep.agent, seqStep.context, seqStep.sessionName)
+					: pausedStepResult(seqStep.agent, seqStep.context, seqStep.sessionName));
+				if (interrupted) requiredStatusStep(statusPayload, flatIndex).status = "paused";
+				flatIndex++;
+				continue;
 			}
 			const singleCwd = singleWorktreeSetup?.worktrees[0]?.agentCwd ?? cwd;
 			const stepStartTime = Date.now();
@@ -4332,7 +4431,7 @@ async function runSubagent(
 				orcaProgressTab,
 				}), config.deadlineAt);
 			} catch (error) {
-				if (singleWorktreeSetup) cleanupWorktrees(singleWorktreeSetup);
+				if (singleWorktreeSetup) await cleanupRemainingWorktree(singleWorktreeSetup, stepIndex, flatIndex);
 				throw error;
 			}
 			if (seqStep.sessionFile) {
@@ -4485,48 +4584,51 @@ async function runSubagent(
 			}));
 			if (stopped || childStopped) appendTerminalChildStatusEvent(flatIndex, stepEndTime);
 			if (singleWorktreeSetup && !singleResult.detached) {
-				const diffs = diffWorktrees(singleWorktreeSetup, [seqStep.agent], path.join(asyncDir, "worktree-diffs", `step-${stepIndex}`));
-				const diffSummary = formatWorktreeDiffSummary(diffs);
-				const manifestPath = parallelHandoffPath(asyncDir);
-				const handoff = {
-					manifestPath,
-					runId: id,
-					mode: "single" as const,
-					source: "async" as const,
-					cwd,
-					stepIndex,
-					flatStartIndex: flatIndex,
-					setup: singleWorktreeSetup,
-					diffs,
-					results: [{
-						agent: singleResult.agent,
-						...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}),
-						...(handoffChildRunId ? { runId: handoffChildRunId } : {}),
-						...(config.lane ? { lane: config.lane } : {}),
-						status: singleResult.stopped ? "stopped" as const : singleResult.interrupted ? "paused" as const : singleResult.exitCode === 0 ? "completed" as const : "failed" as const,
-						summary: singleResult.output || singleResult.error || "(no output)",
-						...(singleResult.artifactPaths?.outputPath ? { outputPath: singleResult.artifactPaths.outputPath } : {}),
-						...(singleResult.structuredOutput !== undefined ? { structuredOutput: singleResult.structuredOutput } : {}),
-						...(singleResult.structuredOutputPath ? { structuredOutputPath: singleResult.structuredOutputPath } : {}),
-						...(singleResult.sessionFile ? { sessionPath: singleResult.sessionFile } : {}),
-					}],
-				};
-				try {
-					writeParallelHandoffGroup(handoff);
-					const cleanup = cleanupWorktrees(singleWorktreeSetup, {
-						kind: "preserve",
-						capturedDiffs: diffs,
-						handoffManifestPath: manifestPath,
-						...(config.parentWorkflowRunId && singleResult.sessionFile && fs.existsSync(singleResult.sessionFile) && !singleResult.stopped
-							? { cleanupBlocker: "retained child resume requires managed worktree cwd" }
-							: {}),
-					});
-					statusPayload.parallelHandoff = writeParallelHandoffGroup({ ...handoff, cleanup });
-					previousOutput = [previousOutput, diffSummary, formatParallelHandoffReference(statusPayload.parallelHandoff)].filter(Boolean).join("\n\n");
-				} catch (error) {
-					previousOutput = [previousOutput, diffSummary, formatParallelHandoffError(error)].filter(Boolean).join("\n\n");
-				}
-				writeStatusPayload();
+				const setup = singleWorktreeSetup;
+				await finalizeWorktree(setup, stepIndex, flatIndex, () => {
+					const diffs = diffWorktrees(setup, [seqStep.agent], path.join(asyncDir, "worktree-diffs", `step-${stepIndex}`));
+					const diffSummary = formatWorktreeDiffSummary(diffs);
+					const manifestPath = parallelHandoffPath(asyncDir);
+					const handoff = {
+						manifestPath,
+						runId: id,
+						mode: "single" as const,
+						source: "async" as const,
+						cwd,
+						stepIndex,
+						flatStartIndex: flatIndex,
+						setup,
+						diffs,
+						results: [{
+							agent: singleResult.agent,
+							...(handoffWorkflowKey ? { workflowKey: handoffWorkflowKey } : {}),
+							...(handoffChildRunId ? { runId: handoffChildRunId } : {}),
+							...(config.lane ? { lane: config.lane } : {}),
+							status: singleResult.stopped ? "stopped" as const : singleResult.interrupted ? "paused" as const : singleResult.exitCode === 0 ? "completed" as const : "failed" as const,
+							summary: singleResult.output || singleResult.error || "(no output)",
+							...(singleResult.artifactPaths?.outputPath ? { outputPath: singleResult.artifactPaths.outputPath } : {}),
+							...(singleResult.structuredOutput !== undefined ? { structuredOutput: singleResult.structuredOutput } : {}),
+							...(singleResult.structuredOutputPath ? { structuredOutputPath: singleResult.structuredOutputPath } : {}),
+							...(singleResult.sessionFile ? { sessionPath: singleResult.sessionFile } : {}),
+						}],
+					};
+					try {
+						writeParallelHandoffGroup(handoff);
+						const cleanup = cleanupWorktrees(setup, {
+							kind: "preserve",
+							capturedDiffs: diffs,
+							handoffManifestPath: manifestPath,
+							...(config.parentWorkflowRunId && singleResult.sessionFile && fs.existsSync(singleResult.sessionFile) && !singleResult.stopped
+								? { cleanupBlocker: "retained child resume requires managed worktree cwd" }
+								: {}),
+						});
+						statusPayload.parallelHandoff = writeParallelHandoffGroup({ ...handoff, cleanup });
+						previousOutput = [previousOutput, diffSummary, formatParallelHandoffReference(statusPayload.parallelHandoff)].filter(Boolean).join("\n\n");
+					} catch (error) {
+						previousOutput = [previousOutput, diffSummary, formatParallelHandoffError(error)].filter(Boolean).join("\n\n");
+					}
+					writeStatusPayload();
+				});
 			}
 
 			if (singleResult.completionGuardTriggered) {

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -2247,13 +2247,13 @@ export async function runSync(
 	});
 
 	let terminalCallbackInvoked = false;
-	void authoritativeCompletion.then((terminalResult) => {
+	void authoritativeCompletion.then(async (terminalResult) => {
 		if (!detachedReason || terminalCallbackInvoked) return;
 		terminalCallbackInvoked = true;
 		terminalResult.detached = undefined;
 		terminalResult.detachedReason = detachedReason;
 		try {
-			options.onDetachedExit?.(terminalResult);
+			await options.onDetachedExit?.(terminalResult);
 		} catch {
 			// The authoritative result has settled. Consumer callback failures are
 			// contained here; each consumer owns cleanup through its own finally block.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -71,7 +71,7 @@ import { finalizeSingleOutput, injectSingleOutputInstruction, normalizeSingleOut
 import { assertJsonSchemaObject, cleanupStructuredOutputRuntime, createStructuredOutputRuntime } from "../shared/structured-output.ts";
 import { compactForegroundDetails, getSingleResultOutput, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage, toAgentToolUsage } from "../../shared/utils.ts";
 import { createTaskMutationArbiter } from "../shared/llm-intent-arbiter.ts";
-import { discardPreservedWorktrees, formatParallelHandoffError, formatParallelHandoffReference, formatStoredParallelHandoffCleanup, parallelHandoffPath, readParallelHandoffManifest, recordParallelHandoffMerge, recordParallelHandoffSupersession, writeParallelHandoffGroup, writePendingParallelHandoff } from "../shared/parallel-handoff.ts";
+import { discardPreservedWorktrees, formatParallelHandoffError, formatParallelHandoffReference, formatStoredParallelHandoffCleanup, parallelHandoffPath, readParallelHandoffManifest, recordParallelHandoffMerge, recordParallelHandoffSupersession, writeParallelHandoffGroup, writeWorktreeSetupHandoff } from "../shared/parallel-handoff.ts";
 import { summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
 import {
 	attachNestedChildrenToResultChildren,
@@ -135,6 +135,8 @@ import { resolveWorkflowResource } from "../../workflows/workflow-resources.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
+	withWorktreeTransaction,
+	type WorktreeSetupProgress,
 	diffWorktrees,
 	formatWorktreeDiffSummary,
 	type WorktreeSetup,
@@ -3346,7 +3348,7 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 	return null;
 }
 
-function createSingleWorktreeSetup(
+async function createSingleWorktreeSetup(
 	enabled: boolean | undefined,
 	cwd: string,
 	runId: string,
@@ -3359,12 +3361,14 @@ function createSingleWorktreeSetup(
 	branchPrefix: ExtensionConfig["worktreeBranchPrefix"],
 	label?: string,
 	task?: string,
-	beforeCreate?: (setup: WorktreeSetup) => void,
-): { setup?: WorktreeSetup; errorResult?: AgentToolResult<Details> } {
+	onProgress?: (snapshot: WorktreeSetupProgress) => void,
+	signal?: AbortSignal,
+	deadlineAt?: number,
+): Promise<{ setup?: WorktreeSetup; errorResult?: AgentToolResult<Details> }> {
 	if (!enabled) return {};
 	try {
 		return {
-			setup: createWorktrees(cwd, runId, 1, omitUndefinedProperties({
+			setup: await createWorktrees(cwd, runId, 1, omitUndefinedProperties({
 				agents: [agent],
 				setupHook: setupHook
 					? { hookPath: setupHook, ...(setupHookTimeoutMs === undefined ? {} : { timeoutMs: setupHookTimeoutMs }) }
@@ -3375,7 +3379,9 @@ function createSingleWorktreeSetup(
 				branchPrefix,
 				labels: [label],
 				tasks: [task],
-				beforeCreate,
+				onProgress,
+				signal,
+				deadlineAt,
 			})),
 		};
 	} catch (error) {
@@ -3594,7 +3600,7 @@ function prepareWorkflowChildLaunchParams(input: {
 	return prepareWorkflowLaunchParams(input.workflowDefaults, childParams, input.parentWorkflowRunId, input.workflowKey, { ...input.options, externalAsyncRequired, outputClaimPath: input.outputClaimPath });
 }
 
-function finalizeSingleWorktreeHandoff(input: {
+async function finalizeSingleWorktreeHandoff(input: {
 	worktreeSetup: WorktreeSetup;
 	artifactsDir: string;
 	runId: string;
@@ -3603,55 +3609,78 @@ function finalizeSingleWorktreeHandoff(input: {
 	result: SingleResult;
 	workflowKey?: string;
 	lane?: import("../../shared/types.ts").WorkflowLaneMetadata;
-}): { suffix: string; reference?: NonNullable<Details["parallelHandoff"]> } {
-	const diffsDir = path.join(input.artifactsDir, "worktree-diffs", input.runId);
-	const diffs = diffWorktrees(input.worktreeSetup, [input.agent], diffsDir);
-	const diffSummary = formatWorktreeDiffSummary(diffs);
-	const manifestPath = parallelHandoffPath(input.artifactsDir, input.runId);
-	const handoff = {
-		manifestPath,
-		runId: input.runId,
-		mode: "single" as const,
-		source: "foreground" as const,
-		cwd: input.cwd,
-		stepIndex: 0,
-		flatStartIndex: 0,
-		setup: input.worktreeSetup,
-		laneBindings: input.workflowKey || input.lane ? [{ index: 0, taskIndex: 0, ...(input.workflowKey ? { workflowKey: input.workflowKey } : {}), runId: input.workflowKey ? input.runId : undefined, ...(input.lane ? { lane: input.lane } : {}) }] : undefined,
-		diffs,
-		results: [{
-			agent: input.result.agent,
-			...(input.workflowKey ? { workflowKey: input.workflowKey } : {}),
-			...(input.workflowKey ? { runId: input.runId } : {}),
-			...(input.lane ? { lane: input.lane } : {}),
-			status: resolveSubagentResultStatus(omitUndefinedProperties({
-				exitCode: input.result.exitCode,
-				interrupted: input.result.interrupted,
-				detached: input.result.detached,
-				state: input.result.stopped ? "stopped" : undefined,
-				processSignal: input.result.processSignal,
-				timedOut: input.result.timedOut,
-				stopped: input.result.stopped,
-				turnBudgetExceeded: input.result.turnBudgetExceeded,
-			})),
-			summary: resultSummaryForIntercom(input.result),
-			...(input.result.artifactPaths?.outputPath ? { outputPath: input.result.artifactPaths.outputPath } : {}),
-			...(input.result.structuredOutput !== undefined ? { structuredOutput: input.result.structuredOutput } : {}),
-			...(input.result.structuredOutputPath ? { structuredOutputPath: input.result.structuredOutputPath } : {}),
-			...(input.result.sessionFile ? { sessionPath: input.result.sessionFile } : {}),
-		}],
-	};
+}): Promise<{ suffix: string; reference?: NonNullable<Details["parallelHandoff"]> }> {
+	let admitted = false;
 	try {
-		writeParallelHandoffGroup(handoff);
-		const cleanup = cleanupWorktrees(input.worktreeSetup, { kind: "preserve", capturedDiffs: diffs, handoffManifestPath: manifestPath });
-		const reference = writeParallelHandoffGroup({ ...handoff, cleanup });
-		return {
-			suffix: [diffSummary, formatParallelHandoffReference(reference)].filter(Boolean).join("\n\n"),
-			reference,
-		};
+		return await withWorktreeTransaction(() => {
+			admitted = true;
+			const diffsDir = path.join(input.artifactsDir, "worktree-diffs", input.runId);
+			const diffs = diffWorktrees(input.worktreeSetup, [input.agent], diffsDir);
+			const diffSummary = formatWorktreeDiffSummary(diffs);
+			const manifestPath = parallelHandoffPath(input.artifactsDir, input.runId);
+			const handoff = {
+				manifestPath,
+				runId: input.runId,
+				mode: "single" as const,
+				source: "foreground" as const,
+				cwd: input.cwd,
+				stepIndex: 0,
+				flatStartIndex: 0,
+				setup: input.worktreeSetup,
+				laneBindings: input.workflowKey || input.lane ? [{ index: 0, taskIndex: 0, ...(input.workflowKey ? { workflowKey: input.workflowKey } : {}), runId: input.workflowKey ? input.runId : undefined, ...(input.lane ? { lane: input.lane } : {}) }] : undefined,
+				diffs,
+				results: [{
+					agent: input.result.agent,
+					...(input.workflowKey ? { workflowKey: input.workflowKey } : {}),
+					...(input.workflowKey ? { runId: input.runId } : {}),
+					...(input.lane ? { lane: input.lane } : {}),
+					status: resolveSubagentResultStatus(omitUndefinedProperties({
+						exitCode: input.result.exitCode,
+						interrupted: input.result.interrupted,
+						detached: input.result.detached,
+						state: input.result.stopped ? "stopped" : undefined,
+						processSignal: input.result.processSignal,
+						timedOut: input.result.timedOut,
+						stopped: input.result.stopped,
+						turnBudgetExceeded: input.result.turnBudgetExceeded,
+					})),
+					summary: resultSummaryForIntercom(input.result),
+					...(input.result.artifactPaths?.outputPath ? { outputPath: input.result.artifactPaths.outputPath } : {}),
+					...(input.result.structuredOutput !== undefined ? { structuredOutput: input.result.structuredOutput } : {}),
+					...(input.result.structuredOutputPath ? { structuredOutputPath: input.result.structuredOutputPath } : {}),
+					...(input.result.sessionFile ? { sessionPath: input.result.sessionFile } : {}),
+				}],
+			};
+			try {
+				writeParallelHandoffGroup(handoff);
+				const cleanup = cleanupWorktrees(input.worktreeSetup, { kind: "preserve", capturedDiffs: diffs, handoffManifestPath: manifestPath });
+				const reference = writeParallelHandoffGroup({ ...handoff, cleanup });
+				return {
+					suffix: [diffSummary, formatParallelHandoffReference(reference)].filter(Boolean).join("\n\n"),
+					reference,
+				};
+			} catch (error) {
+				return { suffix: [diffSummary, formatParallelHandoffError(error)].filter(Boolean).join("\n\n") };
+			}
+		});
 	} catch (error) {
-		return { suffix: [diffSummary, formatParallelHandoffError(error)].filter(Boolean).join("\n\n") };
+		if (admitted) throw error;
+		const reference = retainSingleWorktreeHandoff(input, error);
+		return { suffix: `${formatParallelHandoffError(error)}\n\n${formatParallelHandoffReference(reference)}`, reference };
 	}
+}
+
+function retainSingleWorktreeHandoff(input: { worktreeSetup: WorktreeSetup; artifactsDir: string; runId: string; cwd: string }, error: unknown): NonNullable<Details["parallelHandoff"]> {
+	const reason = `Worktree finalization retained; manual reconciliation required: ${error instanceof Error ? error.message : String(error)}`;
+	return writeParallelHandoffGroup({
+		manifestPath: parallelHandoffPath(input.artifactsDir, input.runId), runId: input.runId,
+		mode: "single", source: "foreground", cwd: input.cwd, stepIndex: 0, flatStartIndex: 0,
+		setup: input.worktreeSetup, diffs: [], results: [],
+		cleanup: { state: "partial", pruned: false, errors: [reason], tasks: input.worktreeSetup.worktrees.map((worktree) => ({
+			index: worktree.index, path: worktree.path, branch: worktree.branch, provider: worktree.provider, naming: worktree.naming,
+			worktreeRemoved: false, branchRemoved: false, preserved: true, reason,
+		})) },
+	});
 }
 
 async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Promise<AgentToolResult<Details>> {
@@ -3732,7 +3761,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 
 	const sourceCwd = effectiveCwd;
 	let pendingHandoff: Details["parallelHandoff"];
-	const { setup: worktreeSetup, errorResult: worktreeSetupError } = createSingleWorktreeSetup(
+	const { setup: worktreeSetup, errorResult: worktreeSetupError } = params.worktree ? await createSingleWorktreeSetup(
 		params.worktree,
 		sourceCwd,
 		runId,
@@ -3745,8 +3774,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		deps.config.worktreeBranchPrefix,
 		params.lane?.key ?? params.workflowKey,
 		task,
-		(plannedSetup) => {
-			pendingHandoff = writePendingParallelHandoff({
+		(progress) => {
+			pendingHandoff = writeWorktreeSetupHandoff({
 				manifestPath: parallelHandoffPath(artifactsDir, runId),
 				runId,
 				mode: "single",
@@ -3754,13 +3783,42 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				cwd: sourceCwd,
 				stepIndex: 0,
 				flatStartIndex: 0,
-				setup: plannedSetup,
+				progress,
 				laneBindings: params.workflowKey || lane ? [{ index: 0, taskIndex: 0, ...(params.workflowKey ? { workflowKey: params.workflowKey, runId } : {}), ...(lane ? { lane } : {}) }] : undefined,
 			});
 		},
-	);
-	if (worktreeSetupError) return worktreeSetupError;
+		signal,
+		data.deadlineAt,
+	) : {};
+	if (worktreeSetupError) {
+		if (pendingHandoff) {
+			worktreeSetupError.details!.parallelHandoff = pendingHandoff;
+			worktreeSetupError.content.push({ type: "text", text: formatParallelHandoffReference(pendingHandoff) });
+		}
+		return worktreeSetupError;
+	}
 	const singleCwd = worktreeSetup?.worktrees[0]?.agentCwd ?? sourceCwd;
+	const cleanupSingleWorktree = async () => {
+		if (!worktreeSetup) return;
+		let admitted = false;
+		try { await withWorktreeTransaction(() => {
+			if (data.deadlineAt !== undefined && Date.now() >= data.deadlineAt) throw new Error("Run deadline expired before unlaunched worktree cleanup");
+			admitted = true;
+			const cleanup = cleanupWorktrees(worktreeSetup);
+			pendingHandoff = writeParallelHandoffGroup({
+				manifestPath: parallelHandoffPath(artifactsDir, runId), runId, mode: "single", source: "foreground",
+				cwd: sourceCwd, stepIndex: 0, flatStartIndex: 0, setup: worktreeSetup, diffs: [], results: [], cleanup,
+			});
+		}); }
+		catch (error) {
+			if (admitted) throw error;
+			pendingHandoff = retainSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd }, error);
+		}
+	};
+	if (worktreeSetup && (signal?.aborted || (data.deadlineAt !== undefined && Date.now() >= data.deadlineAt))) {
+		await cleanupSingleWorktree();
+		return { content: [{ type: "text", text: "Subagent setup canceled before child launch." }], isError: true, details: { mode: "single", results: [], parallelHandoff: pendingHandoff } };
+	}
 
 	const authoredTask = task;
 	if (shouldForkAgent(contextPolicy, params.agent!)) {
@@ -3770,8 +3828,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const outputPath = resolveSingleOutputPath(effectiveOutput, ctx.cwd, singleCwd, resolveSingleRunOutputBaseDir(deps, artifactsDir, runId));
 	const validationError = validateFileOnlyOutputMode(effectiveOutputMode, outputPath, `Single run (${params.agent})`);
 	if (validationError) {
-		if (worktreeSetup) cleanupWorktrees(worktreeSetup);
-		return { content: [{ type: "text", text: validationError }], isError: true, details: { mode: "single", results: [] } };
+		await cleanupSingleWorktree();
+		return { content: [{ type: "text", text: validationError }], isError: true, details: { mode: "single", results: [], parallelHandoff: pendingHandoff } };
 	}
 	const structuredRuntime = params.outputSchema
 		? createStructuredOutputRuntime(params.outputSchema, artifactConfig.enabled ? path.join(artifactsDir, "structured-output", runId) : undefined, { acceptanceReport: resolveAcceptanceReportMode(params.acceptance) })
@@ -3904,14 +3962,14 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			onDetachReady: (detach) => {
 				detachForeground = detach;
 			},
-			onDetachedExit: (result) => {
+			onDetachedExit: async (result) => {
 				if (resolveDetachedWorkflowChild) {
 					resolveDetachedWorkflowChild(result);
 					return;
 				}
 				try {
 					if (worktreeSetup) {
-						finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result, workflowKey: params.workflowKey, lane });
+						await finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result, workflowKey: params.workflowKey, lane });
 					}
 					try {
 						updateRememberedForegroundChild(deps.state, { runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, index: 0, result, events: deps.pi.events, notify: true });
@@ -3952,7 +4010,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		}));
 		r = launched.detached && detachedWorkflowChild ? await detachedWorkflowChild : launched;
 	} catch (error) {
-		if (worktreeSetup) cleanupWorktrees(worktreeSetup);
+		await cleanupSingleWorktree();
 		throw error;
 	} finally {
 		// An attached runSync rejection still owns its child and structured runtime.
@@ -3967,11 +4025,11 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		recordRun(params.agent!, cleanTask, r.exitCode, r.progressSummary?.durationMs ?? 0, r);
 	}
 
-	let worktreeHandoff: ReturnType<typeof finalizeSingleWorktreeHandoff> | undefined;
+	let worktreeHandoff: Awaited<ReturnType<typeof finalizeSingleWorktreeHandoff>> | undefined;
 	if (worktreeSetup) {
 		worktreeHandoff = r.detached
 			? { suffix: pendingHandoff ? formatParallelHandoffReference(pendingHandoff) : "", reference: pendingHandoff }
-			: finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result: r, workflowKey: params.workflowKey, lane });
+			: await finalizeSingleWorktreeHandoff({ worktreeSetup, artifactsDir, runId, cwd: sourceCwd, agent: params.agent!, result: r, workflowKey: params.workflowKey, lane });
 	}
 
 	if (r.progress) allProgress.push(r.progress);
@@ -5751,10 +5809,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 				if (!confirmed) return { content: [{ type: "text", text: "Worktree discard canceled; preserved worktrees were not changed." }], details: { mode: "management", results: [] } };
 				try {
-					const discarded = discardPreservedWorktrees(
-						path.isAbsolute(paramsWithResolvedCwd.handoffPath) ? paramsWithResolvedCwd.handoffPath : path.resolve(requestCwd, paramsWithResolvedCwd.handoffPath),
+					const manifestPath = path.isAbsolute(paramsWithResolvedCwd.handoffPath) ? paramsWithResolvedCwd.handoffPath : path.resolve(requestCwd, paramsWithResolvedCwd.handoffPath);
+					const discarded = await withWorktreeTransaction(() => discardPreservedWorktrees(
+						manifestPath,
 						{ kind: decision === "confirm" ? "confirmed" : "policy", ...(deps.config.authorityPolicy ? { policy: deps.config.authorityPolicy } : {}) },
-					);
+					));
 					return { content: [{ type: "text", text: discarded.text }], details: { mode: "management", results: [] } };
 				} catch (error) {
 					return { content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }], isError: true, details: { mode: "management", results: [] } };

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3349,7 +3349,6 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 }
 
 async function createSingleWorktreeSetup(
-	enabled: boolean | undefined,
 	cwd: string,
 	runId: string,
 	agent: string,
@@ -3365,7 +3364,6 @@ async function createSingleWorktreeSetup(
 	signal?: AbortSignal,
 	deadlineAt?: number,
 ): Promise<{ setup?: WorktreeSetup; errorResult?: AgentToolResult<Details> }> {
-	if (!enabled) return {};
 	try {
 		return {
 			setup: await createWorktrees(cwd, runId, 1, omitUndefinedProperties({
@@ -3762,7 +3760,6 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	const sourceCwd = effectiveCwd;
 	let pendingHandoff: Details["parallelHandoff"];
 	const { setup: worktreeSetup, errorResult: worktreeSetupError } = params.worktree ? await createSingleWorktreeSetup(
-		params.worktree,
 		sourceCwd,
 		runId,
 		params.agent!,

--- a/src/runs/shared/parallel-handoff.ts
+++ b/src/runs/shared/parallel-handoff.ts
@@ -616,7 +616,7 @@ export function parallelHandoffPath(baseDir: string, runId?: string): string {
 }
 
 /** Synchronous onProgress projection shared by setup owners; snapshots are cumulative. */
-export function writeWorktreeSetupHandoff(input: Omit<Parameters<typeof writePendingParallelHandoff>[0], "setup"> & {
+export function writeWorktreeSetupHandoff(input: Omit<Parameters<typeof writeParallelHandoffGroup>[0], "setup" | "diffs" | "results" | "cleanup" | "now"> & {
 	progress: WorktreeSetupProgress;
 }): ParallelHandoffReference | undefined {
 	const { progress, ...handoff } = input;
@@ -671,20 +671,6 @@ export function writeWorktreeSetupHandoff(input: Omit<Parameters<typeof writePen
 			}),
 		},
 	});
-}
-
-export function writePendingParallelHandoff(input: {
-	manifestPath: string;
-	runId: string;
-	mode: "single" | "parallel" | "chain";
-	source: "foreground" | "async";
-	cwd: string;
-	stepIndex: number;
-	flatStartIndex: number;
-	setup: WorktreeSetup;
-	laneBindings?: ParallelHandoffLaneBinding[];
-}): ParallelHandoffReference {
-	return writeParallelHandoffGroup({ ...input, diffs: [], results: [] });
 }
 
 export function formatParallelHandoffReference(reference: ParallelHandoffReference): string {

--- a/src/runs/shared/parallel-handoff.ts
+++ b/src/runs/shared/parallel-handoff.ts
@@ -17,6 +17,7 @@ import type {
 	WorktreeCleanupReport,
 	WorktreeDiff,
 	WorktreeSetup,
+	WorktreeSetupProgress,
 	WorktreeCleanupIntent,
 } from "./worktree.ts";
 import { cleanupWorktrees } from "./worktree.ts";
@@ -612,6 +613,64 @@ export function writeParallelHandoffGroup(input: {
 
 export function parallelHandoffPath(baseDir: string, runId?: string): string {
 	return runId ? path.join(baseDir, "handoffs", `${runId}.json`) : path.join(baseDir, "handoff.json");
+}
+
+/** Synchronous onProgress projection shared by setup owners; snapshots are cumulative. */
+export function writeWorktreeSetupHandoff(input: Omit<Parameters<typeof writePendingParallelHandoff>[0], "setup"> & {
+	progress: WorktreeSetupProgress;
+}): ParallelHandoffReference | undefined {
+	const { progress, ...handoff } = input;
+	const { setup, attempts, cleanup } = progress;
+	// Preflight has no allocation identity yet. Its original error belongs to the caller.
+	if (attempts.length === 0 && setup.worktrees.length === 0) return undefined;
+	if (!setup.cwd || !setup.baseCommit) throw new Error("Cannot publish worktree allocation evidence without repository and base commit.");
+	const diagnostic = (text: string): string => text.slice(0, 512);
+	// Never copy argv, environment, Error objects or captured stdout/stderr into artifacts.
+	const commandEvidence = (command: WorktreeSetupProgress["command"]) => command && ({
+		pid: command.pid,
+		processGroupId: command.processGroupId,
+		...(command.result ? {
+			status: command.result.status,
+			signal: command.result.signal,
+			failed: Boolean(command.result.error),
+			outputIncomplete: command.result.outputIncomplete,
+			processTree: command.result.processTree?.state,
+		} : {}),
+	});
+	const errors = [
+		`Worktree setup ${JSON.stringify({ runId: input.runId, stepIndex: input.stepIndex, phase: progress.phase,
+			unknown: Boolean(progress.unknown), command: commandEvidence(progress.command) })}`,
+		...attempts.map((attempt) => {
+			const task = cleanup?.tasks.find((candidate) => candidate.index === attempt.index);
+			return `Allocation attempt ${JSON.stringify({ index: attempt.index, branch: attempt.branch,
+				path: attempt.path ?? null, validated: attempt.validated,
+				command: commandEvidence(attempt.command), hookCommand: commandEvidence(attempt.hookCommand),
+				...(task ? { worktreeRemoved: task.worktreeRemoved, branchRemoved: task.branchRemoved,
+					preserved: task.preserved, reason: task.reason && diagnostic(task.reason), errors: task.errors?.map(diagnostic) } : {}),
+			})}`;
+		}),
+		...(cleanup?.errors?.map(diagnostic) ?? []),
+		...(progress.unknown ? ["Setup settlement unknown; manual reconciliation required."] : []),
+	];
+	return writeParallelHandoffGroup({
+		...handoff, setup, diffs: [], results: [],
+		laneBindings: input.laneBindings?.filter((binding) => setup.worktrees.some((worktree) => worktree.index === binding.taskIndex)),
+		cleanup: {
+			state: cleanup?.state ?? "partial",
+			pruned: cleanup?.pruned ?? false,
+			errors,
+			// An attempted native path is not a validated recovery task, even during rollback.
+			tasks: setup.worktrees.map((worktree) => {
+				const task = cleanup?.tasks.find((candidate) => candidate.index === worktree.index);
+				return task ? { ...task, reason: task.reason && diagnostic(task.reason), errors: task.errors?.map(diagnostic) } : {
+					index: worktree.index, path: worktree.path, branch: worktree.branch,
+					provider: worktree.provider, naming: worktree.naming,
+					worktreeRemoved: false, branchRemoved: false, preserved: true,
+					reason: "setup pending durable handoff capture",
+				};
+			}),
+		},
+	});
 }
 
 export function writePendingParallelHandoff(input: {

--- a/src/runs/shared/worktree-setup-command.ts
+++ b/src/runs/shared/worktree-setup-command.ts
@@ -54,10 +54,13 @@ export async function runSetupCommand(
 	if (options.hookTimeoutMs !== undefined && (!Number.isSafeInteger(options.hookTimeoutMs) || options.hookTimeoutMs <= 0)) {
 		throw new Error("Invalid setup hook timeout");
 	}
-	const cancellation = (): Error | undefined => options.signal?.aborted
-		? commandError("Worktree setup aborted", "ABORT_ERR")
-		: options.deadlineAt !== undefined && Date.now() >= options.deadlineAt
-			? commandError("Worktree setup deadline exceeded", "ETIMEDOUT") : undefined;
+	const cancellation = (): Error | undefined => {
+		if (options.signal?.aborted) return commandError("Worktree setup aborted", "ABORT_ERR");
+		if (options.deadlineAt !== undefined && Date.now() >= options.deadlineAt) {
+			return commandError("Worktree setup deadline exceeded", "ETIMEDOUT");
+		}
+		return undefined;
+	};
 	result.error = cancellation();
 	if (result.error) return result;
 

--- a/src/runs/shared/worktree-setup-command.ts
+++ b/src/runs/shared/worktree-setup-command.ts
@@ -1,0 +1,187 @@
+import { spawn } from "node:child_process";
+import { createOwnedProcessTreeController } from "../background/owned-process-tree.ts";
+import type { ProcessTreeTerminalV1 } from "../../shared/types.ts";
+
+export interface SetupCommandOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	input?: string;
+	/** Worktrunk uses 128 KiB; Git and hooks use spawnSync's 1 MiB default. */
+	maxBuffer?: number;
+	signal?: AbortSignal;
+	deadlineAt?: number;
+	/** Only the existing configured setup-hook timeout, not a new Git budget. */
+	hookTimeoutMs?: number;
+	/** Read-only probes may define negative answers as completed commands. */
+	acceptedExitCodes?: readonly number[];
+	onSpawn?: (process: { pid: number; processGroupId?: number }) => void;
+}
+
+export interface SetupCommandResult {
+	stdout: string;
+	stderr: string;
+	status: number | null;
+	signal: NodeJS.Signals | null;
+	error?: Error;
+	pid?: number;
+	processGroupId?: number;
+	/** Absent on normal completion: trusted command completion is NOT tree proof. */
+	processTree?: ProcessTreeTerminalV1;
+	outputIncomplete: boolean;
+}
+
+function commandError(message: string, code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(message), { code });
+}
+
+/**
+ * Setup I/O only. Commands must await their descendants before reporting success.
+ * Exit 0 + natural close + complete output still requires caller JSON/path validation.
+ * Invalid output is NOT accepted completion: retain unknown ownership, never signal
+ * this completed command's PID later. Callers own compensation and admission.
+ */
+export async function runSetupCommand(
+	command: string,
+	args: string[],
+	options: SetupCommandOptions,
+): Promise<SetupCommandResult> {
+	const result: SetupCommandResult = {
+		stdout: "", stderr: "", status: null, signal: null, outputIncomplete: false,
+	};
+	const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+	if (!Number.isSafeInteger(maxBuffer) || maxBuffer <= 0) throw new Error("Invalid setup command maxBuffer");
+	if (options.deadlineAt !== undefined && !Number.isFinite(options.deadlineAt)) throw new Error("Invalid setup deadline");
+	if (options.hookTimeoutMs !== undefined && (!Number.isSafeInteger(options.hookTimeoutMs) || options.hookTimeoutMs <= 0)) {
+		throw new Error("Invalid setup hook timeout");
+	}
+	const cancellation = (): Error | undefined => options.signal?.aborted
+		? commandError("Worktree setup aborted", "ABORT_ERR")
+		: options.deadlineAt !== undefined && Date.now() >= options.deadlineAt
+			? commandError("Worktree setup deadline exceeded", "ETIMEDOUT") : undefined;
+	result.error = cancellation();
+	if (result.error) return result;
+
+	let child;
+	try {
+		child = spawn(command, args, {
+			cwd: options.cwd,
+			env: options.env ? { ...process.env, ...options.env } : process.env,
+			stdio: "pipe", shell: false, windowsHide: true,
+			// Isolated owned POSIX group, never unref'd or fire-and-forget.
+			detached: process.platform !== "win32",
+		});
+	} catch (error) {
+		result.error = error instanceof Error ? error : new Error(String(error));
+		return result;
+	}
+	result.pid = child.pid;
+	if (child.pid !== undefined && process.platform !== "win32") result.processGroupId = child.pid;
+	const tree = child.pid === undefined ? undefined : createOwnedProcessTreeController(child.pid);
+	let termination: Promise<ProcessTreeTerminalV1> | undefined;
+	let directSettled = false;
+	const releaseUnknownIO = () => {
+		if (!directSettled || result.processTree?.state !== "unknown") return;
+		result.error ??= commandError("Worktree setup process tree settlement is unverified", "PROCESS_TREE_UNVERIFIED");
+		result.outputIncomplete = true;
+		// Only local I/O is released; unknown descendant ownership remains retained.
+		child.stdin.destroy();
+		child.stdout.destroy();
+		child.stderr.destroy();
+	};
+	const terminate = () => {
+		if (termination || !tree) return;
+		if (directSettled) {
+			result.processTree = {
+				state: "unknown", reason: "verification-failed",
+				diagnostic: "Command exited before termination began; no longer safe to signal its recorded PID.",
+			};
+			releaseUnknownIO();
+			return;
+		}
+		termination = tree.terminate().then((proof) => {
+			result.processTree = proof;
+			releaseUnknownIO();
+			return proof;
+		});
+	};
+	const fail = (error: Error) => {
+		result.error ??= error;
+		terminate();
+	};
+	const onAbort = () => fail(commandError("Worktree setup aborted", "ABORT_ERR"));
+	const stdout: Buffer[] = [];
+	const stderr: Buffer[] = [];
+	let capturedBytes = 0;
+	const capture = (chunks: Buffer[], chunk: Buffer) => {
+		const remaining = maxBuffer - capturedBytes;
+		if (remaining > 0) {
+			const saved = Buffer.from(chunk.subarray(0, remaining));
+			chunks.push(saved);
+			capturedBytes += saved.length;
+		}
+		if (chunk.length > remaining) {
+			result.outputIncomplete = true;
+			fail(commandError("Worktree setup command output exceeds maxBuffer", "ENOBUFS"));
+		}
+	};
+	const onStdout = (chunk: Buffer) => capture(stdout, chunk);
+	const onStderr = (chunk: Buffer) => capture(stderr, chunk);
+	child.stdout.on("data", onStdout);
+	child.stderr.on("data", onStderr);
+	child.stdin.on("error", fail);
+	const close = new Promise<void>((resolve) => child.once("close", () => resolve()));
+	const directExit = new Promise<void>((resolve) => {
+		child.once("exit", (status, signal) => {
+			directSettled = true;
+			result.status = status;
+			result.signal = signal;
+			if (status === null || !(options.acceptedExitCodes ?? [0]).includes(status)) terminate();
+			releaseUnknownIO();
+			resolve();
+		});
+		child.once("error", (error) => {
+			fail(error);
+			// A failed spawn has no direct process to await. Other errors do not prove exit.
+			if (child.pid === undefined) {
+				directSettled = true;
+				resolve();
+			}
+		});
+	});
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const deadlineAt = Math.min(options.deadlineAt ?? Infinity,
+		options.hookTimeoutMs === undefined ? Infinity : Date.now() + options.hookTimeoutMs);
+	const armDeadline = () => {
+		if (deadlineAt === Infinity) return;
+		const remaining = deadlineAt - Date.now();
+		if (remaining <= 0) fail(commandError("Worktree setup command timed out", "ETIMEDOUT"));
+		else timer = setTimeout(armDeadline, Math.min(remaining, 2 ** 31 - 1));
+	};
+	options.signal?.addEventListener("abort", onAbort, { once: true });
+	try {
+		armDeadline();
+		if (options.signal?.aborted) onAbort();
+		if (child.pid !== undefined) {
+			try { options.onSpawn?.({ pid: child.pid, processGroupId: result.processGroupId }); }
+			catch (error) { fail(error instanceof Error ? error : new Error(String(error))); }
+		}
+		child.stdin.end(options.input);
+		await directExit;
+		if (termination) result.processTree = await termination;
+		releaseUnknownIO();
+		await close;
+		// Abort/overflow may arrive while draining stdio after direct exit.
+		if (termination) result.processTree = await termination;
+		const cancelled = cancellation();
+		if (cancelled) fail(cancelled);
+		result.stdout = Buffer.concat(stdout).toString("utf8");
+		result.stderr = Buffer.concat(stderr).toString("utf8");
+		return result;
+	} finally {
+		if (timer) clearTimeout(timer);
+		options.signal?.removeEventListener("abort", onAbort);
+		child.stdout.removeListener("data", onStdout);
+		child.stderr.removeListener("data", onStderr);
+		child.stdin.removeListener("error", fail);
+	}
+}

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -168,7 +168,6 @@ interface GitResult {
 interface RepoState {
 	toplevel: string;
 	cwdRelative: string;
-	sourceCheckout: SourceCheckoutSnapshot;
 	baseCommit: string;
 }
 
@@ -240,7 +239,6 @@ class SetupTransaction {
 		this.progress.command = { command, args };
 		if (this.progress.phase === "allocation") this.progress.attempts.at(-1)!.command = this.progress.command;
 		if (this.progress.phase === "hook") this.progress.attempts.find((attempt) => attempt.path === options.cwd)!.hookCommand = this.progress.command;
-		this.publish();
 		const result = await runSetupCommand(command, args, {
 			...options, signal: this.options.signal, deadlineAt: this.options.deadlineAt,
 			onSpawn: (process) => { Object.assign(this.progress.command!, process); this.publish(); },
@@ -356,9 +354,6 @@ async function resolveRepoState(tx: SetupTransaction, cwd: string, requestedBase
 		throw new Error("worktree isolation requires a clean git working tree. Commit or stash changes first.");
 	}
 
-	const sourceHead = (await tx.gitChecked(toplevel, ["rev-parse", "HEAD"])).trim();
-	const sourceBranch = await tx.git(toplevel, ["symbolic-ref", "--quiet", "--short", "HEAD"], [0, 1]);
-	const sourceCheckout = { head: sourceHead, ...(sourceBranch.status === 0 ? { branch: sourceBranch.stdout.trim() } : {}) };
 	const baseRef = normalizeWorktreeBaseRef(requestedBaseRef) ?? DEFAULT_WORKTREE_BASE_REF;
 	let baseCommit: string;
 	try {
@@ -369,7 +364,7 @@ async function resolveRepoState(tx: SetupTransaction, cwd: string, requestedBase
 		throw new Error(`baseRef '${baseRef}' could not be resolved to a commit: ${error instanceof Error ? error.message : String(error)}`, { cause: error instanceof Error ? error : undefined });
 	}
 	if (!baseCommit) throw new Error(`baseRef '${baseRef}' could not be resolved to a commit`);
-	return { toplevel, cwdRelative, sourceCheckout, baseCommit };
+	return { toplevel, cwdRelative, baseCommit };
 }
 
 function normalizeComparableCwd(cwd: string): string {
@@ -537,11 +532,6 @@ interface WorktrunkCapability {
 	reason?: string;
 }
 
-interface SourceCheckoutSnapshot {
-	head: string;
-	branch?: string;
-}
-
 function runWorktrunk(args: string[], cwd?: string): WorktreeCommandResult {
 	try {
 		const result = spawnSync("wt", args, {
@@ -589,7 +579,6 @@ export function resolveWorktreeProvider(requested: WorktreeProvider | undefined,
 	return "native";
 }
 
-/** Whether a launch must bind its worktree-dependent paths after allocation. */
 async function resolveSetupProvider(tx: SetupTransaction, requested: WorktreeProvider | undefined, baseDir?: string): Promise<ManagedWorktreeProvider> {
 	const selection = requested ?? DEFAULT_WORKTREE_PROVIDER;
 	if (selection !== "auto" && selection !== "native" && selection !== "worktrunk") throw new Error('worktree provider must be "auto", "native", or "worktrunk"');
@@ -617,6 +606,7 @@ async function resolveSetupProvider(tx: SetupTransaction, requested: WorktreePro
 	return "native";
 }
 
+/** Whether a launch must bind its worktree-dependent paths after allocation. */
 export function shouldDeferWorktreeCwd(requested: WorktreeProvider | undefined, baseDir?: string): boolean {
 	return (requested ?? DEFAULT_WORKTREE_PROVIDER) !== "native" && !hasConfiguredWorktreeBaseDir(baseDir);
 }
@@ -972,18 +962,13 @@ async function createWorktrunkWorktree(
 		const message = result.error?.message || result.stderr.trim() || result.stdout.trim() || "Worktrunk provisioning failed";
 		throw new Error(`Worktrunk provisioning failed: ${message}`);
 	}
-	let createdAllocation = false;
-	let returnedPath: string | undefined;
 	try {
 		const output = parseWorktrunkSwitchOutput(result.stdout);
-		createdAllocation = output.action === "created" && output.created_branch === true;
-		if (typeof output.path === "string" && path.isAbsolute(output.path)) returnedPath = path.resolve(output.path);
-		if (!createdAllocation || output.branch !== naming.requestedBranch || output.base_branch !== baseCommit) {
+		if (output.action !== "created" || output.created_branch !== true || output.branch !== naming.requestedBranch || output.base_branch !== baseCommit) {
 			throw new Error("Worktrunk provisioning returned inconsistent creation metadata");
 		}
 		if (typeof output.path !== "string" || !path.isAbsolute(output.path)) throw new Error("Worktrunk provisioning returned a non-absolute worktree path");
-		const worktreePathCandidate = returnedPath;
-		if (!worktreePathCandidate) throw new Error("Worktrunk provisioning returned a non-absolute worktree path");
+		const worktreePathCandidate = path.resolve(output.path);
 		let stat: fs.Stats;
 		try {
 			stat = fs.lstatSync(worktreePathCandidate);
@@ -1296,12 +1281,12 @@ async function compensateSetup(tx: SetupTransaction): Promise<WorktreeCleanupRep
 	const git = async (args: string[], acceptedExitCodes: readonly number[] = [0]) => {
 		if (setupPoison) throw new Error(setupPoison);
 		tx.progress.command = { command: "git", args: ["-C", setup.cwd, ...args] };
-		tx.publish();
 		const result = await runSetupCommand("git", tx.progress.command.args, {
 			deadlineAt: tx.options.deadlineAt, acceptedExitCodes,
 			onSpawn: (process) => { Object.assign(tx.progress.command!, process); tx.publish(); },
 		});
-		tx.progress.command.result = result;
+		const { stdout: _stdout, stderr: _stderr, ...metadata } = result;
+		tx.progress.command.result = metadata;
 		if (result.processTree?.state === "unknown") tx.unknown(result.error ?? "Rollback command settlement unverified");
 		tx.publish();
 		if (result.error || result.status === null || !acceptedExitCodes.includes(result.status)) throw result.error ?? new Error(result.stderr.trim() || "Rollback command failed");

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { runSetupCommand, type SetupCommandOptions, type SetupCommandResult } from "./worktree-setup-command.ts";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -118,6 +119,10 @@ interface WorktreeSetupHookConfig {
 }
 
 export interface CreateWorktreesOptions {
+	signal?: AbortSignal;
+	/** Existing absolute run deadline only; setup does not start a child budget. */
+	deadlineAt?: number;
+	onProgress?: (snapshot: WorktreeSetupProgress) => void;
 	agents?: string[];
 	/** Optional stable labels used to make branch identity readable. */
 	labels?: Array<string | undefined>;
@@ -131,8 +136,6 @@ export interface CreateWorktreesOptions {
 	branchPrefix?: string;
 	setupHook?: WorktreeSetupHookConfig;
 	baseDir?: string;
-	/** Called with deterministic ownership metadata before setup hooks and child launch; native reports planned paths before allocation, while Worktrunk reports its returned paths after allocation. */
-	beforeCreate?: (setup: WorktreeSetup) => void;
 }
 
 interface ResolvedWorktreeSetupHook {
@@ -171,6 +174,107 @@ interface RepoState {
 
 const DEFAULT_WORKTREE_SETUP_HOOK_TIMEOUT_MS = 30000;
 
+/** In-memory evidence only. Callers project this into existing handoff diagnostics. */
+export interface WorktreeSetupProgress {
+	setup: WorktreeSetup;
+	attempts: Array<{ index: number; branch: string; path?: string; validated: boolean; command?: WorktreeSetupProgress["command"]; hookCommand?: WorktreeSetupProgress["command"] }>;
+	phase: string;
+	command?: { command: string; args: string[]; pid?: number; processGroupId?: number; result?: Omit<SetupCommandResult, "stdout" | "stderr"> };
+	unknown?: string;
+	cleanup?: WorktreeCleanupReport;
+}
+
+export class WorktreeSetupError extends Error {
+	readonly snapshot: WorktreeSetupProgress;
+	constructor(error: unknown, snapshot: WorktreeSetupProgress) {
+		super(`${error instanceof Error ? error.message : String(error)}${snapshot.unknown ? `; setup settlement unknown: ${snapshot.unknown}; manual reconciliation required` : ""}`, { cause: error });
+		this.name = "WorktreeSetupError";
+		this.snapshot = snapshot;
+	}
+}
+
+let worktreeTurn: Promise<void> = Promise.resolve();
+let setupActive = false;
+let setupPoison: string | undefined;
+
+function assertWorktreeMutationAllowed(): void {
+	if (setupPoison) throw new Error(`Worktree mutation blocked: ${setupPoison}`);
+	if (setupActive) throw new Error("Worktree setup is active; finalization must await withWorktreeTransaction");
+}
+
+/** Later async finalization owners wrap their synchronous diff/cleanup as ONE turn. */
+export async function withWorktreeTransaction<T>(action: () => T | Promise<T>): Promise<T> {
+	const previous = worktreeTurn;
+	let release!: () => void;
+	worktreeTurn = new Promise<void>((resolve) => { release = resolve; });
+	await previous;
+	try {
+		if (setupPoison) throw new Error(`Worktree mutation blocked: ${setupPoison}`);
+		return await action();
+	} finally { release(); }
+}
+
+class SetupTransaction {
+	readonly progress: WorktreeSetupProgress;
+	readonly options: CreateWorktreesOptions;
+	constructor(cwd: string, options: CreateWorktreesOptions) {
+		this.options = options;
+		this.progress = { setup: { cwd, baseCommit: "", worktrees: [] }, attempts: [], phase: "preflight" };
+	}
+	snapshot(): WorktreeSetupProgress {
+		return structuredClone(this.progress);
+	}
+	publish(): void { this.options.onProgress?.(this.snapshot()); }
+	check(): void {
+		if (setupPoison) throw new Error(setupPoison);
+		if (this.options.signal?.aborted) throw new Error("Worktree setup aborted");
+		if (this.options.deadlineAt !== undefined && Date.now() >= this.options.deadlineAt) throw new Error("Worktree setup deadline exceeded");
+	}
+	unknown(error: unknown): void {
+		const reason = error instanceof Error ? error.message : String(error);
+		this.progress.unknown ??= reason;
+		setupPoison ??= reason;
+	}
+	async command(command: string, args: string[], options: SetupCommandOptions = {}): Promise<SetupCommandResult> {
+		this.check();
+		this.progress.command = { command, args };
+		if (this.progress.phase === "allocation") this.progress.attempts.at(-1)!.command = this.progress.command;
+		if (this.progress.phase === "hook") this.progress.attempts.find((attempt) => attempt.path === options.cwd)!.hookCommand = this.progress.command;
+		this.publish();
+		const result = await runSetupCommand(command, args, {
+			...options, signal: this.options.signal, deadlineAt: this.options.deadlineAt,
+			onSpawn: (process) => { Object.assign(this.progress.command!, process); this.publish(); },
+		});
+		const { stdout: _stdout, stderr: _stderr, ...metadata } = result;
+		this.progress.command.result = metadata;
+		if (result.processTree?.state === "unknown") this.unknown(result.error ?? "Command tree settlement unverified");
+		this.publish();
+		if (result.error) throw result.error;
+		return result;
+	}
+	async git(cwd: string, args: string[], acceptedExitCodes?: readonly number[]): Promise<SetupCommandResult> {
+		return this.command("git", ["-C", cwd, ...args], { acceptedExitCodes });
+	}
+	async gitChecked(cwd: string, args: string[]): Promise<string> {
+		const result = await this.git(cwd, args);
+		if (result.status !== 0) throw new Error(result.stderr.trim() || result.stdout.trim() || `git ${args.join(" ")} failed`);
+		return result.stdout;
+	}
+	attempt(index: number, branch: string, worktreePath?: string): void {
+		this.check();
+		this.progress.phase = "allocation";
+		this.progress.command = undefined;
+		this.progress.attempts.push({ index, branch, path: worktreePath, validated: false });
+		this.publish();
+	}
+	validated(worktree: WorktreeInfo): void {
+		this.progress.phase = "validated";
+		Object.assign(this.progress.attempts.at(-1)!, { path: worktree.path, validated: true });
+		this.progress.setup.worktrees.push(worktree);
+		this.publish();
+	}
+}
+
 function runGit(cwd: string, args: string[], env?: NodeJS.ProcessEnv): GitResult {
 	const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8", windowsHide: true, shell: false, ...(env ? { env: { ...process.env, ...env } } : {}) });
 	return {
@@ -198,6 +302,7 @@ export function validateWorktreePatch(worktreePath: string, patchPath: string): 
 }
 
 function currentWorktreePatch(worktreePath: string, baseCommit: string): { patch: string } | { error: string } {
+	assertWorktreeMutationAllowed();
 	let tempDir: string;
 	try {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-index-"));
@@ -237,33 +342,29 @@ export function validateWorktreePatchRepresentsCurrentWorktree(worktreePath: str
 	return undefined;
 }
 
-function findGitWorktreePath(cwd: string, branch: string): string | undefined {
-	const targetBranch = `branch refs/heads/${branch}`;
-	let currentPath: string | undefined;
-	for (const line of runGitChecked(cwd, ["worktree", "list", "--porcelain"]).split("\n")) {
-		if (line.startsWith("worktree ")) currentPath = line.slice("worktree ".length).trim();
-		else if (line.trim() === targetBranch) return currentPath;
-	}
-	return undefined;
-}
-
-function resolveRepoState(cwd: string, requestedBaseRef: string | undefined): RepoState {
-	const cwdRelative = resolveRepoCwdRelative(cwd);
-	const toplevel = runGitChecked(cwd, ["rev-parse", "--show-toplevel"]).trim();
+async function resolveRepoState(tx: SetupTransaction, cwd: string, requestedBaseRef: string | undefined): Promise<RepoState> {
+	const repoCheck = await tx.git(cwd, ["rev-parse", "--is-inside-work-tree"], [0, 128]);
+	if (repoCheck.status !== 0 || repoCheck.stdout.trim() !== "true") throw new Error("worktree isolation requires a git repository");
+	const rawPrefix = (await tx.gitChecked(cwd, ["rev-parse", "--show-prefix"])).trim();
+	const cwdRelative = rawPrefix ? path.normalize(rawPrefix.replace(/[\\/]+$/, "")) : "";
+	const toplevel = (await tx.gitChecked(cwd, ["rev-parse", "--show-toplevel"])).trim();
 
 	// pi-subagents writes durable runtime state under .pi/subagents/ by default;
 	// that state must not make managed isolation unusable for later runs.
-	const status = runGitChecked(toplevel, ["status", "--porcelain", "--", `:!${PROJECT_SUBAGENTS_RELATIVE_DIR}`]);
+	const status = await tx.gitChecked(toplevel, ["status", "--porcelain", "--", `:!${PROJECT_SUBAGENTS_RELATIVE_DIR}`]);
 	if (status.trim().length > 0) {
 		throw new Error("worktree isolation requires a clean git working tree. Commit or stash changes first.");
 	}
 
-	const sourceHead = runGitChecked(toplevel, ["rev-parse", "HEAD"]).trim();
-	const sourceCheckout = snapshotSourceCheckout(toplevel, sourceHead);
+	const sourceHead = (await tx.gitChecked(toplevel, ["rev-parse", "HEAD"])).trim();
+	const sourceBranch = await tx.git(toplevel, ["symbolic-ref", "--quiet", "--short", "HEAD"], [0, 1]);
+	const sourceCheckout = { head: sourceHead, ...(sourceBranch.status === 0 ? { branch: sourceBranch.stdout.trim() } : {}) };
 	const baseRef = normalizeWorktreeBaseRef(requestedBaseRef) ?? DEFAULT_WORKTREE_BASE_REF;
 	let baseCommit: string;
 	try {
-		baseCommit = runGitChecked(toplevel, ["rev-parse", "--verify", "--end-of-options", `${baseRef}^{commit}`]).trim();
+		const base = await tx.git(toplevel, ["rev-parse", "--verify", "--end-of-options", `${baseRef}^{commit}`], [0, 128]);
+		if (base.status !== 0) throw new Error(base.stderr.trim() || "ref not found");
+		baseCommit = base.stdout.trim();
 	} catch (error) {
 		throw new Error(`baseRef '${baseRef}' could not be resolved to a commit: ${error instanceof Error ? error.message : String(error)}`, { cause: error instanceof Error ? error : undefined });
 	}
@@ -473,18 +574,6 @@ function probeWorktrunk(): WorktrunkCapability {
 	return { available: true };
 }
 
-function snapshotSourceCheckout(toplevel: string, head: string): SourceCheckoutSnapshot {
-	const branch = runGit(toplevel, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
-	const branchName = branch.status === 0 ? branch.stdout.trim() : "";
-	return branchName ? { head, branch: branchName } : { head };
-}
-
-function restoreSourceCheckoutIfWorktrunkSwitchedIt(toplevel: string, createdBranch: string, sourceCheckout: SourceCheckoutSnapshot): void {
-	const current = runGit(toplevel, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
-	if (current.status !== 0 || current.stdout.trim() !== createdBranch) return;
-	runGitChecked(toplevel, sourceCheckout.branch ? ["checkout", sourceCheckout.branch] : ["checkout", "--detach", sourceCheckout.head]);
-}
-
 /** Resolve a requested provider without silently switching after allocation starts. */
 export function resolveWorktreeProvider(requested: WorktreeProvider | undefined, baseDir?: string): ManagedWorktreeProvider {
 	const selection = requested ?? DEFAULT_WORKTREE_PROVIDER;
@@ -501,6 +590,33 @@ export function resolveWorktreeProvider(requested: WorktreeProvider | undefined,
 }
 
 /** Whether a launch must bind its worktree-dependent paths after allocation. */
+async function resolveSetupProvider(tx: SetupTransaction, requested: WorktreeProvider | undefined, baseDir?: string): Promise<ManagedWorktreeProvider> {
+	const selection = requested ?? DEFAULT_WORKTREE_PROVIDER;
+	if (selection !== "auto" && selection !== "native" && selection !== "worktrunk") throw new Error('worktree provider must be "auto", "native", or "worktrunk"');
+	if (selection === "native") return "native";
+	if (hasConfiguredWorktreeBaseDir(baseDir)) {
+		if (selection === "worktrunk") throw new Error("worktreeProvider='worktrunk' cannot be combined with worktreeBaseDir or PI_SUBAGENTS_WORKTREE_DIR");
+		return "native";
+	}
+	let reason: string | undefined;
+	try {
+		const probeExitCodes = Array.from({ length: 256 }, (_, code) => code);
+		const version = await tx.command("wt", ["--version"], { maxBuffer: WORKTREE_COMMAND_OUTPUT_MAX_BYTES, acceptedExitCodes: probeExitCodes });
+		if (version.status !== 0 || !/\b(?:wt\s+)?v?(\d+\.\d+(?:\.\d+)?)\b/i.test(version.stdout.trim())) reason = "Worktrunk is unavailable or returned an invalid version";
+		else {
+			const help = await tx.command("wt", ["switch", "--help"], { maxBuffer: WORKTREE_COMMAND_OUTPUT_MAX_BYTES, acceptedExitCodes: probeExitCodes });
+			const missing = ["--create", "--base", "--no-cd", "--no-hooks", "--format"].filter((flag) => !`${help.stdout}\n${help.stderr}`.includes(flag));
+			if (help.status !== 0 || missing.length) reason = `Worktrunk switch capability unavailable: ${missing.join(", ")}`;
+		}
+	} catch (error) {
+		if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+		reason = error.message;
+	}
+	if (!reason) return "worktrunk";
+	if (selection === "worktrunk") throw new Error(`Worktrunk provider is unavailable: ${reason}`);
+	return "native";
+}
+
 export function shouldDeferWorktreeCwd(requested: WorktreeProvider | undefined, baseDir?: string): boolean {
 	return (requested ?? DEFAULT_WORKTREE_PROVIDER) !== "native" && !hasConfiguredWorktreeBaseDir(baseDir);
 }
@@ -677,11 +793,6 @@ function normalizeSyntheticPath(worktreePath: string, rawPath: string): string {
 	return path.normalize(relative);
 }
 
-function hasTrackedEntries(worktreePath: string, relativePath: string): boolean {
-	const result = runGit(worktreePath, ["ls-files", "--", relativePath]);
-	return result.status === 0 && result.stdout.trim().length > 0;
-}
-
 function parseWorktreeSetupHookOutput(rawStdout: string): WorktreeSetupHookOutput {
 	const trimmed = rawStdout.trim();
 	if (!trimmed) {
@@ -700,53 +811,58 @@ function parseWorktreeSetupHookOutput(rawStdout: string): WorktreeSetupHookOutpu
 	return parsed as WorktreeSetupHookOutput;
 }
 
-function runWorktreeSetupHook(
+async function runWorktreeSetupHook(
+	tx: SetupTransaction,
 	hook: ResolvedWorktreeSetupHook,
 	input: WorktreeSetupHookInput,
-): string[] {
-	const result = spawnSync(hook.hookPath, [], {
-		windowsHide: true,
-		cwd: input.worktreePath,
-		encoding: "utf-8",
-		input: JSON.stringify(input),
-		timeout: hook.timeoutMs,
-		shell: false,
-	});
-
-	if (result.error) {
-		const code = "code" in result.error ? result.error.code : undefined;
+): Promise<string[]> {
+	tx.progress.phase = "hook";
+	let result: SetupCommandResult;
+	try {
+		result = await tx.command(hook.hookPath, [], {
+			cwd: input.worktreePath,
+			input: JSON.stringify(input),
+			hookTimeoutMs: hook.timeoutMs,
+		});
+	} catch (error) {
+		const code = error instanceof Error && "code" in error ? error.code : undefined;
 		if (code === "ETIMEDOUT") {
 			throw new Error(`worktree setup hook timed out after ${hook.timeoutMs}ms`);
 		}
-		throw new Error(`worktree setup hook failed: ${result.error.message}`);
+		throw new Error(`worktree setup hook failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
 	}
+	tx.progress.phase = "hook-validation";
 
 	if (result.status !== 0) {
 		const details = result.stderr.trim() || result.stdout.trim() || "no output";
 		throw new Error(`worktree setup hook failed with exit code ${result.status}: ${details}`);
 	}
 
-	const output = parseWorktreeSetupHookOutput(result.stdout);
-	if (output.syntheticPaths === undefined) return [];
-	if (!Array.isArray(output.syntheticPaths)) {
-		throw new Error("worktree setup hook output field 'syntheticPaths' must be an array of relative paths");
-	}
-
-	const uniquePaths = new Set<string>();
-	for (const candidate of output.syntheticPaths) {
-		if (typeof candidate !== "string") {
-			throw new Error("worktree setup hook output field 'syntheticPaths' must contain only strings");
+	try {
+		const output = parseWorktreeSetupHookOutput(result.stdout);
+		if (output.syntheticPaths === undefined) return [];
+		if (!Array.isArray(output.syntheticPaths)) {
+			throw new Error("worktree setup hook output field 'syntheticPaths' must be an array of relative paths");
 		}
-		const normalizedPath = normalizeSyntheticPath(input.worktreePath, candidate);
-		if (hasTrackedEntries(input.worktreePath, normalizedPath)) {
-			throw new Error(`worktree setup hook cannot mark tracked paths as synthetic: ${normalizedPath}`);
+		const uniquePaths = new Set<string>();
+		for (const candidate of output.syntheticPaths) {
+			if (typeof candidate !== "string") throw new Error("worktree setup hook output field 'syntheticPaths' must contain only strings");
+			const normalizedPath = normalizeSyntheticPath(input.worktreePath, candidate);
+			if ((await tx.gitChecked(input.worktreePath, ["ls-files", "--", normalizedPath])).trim()) {
+				throw new Error(`worktree setup hook cannot mark tracked paths as synthetic: ${normalizedPath}`);
+			}
+			uniquePaths.add(normalizedPath);
 		}
-		uniquePaths.add(normalizedPath);
+		return [...uniquePaths];
+	} catch (error) {
+		// Semantic rejection occurs after exit: retain uncertainty, never signal an old PID.
+		tx.unknown(error);
+		throw error;
 	}
-	return [...uniquePaths];
 }
 
-function finalizeCreatedWorktree(
+async function finalizeCreatedWorktree(
+	tx: SetupTransaction,
 	toplevel: string,
 	cwdRelative: string,
 	runId: string,
@@ -754,38 +870,23 @@ function finalizeCreatedWorktree(
 	setupHook: ResolvedWorktreeSetupHook | undefined,
 	agent: string | undefined,
 	worktree: WorktreeInfo,
-): WorktreeInfo {
+): Promise<WorktreeInfo> {
 	const agentCwd = cwdRelative ? path.join(worktree.path, cwdRelative) : worktree.path;
-	try {
-		const nodeModulesLinked = linkNodeModulesIfPresent(toplevel, worktree.path);
-		const syntheticPaths = nodeModulesLinked ? ["node_modules"] : [];
-		if (setupHook) {
-			const hookSyntheticPaths = runWorktreeSetupHook(setupHook, {
-				version: 1,
-				repoRoot: toplevel,
-				worktreePath: worktree.path,
-				agentCwd,
-				branch: worktree.branch,
-				index: worktree.index,
-				runId,
-				baseCommit,
-				agent,
-			});
-			syntheticPaths.push(...hookSyntheticPaths);
-		}
-		return { ...worktree, agentCwd, nodeModulesLinked, syntheticPaths };
-	} catch (error) {
-		try { runGitChecked(toplevel, ["worktree", "remove", "--force", worktree.path]); } catch {
-			// Best-effort rollback; preserve the original setup failure.
-		}
-		try { runGitChecked(toplevel, ["branch", "-D", worktree.branch]); } catch {
-			// Best-effort rollback; preserve the original setup failure.
-		}
-		throw error;
+	tx.check();
+	const nodeModulesLinked = linkNodeModulesIfPresent(toplevel, worktree.path);
+	const syntheticPaths = nodeModulesLinked ? ["node_modules"] : [];
+	if (setupHook) {
+		const hookSyntheticPaths = await runWorktreeSetupHook(tx, setupHook, {
+			version: 1, repoRoot: toplevel, worktreePath: worktree.path, agentCwd,
+			branch: worktree.branch, index: worktree.index, runId, baseCommit, agent,
+		});
+		syntheticPaths.push(...hookSyntheticPaths);
 	}
+	return { ...worktree, agentCwd, nodeModulesLinked, syntheticPaths };
 }
 
-function createNativeWorktree(
+async function createNativeWorktree(
+	tx: SetupTransaction,
 	toplevel: string,
 	cwdRelative: string,
 	runId: string,
@@ -797,17 +898,24 @@ function createNativeWorktree(
 	labels: Array<string | undefined> | undefined,
 	tasks: Array<string | undefined> | undefined,
 	branchPrefix: string | undefined,
-): WorktreeInfo {
+): Promise<WorktreeInfo> {
 	const naming = buildWorktreeNaming({ runId, index, agent, label: labels?.[index], task: tasks?.[index], branchPrefix });
 	const worktreePath = buildNativeWorktreePath(dedicatedRoot, toplevel, runId, index);
 	assertSafeWorktreeLocation(worktreePath, toplevel, dedicatedRoot);
+	// Absence is required before claiming any partial artifacts from this attempt.
+	const branch = await tx.git(toplevel, ["show-ref", "--verify", "--quiet", `refs/heads/${naming.requestedBranch}`], [0, 1]);
+	let pathExists = false;
+	try { fs.lstatSync(worktreePath); pathExists = true; }
+	catch (error) { if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error; }
+	if (branch.status !== 1 || pathExists) throw new Error(`worktree path or branch already exists: ${worktreePath}, ${naming.requestedBranch}`);
+	tx.attempt(index, naming.requestedBranch, worktreePath);
 	ensureProjectWorktreeDir(dedicatedRoot, toplevel);
-	const add = runGit(toplevel, ["worktree", "add", worktreePath, "-b", naming.requestedBranch, baseCommit]);
+	const add = await tx.git(toplevel, ["worktree", "add", worktreePath, "-b", naming.requestedBranch, baseCommit]);
 	if (add.status !== 0) {
 		const message = add.stderr.trim() || add.stdout.trim() || `failed to create worktree ${worktreePath}`;
 		throw new Error(message);
 	}
-	return finalizeCreatedWorktree(toplevel, cwdRelative, runId, baseCommit, setupHook, agent, {
+	const worktree: WorktreeInfo = {
 		path: worktreePath,
 		agentCwd: worktreePath,
 		branch: naming.requestedBranch,
@@ -816,7 +924,9 @@ function createNativeWorktree(
 		syntheticPaths: [],
 		provider: "native",
 		naming,
-	});
+	};
+	tx.validated(worktree);
+	return finalizeCreatedWorktree(tx, toplevel, cwdRelative, runId, baseCommit, setupHook, agent, worktree);
 }
 
 interface WorktrunkSwitchOutput {
@@ -841,21 +951,23 @@ function parseWorktrunkSwitchOutput(rawStdout: string): WorktrunkSwitchOutput {
 	return parsed as WorktrunkSwitchOutput;
 }
 
-function createWorktrunkWorktree(
+async function createWorktrunkWorktree(
+	tx: SetupTransaction,
 	toplevel: string,
 	cwdRelative: string,
 	runId: string,
 	index: number,
 	baseCommit: string,
-	sourceCheckout: SourceCheckoutSnapshot,
 	agents: string[] | undefined,
 	labels: Array<string | undefined> | undefined,
 	tasks: Array<string | undefined> | undefined,
 	branchPrefix: string | undefined,
-): WorktreeInfo {
+): Promise<WorktreeInfo> {
 	const naming = buildWorktreeNaming({ runId, index, agent: agents?.[index], label: labels?.[index], task: tasks?.[index], branchPrefix });
 	const args = ["-C", toplevel, "switch", "--create", naming.requestedBranch, "--base", baseCommit, "--no-cd", "--no-hooks", "--format", "json"];
-	const result = runWorktrunk(args, toplevel);
+	tx.attempt(index, naming.requestedBranch);
+	const result = await tx.command("wt", args, { cwd: toplevel, maxBuffer: WORKTREE_COMMAND_OUTPUT_MAX_BYTES });
+	tx.progress.phase = "validation";
 	if (result.status !== 0) {
 		const message = result.error?.message || result.stderr.trim() || result.stdout.trim() || "Worktrunk provisioning failed";
 		throw new Error(`Worktrunk provisioning failed: ${message}`);
@@ -881,16 +993,16 @@ function createWorktrunkWorktree(
 		if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Worktrunk provisioning returned a path that is not a real directory");
 		const worktreePath = normalizeComparableCwd(worktreePathCandidate);
 		if (worktreePath === normalizeComparableCwd(toplevel)) throw new Error("Worktrunk provisioning returned the source checkout path");
-		const sourceCommonDirRaw = runGitChecked(toplevel, ["rev-parse", "--git-common-dir"]).trim();
-		const returnedCommonDirRaw = runGitChecked(worktreePath, ["rev-parse", "--git-common-dir"]).trim();
+		const sourceCommonDirRaw = (await tx.gitChecked(toplevel, ["rev-parse", "--git-common-dir"])).trim();
+		const returnedCommonDirRaw = (await tx.gitChecked(worktreePath, ["rev-parse", "--git-common-dir"])).trim();
 		const sourceCommonDir = normalizeComparableCwd(path.isAbsolute(sourceCommonDirRaw) ? sourceCommonDirRaw : path.resolve(toplevel, sourceCommonDirRaw));
 		const returnedCommonDir = normalizeComparableCwd(path.isAbsolute(returnedCommonDirRaw) ? returnedCommonDirRaw : path.resolve(worktreePath, returnedCommonDirRaw));
 		if (returnedCommonDir !== sourceCommonDir) throw new Error("Worktrunk provisioning returned a worktree for a different repository");
-		const returnedBranch = runGitChecked(worktreePath, ["symbolic-ref", "--quiet", "--short", "HEAD"]).trim();
+		const returnedBranch = (await tx.gitChecked(worktreePath, ["symbolic-ref", "--quiet", "--short", "HEAD"])).trim();
 		if (returnedBranch !== naming.requestedBranch) throw new Error("Worktrunk provisioning returned a worktree on a different branch");
-		const returnedHead = runGitChecked(worktreePath, ["rev-parse", "HEAD"]).trim();
+		const returnedHead = (await tx.gitChecked(worktreePath, ["rev-parse", "HEAD"])).trim();
 		if (returnedHead !== baseCommit) throw new Error("Worktrunk provisioning returned a worktree at a different base commit");
-		return {
+		const worktree: WorktreeInfo = {
 			path: worktreePath,
 			agentCwd: cwdRelative ? path.join(worktreePath, cwdRelative) : worktreePath,
 			branch: naming.requestedBranch,
@@ -900,35 +1012,16 @@ function createWorktrunkWorktree(
 			provider: "worktrunk",
 			naming,
 		};
+		tx.validated(worktree);
+		return worktree;
 	} catch (error) {
-		if (createdAllocation) {
-			try { restoreSourceCheckoutIfWorktrunkSwitchedIt(toplevel, naming.requestedBranch, sourceCheckout); } catch {
-				// Best-effort rollback; preserve the validation failure.
-			}
-			try {
-				const listedPath = findGitWorktreePath(toplevel, naming.requestedBranch);
-				const candidates = [listedPath, returnedPath].filter((candidate, candidateIndex, all): candidate is string => Boolean(candidate) && all.indexOf(candidate) === candidateIndex);
-				for (const candidate of candidates) {
-					if (normalizeComparableCwd(candidate) === normalizeComparableCwd(toplevel)) continue;
-					try {
-						runGitChecked(toplevel, ["worktree", "remove", "--force", candidate]);
-						break;
-					} catch {
-						// Try another provider-reported/listed path before giving up.
-					}
-				}
-			} catch {
-				// Best-effort rollback; preserve the validation failure.
-			}
-			try { runGitChecked(toplevel, ["branch", "-D", naming.requestedBranch]); } catch {
-				// Best-effort rollback; preserve the validation failure.
-			}
-		}
+		tx.unknown(error);
 		throw error;
 	}
 }
 
 function removeSyntheticPath(worktree: WorktreeInfo, syntheticPath: string): void {
+	assertWorktreeMutationAllowed();
 	const resolved = path.resolve(worktree.path, syntheticPath);
 	const relative = path.relative(worktree.path, resolved);
 	if (!relative || relative === "." || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
@@ -1193,39 +1286,94 @@ function hasWorktreeChanges(diff: WorktreeDiff): boolean {
 	return diff.filesChanged > 0 || diff.insertions > 0 || diff.deletions > 0 || diff.diffStat.trim().length > 0;
 }
 
-export function createWorktrees(cwd: string, runId: string, count: number, options?: CreateWorktreesOptions): WorktreeSetup {
+async function compensateSetup(tx: SetupTransaction): Promise<WorktreeCleanupReport> {
+	const { setup, attempts } = tx.progress;
+	const report: WorktreeCleanupReport = { state: "partial", tasks: [], pruned: false, errors: [] };
+	tx.progress.cleanup = report;
+	tx.progress.phase = "rollback";
+	// Cancellation stops allocation, not accounting. Compensation has ONLY the
+	// remaining original absolute deadline; it does not reuse the launch signal.
+	const git = async (args: string[], acceptedExitCodes: readonly number[] = [0]) => {
+		if (setupPoison) throw new Error(setupPoison);
+		tx.progress.command = { command: "git", args: ["-C", setup.cwd, ...args] };
+		tx.publish();
+		const result = await runSetupCommand("git", tx.progress.command.args, {
+			deadlineAt: tx.options.deadlineAt, acceptedExitCodes,
+			onSpawn: (process) => { Object.assign(tx.progress.command!, process); tx.publish(); },
+		});
+		tx.progress.command.result = result;
+		if (result.processTree?.state === "unknown") tx.unknown(result.error ?? "Rollback command settlement unverified");
+		tx.publish();
+		if (result.error || result.status === null || !acceptedExitCodes.includes(result.status)) throw result.error ?? new Error(result.stderr.trim() || "Rollback command failed");
+		return result;
+	};
+	for (const attempt of [...attempts].reverse()) {
+		if (!attempt.path) {
+			tx.unknown(`Allocation path unconfirmed for branch ${attempt.branch}`);
+			report.errors!.push(tx.progress.unknown!);
+			continue;
+		}
+		const known = setup.worktrees.find((worktree) => worktree.index === attempt.index);
+		const task: WorktreeCleanupTask = { index: attempt.index, path: attempt.path, branch: attempt.branch,
+			provider: known?.provider ?? "native", naming: known?.naming, worktreeRemoved: false, branchRemoved: false };
+		report.tasks.push(task);
+		try {
+			if (normalizeComparableCwd(attempt.path) === normalizeComparableCwd(setup.cwd)) throw new Error("Refusing source-checkout removal");
+			if (attempt.validated) {
+				await git(["worktree", "remove", "--force", attempt.path]);
+				task.worktreeRemoved = true;
+			} else {
+				// Native attempts were absent before mutation. Reconcile only exact
+				// registered path/branch identity; never recursively delete a guessed leaf.
+				const listed = (await git(["worktree", "list", "--porcelain"])).stdout;
+				const entry = listed.split("\n\n").find((block) => block.split("\n").includes(`worktree ${attempt.path}`));
+				if (entry) {
+					if (!entry.split("\n").includes(`branch refs/heads/${attempt.branch}`)) {
+						tx.unknown("Partial allocation ownership mismatch");
+						throw new Error(tx.progress.unknown);
+					}
+					await git(["worktree", "remove", "--force", attempt.path]);
+				} else if (fs.existsSync(attempt.path)) {
+					tx.unknown("Unregistered partial allocation retained");
+					throw new Error(tx.progress.unknown);
+				}
+				task.worktreeRemoved = true;
+			}
+			const branch = await git(["show-ref", "--verify", "--quiet", `refs/heads/${attempt.branch}`], [0, 1]);
+			if (branch.status === 0) await git(["branch", "-D", attempt.branch]);
+			task.branchRemoved = true;
+		} catch (error) {
+			task.preserved = true;
+			task.errors = [error instanceof Error ? error.message : String(error)];
+		}
+	}
+	try {
+		if (attempts.length > 0) { await git(["worktree", "prune"]); report.pruned = true; }
+	} catch (error) { report.errors!.push(error instanceof Error ? error.message : String(error)); }
+	if (tx.progress.unknown) report.errors!.push(tx.progress.unknown);
+	report.tasks.sort((a, b) => a.index - b.index);
+	if (!setupPoison && (report.pruned || attempts.length === 0) && report.tasks.every((task) => task.worktreeRemoved && task.branchRemoved) && !report.errors!.length) report.state = "complete";
+	return report;
+}
+
+async function allocateWorktrees(tx: SetupTransaction, cwd: string, runId: string, count: number): Promise<WorktreeSetup> {
+	const options = tx.options;
+	tx.check();
 	if (!Number.isSafeInteger(count) || count < 0) throw new Error("worktree count must be a non-negative integer");
-	const repo = resolveRepoState(cwd, options?.baseRef);
+	const repo = await resolveRepoState(tx, cwd, options?.baseRef);
+	tx.progress.setup.cwd = repo.toplevel;
+	tx.progress.setup.baseCommit = repo.baseCommit;
 	const setupHook = resolveWorktreeSetupHook(repo.toplevel, options?.setupHook);
-	const provider = resolveWorktreeProvider(options?.provider, options?.baseDir);
+	const provider = await resolveSetupProvider(tx, options?.provider, options?.baseDir);
 	const branchPrefix = normalizeWorktreeBranchPrefix(options?.branchPrefix);
 	const dedicatedRoot = provider === "native" ? resolveWorktreeDedicatedRoot(options?.baseDir, repo.toplevel) : undefined;
-	const worktrees: WorktreeInfo[] = [];
+	const worktrees = tx.progress.setup.worktrees;
 
 	try {
 		if (provider === "native") {
-			const plannedSetup: WorktreeSetup = {
-				cwd: repo.toplevel,
-				baseCommit: repo.baseCommit,
-				worktrees: Array.from({ length: count }, (_, index) => {
-					const naming = buildWorktreeNaming({ runId, index, agent: options?.agents?.[index], label: options?.labels?.[index], task: options?.tasks?.[index], branchPrefix });
-					const worktreePath = buildNativeWorktreePath(dedicatedRoot!, repo.toplevel, runId, index);
-					assertSafeWorktreeLocation(worktreePath, repo.toplevel, dedicatedRoot!);
-					return {
-						path: worktreePath,
-						agentCwd: repo.cwdRelative ? path.join(worktreePath, repo.cwdRelative) : worktreePath,
-						branch: naming.requestedBranch,
-						index,
-						nodeModulesLinked: false,
-						syntheticPaths: [],
-						provider: "native",
-						naming,
-					};
-				}),
-			};
-			options?.beforeCreate?.(plannedSetup);
 			for (let index = 0; index < count; index++) {
-				worktrees.push(createNativeWorktree(
+				worktrees[index] = await createNativeWorktree(
+					tx,
 					repo.toplevel,
 					repo.cwdRelative,
 					runId,
@@ -1237,28 +1385,26 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 					options?.labels,
 					options?.tasks,
 					branchPrefix,
-				));
+				);
 			}
 		} else {
 			for (let index = 0; index < count; index++) {
-				worktrees.push(createWorktrunkWorktree(
+				await createWorktrunkWorktree(
+					tx,
 					repo.toplevel,
 					repo.cwdRelative,
 					runId,
 					index,
 					repo.baseCommit,
-					repo.sourceCheckout,
 					options?.agents,
 					options?.labels,
 					options?.tasks,
 					branchPrefix,
-				));
+				);
 			}
-			// Worktrunk determines its path only after creation. Journal the exact
-			// returned ownership before Pi runs setup hooks or launches a child.
-			options?.beforeCreate?.({ cwd: repo.toplevel, baseCommit: repo.baseCommit, worktrees: [...worktrees] });
 			for (let index = 0; index < worktrees.length; index++) {
-				worktrees[index] = finalizeCreatedWorktree(
+				worktrees[index] = await finalizeCreatedWorktree(
+					tx,
 					repo.toplevel,
 					repo.cwdRelative,
 					runId,
@@ -1269,23 +1415,37 @@ export function createWorktrees(cwd: string, runId: string, count: number, optio
 				);
 			}
 		}
+		tx.check();
+		tx.progress.phase = "ready";
+		tx.publish();
+		tx.check();
+		return tx.progress.setup;
 	} catch (error) {
-		cleanupWorktrees({
-			cwd: repo.toplevel,
-			worktrees,
-			baseCommit: repo.baseCommit,
-		}, { kind: "setup-rollback" });
+		await compensateSetup(tx);
 		throw error;
 	}
+}
 
-	return {
-		cwd: repo.toplevel,
-		worktrees,
-		baseCommit: repo.baseCommit,
-	};
+export async function createWorktrees(cwd: string, runId: string, count: number, options: CreateWorktreesOptions = {}): Promise<WorktreeSetup> {
+	const tx = new SetupTransaction(cwd, options);
+	try {
+		return await withWorktreeTransaction(async () => {
+			setupActive = true;
+			try { return await allocateWorktrees(tx, cwd, runId, count); }
+			finally { setupActive = false; }
+		});
+	} catch (error) {
+		if (setupPoison) tx.progress.unknown ??= setupPoison;
+		tx.progress.cleanup ??= { state: tx.progress.unknown ? "partial" : "complete", tasks: [], pruned: false, errors: tx.progress.unknown ? [tx.progress.unknown] : [] };
+		try { tx.publish(); } catch (publicationError) {
+			tx.progress.cleanup?.errors?.push(`Recovery publication failed: ${String(publicationError)}`);
+		}
+		throw new WorktreeSetupError(error, tx.snapshot());
+	}
 }
 
 export function diffWorktrees(setup: WorktreeSetup, agents: string[], diffsDir: string): WorktreeDiff[] {
+	assertWorktreeMutationAllowed();
 	try {
 		fs.mkdirSync(diffsDir, { recursive: true });
 	} catch {
@@ -1315,6 +1475,7 @@ export function cleanupWorktrees(
 	setup: WorktreeSetup,
 	intent: WorktreeCleanupIntent = { kind: "preserve", ...(setup.capturedDiffs ? { capturedDiffs: setup.capturedDiffs } : {}) },
 ): WorktreeCleanupReport {
+	assertWorktreeMutationAllowed();
 	const tasks: WorktreeCleanupTask[] = [];
 	for (let index = setup.worktrees.length - 1; index >= 0; index--) {
 		tasks.push(cleanupSingleWorktree(setup, setup.worktrees[index]!, intent));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2373,7 +2373,7 @@ export interface RunSyncOptions {
 	/** Internal foreground receipt proposal; returns true only when the outer waiter accepted it. */
 	onDetachReceipt?: (result: SingleResult) => boolean;
 	/** Authoritative terminal result, emitted only after the full detached run finalizes. */
-	onDetachedExit?: (result: SingleResult) => void;
+	onDetachedExit?: (result: SingleResult) => void | Promise<void>;
 	controlConfig?: ResolvedControlConfig;
 	intercomSessionName?: string;
 	orchestratorIntercomTarget?: string;

--- a/test/integration/async-execution.part-4.test.ts
+++ b/test/integration/async-execution.part-4.test.ts
@@ -9,11 +9,16 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { once } from "node:events";
+import { createServer, type Socket } from "node:net";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { setChildSessionFactoryModule } from "../../src/runs/shared/child-session.ts";
-import { createEventBus, events, makeAgent, removeTempDir } from "../support/helpers.ts";
+import { createEventBus, createTempDir, events, makeAgent, removeTempDir } from "../support/helpers.ts";
+import { deliverInterruptRequest, deliverStopRequest } from "../../src/runs/background/control-channel.ts";
+import { SUBAGENT_PROCESS_TERMINAL_EVENT } from "../../src/shared/types.ts";
 import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
 import type { AsyncResultPayload, AsyncStatusPayload } from "../support/async-execution-fixture.ts";
 import {
@@ -153,6 +158,122 @@ export default function() {
 		assert.equal(report.terminal[0].state, "failed");
 		assert.deepEqual(report.terminal[1], report.terminal[0]);
 	});
+
+	for (const mode of ["success", "stop", "pause", "deadline", "failure-before-JSON"] as const) {
+		it(`background setup lifecycle: ${mode}`, { skip: !isAsyncAvailable() || process.platform === "win32" ? "requires real POSIX setup executable" : undefined, timeout: 25_000 }, async () => {
+			const repo = createRepo("pi-background-setup-");
+			const baseDir = createTempDir();
+			const id = `async-setup-${mode}-${Date.now().toString(36)}`;
+			const asyncDir = path.join(ASYNC_DIR, id);
+			const marker = path.join(repo, ".git", "child-launched");
+			const allocatorFailure = mode === "failure-before-JSON";
+			const oldPath = process.env.PATH;
+			const server = createServer();
+			server.listen(0, "127.0.0.1");
+			await once(server, "listening");
+			const { port } = server.address() as { port: number };
+			const hook = path.join(baseDir, allocatorFailure ? "wt" : "setup-hook.cjs");
+			fs.writeFileSync(hook, `#!${process.execPath}
+const args = process.argv.slice(2);
+if (args.includes('--version')) { console.log('wt v0.75.0'); process.exit(0); }
+if (args.includes('--help')) { console.log('--create --base --no-cd --no-hooks --format'); process.exit(0); }
+if (${allocatorFailure}) require('node:child_process').execFileSync('git', ['branch', args[args.indexOf('--create') + 1]], { cwd: ${JSON.stringify(repo)} });
+const socket = require('node:net').connect(${port}, '127.0.0.1', () => socket.write('ready'));
+socket.on('data', data => {
+ if (data.toString() === 'release') { socket.end(); if (${allocatorFailure}) process.exitCode = 1; else console.log('{}'); }
+});
+setTimeout(() => process.exit(90), 15000).unref();
+`, { mode: 0o755 });
+			if (allocatorFailure) process.env.PATH = `${baseDir}${path.delimiter}${oldPath}`;
+			const bus = createEventBus();
+			let closed = false;
+			const terminal = new Promise<unknown>((resolve) => bus.on(SUBAGENT_PROCESS_TERMINAL_EVENT, (proof) => { closed = true; resolve(proof); }));
+			let socket: Socket | undefined;
+			let started = false;
+			try {
+				mockPi.onCall({ output: "finite setup completed", writeFiles: [{ path: marker, content: "launched" }] });
+				const connection = once(server, "connection", { signal: AbortSignal.timeout(20_000) });
+				const receipt = executeAsyncChain(id, {
+					chain: [{ agent: "worker", task: "Do work", worktree: true }],
+					agents: [makeAgent("worker", { completionGuard: false })],
+					ctx: { pi: { events: bus }, cwd: repo, currentSessionId: "session-1" },
+					artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+					shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2, acceptance: false,
+					...(allocatorFailure ? { worktreeProvider: "worktrunk" } : { worktreeProvider: "native", worktreeBaseDir: path.join(baseDir, "trees"), worktreeSetupHook: hook }),
+					...(mode === "deadline" ? { timeoutMs: 4_000 } : {}),
+				});
+				assert.equal(receipt.isError, undefined, receipt.content[0]?.text);
+				started = true;
+				[socket] = await Promise.race([connection, terminal.then((proof) => { throw new Error(`Runner closed before setup ready: ${JSON.stringify(proof)}`); })]) as [Socket];
+				assert.equal((await once(socket, "data"))[0].toString(), "ready");
+				const held = await waitForAsyncState(id, (status) => Boolean(status.parallelHandoff));
+				assert.equal(closed, false);
+				assert.equal(mockPi.callCount(), 0);
+				assert.equal(fs.existsSync(marker), false);
+				if (mode === "stop") deliverStopRequest({ asyncDir, source: "test" });
+				else if (mode === "pause") deliverInterruptRequest({ asyncDir, source: "test" });
+				else if (mode !== "deadline") socket.write("release");
+				const payload = await readAsyncPayload(id);
+				const proof = await terminal;
+				const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8"));
+				const expected = mode === "success" ? "complete" : mode === "stop" ? "stopped" : mode === "pause" ? "paused" : "failed";
+				assert.equal(payload.state, expected);
+				assert.equal(status.state, expected);
+				assert.equal(status.steps[0].status, expected);
+				assert.equal(payload.success, mode === "success");
+				assert.equal(mockPi.callCount(), mode === "success" ? 1 : 0);
+				assert.equal(fs.existsSync(marker), mode === "success");
+				assert.ok(held.parallelHandoff?.path);
+				const handoff = JSON.parse(fs.readFileSync(held.parallelHandoff.path, "utf8"));
+				const group = handoff.groups[0];
+				if (allocatorFailure) {
+					assert.equal(status.steps[0].worktreePath, undefined);
+					assert.equal(status.steps[0].branch, undefined);
+					assert.deepEqual(group.cleanup.tasks, []);
+					assert.deepEqual(group.children, []);
+					assert.equal(group.cleanup.state, "partial");
+					assert.equal(group.cleanup.pruned, false);
+					assert.match(group.cleanup.errors.join("\n"), /manual reconciliation required/);
+					const attempt = group.cleanup.errors.find((entry: string) => entry.startsWith("Allocation attempt "));
+					const evidence = JSON.parse(attempt.slice("Allocation attempt ".length));
+					assert.equal(evidence.path, null);
+					assert.equal(evidence.validated, false);
+					assert.equal(evidence.command.status, 1);
+					assert.equal(evidence.command.processTree, "unknown");
+					assert.equal(execFileSync("git", ["branch", "--list", evidence.branch], { cwd: repo, encoding: "utf8" }).trim(), evidence.branch);
+					const persisted = JSON.parse(fs.readFileSync(path.join(asyncDir, "process-terminal.json"), "utf8"));
+					assert.equal(persisted.state, "unknown");
+					assert.equal(persisted.reason, "process-tree-unverified");
+					assert.deepEqual(proof, persisted, "actual runner close must not promote setup unknown with zero child writers");
+					const candidate = JSON.parse(fs.readFileSync(path.join(asyncDir, "process-terminal-candidate.json"), "utf8"));
+					assert.deepEqual(Object.values(candidate.writers).flat(), []);
+					assert.deepEqual(Object.values(candidate.expectedWriters), [0]);
+				} else if (mode === "deadline") {
+					assert.equal(payload.timedOut, true);
+					assert.equal(status.timedOut, true);
+					assert.ok(payload.deadlineAt! <= Date.now());
+					assert.equal(group.cleanup.pruned, false);
+					assert.equal(group.cleanup.tasks[0].preserved, true);
+					assert.equal(fs.existsSync(group.cleanup.tasks[0].path), true);
+				} else {
+					assert.equal(group.cleanup.state, "complete");
+					assert.equal(group.cleanup.tasks.length, 1);
+					assert.equal(group.cleanup.tasks[0].worktreeRemoved, true);
+					assert.equal(group.cleanup.tasks[0].branchRemoved, true);
+					assert.equal(fs.existsSync(group.cleanup.tasks[0].path), false);
+					assert.equal(execFileSync("git", ["branch", "--list", group.cleanup.tasks[0].branch], { cwd: repo, encoding: "utf8" }).trim(), "");
+				}
+			} finally {
+				socket?.end("release");
+				if (started && !closed) { deliverStopRequest({ asyncDir, source: "test-cleanup" }); await terminal; }
+				socket?.destroy();
+				await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+				if (oldPath === undefined) delete process.env.PATH; else process.env.PATH = oldPath;
+				removeTempDir(baseDir);
+				removeTempDir(repo);
+			}
+		});
+	}
 
 	it("does not start child work when initial async status cannot be written", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const id = `async-status-write-fail-${Date.now().toString(36)}`;

--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -23,6 +23,9 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
+import { createServer, type Socket } from "node:net";
+import { once } from "node:events";
+import { SUBAGENT_FOREGROUND_COMPLETE_EVENT } from "../../src/shared/types.ts";
 import {
 	createTempDir,
 	createEventBus,
@@ -66,6 +69,118 @@ import { toSubagentDelegationExecutionParams } from "../../src/slash/delegation-
 
 describe("single sync execution", { skip: !available ? "pi packages not available" : undefined }, () => {
 	installSingleExecutionHooks();
+
+	for (const mode of ["abort", "attached", "detached"] as const) {
+		it(`foreground setup lifecycle: ${mode}`, { skip: !createSubagentExecutor || process.platform === "win32" ? "requires real POSIX setup hook" : undefined, timeout: 20_000 }, async () => {
+			execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+			execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir });
+			execFileSync("git", ["config", "user.name", "Test User"], { cwd: tempDir });
+			fs.writeFileSync(path.join(tempDir, "base.txt"), "base\n");
+			execFileSync("git", ["add", "base.txt"], { cwd: tempDir });
+			execFileSync("git", ["commit", "-m", "base"], { cwd: tempDir, stdio: "ignore" });
+			const holdPath = path.join(tempDir, ".git", "hold-hook");
+			const releaseChild = path.join(tempDir, ".git", "release-child");
+			const launchMarker = path.join(tempDir, ".git", "model-launched.txt");
+			const server = createServer();
+			server.listen(0, "127.0.0.1");
+			await once(server, "listening");
+			const address = server.address() as { port: number };
+			const hook = path.join(tempDir, ".git", "setup-hook.cjs");
+			fs.writeFileSync(hook, `#!${process.execPath}\nconst fs = require('node:fs');
+if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
+ const socket = require('node:net').connect(${address.port}, '127.0.0.1', () => socket.write('ready'));
+ socket.on('data', data => { if (data.toString() === 'release') { socket.end(); console.log('{}'); } else socket.write('ack'); });
+ setTimeout(() => process.exit(90), 15000).unref();
+}\n`, { mode: 0o755 });
+			const baseDir = createTempDir();
+			const bus = createEventBus();
+			const executor = makeExecutor([makeAgent("worker", { systemPrompt: "Intercom orchestration channel:" })], { worktreeBaseDir: baseDir, worktreeSetupHook: hook }, false, { sessionId: "session-123", count: 0 }, true, new Map(), undefined, undefined, bus);
+			let notified = false;
+			let notify!: () => void;
+			const notification = new Promise<void>((resolve) => { notify = resolve; });
+			bus.on(SUBAGENT_FOREGROUND_COMPLETE_EVENT, () => { notified = true; notify(); });
+			const controller = new AbortController();
+			let socket: Socket | undefined;
+			let child: Promise<ExecutorToolResult> | undefined;
+			let setup: Promise<ExecutorToolResult> | undefined;
+			try {
+				let childSettled = false;
+				let childCompleted!: () => void;
+				const completed = new Promise<void>((resolve) => { childCompleted = resolve; });
+				if (mode !== "abort") {
+					let childReady!: () => void;
+					const ready = new Promise<void>((resolve) => { childReady = resolve; });
+					mockPi.onCall({ steps: [{ jsonl: [events.toolStart("contact_supervisor", { reason: "need_decision", message: "Ready" })] }, { waitForPath: releaseChild, jsonl: [events.assistantMessage("child A done")] }] });
+					child = executor.execute("lifecycle-A", { async: false, agent: "worker", task: "A", worktree: true, acceptance: false }, controller.signal, (update) => {
+						if (update.details?.progress?.some((entry) => entry.currentTool === "contact_supervisor")) childReady();
+						if (update.details?.progress?.some((entry) => entry.status === "completed")) childCompleted();
+					}, makeMinimalCtx(tempDir));
+					void child.then(() => { childSettled = true; });
+					await Promise.race([ready, child.then((result) => { throw new Error(`A returned before ready: ${JSON.stringify(result)}`); })]);
+					if (mode === "detached") {
+						bus.emit(INTERCOM_DETACH_REQUEST_EVENT, { requestId: "lifecycle-detach" });
+						assert.equal((await child).details.results[0]?.detached, true);
+					}
+				}
+				fs.writeFileSync(holdPath, "hold");
+				const connection = once(server, "connection");
+				mockPi.onCall({ output: "child B done", writeFiles: [{ path: launchMarker, content: "launched" }] });
+				const otherOwner = makeExecutor([makeAgent("worker")], { worktreeBaseDir: baseDir, worktreeSetupHook: hook });
+				setup = otherOwner.execute("lifecycle-B", { async: false, agent: "worker", task: "B", worktree: true, acceptance: false }, controller.signal, undefined, makeMinimalCtx(tempDir));
+				[socket] = await Promise.race([connection, setup.then((result) => { throw new Error(`Setup returned before hook ready: ${JSON.stringify(result)}`); })]) as [Socket];
+				await once(socket, "data"); // Real hook ready; the owner serviced I/O while setup remains held.
+				if (mode === "abort") {
+					controller.abort();
+					const result = await setup;
+					assert.equal(result.isError, true);
+					assert.equal(mockPi.callCount(), 0);
+					assert.equal(fs.existsSync(launchMarker), false, "aborted setup must not reach child side effects");
+					assert.ok(result.details.parallelHandoff?.path, result.content[0]?.text);
+					const handoff = JSON.parse(fs.readFileSync(result.details.parallelHandoff.path, "utf8"));
+					const cleanup = handoff.groups[0].cleanup;
+					assert.equal(cleanup.state, "complete");
+					assert.equal(cleanup.tasks.length, 1);
+					assert.match(cleanup.errors.join("\n"), /"processTree":"observed"/);
+					for (const task of cleanup.tasks) {
+						assert.equal(task.worktreeRemoved, true);
+						assert.equal(task.branchRemoved, true);
+						assert.equal(fs.existsSync(task.path), false);
+						assert.equal(execFileSync("git", ["branch", "--list", task.branch], { cwd: tempDir, encoding: "utf8" }).trim(), "");
+					}
+				} else {
+					fs.writeFileSync(releaseChild, "release");
+					await completed;
+					const ack = once(socket, "data");
+					socket.write("ping");
+					await ack;
+					assert.equal(mode === "detached" ? notified : childSettled, false, "A must await finalization behind B setup");
+					socket.write("release");
+					const [a, b] = await Promise.all([child!, setup]);
+					if (mode === "detached") await notification;
+					assert.equal(fs.readFileSync(launchMarker, "utf8"), "launched");
+					for (const result of [a, b]) {
+						assert.equal(result.isError, undefined, result.content[0]?.text);
+						assert.ok(result.details.parallelHandoff?.path);
+						const handoff = JSON.parse(fs.readFileSync(result.details.parallelHandoff.path, "utf8"));
+						assert.equal(handoff.groups[0].cleanup.state, "complete");
+						for (const task of handoff.groups[0].cleanup.tasks) {
+							assert.equal(task.worktreeRemoved, true);
+							assert.equal(task.branchRemoved, true);
+							assert.equal(fs.existsSync(task.path), false);
+						}
+					}
+				}
+			} finally {
+				controller.abort();
+				fs.writeFileSync(releaseChild, "release");
+				socket?.end("release");
+				await Promise.allSettled([child, setup]);
+				socket?.destroy();
+				await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+				removeTempDir(baseDir);
+			}
+		});
+	}
 
 	it("keeps async workflows failed when a coordinated child is mixed with a real failure", { skip: !createSubagentExecutor ? "executor unavailable" : undefined }, async () => {
 		mockPi.onCall({
@@ -1140,7 +1255,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.writeFileSync(path.join(repo, "base.txt"), "base\n", "utf-8");
 		execFileSync("git", ["add", "base.txt"], { cwd: repo });
 		execFileSync("git", ["commit", "-m", "base"], { cwd: repo, stdio: "ignore" });
-		const setup = createWorktrees(repo, "action", 1, { baseDir });
+		const setup = await createWorktrees(repo, "action", 1, { baseDir });
 		const worktree = setup.worktrees[0]!;
 		const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 		const baseCommit = execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();

--- a/test/unit/parallel-handoff.test.ts
+++ b/test/unit/parallel-handoff.test.ts
@@ -11,7 +11,6 @@ import {
 	recordParallelHandoffSupersession,
 	resolveParallelHandoffChild,
 	writeParallelHandoffGroup,
-	writePendingParallelHandoff,
 } from "../../src/runs/shared/parallel-handoff.ts";
 import type { ParallelHandoffManifest } from "../../src/shared/types.ts";
 import type { WorktreeCleanupReport, WorktreeDiff, WorktreeSetup } from "../../src/runs/shared/worktree.ts";
@@ -56,7 +55,8 @@ describe("parallel handoff", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-parallel-handoff-pending-"));
 		try {
 			const manifestPath = path.join(dir, "handoff.json");
-			const reference = writePendingParallelHandoff({
+			const reference = writeParallelHandoffGroup({
+				diffs: [], results: [],
 				manifestPath,
 				runId: "run-pending",
 				mode: "parallel",
@@ -416,7 +416,8 @@ describe("parallel handoff", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-parallel-handoff-merge-unknown-"));
 		try {
 			const manifestPath = path.join(dir, "handoff.json");
-			writePendingParallelHandoff({
+			writeParallelHandoffGroup({
+				diffs: [], results: [],
 				manifestPath,
 				runId: "lane-unknown",
 				mode: "single",

--- a/test/unit/worktree-cleanup-plan.test.ts
+++ b/test/unit/worktree-cleanup-plan.test.ts
@@ -148,12 +148,12 @@ describe("worktree cleanup plan", () => {
 		assert.equal(fallbackCalls, 1);
 	});
 
-	it("builds and persists a deterministic metadata-backed plan without removing worktrees", () => {
+	it("builds and persists a deterministic metadata-backed plan without removing worktrees", async () => {
 		const repo = createRepo("pi-cleanup-plan-safe-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "safe", 1, { baseDir });
+			setup = await createWorktrees(repo, "safe", 1, { baseDir });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			fs.mkdirSync(path.join(baseDir, "unrelated-directory"));
@@ -194,12 +194,12 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("keeps dirty and unowned worktrees out of the removable set", () => {
+	it("keeps dirty and unowned worktrees out of the removable set", async () => {
 		const repo = createRepo("pi-cleanup-plan-unknown-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "unknown", 2, { baseDir });
+			setup = await createWorktrees(repo, "unknown", 2, { baseDir });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			fs.writeFileSync(path.join(setup.worktrees[0]!.path, "tracked.txt"), "dirty\n", "utf-8");
@@ -223,12 +223,12 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("keeps active async ownership and reports missing Git worktrees as stale", () => {
+	it("keeps active async ownership and reports missing Git worktrees as stale", async () => {
 		const repo = createRepo("pi-cleanup-plan-active-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "active", 1, { baseDir });
+			setup = await createWorktrees(repo, "active", 1, { baseDir });
 			const asyncDir = path.join(repo, ".pi", "subagents", "async", "active-run");
 			const manifestPath = path.join(asyncDir, "handoff.json");
 			writeManifest({ repo, manifestPath, setup, runId: "active-run", source: "async" });
@@ -252,12 +252,12 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("requires foreground ownership proof instead of inferring activity from the artifacts directory", () => {
+	it("requires foreground ownership proof instead of inferring activity from the artifacts directory", async () => {
 		const repo = createRepo("pi-cleanup-plan-foreground-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "foreground", 1, { baseDir });
+			setup = await createWorktrees(repo, "foreground", 1, { baseDir });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup, runId: "foreground-run", source: "foreground" });
 			const noProof = buildWorktreeCleanupPlan({ repo, handoffPath: manifestPath, worktreeBaseDir: baseDir, now: 35_000, planId: "foreground-no-proof" });
@@ -275,12 +275,12 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("requires a recorded patch or local target ancestry for committed divergence", () => {
+	it("requires a recorded patch or local target ancestry for committed divergence", async () => {
 		const repo = createRepo("pi-cleanup-plan-divergence-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "divergence", 1, { baseDir });
+			setup = await createWorktrees(repo, "divergence", 1, { baseDir });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			const worktree = setup.worktrees[0]!;
@@ -306,13 +306,13 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("does not let trusted external diff hide cleanup-plan divergence", { skip: hookScriptSkip }, () => {
+	it("does not let trusted external diff hide cleanup-plan divergence", { skip: hookScriptSkip }, async () => {
 		const repo = createRepo("pi-cleanup-plan-external-diff-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
 		const externalDiffPath = createHookScript("external-diff-plan.mjs", "process.exit(0);");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "external-diff", 1, { baseDir });
+			setup = await createWorktrees(repo, "external-diff", 1, { baseDir });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			const worktree = setup.worktrees[0]!;
@@ -333,12 +333,12 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("keeps stale markers, pending captures, and inconsistent cleanup metadata non-removable", () => {
+	it("keeps stale markers, pending captures, and inconsistent cleanup metadata non-removable", async () => {
 		const repo = createRepo("pi-cleanup-plan-stale-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-base-"));
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "stale", 1, { baseDir });
+			setup = await createWorktrees(repo, "stale", 1, { baseDir });
 			const asyncDir = path.join(repo, ".pi", "subagents", "async", "stale-run");
 			const manifestPath = path.join(asyncDir, "handoff.json");
 			writeManifest({ repo, manifestPath, setup, runId: "stale-run", source: "async" });
@@ -386,12 +386,12 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("treats nested project directory as cleanup containment root", () => {
+	it("treats nested project directory as cleanup containment root", async () => {
 		const repo = createRepo("pi-cleanup-plan-nested-root-");
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-cleanup-plan-nested-base-"));
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repo, "nested-root", 1, { baseDir });
+			setup = await createWorktrees(repo, "nested-root", 1, { baseDir });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			const plan = buildPlan({ repo, worktreeBaseDir: baseDir, now: 60_000, planId: "nested-root-plan" });
@@ -405,14 +405,14 @@ describe("worktree cleanup plan", () => {
 		}
 	});
 
-	it("uses git toplevel parent as default cleanup root when input.repo is a subdirectory", () => {
+	it("uses git toplevel parent as default cleanup root when input.repo is a subdirectory", async () => {
 		const repo = createRepo("pi-cleanup-plan-subdir-root-");
 		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
 		delete process.env.PI_SUBAGENTS_WORKTREE_DIR;
 		let setup: WorktreeSetup | undefined;
 		try {
 			fs.mkdirSync(path.join(repo, "packages", "app"), { recursive: true });
-			setup = createWorktrees(repo, "from-subdir", 1, { provider: "native" });
+			setup = await createWorktrees(repo, "from-subdir", 1, { provider: "native" });
 			const manifestPath = path.join(repo, ".pi", "subagents", "artifacts", "handoff.json");
 			writeManifest({ repo, manifestPath, setup });
 			const plan = buildPlan({ repo: path.join(repo, "packages", "app"), now: 61_500, planId: "subdir-root-plan" });

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -156,6 +156,33 @@ describe("worktree", () => {
 		}
 	});
 
+	it("compensates a rejected ready publication without retaining command output in snapshots", async () => {
+		const repoDir = createRepo("pi-worktree-ready-rejected-");
+		try {
+			await assert.rejects(() => createWorktrees(repoDir, "ready-rejected", 1, {
+				provider: "native",
+				onProgress: (snapshot) => {
+					if (snapshot.command?.result) {
+						assert.equal("stdout" in snapshot.command.result, false);
+						assert.equal("stderr" in snapshot.command.result, false);
+					}
+					if (snapshot.phase === "ready") throw new Error("ready publication rejected");
+				},
+			}), (error: unknown) => {
+				assert.ok(error instanceof WorktreeSetupError);
+				assert.match(error.message, /ready publication rejected/);
+				assert.equal(error.snapshot.cleanup?.state, "complete");
+				assert.equal(error.snapshot.cleanup.tasks.length, 1);
+				const task = error.snapshot.cleanup.tasks[0]!;
+				assert.equal(task.worktreeRemoved, true);
+				assert.equal(task.branchRemoved, true);
+				assert.equal(fs.existsSync(task.path), false);
+				assert.equal(git(repoDir, ["branch", "--list", task.branch]), "");
+				return true;
+			});
+		} finally { cleanupRepo(repoDir); }
+	});
+
 	it("records Worktrunk ownership and uses its returned path", async () => {
 		try { resolveWorktreeProvider("worktrunk"); } catch { return; }
 		const repoDir = createRepo("pi-worktree-worktrunk-");

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import {
 	cleanupWorktrees,
 	createWorktrees,
@@ -17,6 +19,7 @@ import {
 	resolveWorktreeProvider,
 	sanitizeWorktreePathComponent,
 	shouldDeferWorktreeCwd,
+	WorktreeSetupError,
 	type WorktreeSetup,
 } from "../../src/runs/shared/worktree.ts";
 
@@ -68,12 +71,41 @@ const worktrunkShimSkip = process.platform === "win32"
 	? "Windows Terminal installs a wt.exe app alias that can outrank test command shims."
 	: undefined;
 
+// Unknown settlement intentionally poisons the process. Re-run only that case in
+// an awaited real child so subsequent tests retain normal mutation admission.
+async function runPoisonCaseInChild(name: string): Promise<boolean> {
+	if (process.env.PI_WORKTREE_POISON_CASE === name) return false;
+	await promisify(execFile)(process.execPath, [
+		"--experimental-strip-types", "--import", "./test/support/register-loader.mjs",
+		"--test", `--test-name-pattern=${name}`, fileURLToPath(import.meta.url),
+	], { env: { ...process.env, NODE_TEST_CONTEXT: undefined, PI_WORKTREE_POISON_CASE: name } });
+	return true;
+}
+
+function assertRetainedHookFailure(error: unknown, message: RegExp): true {
+	assert.ok(error instanceof WorktreeSetupError);
+	assert.match(error.message, message);
+	assert.match(error.message, /manual reconciliation required/i);
+	assert.ok(error.snapshot.unknown);
+	assert.equal(error.snapshot.cleanup?.state, "partial");
+	assert.equal(error.snapshot.cleanup?.pruned, false);
+	const worktree = error.snapshot.setup.worktrees[0]!;
+	assert.ok(worktree);
+	assert.equal(error.snapshot.attempts[0]?.validated, true);
+	assert.equal(fs.existsSync(worktree.path), true);
+	assert.equal(git(worktree.path, ["branch", "--show-current"]), worktree.branch);
+	assert.equal(fs.readFileSync(path.join(worktree.path, "tracked.txt"), "utf-8"), "initial\n");
+	assert.throws(() => cleanupWorktrees(error.snapshot.setup, { kind: "setup-rollback" }), /Worktree mutation blocked/i);
+	assert.equal(fs.existsSync(worktree.path), true);
+	return true;
+}
+
 describe("worktree", () => {
-	it("createWorktrees returns expected structure", () => {
+	it("createWorktrees returns expected structure", async () => {
 		const repoDir = createRepo("pi-worktree-structure-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "structure", 2, { provider: "native" });
+			setup = await createWorktrees(repoDir, "structure", 2, { provider: "native" });
 			assert.equal(setup.worktrees.length, 2);
 			assert.equal(setup.cwd, git(repoDir, ["rev-parse", "--show-toplevel"]));
 			for (let i = 0; i < setup.worktrees.length; i++) {
@@ -91,21 +123,32 @@ describe("worktree", () => {
 		}
 	});
 
-	it("invokes beforeCreate with deterministic ownership metadata before creating worktrees", () => {
+	it("reports attempted ownership before spawn and only validated worktrees after allocation", async () => {
 		const repoDir = createRepo("pi-worktree-before-create-");
 		let setup: WorktreeSetup | undefined;
-		let planned: WorktreeSetup | undefined;
+		let attemptedPath: string | undefined;
+		let validated: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "before-create", 1, {
+			setup = await createWorktrees(repoDir, "before-create", 1, {
 				provider: "native",
-				beforeCreate: (candidate) => {
-					planned = candidate;
-					assert.equal(fs.existsSync(candidate.worktrees[0]!.path), false);
-					assert.equal(candidate.worktrees[0]!.branch, "pi-subagents/task-before-creat-s0-t0");
+				onProgress: (snapshot) => {
+					const attempt = snapshot.attempts[0];
+					if (attempt && !attempt.command?.pid && !attempt.validated) {
+						attemptedPath = attempt.path;
+						assert.ok(attemptedPath);
+						assert.equal(fs.existsSync(attemptedPath), false);
+						assert.equal(attempt.branch, "pi-subagents/task-before-creat-s0-t0");
+						assert.deepEqual(snapshot.setup.worktrees, []);
+					}
+					if (snapshot.setup.worktrees.length) {
+						assert.equal(attempt?.validated, true);
+						validated = snapshot.setup;
+					}
 				},
 			});
-			assert.equal(planned?.baseCommit, setup.baseCommit);
-			assert.equal(planned?.worktrees[0]?.path, setup.worktrees[0]?.path);
+			assert.equal(attemptedPath, setup.worktrees[0]?.path);
+			assert.equal(validated?.baseCommit, setup.baseCommit);
+			assert.equal(validated?.worktrees[0]?.path, setup.worktrees[0]?.path);
 			assert.equal(fs.existsSync(setup.worktrees[0]!.path), true);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
@@ -113,12 +156,12 @@ describe("worktree", () => {
 		}
 	});
 
-	it("records Worktrunk ownership and uses its returned path", () => {
+	it("records Worktrunk ownership and uses its returned path", async () => {
 		try { resolveWorktreeProvider("worktrunk"); } catch { return; }
 		const repoDir = createRepo("pi-worktree-worktrunk-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "worktrunk-s0", 1, {
+			setup = await createWorktrees(repoDir, "worktrunk-s0", 1, {
 				provider: "worktrunk",
 				agents: ["worker"],
 				labels: ["Review API"],
@@ -137,7 +180,8 @@ describe("worktree", () => {
 		}
 	});
 
-	it("rejects Worktrunk responses that point at the source checkout", { skip: worktrunkShimSkip }, () => {
+	it("rejects Worktrunk responses that point at the source checkout", { skip: worktrunkShimSkip }, async () => {
+		if (await runPoisonCaseInChild("rejects Worktrunk responses that point at the source checkout")) return;
 		const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-fake-source-wt-"));
 		const fakeScript = path.join(fakeBin, "wt.cjs");
 		const fakeWt = path.join(fakeBin, process.platform === "win32" ? "wt.cmd" : "wt");
@@ -162,16 +206,30 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		const previousPathExt = process.env.PATHEXT;
 		const repoDir = createRepo("pi-worktree-source-wt-");
 		try {
-			const originalBranch = git(repoDir, ["branch", "--show-current"]);
+			const originalHead = git(repoDir, ["rev-parse", "HEAD"]);
 			process.env.PATH = `${fakeBin}${path.delimiter}${previousPath ?? ""}`;
 			process.env.Path = `${fakeBin}${path.delimiter}${previousWindowsPath ?? previousPath ?? ""}`;
 			process.env.PATHEXT = [".CMD", ".EXE", ".BAT", previousPathExt ?? ""].filter(Boolean).join(path.delimiter);
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "source-path", 1, { provider: "worktrunk" }),
-				/source checkout path/i,
+				(error: unknown) => {
+					assert.ok(error instanceof WorktreeSetupError);
+					assert.match(error.message, /source checkout path/i);
+					assert.match(error.message, /manual reconciliation required/i);
+					assert.ok(error.snapshot.unknown);
+					assert.deepEqual(error.snapshot.setup.worktrees, []);
+					assert.equal(error.snapshot.attempts[0]?.validated, false);
+					assert.equal(error.snapshot.attempts[0]?.branch, "pi-subagents/task-source-path-s0-t0");
+					assert.equal(error.snapshot.cleanup?.pruned, false);
+					return true;
+				},
 			);
-			assert.equal(git(repoDir, ["branch", "--show-current"]), originalBranch);
-			assert.equal(git(repoDir, ["branch", "--list", "pi-subagents/task-source-path-s0-t0"]), "");
+			// Invalid output grants no authority to restore or delete source state.
+			assert.equal(git(repoDir, ["branch", "--show-current"]), "pi-subagents/task-source-path-s0-t0");
+			assert.equal(git(repoDir, ["rev-parse", "HEAD"]), originalHead);
+			assert.equal(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8"), "initial\n");
+			await assert.rejects(() => createWorktrees(repoDir, "after-unknown", 1, { provider: "native" }), /unknown|manual reconciliation/i);
+			assert.equal(git(repoDir, ["branch", "--list", "pi-subagents/task-after-unknow-s0-t0"]), "");
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
@@ -184,7 +242,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("falls back to native only when Worktrunk capability probing fails", () => {
+	it("falls back to native only when Worktrunk capability probing fails", async () => {
 		const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-fake-wt-"));
 		const fakeWt = path.join(fakeBin, process.platform === "win32" ? "wt.cmd" : "wt");
 		fs.writeFileSync(fakeWt, process.platform === "win32" ? "@echo not-worktrunk\r\n" : "#!/bin/sh\nprintf 'not-worktrunk\\n'\n", "utf-8");
@@ -202,8 +260,8 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			assert.equal(shouldDeferWorktreeCwd(undefined), true);
 			assert.equal(resolveWorktreeProvider(undefined, " "), "native");
 			assert.equal(shouldDeferWorktreeCwd(undefined, " "), false);
-			assert.throws(() => createWorktrees(repoDir, "provider-fallback", 1, { baseDir: " " }), /cannot be empty/i);
-			setup = createWorktrees(repoDir, "provider-fallback", 1);
+			await assert.rejects(() => createWorktrees(repoDir, "provider-fallback", 1, { baseDir: " " }), /cannot be empty/i);
+			setup = await createWorktrees(repoDir, "provider-fallback", 1);
 			assert.equal(setup.worktrees[0]?.provider, "native");
 			assert.throws(() => resolveWorktreeProvider("worktrunk"), /Worktrunk provider is unavailable/i);
 		} finally {
@@ -236,7 +294,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		assert.throws(() => normalizeWorktreeBranchPrefix("../unsafe"), /invalid/i);
 	});
 
-	it("createWorktrees maps subdirectory cwd to each agentCwd", () => {
+	it("createWorktrees maps subdirectory cwd to each agentCwd", async () => {
 		const repoDir = createRepo("pi-worktree-subdir-");
 		const nestedDir = path.join(repoDir, "packages", "app");
 		fs.mkdirSync(nestedDir, { recursive: true });
@@ -246,7 +304,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(nestedDir, "subdir", 1);
+			setup = await createWorktrees(nestedDir, "subdir", 1);
 			assert.equal(setup.worktrees[0]!.agentCwd, path.join(setup.worktrees[0]!.path, "packages", "app"));
 		} finally {
 			if (setup) cleanupWorktrees(setup);
@@ -280,12 +338,12 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("creates worktrees under a configured base directory", () => {
+	it("creates worktrees under a configured base directory", async () => {
 		const repoDir = createRepo("pi-worktree-base-dir-");
 		const baseDir = path.join(os.tmpdir(), `pi-worktree-base-${Date.now().toString(36)}`, "nested");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "base-dir", 1, { baseDir });
+			setup = await createWorktrees(repoDir, "base-dir", 1, { baseDir });
 			assert.equal(
 				setup.worktrees[0]!.path,
 				path.join(baseDir, path.basename(repoDir), "pi-worktree-base-dir-0"),
@@ -297,7 +355,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("rejects worktree base directories inside Pi extensions", () => {
+	it("rejects worktree base directories inside Pi extensions", async () => {
 		const repoDir = createRepo("pi-worktree-extension-dir-");
 		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
 		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -308,11 +366,11 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			process.env.HOME = tempHome;
 			process.env.USERPROFILE = tempHome;
 			delete process.env.PI_CODING_AGENT_DIR;
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "extension-dir", 1, { baseDir: extensionsDir }),
 				/worktree base directory cannot be inside Pi extensions directory/i,
 			);
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "extension-subdir", 1, { baseDir: path.join(extensionsDir, "checkout") }),
 				/worktree base directory cannot be inside Pi extensions directory/i,
 			);
@@ -328,7 +386,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("rejects symlinked worktree base directories inside Pi extensions", () => {
+	it("rejects symlinked worktree base directories inside Pi extensions", async () => {
 		const repoDir = createRepo("pi-worktree-extension-symlink-");
 		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
 		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -342,7 +400,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			delete process.env.PI_CODING_AGENT_DIR;
 			fs.mkdirSync(extensionsDir, { recursive: true });
 			fs.symlinkSync(extensionsDir, aliasDir, process.platform === "win32" ? "junction" : "dir");
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "extension-symlink", 1, { baseDir: path.join(aliasDir, "checkout") }),
 				/worktree base directory cannot be inside Pi extensions directory/i,
 			);
@@ -358,7 +416,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("rejects a final project directory inside Pi extensions", () => {
+	it("rejects a final project directory inside Pi extensions", async () => {
 		const sourceRepo = createRepo("pi-worktree-extension-project-");
 		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
 		const repoDir = path.join(tempHome, "extensions");
@@ -374,7 +432,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			process.env.HOME = tempHome;
 			process.env.USERPROFILE = tempHome;
 
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "extension-project", 1, { provider: "native", baseDir: agentDir }),
 				/worktree path cannot be inside Pi extensions directory/i,
 			);
@@ -397,7 +455,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("rejects a project directory symlink into Pi extensions", () => {
+	it("rejects a project directory symlink into Pi extensions", async () => {
 		const repoDir = createRepo("pi-worktree-extension-project-symlink-");
 		const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-home-"));
 		const agentDir = path.join(tempHome, ".pi", "agent");
@@ -414,7 +472,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			process.env.HOME = tempHome;
 			process.env.USERPROFILE = tempHome;
 
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "extension-project-symlink", 1, { provider: "native", baseDir }),
 				/worktree path cannot be inside Pi extensions directory/i,
 			);
@@ -436,14 +494,14 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("uses PI_SUBAGENTS_WORKTREE_DIR when no base directory is configured", () => {
+	it("uses PI_SUBAGENTS_WORKTREE_DIR when no base directory is configured", async () => {
 		const repoDir = createRepo("pi-worktree-env-base-dir-");
 		const previous = process.env.PI_SUBAGENTS_WORKTREE_DIR;
 		const baseDir = path.join(os.tmpdir(), `pi-worktree-env-base-${Date.now().toString(36)}`);
 		let setup: WorktreeSetup | undefined;
 		try {
 			process.env.PI_SUBAGENTS_WORKTREE_DIR = baseDir;
-			setup = createWorktrees(repoDir, "env-base-dir", 1);
+			setup = await createWorktrees(repoDir, "env-base-dir", 1);
 			assert.equal(
 				setup.worktrees[0]!.path,
 				path.join(baseDir, path.basename(repoDir), "pi-worktree-env-base-dir-0"),
@@ -459,10 +517,10 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("rejects empty worktree base directory", () => {
+	it("rejects empty worktree base directory", async () => {
 		const repoDir = createRepo("pi-worktree-empty-base-");
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "empty-base", 1, { baseDir: "   " }),
 				/worktree base directory cannot be empty/,
 			);
@@ -471,12 +529,12 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("rejects worktree paths that would land inside the repository checkout", () => {
+	it("rejects worktree paths that would land inside the repository checkout", async () => {
 		const repoDir = createRepo("pi-worktree-inside-");
 		const repoParent = path.dirname(repoDir);
 		const leakedLeaf = "pi-worktree-inside-0";
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "inside", 1, { baseDir: repoParent }),
 				/inside the repository/i,
 			);
@@ -495,7 +553,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("rejects worktree paths that are direct children of the repository parent", () => {
+	it("rejects worktree paths that are direct children of the repository parent", async () => {
 		const repoDir = createRepo("pi-worktree-parent-child-");
 		const repoParent = path.dirname(repoDir);
 		const dedicatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-worktree-parent-child-root-"));
@@ -503,7 +561,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		const leakedLeaf = path.join(repoParent, "pi-worktree-parent-child-0");
 		try {
 			fs.symlinkSync(repoParent, projectDir, process.platform === "win32" ? "junction" : "dir");
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "parent-child", 1, { baseDir: dedicatedRoot }),
 				/direct child of the repository parent/i,
 			);
@@ -523,10 +581,10 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("does not mkdir inside the checkout when rejecting unsafe locations", () => {
+	it("does not mkdir inside the checkout when rejecting unsafe locations", async () => {
 		const repoDir = createRepo("pi-worktree-no-mkdir-inside-");
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "inside-self", 1, { baseDir: repoDir }),
 				/inside the repository/i,
 			);
@@ -536,7 +594,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 			);
 			assert.equal(fs.existsSync(path.join(repoDir, path.basename(repoDir))), false);
 
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "rel-worktrees", 1, { baseDir: "worktrees" }),
 				/inside the repository/i,
 			);
@@ -547,11 +605,11 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("createWorktrees rejects dirty repositories before resolving the requested base ref", () => {
+	it("createWorktrees rejects dirty repositories before resolving the requested base ref", async () => {
 		const repoDir = createRepo("pi-worktree-dirty-");
 		try {
 			fs.writeFileSync(path.join(repoDir, "tracked.txt"), "dirty\n", "utf-8");
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "dirty", 1, { baseRef: "unsafe..ref" }),
 				/worktree isolation requires a clean git working tree/i,
 			);
@@ -560,7 +618,7 @@ console.log(JSON.stringify({ action: "created", branch, path: repo, created_bran
 		}
 	});
 
-	it("allocates from baseRef while preserving source HEAD and propagating baseCommit to hooks and diffs", { skip: hookScriptSkip }, () => {
+	it("allocates from baseRef while preserving source HEAD and propagating baseCommit to hooks and diffs", { skip: hookScriptSkip }, async () => {
 		const repoDir = createRepo("pi-worktree-base-ref-");
 		const firstCommit = git(repoDir, ["rev-parse", "HEAD"]);
 		git(repoDir, ["branch", "release"]);
@@ -576,7 +634,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 `);
 	let setup: WorktreeSetup | undefined;
 	try {
-		setup = createWorktrees(repoDir, "base-ref", 1, {
+		setup = await createWorktrees(repoDir, "base-ref", 1, {
 			provider: "native",
 			baseRef: "release",
 			setupHook: { hookPath: path.relative(repoDir, hookPath) },
@@ -596,28 +654,28 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 	}
 	});
 
-	it("rejects unsafe and unresolved base refs before allocation", () => {
+	it("rejects unsafe and unresolved base refs before allocation", async () => {
 		const repoDir = createRepo("pi-worktree-invalid-base-ref-");
 		try {
 			for (const baseRef of ["unsafe..ref", "branch name", "HEAD^{tree}", "@", "a".repeat(40), "a".repeat(64)] as const) {
-				assert.throws(() => createWorktrees(repoDir, `invalid-${baseRef.length}`, 1, { provider: "native", baseRef }), /valid Git ref|could not be resolved/i);
+				await assert.rejects(() => createWorktrees(repoDir, `invalid-${baseRef.length}`, 1, { provider: "native", baseRef }), /valid Git ref|could not be resolved/i);
 			}
 			git(repoDir, ["tag", "tree-object", "HEAD^{tree}"]);
-			assert.throws(() => createWorktrees(repoDir, "invalid-tree", 1, { provider: "native", baseRef: "tree-object" }), /could not be resolved to a commit/i);
-			assert.throws(() => createWorktrees(repoDir, "invalid-missing", 1, { provider: "native", baseRef: "refs/heads/missing" }), /could not be resolved to a commit/i);
+			await assert.rejects(() => createWorktrees(repoDir, "invalid-tree", 1, { provider: "native", baseRef: "tree-object" }), /could not be resolved to a commit/i);
+			await assert.rejects(() => createWorktrees(repoDir, "invalid-missing", 1, { provider: "native", baseRef: "refs/heads/missing" }), /could not be resolved to a commit/i);
 			assert.equal(git(repoDir, ["worktree", "list", "--porcelain"]).split("\n").filter((line) => line.startsWith("worktree ")).length, 1);
 		} finally {
 			cleanupRepo(repoDir);
 		}
 	});
 
-	it("createWorktrees ignores pi-subagents runtime artifacts in the source checkout", () => {
+	it("createWorktrees ignores pi-subagents runtime artifacts in the source checkout", async () => {
 		const repoDir = createRepo("pi-worktree-runtime-artifacts-");
 		let setup: WorktreeSetup | undefined;
 		try {
 			fs.mkdirSync(path.join(repoDir, ".pi/subagents", "missions"), { recursive: true });
 			fs.writeFileSync(path.join(repoDir, ".pi/subagents", "missions", "mission.json"), "{}\n", "utf-8");
-			setup = createWorktrees(repoDir, "runtime-artifacts", 1);
+			setup = await createWorktrees(repoDir, "runtime-artifacts", 1);
 			assert.equal(setup.worktrees.length, 1);
 		} finally {
 			if (setup) cleanupWorktrees(setup);
@@ -666,7 +724,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 		});
 	});
 
-	it("diffWorktrees captures committed, modified, and new files without staging the node_modules symlink", () => {
+	it("diffWorktrees captures committed, modified, and new files without staging the node_modules symlink", async () => {
 		const repoDir = createRepo("pi-worktree-diff-");
 		const nodeModulesDir = path.join(repoDir, "node_modules");
 		fs.mkdirSync(nodeModulesDir, { recursive: true });
@@ -674,7 +732,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, `diff-${process.pid}`, 1);
+			setup = await createWorktrees(repoDir, `diff-${process.pid}`, 1);
 			const worktree = setup.worktrees[0]!;
 			fs.writeFileSync(path.join(worktree.path, "committed.ts"), "export const committed = true;\n", "utf-8");
 			git(worktree.path, ["add", "committed.ts"]);
@@ -705,7 +763,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".base-commit"] }));
 		}
 	});
 
-	it("captures applyable patches despite external diffs and display configuration", { skip: hookScriptSkip }, () => {
+	it("captures applyable patches despite external diffs and display configuration", { skip: hookScriptSkip }, async () => {
 		const repoDir = createRepo("pi-worktree-diff-external-");
 		const externalDiffPath = createHookScript(repoDir, "external-diff.mjs", `
 process.stdout.write("corrupt external diff output\\n");
@@ -717,7 +775,7 @@ process.stdout.write("corrupt external diff output\\n");
 			git(repoDir, ["config", "diff.noprefix", "true"]);
 			git(repoDir, ["config", "diff.linePrefix", "corrupt display prefix "]);
 			git(repoDir, ["config", "diff.relative", "true"]);
-			setup = createWorktrees(repoDir, "diff-external", 1);
+			setup = await createWorktrees(repoDir, "diff-external", 1);
 			const worktree = setup.worktrees[0]!;
 			fs.writeFileSync(path.join(worktree.path, "tracked.txt"), "external-safe\n", "utf-8");
 
@@ -733,11 +791,11 @@ process.stdout.write("corrupt external diff output\\n");
 		}
 	});
 
-	it("includes binary data in captured patches", () => {
+	it("includes binary data in captured patches", async () => {
 		const repoDir = createRepo("pi-worktree-diff-binary-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "diff-binary", 1);
+			setup = await createWorktrees(repoDir, "diff-binary", 1);
 			const worktree = setup.worktrees[0]!;
 			fs.writeFileSync(path.join(worktree.path, "binary.dat"), Buffer.from([0, 1, 2, 255, 0, 3]));
 
@@ -752,11 +810,11 @@ process.stdout.write("corrupt external diff output\\n");
 		}
 	});
 
-	it("cleanupWorktrees removes worktrees and branches", () => {
+	it("cleanupWorktrees removes worktrees and branches", async () => {
 		const repoDir = createRepo("pi-worktree-cleanup-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "cleanup", 2);
+			setup = await createWorktrees(repoDir, "cleanup", 2);
 			const worktreePaths = setup.worktrees.map((worktree) => worktree.path);
 			const branches = setup.worktrees.map((worktree) => worktree.branch);
 			const cleanup = cleanupWorktrees(setup);
@@ -779,11 +837,11 @@ process.stdout.write("corrupt external diff output\\n");
 		}
 	});
 
-	it("preserves dirty worktrees when no patch was captured", () => {
+	it("preserves dirty worktrees when no patch was captured", async () => {
 		const repoDir = createRepo("pi-worktree-uncaptured-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "uncaptured", 1);
+			setup = await createWorktrees(repoDir, "uncaptured", 1);
 			const worktree = setup.worktrees[0]!;
 			fs.writeFileSync(path.join(worktree.path, "tracked.txt"), "uncaptured\n", "utf-8");
 
@@ -806,11 +864,11 @@ process.stdout.write("corrupt external diff output\\n");
 		}
 	});
 
-	it("preserves committed branch work when no patch was captured", () => {
+	it("preserves committed branch work when no patch was captured", async () => {
 		const repoDir = createRepo("pi-worktree-committed-uncaptured-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "committed-uncaptured", 1);
+			setup = await createWorktrees(repoDir, "committed-uncaptured", 1);
 			const worktree = setup.worktrees[0]!;
 			fs.writeFileSync(path.join(worktree.path, "committed.txt"), "unlanded commit\n", "utf-8");
 			git(worktree.path, ["add", "committed.txt"]);
@@ -830,14 +888,14 @@ process.stdout.write("corrupt external diff output\\n");
 		}
 	});
 
-	it("does not let trusted external diff hide uncaptured committed work during cleanup", { skip: hookScriptSkip }, () => {
+	it("does not let trusted external diff hide uncaptured committed work during cleanup", { skip: hookScriptSkip }, async () => {
 		const repoDir = createRepo("pi-worktree-cleanup-external-diff-");
 		const externalDiffPath = createHookScript(repoDir, "external-diff-clean.mjs", "process.exit(0);");
 		let setup: WorktreeSetup | undefined;
 		try {
 			git(repoDir, ["config", "diff.external", externalDiffPath]);
 			git(repoDir, ["config", "diff.trustExitCode", "true"]);
-			setup = createWorktrees(repoDir, "cleanup-external-diff", 1);
+			setup = await createWorktrees(repoDir, "cleanup-external-diff", 1);
 			const worktree = setup.worktrees[0]!;
 			fs.writeFileSync(path.join(worktree.path, "committed.txt"), "unlanded work\n", "utf-8");
 			git(worktree.path, ["add", "committed.txt"]);
@@ -855,11 +913,11 @@ process.stdout.write("corrupt external diff output\\n");
 		}
 	});
 
-	it("removes dirty worktrees only after their captured patch is recorded in the handoff manifest", () => {
+	it("removes dirty worktrees only after their captured patch is recorded in the handoff manifest", async () => {
 		const repoDir = createRepo("pi-worktree-captured-");
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "captured", 1);
+			setup = await createWorktrees(repoDir, "captured", 1);
 			const worktreePath = setup.worktrees[0]!.path;
 			fs.writeFileSync(path.join(worktreePath, "tracked.txt"), "captured\n", "utf-8");
 			const diffs = diffWorktrees(setup, ["worker"], path.join(repoDir, "artifacts", "captured"));
@@ -901,7 +959,7 @@ process.stdout.write("corrupt external diff output\\n");
 
 	it("createWorktrees creates node_modules symlink when node_modules exists", {
 		skip: process.platform === "win32" ? "Symlink behavior differs on Windows CI environments." : undefined,
-	}, () => {
+	}, async () => {
 		const repoDir = createRepo("pi-worktree-node-modules-");
 		const nodeModulesDir = path.join(repoDir, "node_modules");
 		fs.mkdirSync(nodeModulesDir, { recursive: true });
@@ -909,7 +967,7 @@ process.stdout.write("corrupt external diff output\\n");
 
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "node-modules", 1);
+			setup = await createWorktrees(repoDir, "node-modules", 1);
 			const symlinkPath = path.join(setup.worktrees[0]!.path, "node_modules");
 			assert.equal(setup.worktrees[0]!.nodeModulesLinked, true);
 			assert.deepEqual(setup.worktrees[0]!.syntheticPaths, ["node_modules"]);
@@ -924,7 +982,7 @@ process.stdout.write("corrupt external diff output\\n");
 
 	it("diffWorktrees preserves a tracked node_modules symlink", {
 		skip: process.platform === "win32" ? "Symlink behavior differs on Windows CI environments." : undefined,
-	}, () => {
+	}, async () => {
 		const repoDir = createRepo("pi-worktree-tracked-node-modules-");
 		const vendorDir = path.join(repoDir, "vendor-modules");
 		fs.mkdirSync(vendorDir, { recursive: true });
@@ -935,7 +993,7 @@ process.stdout.write("corrupt external diff output\\n");
 
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, `tracked-node-modules-${process.pid}`, 1);
+			setup = await createWorktrees(repoDir, `tracked-node-modules-${process.pid}`, 1);
 			assert.equal(setup.worktrees[0]!.nodeModulesLinked, false);
 			assert.deepEqual(setup.worktrees[0]!.syntheticPaths, []);
 			fs.writeFileSync(path.join(setup.worktrees[0]!.path, "tracked.txt"), "modified\n", "utf-8");
@@ -951,7 +1009,7 @@ process.stdout.write("corrupt external diff output\\n");
 		}
 	});
 
-	it("runs a repo-relative worktree setup hook and records synthetic paths", { skip: hookScriptSkip }, () => {
+	it("runs a repo-relative worktree setup hook and records synthetic paths", { skip: hookScriptSkip }, async () => {
 		const repoDir = createRepo("pi-worktree-hook-relative-");
 		const hookPath = createHookScript(repoDir, "setup-hook.mjs", `
 import * as fs from "node:fs";
@@ -964,7 +1022,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".venv"] }));
 
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "hook-relative", 1, {
+			setup = await createWorktrees(repoDir, "hook-relative", 1, {
 				setupHook: { hookPath: path.relative(repoDir, hookPath) },
 			});
 			assert.ok(setup.worktrees[0]!.syntheticPaths.includes(".venv"));
@@ -974,7 +1032,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".venv"] }));
 		}
 	});
 
-	it("runs an absolute worktree setup hook path", { skip: hookScriptSkip }, () => {
+	it("runs an absolute worktree setup hook path", { skip: hookScriptSkip }, async () => {
 		const repoDir = createRepo("pi-worktree-hook-absolute-");
 		const hookPath = createHookScript(repoDir, "setup-hook.mjs", `
 import * as fs from "node:fs";
@@ -984,7 +1042,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, "hook-absolute", 1, {
+			setup = await createWorktrees(repoDir, "hook-absolute", 1, {
 				setupHook: { hookPath },
 			});
 			assert.equal(setup.worktrees.length, 1);
@@ -994,10 +1052,10 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 		}
 	});
 
-	it("rejects bare command names for worktree setup hooks", () => {
+	it("rejects bare command names for worktree setup hooks", async () => {
 		const repoDir = createRepo("pi-worktree-hook-bare-");
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, "hook-bare", 1, { setupHook: { hookPath: "node" } }),
 				/worktree setup hook must be an absolute path or a repo-relative path/i,
 			);
@@ -1006,7 +1064,8 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 		}
 	});
 
-	it("rejects tracked synthetic paths from hook output", { skip: hookScriptSkip }, () => {
+	it("rejects tracked synthetic paths from hook output", { skip: hookScriptSkip }, async () => {
+		if (await runPoisonCaseInChild("rejects tracked synthetic paths from hook output")) return;
 		const repoDir = createRepo("pi-worktree-hook-tracked-");
 		const hookPath = createHookScript(repoDir, "tracked-hook.mjs", `
 import * as fs from "node:fs";
@@ -1014,17 +1073,24 @@ JSON.parse(fs.readFileSync(0, "utf-8"));
 process.stdout.write(JSON.stringify({ syntheticPaths: ["tracked.txt"] }));
 `);
 		const runId = `hook-tracked-${Date.now().toString(36)}`;
+		let retained: WorktreeSetup | undefined;
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, runId, 1, { setupHook: { hookPath: path.relative(repoDir, hookPath) } }),
-				/cannot mark tracked paths as synthetic/i,
+				(error: unknown) => {
+					assert.ok(error instanceof WorktreeSetupError);
+					retained = error.snapshot.setup;
+					return assertRetainedHookFailure(error, /cannot mark tracked paths as synthetic/i);
+				},
 			);
 		} finally {
+			for (const worktree of retained?.worktrees ?? []) fs.rmSync(worktree.path, { recursive: true, force: true });
 			cleanupRepo(repoDir);
 		}
 	});
 
-	it("rejects absolute synthetic paths from hook output", { skip: hookScriptSkip }, () => {
+	it("rejects absolute synthetic paths from hook output", { skip: hookScriptSkip }, async () => {
+		if (await runPoisonCaseInChild("rejects absolute synthetic paths from hook output")) return;
 		const repoDir = createRepo("pi-worktree-hook-absolute-synthetic-");
 		const hookPath = createHookScript(repoDir, "absolute-path-hook.mjs", `
 import * as fs from "node:fs";
@@ -1032,17 +1098,23 @@ const payload = JSON.parse(fs.readFileSync(0, "utf-8"));
 process.stdout.write(JSON.stringify({ syntheticPaths: [payload.worktreePath + "/.venv"] }));
 `);
 		const runId = `hook-absolute-synthetic-${Date.now().toString(36)}`;
+		let retained: WorktreeSetup | undefined;
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, runId, 1, { setupHook: { hookPath: path.relative(repoDir, hookPath) } }),
-				/synthetic path must be relative/i,
+				(error: unknown) => {
+					assert.ok(error instanceof WorktreeSetupError);
+					retained = error.snapshot.setup;
+					return assertRetainedHookFailure(error, /synthetic path must be relative/i);
+				},
 			);
 		} finally {
+			for (const worktree of retained?.worktrees ?? []) fs.rmSync(worktree.path, { recursive: true, force: true });
 			cleanupRepo(repoDir);
 		}
 	});
 
-	it("excludes hook-created synthetic files from captured patch output", { skip: hookScriptSkip }, () => {
+	it("excludes hook-created synthetic files from captured patch output", { skip: hookScriptSkip }, async () => {
 		const repoDir = createRepo("pi-worktree-hook-diff-");
 		const hookPath = createHookScript(repoDir, "setup-copy-hook.mjs", `
 import * as fs from "node:fs";
@@ -1054,7 +1126,7 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".env.local"] }));
 
 		let setup: WorktreeSetup | undefined;
 		try {
-			setup = createWorktrees(repoDir, `hook-diff-${process.pid}`, 1, {
+			setup = await createWorktrees(repoDir, `hook-diff-${process.pid}`, 1, {
 				setupHook: { hookPath: path.relative(repoDir, hookPath) },
 			});
 			fs.writeFileSync(path.join(setup.worktrees[0]!.path, "tracked.txt"), "modified-by-agent\n", "utf-8");
@@ -1068,9 +1140,11 @@ process.stdout.write(JSON.stringify({ syntheticPaths: [".env.local"] }));
 		}
 	});
 
-	it("cleans up created worktrees when a later hook setup fails", { skip: hookScriptSkip }, () => {
+	it("retains created worktrees when a later hook failure has unknown settlement", { skip: hookScriptSkip }, async () => {
+		if (await runPoisonCaseInChild("retains created worktrees when a later hook failure has unknown settlement")) return;
 		const repoDir = createRepo("pi-worktree-hook-cleanup-");
 		const runId = `hook-cleanup-${Date.now().toString(36)}`;
+		let retained: WorktreeSetup | undefined;
 		const hookPath = createHookScript(repoDir, "flaky-hook.mjs", `
 import * as fs from "node:fs";
 const payload = JSON.parse(fs.readFileSync(0, "utf-8"));
@@ -1081,18 +1155,29 @@ if (payload.index === 1) {
 process.stdout.write(JSON.stringify({ syntheticPaths: [] }));
 `);
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, runId, 2, { setupHook: { hookPath: path.relative(repoDir, hookPath) } }),
-				/worktree setup hook failed with exit code 1/i,
+				(error: unknown) => {
+					assert.ok(error instanceof WorktreeSetupError);
+					retained = error.snapshot.setup;
+					assertRetainedHookFailure(error, /worktree setup hook failed/i);
+					assert.equal(error.snapshot.attempts[1]?.hookCommand?.result?.status, 1);
+					assert.equal(error.snapshot.setup.worktrees.length, 2);
+					for (const worktree of error.snapshot.setup.worktrees) {
+						assert.equal(fs.existsSync(worktree.path), true);
+						assert.equal(git(worktree.path, ["branch", "--show-current"]), worktree.branch);
+					}
+					return true;
+				},
 			);
-			const branchList = git(repoDir, ["branch", "--list", "pi-subagents/task-hook-cleanup-s0-t*"]);
-			assert.equal(branchList.trim(), "", "temporary branches should be cleaned up after setup failure");
+			await assert.rejects(() => createWorktrees(repoDir, "after-hook-failure", 1, { provider: "native" }), /Worktree mutation blocked/i);
 		} finally {
+			for (const worktree of retained?.worktrees ?? []) fs.rmSync(worktree.path, { recursive: true, force: true });
 			cleanupRepo(repoDir);
 		}
 	});
 
-	it("fails when the hook exceeds the configured timeout", { skip: hookScriptSkip }, () => {
+	it("fails when the hook exceeds the configured timeout", { skip: hookScriptSkip }, async () => {
 		const repoDir = createRepo("pi-worktree-hook-timeout-");
 		const hookPath = createHookScript(repoDir, "slow-hook.mjs", `
 import * as fs from "node:fs";
@@ -1103,7 +1188,7 @@ setTimeout(() => {
 `);
 		const runId = `hook-timeout-${Date.now().toString(36)}`;
 		try {
-			assert.throws(
+			await assert.rejects(
 				() => createWorktrees(repoDir, runId, 1, {
 					setupHook: { hookPath: path.relative(repoDir, hookPath), timeoutMs: 50 },
 				}),


### PR DESCRIPTION
## Summary
Make managed-worktree setup subprocess waits asynchronous and cancellable without launching children into incomplete worktrees.

- Await Git, Worktrunk and setup-hook commands through a setup-specific helper with bounded output and existing cancellation/deadline handling.
- Record allocation attempts before mutation; expose cleanup paths only after validation. Preserve uncertain allocations and explicit recovery evidence instead of inventing paths or claiming cleanup.
- Serialize setup and normal finalization in one in-process transaction, including awaited detached finalization.
- Remove unused setup probes/bookkeeping and document the finite-hook contract.

Closes #1902 under the [owner-approved completion contract](https://github.com/nicobailon/pi-subagents/issues/1902#issuecomment-5549028757).

## Completion and safety contract
Setup commands and hooks must be finite and await their descendants. Exit zero, natural pipe closure, complete bounded output and valid metadata are **trusted successful completion**, not observed process-tree proof. Undisclosed live descendants violate the supported contract; protection against deleting their workspace is not guaranteed.

Exceptional cancellation/error/invalid-output paths retain artifacts when safe settlement cannot be proven. Completed PIDs are not signaled. No new timeout setting, successful-path process scan, cross-process lock or Windows containment primitive is introduced. Existing timeout start semantics remain unchanged.

This improves responsiveness during setup waits, not Git checkout speed. Preexisting synchronous metadata/caller capability probes remain outside that guarantee; queued cancellation is checked on admission.

## Validation
- 85 focused tests passed after rebase and reduction: allocator/cleanup/handoff units, foreground and background lifecycle cases, and #1901/#1903 overlap regressions.
- Eight affected foreground/background lifecycle cases passed again after the final cancellation-precedence readability change; typecheck and diff hygiene passed.
- Executed a targeted rollback-snapshot negative control: old full-output assignment failed; restored metadata-only code passed.
- Two retained-writer cleanup passes, dedicated simplification, and fresh exact-head lifecycle review completed. No review findings remain.
- Full cross-platform validation is deferred to this PR's exact-head CI. Local exceptional-process evidence is POSIX-only, not additional Windows containment proof.

## Scope
15 files: setup/caller/finalizer/handoff changes, focused existing tests and concise operator docs/changelog. No new dependency, configuration or service-management API. Existing status batching and retained-output routing are preserved.
