### PR TITLE
feat: register trusted session-scoped workflow resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
+
 ### Fixed
 - Rescue confident read-only background completions misclassified as implementation before publishing missing-edit failures (#1911). Thanks to [@yanqianglu](https://github.com/yanqianglu).
 - Keep background streaming status updates batched during long-running and attention states while publishing child activity transitions immediately (#1901).

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ The full reference lives in `docs/`:
 | [Observability](https://github.com/nicobailon/pi-subagents/blob/main/docs/observability.md) | FleetView, the fleet inspector, lifecycle artifacts, events, logs, session sharing. |
 | [Missions and schedules](https://github.com/nicobailon/pi-subagents/blob/main/docs/missions.md) | Durable mission records, delivery receipts, timed and recurring runs. |
 | [Configuration](https://github.com/nicobailon/pi-subagents/blob/main/docs/configuration.md) | Every `config.json` key and environment variable. |
-| [Extension API](https://github.com/nicobailon/pi-subagents/blob/main/docs/extension-api.md) | The RPC, delegation API, preflight, capability ceilings, background-work providers, Herdr integration. |
+| [Extension API](https://github.com/nicobailon/pi-subagents/blob/main/docs/extension-api.md) | The RPC, delegation API, preflight, capability ceilings, [trusted workflow resources](docs/extension-api.md#trusted-workflow-resources), background-work providers, Herdr integration. |

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -2,6 +2,97 @@
 
 Public seams for other Pi extensions and host integrations: the in-process RPC, the structured delegation API, launch preflight, capability ceilings, the background-work provider contract, and the Herdr integration.
 
+## Trusted workflow resources
+
+Loaded trusted TypeScript extensions can import `registerWorkflowResource` from `pi-subagents/workflow-resources`. This subpath does not load the main extension and exposes no resolver or permit constructor. Its exported types are `RegisterWorkflowResourceInput`, `WorkflowResourceDefinition`, and `WorkflowResourceRegistration`:
+
+```typescript
+registerWorkflowResource({
+  sessionId: string,
+  definition: {
+    name: string,
+    version: number,
+    resolve(args: Readonly<Record<string, unknown>>):
+      | { script: string; hostCommands?: readonly { key: string; command: string }[] }
+      | { error: string },
+  },
+}): { dispose(): void }
+```
+
+Names are case-sensitive, at most 128 characters, and match `[A-Za-z0-9][A-Za-z0-9._-]*`; use an extension prefix. Versions are positive safe integers. Registration throws for invalid input, protected builtins (`review`, `run-ci`), or duplicate names within the same session. Different sessions may register the same name. Dispose before replacement; there is no silent overwrite.
+
+Register in `session_start` using **`ctx.sessionManager.getSessionId()`**, not the session file path or a tool argument. Dispose in `session_shutdown`. New/resumed/forked sessions and reloads need registration from the replacement runtime's `session_start`; do not retain old `pi`/`ctx` references. The extension owns cleanup, not an automatic registration lifecycle manager. Disposal is idempotent and cannot remove a newer replacement. Missing cleanup can cause a duplicate-registration failure on reload.
+
+`resolve` must do synchronous, bounded validation and string construction, without I/O, SDK calls, timers or process work. Core deep-copies plain JSON args: at most 16 KiB encoded, nesting depth 8, 16 fields per object, 64 items per array, finite numbers, and nonempty strings of at most 16 KiB. The extension must additionally reject unsupported fields and validate resource-specific semantics. Throws, promises/thenables and malformed expansions fail before authority is issued; errors are bounded to 4096 characters.
+
+Host grants bind **exact key/trimmed-command pairs**, not independent sets of keys and commands. At most 32 grants are accepted, with unique safe workflow keys and nonempty commands bounded to 16 KiB without NUL. Omitted grants give no host authority. Core snapshots the expansion and grants at resolution. Disposing stops future lookup, but already-admitted workflows retain captured grants, even after replacement. Use existing stop/deadline controls for cancellation; this does not promise survival of host shutdown or durable named scheduling. Existing child admission and capability ceilings still apply.
+
+### Mixed child and finite host example
+
+This extension owns two fixed commands; `scripts/finite-check.mjs` must be an existing trusted finite helper in the workflow cwd. It runs a reviewer first, then a check. No command or flags come from free-form public args.
+
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerWorkflowResource } from "pi-subagents/workflow-resources";
+
+export default function (pi: ExtensionAPI) {
+  let registration: { dispose(): void } | undefined;
+  pi.on("session_start", (_event, ctx) => {
+    registration?.dispose();
+    registration = registerWorkflowResource({
+      sessionId: ctx.sessionManager.getSessionId(),
+      definition: {
+        name: "acme.review-check",
+        version: 1,
+        resolve(args) {
+          if (Object.keys(args).some(k => k !== "task" && k !== "check"))
+            return { error: "Only task and check are supported." };
+          if (typeof args.task !== "string" || !args.task.trim() || args.task.length > 4000)
+            return { error: "task must contain 1–4000 characters." };
+          if (args.check !== "quick" && args.check !== "full")
+            return { error: "check must be quick or full." };
+          const command = args.check === "quick"
+            ? "node ./scripts/finite-check.mjs --mode quick"
+            : "node ./scripts/finite-check.mjs --mode full";
+          const host = { kind: "command", command, timeoutMs: 120000 };
+          return {
+            hostCommands: [{ key: "check", command }],
+            script: `
+              const review = await runs.run("review", {
+                agent: "reviewer", task: ${JSON.stringify(args.task)}
+              });
+              if (!review.ok) throw new Error("Review child failed");
+              const check = await runs.host("check", ${JSON.stringify(host)});
+              return { review: review.output, check };
+            `,
+          };
+        },
+      },
+    });
+  });
+  pi.on("session_shutdown", () => {
+    registration?.dispose();
+    registration = undefined;
+  });
+}
+```
+
+Invoke through the public `subagent` tool (use `async: false` for foreground):
+
+```json
+{
+  "workflow": "acme.review-check",
+  "args": { "task": "Review the current change; return findings only.", "check": "quick" },
+  "async": true
+}
+```
+
+The parent evaluates child findings and ordinary command logs/status/terminal receipts; child success is not approval or proof of a clean review. The timeout above bounds the host command, not the whole workflow.
+
+**Trust boundary:** this API composes already-loaded trusted code; it is neither authentication nor a sandbox. Session IDs scope lookup, not authorization between malicious extensions. Core owns opaque permits and provenance; caller-supplied issuer/trust/permit metadata cannot grant authority. Raw public scripts and script paths do not gain host authority, and registration is not an arbitrary-command entry point for public args.
+
+The existing shell runner uses workflow cwd and inherited environment. Exact matching does not pin PATH resolution, executable bytes, repository helpers, or credentials. Those remain operator/extension trust responsibilities. `JSON.stringify` embeds data in JavaScript source; **it is not shell escaping**. Keep commands fixed as above, or validate strictly bounded numeric/hex tokens before binding known positions; never concatenate arbitrary task text or flags into shell commands. No new runner, cwd confinement, CI/merge policy, or SDK lifecycle framework is provided.
+
 ## In-process event-bus RPC
 
 Other Pi extensions can use the in-process event-bus RPC instead of scraping slash output or calling internal modules. Listen for `subagents:rpc:v1:ready`, send requests on `subagents:rpc:v1:request`, and read replies from `subagents:rpc:v1:reply:<requestId>`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./agents": "./src/api/agents.ts",
     "./delegation": "./src/api/delegation.ts",
     "./capability-ceiling": "./src/api/capability-ceiling.ts",
+    "./workflow-resources": "./src/api/workflow-resources.ts",
     "./preflight": "./src/api/preflight.ts",
     "./control-channel": "./src/api/control-channel.ts",
     "./intercom-bridge": "./src/api/intercom-bridge.ts",

--- a/src/api/workflow-resources.ts
+++ b/src/api/workflow-resources.ts
@@ -1,0 +1,6 @@
+export { registerWorkflowResource } from "../workflows/workflow-resources.ts";
+export type {
+	RegisterWorkflowResourceInput,
+	WorkflowResourceDefinition,
+	WorkflowResourceRegistration,
+} from "../workflows/workflow-resources.ts";

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -7039,7 +7039,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		}
 		let publicParams = normalized.params as SubagentParamsLike;
 		if (publicParams.workflow !== undefined) {
-			const resolved = resolveWorkflowResource(publicParams.workflow, publicParams.args);
+			const resolved = resolveWorkflowResource(publicParams.workflow, publicParams.args, ctx.sessionManager.getSessionId() ?? undefined);
 			if (!resolved.ok) return Promise.resolve({ content: [{ type: "text", text: resolved.error }], isError: true, details: { mode: "workflow", results: [] } });
 			const { workflow: _workflow, args: _args, ...withoutResourceInput } = publicParams;
 			publicParams = { ...withoutResourceInput, workflowScript: resolved.resource.script };

--- a/src/shared/workflow-child-permit.ts
+++ b/src/shared/workflow-child-permit.ts
@@ -117,12 +117,12 @@ export function workflowChildPermitConsumed(permit: WorkflowChildPermit): boolea
 }
 
 export interface WorkflowResourceHostAuthority {
-	keys: readonly string[];
-	commands: readonly string[];
+	key: string;
+	command: string;
 }
 
 export interface WorkflowResourceAuthority {
-	host?: WorkflowResourceHostAuthority;
+	host?: readonly WorkflowResourceHostAuthority[];
 }
 
 export interface WorkflowResourcePermitInput {
@@ -152,11 +152,17 @@ const resourceRecords = new WeakMap<object, WorkflowResourcePermitRecord>();
 function cloneWorkflowResourceAuthority(authority: WorkflowResourceAuthority): WorkflowResourceAuthority {
 	if (!authority || typeof authority !== "object" || Array.isArray(authority)) throw new Error("Workflow resource authority must be an object.");
 	if (authority.host === undefined) return Object.freeze({});
-	if (!authority.host || typeof authority.host !== "object" || Array.isArray(authority.host)) throw new Error("Workflow resource host authority must be an object.");
-	const { keys, commands } = authority.host;
-	if (!Array.isArray(keys) || keys.some((key) => typeof key !== "string" || !key.trim())) throw new Error("Workflow resource host authority keys must be non-empty strings.");
-	if (!Array.isArray(commands) || commands.some((command) => typeof command !== "string" || !command.trim())) throw new Error("Workflow resource host authority commands must be non-empty strings.");
-	return Object.freeze({ host: Object.freeze({ keys: Object.freeze([...keys]), commands: Object.freeze([...commands]) }) });
+	if (!Array.isArray(authority.host) || authority.host.length > 32) throw new Error("Workflow resource host authority must be an array of at most 32 grants.");
+	const keys = new Set<string>();
+	const host = Array.from(authority.host, (grant) => {
+		if (!grant || typeof grant !== "object" || Object.keys(grant).some((field) => field !== "key" && field !== "command")) throw new Error("Workflow resource host grant must contain only key and command.");
+		const { key, command } = grant;
+		if (typeof key !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(key) || keys.has(key)) throw new Error("Workflow resource host grant requires a unique safe key.");
+		if (typeof command !== "string" || !command.trim() || Buffer.byteLength(command.trim(), "utf8") > 16 * 1024 || command.includes("\0")) throw new Error("Workflow resource host grant requires a non-empty command of at most 16384 bytes without NUL.");
+		keys.add(key);
+		return Object.freeze({ key, command: command.trim() });
+	});
+	return Object.freeze({ host: Object.freeze(host) });
 }
 
 /** Package-internal permit for a workflow resource resolved by the extension. */
@@ -201,7 +207,6 @@ export function authorizeWorkflowResourceHost(permit: WorkflowResourcePermit, ke
 	if (!record || record.state !== "consumed") return "Workflow resource authority is unavailable.";
 	const host = record.authority.host;
 	if (!host) return "runs.host is not allowed for this workflow resource.";
-	if (!host.keys.includes(key)) return `runs.host('${key}') is not allowed for workflow resource '${record.resourceName}'.`;
-	if (!host.commands.includes(command.trim())) return `The command for runs.host('${key}') is not allowed for workflow resource '${record.resourceName}'.`;
+	if (!host.some((grant) => grant.key === key && grant.command === command.trim())) return `The command for runs.host('${key}') is not allowed for workflow resource '${record.resourceName}'.`;
 	return undefined;
 }

--- a/src/workflows/workflow-resources.ts
+++ b/src/workflows/workflow-resources.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { stableJsonDigest } from "../shared/launch-contract.ts";
 import {
 	createWorkflowResourcePermit,
-	type WorkflowResourceAuthority,
+	type WorkflowResourceHostAuthority,
 	type WorkflowResourcePermit,
 } from "../shared/workflow-child-permit.ts";
 import type { WorkflowResourceProvenanceV1 } from "../shared/types.ts";
@@ -21,11 +21,68 @@ export type WorkflowResourceResolution =
 	| { ok: true; resource: ResolvedWorkflowResource }
 	| { ok: false; error: string };
 
-type WorkflowResourceDefinition = {
+export interface WorkflowResourceDefinition {
 	name: string;
 	version: number;
-	resolve: (args: Record<string, unknown>) => { script: string; authority: WorkflowResourceAuthority } | { error: string };
-};
+	/** Trusted synchronous validation/expansion. The extension owns semantic command binding. */
+	resolve: (args: Readonly<Record<string, unknown>>) => { script: string; hostCommands?: readonly WorkflowResourceHostAuthority[] } | { error: string };
+}
+
+export interface WorkflowResourceRegistration {
+	dispose(): void;
+}
+
+export interface RegisterWorkflowResourceInput {
+	sessionId: string;
+	definition: WorkflowResourceDefinition;
+}
+
+interface WorkflowResourceRegistry {
+	version: 1;
+	bySession: Map<string, Map<string, WorkflowResourceDefinition>>;
+}
+
+function registry(): WorkflowResourceRegistry {
+	const key = Symbol.for("pi-subagents.workflow-resources.v1");
+	const globalObject = globalThis as Record<PropertyKey, unknown>;
+	const existing = globalObject[key];
+	if (existing === undefined) {
+		const created: WorkflowResourceRegistry = { version: 1, bySession: new Map() };
+		globalObject[key] = created;
+		return created;
+	}
+	if (!isPlainRecord(existing) || existing.version !== 1 || !(existing.bySession instanceof Map)) throw new Error("Malformed or unsupported workflow resource registry.");
+	return existing as unknown as WorkflowResourceRegistry;
+}
+
+/** Session ID scopes lookup, not authentication. Dispose on session_shutdown; issued permits remain valid. */
+export function registerWorkflowResource(input: RegisterWorkflowResourceInput): WorkflowResourceRegistration {
+	if (!isPlainRecord(input) || Object.keys(input).some((key) => key !== "sessionId" && key !== "definition")) throw new Error("Workflow registration requires only sessionId and definition.");
+	const { sessionId, definition } = input;
+	if (typeof sessionId !== "string" || !sessionId || sessionId.trim() !== sessionId || sessionId.length > 256 || sessionId.includes("\0")) throw new Error("Workflow registration requires a non-empty trimmed sessionId of at most 256 characters without NUL.");
+	if (!isPlainRecord(definition) || Object.keys(definition).some((key) => !["name", "version", "resolve"].includes(key))) throw new Error("Workflow definition requires only name, version and resolve.");
+	const { name, version, resolve } = definition;
+	if (typeof name !== "string" || !RESOURCE_NAME_PATTERN.test(name)) throw new Error("Workflow definition requires a safe resource name.");
+	if (!Number.isSafeInteger(version) || version < 1) throw new Error("Workflow definition version must be a positive safe integer.");
+	if (typeof resolve !== "function") throw new Error("Workflow definition requires a synchronous resolve function.");
+	if (findWorkflowResource(name)) throw new Error(`Workflow resource '${name}' is a protected builtin.`);
+	const current = registry();
+	const bucket = current.bySession.get(sessionId) ?? new Map<string, WorkflowResourceDefinition>();
+	if (!(bucket instanceof Map)) throw new Error("Malformed workflow resource session registry.");
+	if (bucket.has(name)) throw new Error(`Workflow resource '${name}' is already registered in this session; dispose it first.`);
+	const snapshot = Object.freeze({ name, version, resolve });
+	bucket.set(name, snapshot);
+	current.bySession.set(sessionId, bucket);
+	let disposed = false;
+	return {
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			if (bucket.get(name) === snapshot) bucket.delete(name);
+			if (bucket.size === 0 && current.bySession.get(sessionId) === bucket) current.bySession.delete(sessionId);
+		},
+	};
+}
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
@@ -74,13 +131,13 @@ function normalizeArgs(value: unknown): { args?: Record<string, unknown>; error?
 	try {
 		validatePlainJson(value, "workflow args");
 		if (jsonByteLength(value) > MAX_ARGS_BYTES) return { error: `workflow args exceed ${MAX_ARGS_BYTES} bytes.` };
-		return { args: { ...value } };
+		return { args: JSON.parse(JSON.stringify(value)) };
 	} catch (error) {
 		return { error: error instanceof Error ? error.message : String(error) };
 	}
 }
 
-function resolveRunCi(args: Record<string, unknown>): { script: string; authority: WorkflowResourceAuthority } | { error: string } {
+function resolveRunCi(args: Readonly<Record<string, unknown>>): ReturnType<WorkflowResourceDefinition["resolve"]> {
 	const allowed = new Set(["command", "timeoutMs"]);
 	const unsupported = Object.keys(args).filter((key) => !allowed.has(key));
 	if (unsupported.length > 0) return { error: `workflow 'run-ci' args contain unsupported fields: ${unsupported.join(", ")}.` };
@@ -91,18 +148,17 @@ function resolveRunCi(args: Record<string, unknown>): { script: string; authorit
 	const params = { kind: "command", command, timeoutMs, role: "ci" };
 	return {
 		script: `return await runs.host("ci", ${JSON.stringify(params)});`,
-		authority: { host: { keys: ["ci"], commands: [command] } },
+		hostCommands: [{ key: "ci", command }],
 	};
 }
 
-function resolveReview(args: Record<string, unknown>): { script: string; authority: WorkflowResourceAuthority } | { error: string } {
+function resolveReview(args: Readonly<Record<string, unknown>>): ReturnType<WorkflowResourceDefinition["resolve"]> {
 	const unsupported = Object.keys(args).filter((key) => key !== "task");
 	if (unsupported.length > 0) return { error: `workflow 'review' args contain unsupported fields: ${unsupported.join(", ")}.` };
 	const task = args.task;
 	if (typeof task !== "string" || !task.trim()) return { error: "workflow 'review' requires a non-empty string args.task." };
 	return {
 		script: `return (await runs.run("review", { agent: "reviewer", task: ${JSON.stringify(task.trim())} })).output;`,
-		authority: {},
 	};
 }
 
@@ -120,23 +176,42 @@ function listWorkflowResourceNames(): string[] {
 }
 
 /** Resolve only extension-owned resources so policy can distinguish them from raw scripts; caller-provided script text is never consulted. */
-export function resolveWorkflowResource(nameValue: unknown, argsValue?: unknown): WorkflowResourceResolution {
+export function resolveWorkflowResource(nameValue: unknown, argsValue?: unknown, sessionId?: string): WorkflowResourceResolution {
+	try {
+		const result = resolveResource(nameValue, argsValue, sessionId);
+		return result.ok ? result : { ok: false, error: result.error.slice(0, 4096) };
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message.slice(0, 4096) : "Workflow resource resolution failed." };
+	}
+}
+
+function resolveResource(nameValue: unknown, argsValue?: unknown, sessionId?: string): WorkflowResourceResolution {
 	if (typeof nameValue !== "string" || !nameValue.trim()) return { ok: false, error: "workflow must be a non-empty resource name." };
 	const name = nameValue.trim();
 	if (!RESOURCE_NAME_PATTERN.test(name)) return { ok: false, error: "workflow must use a safe resource name." };
-	const resource = findWorkflowResource(name);
+	const resource = findWorkflowResource(name) ?? (sessionId ? registry().bySession.get(sessionId)?.get(name) : undefined);
 	if (!resource) return { ok: false, error: `Unknown workflow resource '${name}'. Available resources: ${listWorkflowResourceNames().join(", ")}.` };
 	const normalizedArgs = normalizeArgs(argsValue);
 	if (normalizedArgs.error) return { ok: false, error: normalizedArgs.error };
 	const resolved = resource.resolve(normalizedArgs.args!);
-	if ("error" in resolved) return { ok: false, error: resolved.error };
+	if (resolved && typeof (resolved as unknown as { then?: unknown }).then === "function") {
+		void Promise.resolve(resolved).catch(() => {});
+		throw new Error("Workflow resource resolve must be synchronous.");
+	}
+	if (!isPlainRecord(resolved)) throw new Error("Workflow resource resolve must return an expansion or error object.");
+	if ("error" in resolved) {
+		if (Object.keys(resolved).some((key) => key !== "error") || typeof resolved.error !== "string" || !resolved.error.trim()) throw new Error("Workflow resource returned an invalid error.");
+		return { ok: false, error: resolved.error };
+	}
+	const { script, hostCommands } = resolved;
+	if (Object.keys(resolved).some((key) => key !== "script" && key !== "hostCommands") || typeof script !== "string" || !script.trim()) throw new Error("Workflow resource returned an invalid expansion.");
 	const resourceId = randomUUID();
 	const permit = createWorkflowResourcePermit({
 		resourceName: resource.name,
 		resourceVersion: resource.version,
 		resourceId,
-		scriptDigest: stableJsonDigest(resolved.script),
-		authority: resolved.authority,
+		scriptDigest: stableJsonDigest(script),
+		authority: { host: hostCommands },
 	});
 	const provenance: WorkflowResourceProvenanceV1 = Object.freeze({
 		kind: "workflow",
@@ -146,5 +221,5 @@ export function resolveWorkflowResource(nameValue: unknown, argsValue?: unknown)
 		expansion: "resolved",
 		id: resourceId,
 	});
-	return { ok: true, resource: { script: resolved.script, permit, provenance } };
+	return { ok: true, resource: { script, permit, provenance } };
 }

--- a/test/integration/async-execution.part-1.test.ts
+++ b/test/integration/async-execution.part-1.test.ts
@@ -15,6 +15,8 @@ import { syncBuiltinESMExports } from "node:module";
 import * as path from "node:path";
 import { events, makeAgent, makeMinimalCtx, resolveMockPiCallArgs } from "../support/helpers.ts";
 import { registerSubagentCapabilityCeiling } from "../../src/api/capability-ceiling.ts";
+import { registerWorkflowResource } from "../../src/api/workflow-resources.ts";
+import type { WorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
 import { resolveSubagentLaunchContract } from "../../src/api/preflight.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { runSync } from "../../src/runs/foreground/execution.ts";
@@ -31,6 +33,70 @@ import {
 
 describe("async execution utilities", { skip: !available ? "pi packages not available" : undefined }, () => {
 	installAsyncExecutionHooks();
+
+	it("executes a registered mixed background workflow with captured grants after disposal", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const ctx = makeMinimalCtx(tempDir);
+		const command = `${JSON.stringify(process.execPath)} registered-check.cjs`;
+		fs.writeFileSync(path.join(tempDir, "registered-check.cjs"), `require("node:fs").writeFileSync("registered-marker", "ran"); console.log("background finite check passed");`);
+		const definition = { name: "test.background", version: 1, resolve: () => ({
+			script: `const child = await runs.run("review", { agent: "reviewer", task: "Review the change" }); if (!child.ok) throw new Error("Required review failed"); return await runs.host("check", ${JSON.stringify({ kind: "command", command, timeoutMs: 5000, output: "registered-check.log" })});`,
+			hostCommands: [{ key: "check", command }],
+		}) };
+		const registration = registerWorkflowResource({ sessionId: ctx.sessionManager.getSessionId(), definition });
+		const executor = makeAsyncExecutor([makeAgent("reviewer", { completionGuard: false })]);
+		mockPi.onCall({ output: "Background review completed" });
+		try {
+			const pending = executor.executePublic("registered-background", { workflow: definition.name, async: true }, new AbortController().signal, undefined, ctx);
+			// executePublic has synchronously captured the expansion; no timing-based wait.
+			registration.dispose();
+			const missing = await executor.executePublic("disposed-background", { workflow: definition.name, async: true }, new AbortController().signal, undefined, ctx);
+			assert.equal(missing.isError, true);
+			assert.match(missing.content[0]?.text ?? "", /Unknown workflow/);
+			const replacement = registerWorkflowResource({ sessionId: ctx.sessionManager.getSessionId(), definition: { ...definition, resolve: () => ({ script: "return 'replacement'" }) } });
+			try {
+				const launch = await pending;
+				assert.equal(launch.isError, undefined, launch.content[0]?.text);
+				const id = launch.details?.asyncId;
+				assert.ok(id);
+				const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf8")) as AsyncResultPayload & { workflowReceipt: { path: string; receipt: WorkflowReceipt } };
+				assert.equal(payload.success, true, payload.error);
+				assert.equal((await waitForAsyncState(id, (status) => status.state === "complete")).state, "complete");
+				assert.equal(payload.results[0]?.output, "Background review completed");
+				assert.equal(mockPi.callCount(), 1);
+				assert.equal(fs.readFileSync(path.join(tempDir, "registered-marker"), "utf8"), "ran");
+				assert.match(fs.readFileSync(path.join(tempDir, "registered-check.log"), "utf8"), /background finite check passed/);
+				assert.equal(payload.workflowReceipt.receipt.resource?.name, definition.name);
+				assert.equal(payload.workflowReceipt.receipt.state, "complete");
+				assert.equal(payload.workflowReceipt.receipt.entries.review.agent, "reviewer");
+				assert.ok(payload.workflowReceipt.receipt.entries.review.latestRunId);
+				assert.deepEqual(payload.workflowReceipt.receipt.hostSteps?.map(({ id, state, exitCode }) => ({ id, state, exitCode })), [{ id: "check", state: "done", exitCode: 0 }]);
+				assert.deepEqual(JSON.parse(fs.readFileSync(payload.workflowReceipt.path, "utf8")), payload.workflowReceipt.receipt);
+			} finally { replacement.dispose(); }
+		} finally { registration.dispose(); }
+	});
+
+	it("enforces the registered background command deadline and records terminal failure", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const ctx = makeMinimalCtx(tempDir);
+		const command = `${JSON.stringify(process.execPath)} finite-slow-check.cjs`;
+		fs.writeFileSync(path.join(tempDir, "finite-slow-check.cjs"), `console.log("finite slow check started"); setTimeout(() => console.log("unexpected completion"), 10000);`);
+		const registration = registerWorkflowResource({ sessionId: ctx.sessionManager.getSessionId(), definition: {
+			name: "test.deadline", version: 1, resolve: () => ({ script: `return await runs.host("check", ${JSON.stringify({ kind: "command", command, timeoutMs: 250, output: "deadline.log" })});`, hostCommands: [{ key: "check", command }] }),
+		} });
+		try {
+			const launch = await makeAsyncExecutor([]).executePublic("registered-deadline", { workflow: "test.deadline", async: true }, new AbortController().signal, undefined, ctx);
+			assert.equal(launch.isError, undefined, launch.content[0]?.text);
+			const id = launch.details?.asyncId;
+			assert.ok(id);
+			const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf8")) as AsyncResultPayload & { workflowReceipt: { receipt: WorkflowReceipt } };
+			assert.equal(payload.success, false);
+			assert.equal((await waitForAsyncState(id, (status) => status.state === "failed")).state, "failed");
+			assert.equal(payload.workflowReceipt.receipt.resource?.name, "test.deadline");
+			assert.equal(payload.workflowReceipt.receipt.state, "failed");
+			assert.deepEqual(payload.workflowReceipt.receipt.hostSteps?.map(({ state, reasonCode }) => ({ state, reasonCode })), [{ state: "error", reasonCode: "timed_out" }]);
+			assert.doesNotMatch(fs.readFileSync(path.join(tempDir, "deadline.log"), "utf8"), /unexpected completion/);
+			assert.equal(mockPi.callCount(), 0);
+		} finally { registration.dispose(); }
+	});
 
 	it("reports jiti availability as boolean", () => {
 		const result = isAsyncAvailable();

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -56,6 +56,8 @@ import { createResultWatcher } from "../../src/runs/background/result-watcher.ts
 import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 import { createWorkflowChildPermit, workflowChildPermitConsumed } from "../../src/shared/workflow-child-permit.ts";
 import { toSubagentDelegationExecutionParams } from "../../src/slash/delegation-adapters.ts";
+import { registerWorkflowResource } from "../../src/api/workflow-resources.ts";
+import { registerSubagentCapabilityCeiling } from "../../src/api/capability-ceiling.ts";
 
 describe("single sync execution", { skip: !available ? "pi packages not available" : undefined }, () => {
 	installSingleExecutionHooks();
@@ -632,6 +634,78 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(result.details.workflow?.resource?.invocation, "named");
 		assert.equal(result.details.workflow?.receipt?.resource?.id, result.details.workflow?.resource?.id);
 		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("executes a registered mixed foreground workflow without widening session or child authority", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const ctx = makeMinimalCtx(tempDir);
+		// A persistent session's file path is not its SDK session ID.
+		ctx.sessionManager.getSessionFile = () => path.join(tempDir, "parent.jsonl");
+		const marker = path.join(tempDir, "registered-marker");
+		fs.writeFileSync(path.join(tempDir, "registered-check.cjs"), `require("node:fs").writeFileSync("registered-marker", "ran"); console.log("finite check passed");`);
+		const command = `${JSON.stringify(process.execPath)} registered-check.cjs`;
+		const host = `return await runs.host("check", ${JSON.stringify({ kind: "command", command, timeoutMs: 5000, output: "registered-check.log" })});`;
+		const script = `const child = await runs.run("review", { agent: "reviewer", task: "Review the change", capabilityCeiling: { version: 1, allowedAgents: ["reviewer"], sources: ["resource"] } }); if (!child.ok) throw new Error("Required review failed"); ${host}`;
+		const registration = registerWorkflowResource({ sessionId: ctx.sessionManager.getSessionId(), definition: {
+			name: "test.mixed", version: 1, resolve: () => ({ script, hostCommands: [{ key: "check", command }] }),
+		} });
+		const executor = makeExecutor([makeAgent("reviewer")]);
+		try {
+			const other = makeMinimalCtx(tempDir);
+			other.sessionManager.getSessionId = () => "other-session";
+			const wrongSession = await executor.executePublic("wrong-session", { workflow: "test.mixed", args: { sessionId: ctx.sessionManager.getSessionId() }, async: false }, new AbortController().signal, undefined, other);
+			assert.equal(wrongSession.isError, true);
+			assert.match(wrongSession.content[0]?.text ?? "", /Unknown workflow/);
+			assert.equal(fs.existsSync(marker), false);
+			assert.equal(mockPi.callCount(), 0);
+
+			const ceiling = registerSubagentCapabilityCeiling({ sessionId: ctx.sessionManager.getSessionFile()!, source: "test", ceiling: { allowedAgents: ["echo"] } });
+			try {
+				const denied = await executor.executePublic("ceiling-denied", { workflow: "test.mixed", async: false, capabilityCeiling: { version: 1, allowedAgents: ["reviewer"], sources: ["caller"] } }, new AbortController().signal, undefined, ctx);
+				assert.equal(denied.isError, true);
+				assert.match(denied.content[0]?.text ?? "", /Capability ceiling from caller, test does not allow agent 'reviewer'/);
+				assert.equal(fs.existsSync(marker), false);
+				assert.equal(mockPi.callCount(), 0);
+			} finally { ceiling.dispose(); }
+
+			mockPi.onCall({ output: "Registered review completed" });
+			const result = await executor.executePublic("registered-mixed", { workflow: "test.mixed", async: false }, new AbortController().signal, undefined, ctx);
+			assert.equal(result.isError, undefined, result.content[0]?.text);
+			assert.equal(mockPi.callCount(), 1);
+			assert.equal(fs.readFileSync(marker, "utf8"), "ran");
+			assert.match(fs.readFileSync(path.join(tempDir, "registered-check.log"), "utf8"), /finite check passed/);
+			assert.equal(result.details.workflow?.receipt?.resource?.name, "test.mixed");
+			assert.equal(result.details.workflow?.receipt?.state, "complete");
+			assert.equal(result.details.workflow?.receipt?.entries.review.agent, "reviewer");
+			assert.ok(result.details.workflow?.receipt?.entries.review.latestRunId);
+			assert.deepEqual(result.details.workflow?.receipt?.hostSteps?.map(({ id, state, exitCode }) => ({ id, state, exitCode })), [{ id: "check", state: "done", exitCode: 0 }]);
+		} finally { registration.dispose(); }
+	});
+
+	it("denies untrusted and out-of-grant registered commands before spawning", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const marker = path.join(tempDir, "denied-marker");
+		fs.writeFileSync(path.join(tempDir, "denied-check.cjs"), `require("node:fs").writeFileSync("denied-marker", "ran");`);
+		const command = `${JSON.stringify(process.execPath)} denied-check.cjs`;
+		const script = `return await runs.host("check", ${JSON.stringify({ kind: "command", command, timeoutMs: 5000 })});`;
+		const ctx = makeMinimalCtx(tempDir);
+		const executor = makeExecutor([]);
+		const registration = registerWorkflowResource({ sessionId: ctx.sessionManager.getSessionId(), definition: {
+			name: "test.denied", version: 1, resolve: () => ({ script, hostCommands: [{ key: "different-key", command }, { key: "check", command: `${command} unused` }] }),
+		} });
+		fs.writeFileSync(path.join(tempDir, "raw-workflow.js"), script);
+		try {
+			for (const params of [
+				{ workflowScript: script },
+				{ workflowScriptPath: "raw-workflow.js" },
+				{ workflow: "test.denied", workflowResourcePermit: {} },
+				{ workflow: "test.denied" },
+			]) {
+				const result = await executor.executePublic("denied-command", { ...params, async: false }, new AbortController().signal, undefined, ctx);
+				assert.equal(result.isError, true);
+				assert.match(result.content[0]?.text ?? "", /runs\.host is unavailable|provenance or permit|not allowed/);
+				assert.equal(fs.existsSync(marker), false);
+				assert.equal(mockPi.callCount(), 0);
+			}
+		} finally { registration.dispose(); }
 	});
 
 	it("denies host calls from raw public workflow scripts without resource authority", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/support/async-execution-fixture.ts
+++ b/test/support/async-execution-fixture.ts
@@ -263,6 +263,7 @@ interface TypesModule {
 interface ExecutorModule {
 	createSubagentExecutor?: (...args: unknown[]) => {
 		execute: (...args: unknown[]) => Promise<{ content: Array<{ text?: string }>; isError?: boolean; details?: { asyncId?: string } }>;
+		executePublic: (...args: unknown[]) => Promise<{ content: Array<{ text?: string }>; isError?: boolean; details?: { asyncId?: string } }>;
 	};
 }
 

--- a/test/unit/package-manifest.test.ts
+++ b/test/unit/package-manifest.test.ts
@@ -37,6 +37,17 @@ test("the root entrypoint exposes the runtime error flag to TypeScript consumers
 		fs.writeFileSync(path.join(consumerRoot, "consumer.ts"), `
 import "pi-subagents";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { registerWorkflowResource, type RegisterWorkflowResourceInput, type WorkflowResourceDefinition, type WorkflowResourceRegistration } from "pi-subagents/workflow-resources";
+
+const definition: WorkflowResourceDefinition = {
+	name: "consumer.check", version: 1,
+	resolve: (args) => typeof args.task === "string"
+		? { script: "return 1;", hostCommands: [{ key: "check", command: "node --version" }] }
+		: { error: "task required" },
+};
+const input: RegisterWorkflowResourceInput = { sessionId: "consumer", definition };
+const registration: WorkflowResourceRegistration = registerWorkflowResource(input);
+registration.dispose();
 
 const result: AgentToolResult<undefined> = {
 	content: [],
@@ -60,6 +71,7 @@ void result.isError;
 				baseUrl: consumerRoot,
 				paths: {
 					"pi-subagents": [path.join(projectRoot, "index.ts")],
+					"pi-subagents/workflow-resources": [path.join(projectRoot, "src/api/workflow-resources.ts")],
 				"@earendil-works/pi-agent-core": [path.join(projectRoot, "node_modules", "@earendil-works", "pi-agent-core", "dist", "index.d.ts")],
 				},
 			},
@@ -108,6 +120,7 @@ test("published extension APIs use supported package entrypoints", async () => {
 		"./external-job-provider": "./src/api/external-job-provider.ts",
 		"./external-runs": "./src/api/external-runs.ts",
 		"./capability-ceiling": "./src/api/capability-ceiling.ts",
+		"./workflow-resources": "./src/api/workflow-resources.ts",
 		"./delegation": "./src/api/delegation.ts",
 		"./preflight": "./src/api/preflight.ts",
 		"./control-channel": "./src/api/control-channel.ts",
@@ -134,6 +147,9 @@ test("published extension APIs use supported package entrypoints", async () => {
 	assert.equal(typeof externalRuns.snapshotExternalRuns, "function");
 	assert.equal(typeof externalRuns.unregisterExternalRun, "function");
 	const capability = await import("pi-subagents/capability-ceiling");
+	const workflowResources = await import("pi-subagents/workflow-resources");
+	assert.deepEqual(Object.keys(workflowResources), ["registerWorkflowResource"]);
+	assert.equal(typeof workflowResources.registerWorkflowResource, "function");
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_VERSION, 1);
 	assert.equal(capability.SUBAGENT_CAPABILITY_CEILING_REGISTRY_KEY, "pi-subagents.capability-ceiling.v1");
 	const delegation = await import("pi-subagents/delegation");

--- a/test/unit/workflow-resources.test.ts
+++ b/test/unit/workflow-resources.test.ts
@@ -50,7 +50,6 @@ describe("named workflow resources", () => {
 				assert.match(authorizeWorkflowResourceHost(resolved.resource.permit, "other", "node check.mjs")!, /not allowed/);
 				assert.match(authorizeWorkflowResourceHost(resolved.resource.permit, "check", "node changed.mjs")!, /not allowed/);
 				assert.match(consumeWorkflowResourcePermit(resolved.resource.permit, resolved.resource.script) as string, /already consumed/);
-				assert.equal(Object.isFrozen(typeof consumed === "object" && consumed.authority.host?.[0]), true);
 			} finally { replacement.dispose(); }
 		} finally { registration.dispose(); other.dispose(); }
 	});
@@ -120,23 +119,15 @@ describe("named workflow resources", () => {
 		await new Promise<void>((resolve) => setImmediate(resolve));
 	});
 
-	it("shares registrations across evaluated module copies and fails closed on registry version corruption", async () => {
+	it("shares registrations across evaluated module copies", async () => {
 		const copy = await import(`../../src/workflows/workflow-resources.ts?copy=registration-test`);
 		const registration = copy.registerWorkflowResource({ sessionId: "copies", definition: { name: "acme.copy", version: 1, resolve: () => ({ script: "return true;" }) } });
-		const key = Symbol.for("pi-subagents.workflow-resources.v1");
-		const globals = globalThis as Record<PropertyKey, unknown>;
-		const saved = globals[key];
 		try {
 			assert.notEqual(copy.resolveWorkflowResource, resolveWorkflowResource);
 			const resolved = resolveWorkflowResource("acme.copy", {}, "copies");
 			assert.equal(resolved.ok, true);
 			if (resolved.ok) assert.equal(typeof consumeWorkflowResourcePermit(resolved.resource.permit, resolved.resource.script), "object");
-			for (const invalid of [null, { version: 2, bySession: new Map() }, { version: 1, bySession: [] }]) {
-				globals[key] = invalid;
-				assert.equal(resolveWorkflowResource("acme.copy", {}, "copies").ok, false);
-				assert.throws(() => copy.registerWorkflowResource({ sessionId: "copies", definition: { name: "acme.other", version: 1, resolve: () => ({ script: "return true;" }) } }), /registry/);
-			}
-		} finally { globals[key] = saved; registration.dispose(); }
+		} finally { registration.dispose(); }
 		assert.equal(resolveWorkflowResource("acme.copy", {}, "copies").ok, false);
 	});
 

--- a/test/unit/workflow-resources.test.ts
+++ b/test/unit/workflow-resources.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { registerWorkflowResource, type WorkflowResourceDefinition } from "../../src/api/workflow-resources.ts";
 import {
 	authorizeWorkflowResourceHost,
 	consumeWorkflowResourcePermit,
@@ -8,6 +9,137 @@ import { resolveWorkflowResource } from "../../src/workflows/workflow-resources.
 import { runWorkflowScript, WorkflowScriptError } from "../../src/workflows/scripted-workflow.ts";
 
 describe("named workflow resources", () => {
+	it("scopes registrations by session and snapshots definitions, args and issued grants", () => {
+		const args = { nested: { task: "original" } };
+		const expansion = { script: "return 'original';", hostCommands: [{ key: "check", command: " node check.mjs " }, { key: "other", command: "node other.mjs" }] };
+		const definition: WorkflowResourceDefinition = {
+			name: "acme.check", version: 2,
+			resolve(input) {
+				(input.nested as { task: string }).task = "changed";
+				return expansion;
+			},
+		};
+		const registration = registerWorkflowResource({ sessionId: "one", definition });
+		const other = registerWorkflowResource({ sessionId: "two", definition: { ...definition, resolve: () => ({ script: "return 'two';" }) } });
+		try {
+			definition.version = 99;
+			definition.resolve = () => ({ error: "replacement must not run" });
+			assert.throws(() => registerWorkflowResource({ sessionId: "one", definition }), /already registered/);
+			assert.equal(resolveWorkflowResource("acme.check", args).ok, false);
+			assert.equal(resolveWorkflowResource("acme.check", args, "wrong").ok, false);
+			const resolved = resolveWorkflowResource("acme.check", args, "one");
+			assert.equal(resolved.ok, true);
+			if (!resolved.ok) return;
+			assert.equal(args.nested.task, "original");
+			assert.equal(resolved.resource.provenance.version, 2);
+			expansion.script = "return 'changed';";
+			expansion.hostCommands[0].command = "node changed.mjs";
+			registration.dispose();
+			assert.equal(resolveWorkflowResource("acme.check", args, "one").ok, false);
+			const replacement = registerWorkflowResource({ sessionId: "one", definition: { ...definition, resolve: () => ({ script: "return 'new';" }) } });
+			try {
+				registration.dispose();
+				assert.equal(resolveWorkflowResource("acme.check", {}, "one").ok, true);
+				assert.equal(resolveWorkflowResource("acme.check", {}, "two").ok, true);
+				const consumed = consumeWorkflowResourcePermit(resolved.resource.permit, resolved.resource.script);
+				assert.equal(typeof consumed, "object");
+				assert.equal(resolved.resource.script, "return 'original';");
+				assert.equal(authorizeWorkflowResourceHost(resolved.resource.permit, "check", "node check.mjs"), undefined);
+				assert.equal(authorizeWorkflowResourceHost(resolved.resource.permit, "other", "node other.mjs"), undefined);
+				assert.match(authorizeWorkflowResourceHost(resolved.resource.permit, "check", "node other.mjs")!, /not allowed/);
+				assert.match(authorizeWorkflowResourceHost(resolved.resource.permit, "other", "node check.mjs")!, /not allowed/);
+				assert.match(authorizeWorkflowResourceHost(resolved.resource.permit, "check", "node changed.mjs")!, /not allowed/);
+				assert.match(consumeWorkflowResourcePermit(resolved.resource.permit, resolved.resource.script) as string, /already consumed/);
+				assert.equal(Object.isFrozen(typeof consumed === "object" && consumed.authority.host?.[0]), true);
+			} finally { replacement.dispose(); }
+		} finally { registration.dispose(); other.dispose(); }
+	});
+
+	it("lets trusted validation select fixed commands while task text remains data", async () => {
+		const registration = registerWorkflowResource({ sessionId: "binding", definition: {
+			name: "acme.review-check", version: 1,
+			resolve(args) {
+				if (Object.keys(args).some((key) => key !== "task" && key !== "check") || typeof args.task !== "string" || args.check !== "quick") return { error: "Only task and check=quick are supported." };
+				return { script: `return ${JSON.stringify(args.task)};`, hostCommands: [{ key: "check", command: "node check.mjs --quick" }] };
+			},
+		} });
+		try {
+			const task = `\"); await runs.host("injected", { command: "bad" }); //`;
+			const resolved = resolveWorkflowResource("acme.review-check", { task, check: "quick" }, "binding");
+			assert.equal(resolved.ok, true);
+			if (!resolved.ok) return;
+			const execution = await runWorkflowScript({
+				script: resolved.resource.script,
+				async launch() { throw new Error("No child expected"); },
+				async status() { throw new Error("No status expected"); },
+			});
+			assert.equal(execution.value, task);
+			for (const args of [{ task, check: "quick; bad" }, { task, check: "quick", flags: "--extra" }, { task, check: "quick", command: "bad" }, { task: new Date(), check: "quick" }, { task: "x".repeat(16385), check: "quick" }]) {
+				assert.equal(resolveWorkflowResource("acme.review-check", args, "binding").ok, false);
+			}
+		} finally { registration.dispose(); }
+	});
+
+	it("rejects invalid registrations and protects builtin names", () => {
+		const valid = { sessionId: "validation", definition: { name: "acme.check", version: 1, resolve: () => ({ script: "return true;" }) } };
+		for (const input of [
+			{ ...valid, sessionId: " " },
+			{ ...valid, trusted: true },
+			{ ...valid, definition: { ...valid.definition, name: "run-ci" } },
+			{ ...valid, definition: { ...valid.definition, name: "review" } },
+			{ ...valid, definition: { ...valid.definition, name: "bad name" } },
+			{ ...valid, definition: { ...valid.definition, version: 0 } },
+			{ ...valid, definition: { ...valid.definition, resolve: undefined } },
+			{ ...valid, definition: { ...valid.definition, issuerPackage: "trusted" } },
+		]) assert.throws(() => registerWorkflowResource(input as typeof valid));
+	});
+
+	it("contains throws, async results and malformed expansions without issuing permits", async () => {
+		const invalid = [
+			() => { throw new Error("x".repeat(5000)); },
+			() => Promise.reject(new Error("async rejection")),
+			() => ({ then(resolve: (value: unknown) => void) { resolve({ script: "return true;" }); } }),
+			() => null,
+			() => ({ script: " " }),
+			() => ({ script: "return true;", authority: {} }),
+			() => ({ error: 42 }),
+			() => ({ script: "return true;", hostCommands: { keys: ["a"], commands: ["node a.mjs"] } }),
+			() => ({ script: "return true;", hostCommands: [{ key: "a", command: "node a.mjs" }, { key: "a", command: "node b.mjs" }] }),
+			() => ({ script: "return true;", hostCommands: [{ key: "../a", command: "node a.mjs" }] }),
+			() => ({ script: "return true;", hostCommands: [{ key: "a", command: "node\0a" }] }),
+		];
+		for (const resolve of invalid) {
+			const registration = registerWorkflowResource({ sessionId: "invalid", definition: { name: "acme.invalid", version: 1, resolve: resolve as WorkflowResourceDefinition["resolve"] } });
+			try {
+				const result = resolveWorkflowResource("acme.invalid", {}, "invalid");
+				assert.equal(result.ok, false);
+				assert.equal("resource" in result, false);
+				if (!result.ok) assert.ok(result.error.length <= 4096);
+			} finally { registration.dispose(); }
+		}
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	});
+
+	it("shares registrations across evaluated module copies and fails closed on registry version corruption", async () => {
+		const copy = await import(`../../src/workflows/workflow-resources.ts?copy=registration-test`);
+		const registration = copy.registerWorkflowResource({ sessionId: "copies", definition: { name: "acme.copy", version: 1, resolve: () => ({ script: "return true;" }) } });
+		const key = Symbol.for("pi-subagents.workflow-resources.v1");
+		const globals = globalThis as Record<PropertyKey, unknown>;
+		const saved = globals[key];
+		try {
+			assert.notEqual(copy.resolveWorkflowResource, resolveWorkflowResource);
+			const resolved = resolveWorkflowResource("acme.copy", {}, "copies");
+			assert.equal(resolved.ok, true);
+			if (resolved.ok) assert.equal(typeof consumeWorkflowResourcePermit(resolved.resource.permit, resolved.resource.script), "object");
+			for (const invalid of [null, { version: 2, bySession: new Map() }, { version: 1, bySession: [] }]) {
+				globals[key] = invalid;
+				assert.equal(resolveWorkflowResource("acme.copy", {}, "copies").ok, false);
+				assert.throws(() => copy.registerWorkflowResource({ sessionId: "copies", definition: { name: "acme.other", version: 1, resolve: () => ({ script: "return true;" }) } }), /registry/);
+			}
+		} finally { globals[key] = saved; registration.dispose(); }
+		assert.equal(resolveWorkflowResource("acme.copy", {}, "copies").ok, false);
+	});
+
 	it("resolves and executes an extension-owned named workflow script", async () => {
 		const resolved = resolveWorkflowResource("run-ci", { command: "npm test", timeoutMs: 1_000 });
 		assert.equal(resolved.ok, true);


### PR DESCRIPTION
## Summary

Closes #1907.

Add `registerWorkflowResource` through `pi-subagents/workflow-resources`. Trusted extensions can register session-scoped named workflows that combine child agents with finite host commands through the existing `runs.host` engine.

- Use the actual SDK session ID for lookup; reject builtin collisions and duplicate registrations.
- Validate bounded JSON arguments and synchronous expansions. Snapshot definitions, scripts and exact key/command grants.
- Provide idempotent, identity-safe disposal. Disposal blocks future lookup without revoking already-captured workflow authority.
- Keep raw scripts, script paths and forged metadata from acquiring host authority. Existing child ceilings, host timeouts, cancellation, logs and receipts remain in place.
- Document extension-owned startup/shutdown registration and a mixed child/host example. No new runner, configuration layer or GitHub policy.

## Validation

- 10 workflow-resource unit tests, seven focused foreground/background integration cases, nine package-manifest checks and typecheck passed.
- Packed-consumer import and public TypeScript exports verified.
- Real isolated SDK 0.85.0 file-extension startup, reload, new-session and shutdown smoke passed using the package’s existing aliases/preload support. No model calls, dependency installs or global installation changes.
- Two retained cleanup passes, a dedicated simplification pass and fresh read-only review completed. Internal-only assertions were removed; no outstanding review findings.

Cross-platform CI remains a required exact-head merge gate. The local lifecycle smoke reused installed dependencies and does not claim separate resume/fork, Windows or pristine-install coverage.

## Trust boundary

This is composition for already-loaded trusted extensions, not authentication or a sandbox. The extension owns resource-specific argument validation and lifecycle cleanup. Commands run in the workflow cwd with the inherited environment; exact grants do not pin executable contents or make arbitrary shell interpolation safe. Registration grants no publication or merge authority.
