### PR TITLE
test: await async budget probe terminal publication

### DIFF
--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -518,9 +518,20 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 				const eventsPath = path.join(asyncDir, "events.jsonl");
 				const deadline = Date.now() + 10_000;
 				while (true) {
-					const terminal = fs.existsSync(eventsPath) && fs.readFileSync(eventsPath, "utf-8")
-						.split("\n").filter(Boolean)
-						.some((line) => JSON.parse(line).type === "subagent.run.process_terminal");
+					let journal = "";
+					try {
+						journal = fs.readFileSync(eventsPath, "utf-8");
+					} catch (error) {
+						if (!["ENOENT", "EINTR", "EAGAIN", "EBUSY"].includes((error as NodeJS.ErrnoException).code ?? "")) throw error;
+					}
+					// Ignore an in-flight final record and malformed diagnostics, not terminal proof.
+					const terminal = journal.split("\n").slice(0, -1).some((line) => {
+						try {
+							return JSON.parse(line)?.type === "subagent.run.process_terminal";
+						} catch {
+							return false;
+						}
+					});
 					if (terminal) break;
 					assert.ok(Date.now() <= deadline, `Timed out waiting for async event 'subagent.run.process_terminal': ${eventsPath}`);
 					await new Promise((resolve) => setTimeout(resolve, 50));

--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -492,9 +492,9 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 				ctx,
 			);
 
+			asyncDir = result.details.asyncDir;
 			assert.equal(result.isError, undefined, result.content[0]?.text ?? "async launch failed");
 			assert.ok(result.details.asyncId);
-			asyncDir = result.details.asyncDir;
 			resultPath = path.join(DIRS.results, `${result.details.asyncId}.json`);
 
 			const status = JSON.parse(fs.readFileSync(path.join(asyncDir!, "status.json"), "utf-8")) as { runId?: string; sessionId?: string };
@@ -511,11 +511,25 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 			assert.equal(persisted.state, "complete");
 			assert.deepEqual(readCall().runtime?.toolBudget, toolBudget);
 			assert.equal(mockPi.callCount(), 1);
-			const processTerminalPath = path.join(asyncDir!, "process-terminal.json");
-			const processTerminal = JSON.parse(fs.readFileSync(processTerminalPath, "utf-8")) as { state?: string };
-			assert.match(processTerminal.state ?? "", /^(observed|unknown)$/);
 		} finally {
-			if (asyncDir) fs.rmSync(asyncDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+			// bg_wait completes at the logical result, not the parent's process-close publication.
+			// Await that publication even on assertion failure, before reading proof or deleting artifacts.
+			if (asyncDir) {
+				const eventsPath = path.join(asyncDir, "events.jsonl");
+				const deadline = Date.now() + 10_000;
+				while (true) {
+					const terminal = fs.existsSync(eventsPath) && fs.readFileSync(eventsPath, "utf-8")
+						.split("\n").filter(Boolean)
+						.some((line) => JSON.parse(line).type === "subagent.run.process_terminal");
+					if (terminal) break;
+					assert.ok(Date.now() <= deadline, `Timed out waiting for async event 'subagent.run.process_terminal': ${eventsPath}`);
+					await new Promise((resolve) => setTimeout(resolve, 50));
+				}
+				const processTerminalPath = path.join(asyncDir, "process-terminal.json");
+				const processTerminal = JSON.parse(fs.readFileSync(processTerminalPath, "utf-8")) as { state?: string };
+				assert.match(processTerminal.state ?? "", /^(observed|unknown)$/);
+				fs.rmSync(asyncDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+			}
 			if (resultPath) fs.rmSync(resultPath, { force: true });
 		}
 	});


### PR DESCRIPTION
## Summary

Closes #1912.

The async tool-budget test treated logical result completion as proof that the runner's process-terminal evidence had already been published. Main's Windows run [33946407683](https://github.com/nicobailon/pi-subagents/actions/runs/33946407683) exposed the race.

- Wait for the actual process-terminal event before the strict sidecar assertion and artifact cleanup, including earlier assertion-failure paths.
- Read only complete journal records; ignore malformed diagnostic records and retry transient reads within the existing bound.
- Preserve budget/result assertions, production behavior, and the distinction between logical completion and process-exit evidence.

One test file only. No skips, accepting `pending`, timeout inflation, or production changes. This does not resolve the separate #1906 investigation.

## Validation

- Exact filtered async-budget integration test: 1 passed, 0 failed/skipped.
- `npm run typecheck` and diff hygiene passed.
- Dedicated simplification and fresh review completed; the review's journal-read finding was corrected and revalidated through the compact final-fix gate.
- Local validation: Node 25.2.1/macOS. Cross-platform CI remains required.
