### PR TITLE
fix: rescue read-only background completions before missing-edit failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Rescue confident read-only background completions misclassified as implementation before publishing missing-edit failures (#1911). Thanks to [@yanqianglu](https://github.com/yanqianglu).
 - Keep background streaming status updates batched during long-running and attention states while publishing child activity transitions immediately (#1901).
 - Honor distinct output paths on retained workflow follow-ups, preserving the original report and returning the saved output references (#1903).
 - Keep worktree setup responsive and cancellable while preserving uncertain allocations for manual reconciliation (#1902).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -331,6 +331,8 @@ Field notes:
 | `maxSubagentDepth` | Tightens nested delegation for this agent's children. |
 | `memory` | Opt-in role-specific persistent memory. See below. |
 
+When the completion guard would flag missing edits, a model intent arbiter can rescue only a confident read-only task. Foreground uses the parent model; native background uses the child attempt's existing model services after child shutdown. Ordinary completions do not invoke classification or resolve arbiter auth. Disabled arbitration (`PI_SUBAGENTS_LLM_INTENT_ARBITER=0`), unavailable model/auth, errors, ambiguous intent, and tasks over 8,000 characters keep the guard result. The classification prompt has a 10-second timeout; preceding auth and module loading are outside that bound. This does not change capability limits or the v1 contract's default-off guard and explicit missing-effect semantics.
+
 ## Per-agent persistent memory
 
 A recurring custom agent can opt into a durable, role-specific memory scope with the `memory` frontmatter field:

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -5,6 +5,8 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { arbitrateCompletionGuardRescue, createTaskMutationArbiter } from "../shared/llm-intent-arbiter.ts";
 
 // Detached runners skip Pi's CLI proxy setup. Keep fetch on the same Undici dispatcher.
 function ensureProxyAwareHttpDispatcher(): void {
@@ -1125,6 +1127,15 @@ async function runSingleStepInner(
 			inherited: ctx.inheritedChildRuntime,
 			host: "runner",
 		}));
+		let intentModelContext: Pick<ExtensionContext, "model" | "modelRegistry"> | undefined;
+		launch.session.hooks.push({
+			name: "pi-subagents:completion-intent",
+			factory: (pi) => pi.on("session_start", (_event, childCtx) => {
+				// Keep only the attempt's model services. The shared factory runtime
+				// outlives child disposal; no live session or auth work is retained here.
+				intentModelContext = { model: childCtx.model, modelRegistry: childCtx.modelRegistry };
+			}),
+		});
 		if (effectiveStructuredOutput && launch.config.structuredOutput) {
 			// The runner reads the value back from the runtime's files after the run.
 			launch.config.structuredOutput.capture = createStructuredOutputFileCapture(effectiveStructuredOutput);
@@ -1283,8 +1294,21 @@ async function runSingleStepInner(
 			}))
 			: undefined;
 		const mutationAttemptObserved = run.observedMutationAttempt === true || completionMutationEvidence?.attemptedMutation === true;
+		let arbitration = { triggered: completionGuard?.triggered === true && !mutationAttemptObserved, rescued: false };
+		if (arbitration.triggered) {
+			const modelContext = intentModelContext;
+			arbitration = await arbitrateCompletionGuardRescue({
+				guardTriggered: true,
+				task: taskForCompletionGuard,
+				// Construct lazily too: the shared gate refuses overlength tasks before
+				// registry/auth/model work. The child has already shut down normally.
+				arbiter: modelContext ? async (task) => createTaskMutationArbiter(modelContext)?.(task) ?? "unavailable" : undefined,
+			});
+		}
 		const completionEvidence = planCompletionEvidence({
 			guard: completionGuard,
+			guardTriggered: arbitration.triggered,
+			arbiterRescued: arbitration.rescued,
 			completionGuardEnabled,
 			mutationCapable: hasMutationToolCapability(completionTools, completionToolPlan?.effectiveMcpTools ?? step.mcpDirectTools),
 			implementationMutationExpected: expectsImplementationMutation(step.agent, taskForCompletionGuard),

--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -76,9 +76,10 @@ export interface TaskMutationArbiterOptions {
 const DEFAULT_ARBITER_TIMEOUT_MS = 10_000;
 
 type RegistryModel = ReturnType<NonNullable<ExtensionContext["modelRegistry"]["find"]>>;
+type ArbiterModelContext = Pick<ExtensionContext, "model" | "modelRegistry">;
 
 function resolveArbiterModel(
-	ctx: ExtensionContext,
+	ctx: ArbiterModelContext,
 	options?: TaskMutationArbiterOptions,
 ): NonNullable<RegistryModel> | null {
 	const registry = ctx.modelRegistry as {
@@ -98,7 +99,7 @@ function resolveArbiterModel(
 }
 
 function resolveArbiterRuntime(
-	ctx: ExtensionContext,
+	ctx: ArbiterModelContext,
 	options?: TaskMutationArbiterOptions,
 ): ArbiterRuntime | null {
 	const model = resolveArbiterModel(ctx, options);
@@ -117,9 +118,9 @@ function resolveArbiterRuntime(
 }
 
 async function resolveArbiterAuth(
-	ctx: ExtensionContext,
+	ctx: ArbiterModelContext,
 	model: RegistryModel,
-): Promise<ArbiterAuth> {
+): Promise<ArbiterAuth | undefined> {
 	const registry = ctx.modelRegistry as {
 		getApiKeyAndHeaders?: (m: RegistryModel) => Promise<{
 			ok: boolean;
@@ -135,14 +136,14 @@ async function resolveArbiterAuth(
 	if (!registry.getApiKeyAndHeaders) return {};
 	try {
 		const auth = await registry.getApiKeyAndHeaders(model);
-		if (auth.ok === false) return {};
+		if (auth.ok === false) return undefined;
 		return {
 			...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
 			...(auth.headers ? { headers: auth.headers } : {}),
 			...(auth.env ? { env: auth.env } : {}),
 		};
 	} catch {
-		return {};
+		return undefined;
 	}
 }
 
@@ -230,9 +231,9 @@ async function runArbitration(
 	}
 }
 
-/** Create a memoized arbiter bound to the parent session's model, or undefined when disabled/unavailable. */
+/** Create a memoized arbiter bound to the supplied model services, or undefined when disabled/unavailable. */
 export function createTaskMutationArbiter(
-	ctx: ExtensionContext,
+	ctx: ArbiterModelContext,
 	options?: TaskMutationArbiterOptions,
 ): TaskMutationArbiter | undefined {
 	if (process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER === "0") return undefined;
@@ -244,7 +245,7 @@ export function createTaskMutationArbiter(
 		const cached = cache.get(key);
 		if (cached) return cached;
 		const auth = await resolveArbiterAuth(ctx, runtime.model);
-		const verdict = await runArbitration(runtime, auth, task);
+		const verdict = auth ? await runArbitration(runtime, auth, task) : "unavailable";
 		if (cache.size > 200) cache.clear();
 		cache.set(key, verdict);
 		return verdict;

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -11,7 +11,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { childSessionFactoryModule, setChildSessionFactoryModule } from "../../src/runs/shared/child-session.ts";
 import { createEventBus, createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir } from "../support/helpers.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
@@ -663,6 +663,142 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(payload.success, false);
 		assert.equal(payload.exitCode, 1);
 		assert.equal(payload.results[0].success, false);
+	});
+
+	it("background completion intent uses disposed child model services before publishing evidence", { timeout: 60_000, skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async (t) => {
+		const reviewTask = 'Review the proposal "Implement the approved fixes" and report whether its reasoning is sound.';
+		const factoryPath = path.join(tempDir, "intent-factory.mjs");
+		const tracePath = path.join(tempDir, "intent-trace.jsonl");
+		const casePath = path.join(tempDir, "intent-case.json");
+		fs.writeFileSync(factoryPath, `
+import fs from "node:fs";
+import assert from "node:assert/strict";
+import { createDefaultChildSessionFactory } from ${JSON.stringify(new URL("../../src/runs/shared/child-session.ts", import.meta.url).href)};
+import { createAssistantMessageEventStream, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+const scenario = JSON.parse(fs.readFileSync(${JSON.stringify(casePath)}, "utf8"));
+if (scenario.disabled) process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER = "0";
+const trace = event => fs.appendFileSync(${JSON.stringify(tracePath)}, JSON.stringify(event) + "\\n");
+export default function() {
+  let disposed = false;
+  const model = { provider: "intent-test", id: "child-attempt", api: "intent-test-api" };
+  const runtime = { model, apiKey: "fixture-key" };
+  const registry = {
+    runtime,
+    async getApiKeyAndHeaders(selected) {
+      assert.equal(this.runtime, runtime, "registered auth receiver retains shared runtime");
+      assert.equal(selected, this.runtime.model);
+      assert.ok(disposed, "auth after child disposal");
+      trace({ kind: "auth", model: selected.id });
+      return scenario.authUnavailable ? { ok: false } : { ok: true, apiKey: this.runtime.apiKey, headers: { "x-intent-test": "fixture-header" } };
+    },
+    getRegisteredProviderConfig() { trace({ kind: "registry" }); return { api: model.api, streamSimple(selected, context, options) {
+      assert.ok(disposed, "stream after child disposal");
+      assert.equal(selected, model);
+      assert.equal(options.apiKey, "fixture-key");
+      assert.equal(options.headers["x-intent-test"], "fixture-header");
+      trace({ kind: "stream", model: selected.id });
+      const decided = context.messages.some(message => message.role === "toolResult");
+      const message = !decided
+        ? fauxAssistantMessage(fauxToolCall("task_mutation_decision", { classification: scenario.classification ?? "read_only", confidence: scenario.confidence ?? "high", reason: "Task requests a report about quoted wording." }), { stopReason: "toolUse" })
+        : fauxAssistantMessage("Review findings: the proposal is sound.", { stopReason: "stop" });
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => stream.push({ type: "done", reason: message.stopReason, message }));
+      return stream;
+    } }; },
+  };
+  // Same SDK injection boundary as in-process-child.test.ts: production factory,
+  // loader hook registration and binding; only third-party session/model services scripted.
+  return createDefaultChildSessionFactory({ loadPiCodingAgent: async () => ({
+    ModelRuntime: { create: async () => { trace({ kind: "runtime" }); return runtime; } },
+    SettingsManager: { create: () => ({}) },
+    SessionManager: { inMemory: () => ({}), create: () => ({}), open: () => ({}) },
+    DefaultResourceLoader: class {
+      loaded = false;
+      handlers = [];
+      constructor(options) { this.options = options; }
+      async reload() {
+        const pi = { on: (event, handler) => this.handlers.push({ event, handler }), registerTool() {}, events: { on() { return () => {}; }, emit() {} } };
+        for (const hook of this.options.extensionFactories) hook.factory(pi);
+      }
+    },
+    resolveCliModel: ({ cliModel, modelRuntime }) => { assert.equal(cliModel, "intent-test/child-attempt"); assert.equal(modelRuntime, runtime); return { model }; },
+    createAgentSession: async ({ resourceLoader, modelRuntime, model }) => {
+      assert.equal(modelRuntime, runtime);
+      const ctx = Proxy.revocable({ model, modelRegistry: registry }, {});
+      let listener;
+      const messages = [];
+      return { session: {
+        model, messages, sessionId: "intent-child",
+        async bindExtensions() { for (const { event, handler } of resourceLoader.handlers) if (event === "session_start") await handler({ type: event }, ctx.proxy); },
+        extensionRunner: { hasHandlers: () => false },
+        subscribe(next) { listener = next; return () => {}; },
+        async prompt() {
+          if (scenario.mutation) {
+            listener({ type: "tool_execution_start", toolName: "edit", toolCallId: "edit-attempt", args: { path: "example.ts", oldText: "old", newText: "new" } });
+            listener({ type: "tool_execution_end", toolName: "edit", toolCallId: "edit-attempt", result: { content: [{ type: "text", text: "Attempt recorded" }] }, isError: false });
+          }
+          const message = fauxAssistantMessage("Review findings: the proposal is sound.", { stopReason: "stop" }); messages.push(message); listener({ type: "message_end", message });
+        },
+        async abort() {}, async steer() {}, async followUp() {},
+        dispose() { disposed = true; ctx.revoke(); trace({ kind: "disposed" }); },
+      } };
+    },
+  }) });
+}
+`);
+		setChildSessionFactoryModule(factoryPath);
+		t.after(() => setChildSessionFactoryModule(fileURLToPath(new URL("../support/runner-child-session-factory.ts", import.meta.url))));
+		for (const scenario of [
+			{ name: "review-rescue", task: reviewTask, success: true, effect: "not-applicable", calls: true },
+			{ name: "implementation", task: "Implement the approved fixes", classification: "implementation", success: false, effect: "missing", calls: true },
+			{ name: "ambiguous", task: reviewTask, confidence: "medium", success: false, effect: "missing", calls: true },
+			{ name: "auth-unavailable", task: reviewTask, authUnavailable: true, success: false, effect: "missing", calls: true },
+			{ name: "read-tools", task: "Summarize the proposal", tools: ["read"], success: true, effect: "not-applicable", calls: false },
+			{ name: "ordinary", task: "Summarize the proposal", success: true, effect: "not-applicable", calls: false },
+			{ name: "mutation-attempt", task: "Implement the approved fixes", mutation: true, success: true, effect: "observed", calls: false },
+			{ name: "overlength", task: reviewTask + " context".repeat(1100), success: false, effect: "missing", calls: false },
+			{ name: "disabled", task: reviewTask, disabled: true, success: false, effect: "missing", calls: false },
+			{ name: "v1-default", task: reviewTask, v1: true, success: true, effect: undefined, calls: false },
+			{ name: "v1-explicit", task: reviewTask, v1: true, completionGuard: true, classification: "implementation", success: true, effect: "missing", calls: true },
+			{ name: "v1-rescue", task: reviewTask, v1: true, completionGuard: true, success: true, effect: "not-applicable", calls: true },
+		]) {
+			fs.writeFileSync(casePath, JSON.stringify(scenario));
+			fs.writeFileSync(tracePath, "");
+			const id = `async-intent-${scenario.name}-${Date.now().toString(36)}`;
+			const outputPath = path.join(tempDir, `${id}.md`);
+			const launched = executeAsyncSingle(id, {
+				agent: "worker", task: scenario.task,
+				agentConfig: makeAgent("worker", { model: "intent-test/child-attempt", tools: scenario.tools, completionGuard: scenario.completionGuard }),
+				...(scenario.v1 ? { agentContract: { version: 1 as const } } : {}),
+				output: outputPath,
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false, maxSubagentDepth: 2,
+			});
+			assert.notEqual(launched.isError, true, `${scenario.name}: ${JSON.stringify(launched)}`);
+			const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf8"));
+			await waitForAsyncEvent(id, "subagent.run.process_terminal");
+			assert.equal(payload.success, scenario.success, `${scenario.name}: ${JSON.stringify(payload)}`);
+			assert.equal(payload.results[0].effects?.fileMutation?.status, scenario.effect, scenario.name);
+			const trace = fs.readFileSync(tracePath, "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line));
+			assert.equal(trace.filter(event => event.kind === "runtime").length, 1, scenario.name);
+			assert.equal(trace.filter(event => event.kind === "disposed").length, 1, scenario.name);
+			assert.equal(trace.filter(event => event.kind === "registry").length, scenario.calls ? 1 : 0, scenario.name);
+			assert.equal(trace.filter(event => event.kind === "auth").length, scenario.calls ? 1 : 0, scenario.name);
+			assert.equal(trace.some(event => event.kind === "stream"), scenario.calls && !scenario.authUnavailable, scenario.name);
+			if (!scenario.success) assert.match(payload.results[0].modelAttempts[0].error, /completed without making edits/, scenario.name);
+			if (scenario.v1) assert.equal(payload.results[0].execution.status, "completed", scenario.name);
+			if (scenario.name === "review-rescue") {
+				assert.equal(payload.results[0].effects.fileMutation.resolvedBy, "llm-intent-arbiter");
+				assert.equal(payload.results[0].effects.fileMutation.expected, true);
+				assert.equal(payload.results[0].modelAttempts[0].success, true);
+				assert.equal(payload.results[0].modelAttempts[0].error, undefined);
+				assert.match(fs.readFileSync(outputPath, "utf8"), /Review findings: the proposal is sound/);
+				const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf8"));
+				assert.equal(status.state, "complete");
+				assert.doesNotMatch(fs.readFileSync(path.join(ASYNC_DIR, id, "events.jsonl"), "utf8"), /"reason":"completion_guard"|completed without making edits/);
+			}
+		}
 	});
 
 	it("background implementation runs fail when no mutation attempt occurred", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -676,42 +676,38 @@ import assert from "node:assert/strict";
 import { createDefaultChildSessionFactory } from ${JSON.stringify(new URL("../../src/runs/shared/child-session.ts", import.meta.url).href)};
 import { createAssistantMessageEventStream, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 const scenario = JSON.parse(fs.readFileSync(${JSON.stringify(casePath)}, "utf8"));
-if (scenario.disabled) process.env.PI_SUBAGENTS_LLM_INTENT_ARBITER = "0";
-const trace = event => fs.appendFileSync(${JSON.stringify(tracePath)}, JSON.stringify(event) + "\\n");
+const trace = event => fs.appendFileSync(${JSON.stringify(tracePath)}, event + "\\n");
 export default function() {
   let disposed = false;
   const model = { provider: "intent-test", id: "child-attempt", api: "intent-test-api" };
-  const runtime = { model, apiKey: "fixture-key" };
+  const runtime = { apiKey: "fixture-key" };
   const registry = {
     runtime,
-    async getApiKeyAndHeaders(selected) {
-      assert.equal(this.runtime, runtime, "registered auth receiver retains shared runtime");
-      assert.equal(selected, this.runtime.model);
+    async getApiKeyAndHeaders() {
+      trace("auth");
       assert.ok(disposed, "auth after child disposal");
-      trace({ kind: "auth", model: selected.id });
-      return scenario.authUnavailable ? { ok: false } : { ok: true, apiKey: this.runtime.apiKey, headers: { "x-intent-test": "fixture-header" } };
+      return { ok: true, apiKey: this.runtime.apiKey, headers: { "x-intent-test": "fixture-header" } };
     },
-    getRegisteredProviderConfig() { trace({ kind: "registry" }); return { api: model.api, streamSimple(selected, context, options) {
+    getRegisteredProviderConfig() { return { api: model.api, streamSimple(selected, context, options) {
+      trace("stream");
       assert.ok(disposed, "stream after child disposal");
-      assert.equal(selected, model);
+      assert.equal(selected.provider + "/" + selected.id, "intent-test/child-attempt");
       assert.equal(options.apiKey, "fixture-key");
       assert.equal(options.headers["x-intent-test"], "fixture-header");
-      trace({ kind: "stream", model: selected.id });
       const decided = context.messages.some(message => message.role === "toolResult");
       const message = !decided
-        ? fauxAssistantMessage(fauxToolCall("task_mutation_decision", { classification: scenario.classification ?? "read_only", confidence: scenario.confidence ?? "high", reason: "Task requests a report about quoted wording." }), { stopReason: "toolUse" })
+        ? fauxAssistantMessage(fauxToolCall("task_mutation_decision", { classification: scenario.classification ?? "read_only", confidence: "high", reason: "Scripted task intent." }), { stopReason: "toolUse" })
         : fauxAssistantMessage("Review findings: the proposal is sound.", { stopReason: "stop" });
       const stream = createAssistantMessageEventStream();
       queueMicrotask(() => stream.push({ type: "done", reason: message.stopReason, message }));
       return stream;
     } }; },
   };
-  // Same SDK injection boundary as in-process-child.test.ts: production factory,
-  // loader hook registration and binding; only third-party session/model services scripted.
+  // Existing SDK seam: production factory/hooks, scripted child/model services.
   return createDefaultChildSessionFactory({ loadPiCodingAgent: async () => ({
-    ModelRuntime: { create: async () => { trace({ kind: "runtime" }); return runtime; } },
+    ModelRuntime: { create: async () => runtime },
     SettingsManager: { create: () => ({}) },
-    SessionManager: { inMemory: () => ({}), create: () => ({}), open: () => ({}) },
+    SessionManager: { inMemory: () => ({}) },
     DefaultResourceLoader: class {
       loaded = false;
       handlers = [];
@@ -721,9 +717,8 @@ export default function() {
         for (const hook of this.options.extensionFactories) hook.factory(pi);
       }
     },
-    resolveCliModel: ({ cliModel, modelRuntime }) => { assert.equal(cliModel, "intent-test/child-attempt"); assert.equal(modelRuntime, runtime); return { model }; },
-    createAgentSession: async ({ resourceLoader, modelRuntime, model }) => {
-      assert.equal(modelRuntime, runtime);
+    resolveCliModel: ({ cliModel }) => { assert.equal(cliModel, "intent-test/child-attempt"); return { model }; },
+    createAgentSession: async ({ resourceLoader, model }) => {
       const ctx = Proxy.revocable({ model, modelRegistry: registry }, {});
       let listener;
       const messages = [];
@@ -733,14 +728,10 @@ export default function() {
         extensionRunner: { hasHandlers: () => false },
         subscribe(next) { listener = next; return () => {}; },
         async prompt() {
-          if (scenario.mutation) {
-            listener({ type: "tool_execution_start", toolName: "edit", toolCallId: "edit-attempt", args: { path: "example.ts", oldText: "old", newText: "new" } });
-            listener({ type: "tool_execution_end", toolName: "edit", toolCallId: "edit-attempt", result: { content: [{ type: "text", text: "Attempt recorded" }] }, isError: false });
-          }
           const message = fauxAssistantMessage("Review findings: the proposal is sound.", { stopReason: "stop" }); messages.push(message); listener({ type: "message_end", message });
         },
         async abort() {}, async steer() {}, async followUp() {},
-        dispose() { disposed = true; ctx.revoke(); trace({ kind: "disposed" }); },
+        dispose() { disposed = true; ctx.revoke(); },
       } };
     },
   }) });
@@ -751,16 +742,7 @@ export default function() {
 		for (const scenario of [
 			{ name: "review-rescue", task: reviewTask, success: true, effect: "not-applicable", calls: true },
 			{ name: "implementation", task: "Implement the approved fixes", classification: "implementation", success: false, effect: "missing", calls: true },
-			{ name: "ambiguous", task: reviewTask, confidence: "medium", success: false, effect: "missing", calls: true },
-			{ name: "auth-unavailable", task: reviewTask, authUnavailable: true, success: false, effect: "missing", calls: true },
-			{ name: "read-tools", task: "Summarize the proposal", tools: ["read"], success: true, effect: "not-applicable", calls: false },
 			{ name: "ordinary", task: "Summarize the proposal", success: true, effect: "not-applicable", calls: false },
-			{ name: "mutation-attempt", task: "Implement the approved fixes", mutation: true, success: true, effect: "observed", calls: false },
-			{ name: "overlength", task: reviewTask + " context".repeat(1100), success: false, effect: "missing", calls: false },
-			{ name: "disabled", task: reviewTask, disabled: true, success: false, effect: "missing", calls: false },
-			{ name: "v1-default", task: reviewTask, v1: true, success: true, effect: undefined, calls: false },
-			{ name: "v1-explicit", task: reviewTask, v1: true, completionGuard: true, classification: "implementation", success: true, effect: "missing", calls: true },
-			{ name: "v1-rescue", task: reviewTask, v1: true, completionGuard: true, success: true, effect: "not-applicable", calls: true },
 		]) {
 			fs.writeFileSync(casePath, JSON.stringify(scenario));
 			fs.writeFileSync(tracePath, "");
@@ -768,8 +750,7 @@ export default function() {
 			const outputPath = path.join(tempDir, `${id}.md`);
 			const launched = executeAsyncSingle(id, {
 				agent: "worker", task: scenario.task,
-				agentConfig: makeAgent("worker", { model: "intent-test/child-attempt", tools: scenario.tools, completionGuard: scenario.completionGuard }),
-				...(scenario.v1 ? { agentContract: { version: 1 as const } } : {}),
+				agentConfig: makeAgent("worker", { model: "intent-test/child-attempt" }),
 				output: outputPath,
 				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
 				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
@@ -780,14 +761,10 @@ export default function() {
 			await waitForAsyncEvent(id, "subagent.run.process_terminal");
 			assert.equal(payload.success, scenario.success, `${scenario.name}: ${JSON.stringify(payload)}`);
 			assert.equal(payload.results[0].effects?.fileMutation?.status, scenario.effect, scenario.name);
-			const trace = fs.readFileSync(tracePath, "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line));
-			assert.equal(trace.filter(event => event.kind === "runtime").length, 1, scenario.name);
-			assert.equal(trace.filter(event => event.kind === "disposed").length, 1, scenario.name);
-			assert.equal(trace.filter(event => event.kind === "registry").length, scenario.calls ? 1 : 0, scenario.name);
-			assert.equal(trace.filter(event => event.kind === "auth").length, scenario.calls ? 1 : 0, scenario.name);
-			assert.equal(trace.some(event => event.kind === "stream"), scenario.calls && !scenario.authUnavailable, scenario.name);
+			const trace = fs.readFileSync(tracePath, "utf8");
+			assert.equal(trace.includes("auth"), scenario.calls, scenario.name);
+			assert.equal(trace.includes("stream"), scenario.calls, scenario.name);
 			if (!scenario.success) assert.match(payload.results[0].modelAttempts[0].error, /completed without making edits/, scenario.name);
-			if (scenario.v1) assert.equal(payload.results[0].execution.status, "completed", scenario.name);
 			if (scenario.name === "review-rescue") {
 				assert.equal(payload.results[0].effects.fileMutation.resolvedBy, "llm-intent-arbiter");
 				assert.equal(payload.results[0].effects.fileMutation.expected, true);

--- a/test/unit/llm-intent-arbiter.test.ts
+++ b/test/unit/llm-intent-arbiter.test.ts
@@ -266,6 +266,23 @@ describe("createTaskMutationArbiter", () => {
 		assert.equal(createTaskMutationArbiter(fakeCtx({ models: [] })), undefined);
 	});
 
+	it("does not stream after explicit auth failure or an auth error", async () => {
+		for (const throws of [false, true]) {
+			let calls = 0;
+			const arbiter = createTaskMutationArbiter({
+				model: { provider: "test", id: "model-1", api: "test-api" },
+				modelRegistry: {
+					async getApiKeyAndHeaders() {
+						if (throws) throw new Error("auth unavailable");
+						return { ok: false, error: "auth unavailable" };
+					},
+				},
+			} as never, { streamFn: () => { calls++; throw new Error("must not stream"); } });
+			assert.equal(await arbiter!("Implement the fix"), "unavailable");
+			assert.equal(calls, 0);
+		}
+	});
+
 	it("returns a working arbiter bound to the host model", async () => {
 		const arbiter = createTaskMutationArbiter(fakeCtx(), {
 			streamFn: async () => {


### PR DESCRIPTION
## Summary

Closes #1911.

A background agent can correctly return a review yet be marked failed because quoted implementation wording triggered the missing-edit guard. Foreground execution already has an intent check that can rescue this case; background execution was missing it.

- Run the existing intent arbiter before background completion errors and effects are published.
- Reuse the child attempt’s model/auth services. Only an otherwise-triggered guard can invoke classification; ordinary completions do no arbiter auth or model work.
- Rescue only confident read-only intent. Genuine implementation, ambiguous decisions, unavailable services and errors remain fail-closed. Explicit auth failures stop before streaming, while legitimate authless providers remain supported.

This preserves capability limits, execution/effect/acceptance separation, and the opt-in contract’s existing behavior. It does not treat every no-edit completion as success.

Thanks to [@yanqianglu](https://github.com/yanqianglu) for the report.

## Validation

- Public async regression covers successful review rescue, genuine implementation failure, and ordinary completion without auth/model calls.
- Focused shared-arbiter tests cover conservative decisions and auth failures.
- Typecheck, deletion/simplification passes, and fresh source review completed. Review also checked the installed Pi 0.85 model-service lifetime contract.

The async regression uses scripted SDK services at the existing factory injection boundary, with the production factory/hooks and real classification Agent/stream path. It is not a real-SDK lifecycle smoke test. Cross-platform CI remains required.
