### PR TITLE
test: trace runner disposal and exit phases for Windows timeout

### DIFF
--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -11,6 +11,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { childSessionFactoryModule, setChildSessionFactoryModule } from "../../src/runs/shared/child-session.ts";
 import { createEventBus, createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir } from "../support/helpers.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { ACTIVE_ASYNC_CAPACITY_DIR, acquireActiveAsyncCapacity, activeAsyncCapacitySessionKey } from "../../src/runs/background/active-async-capacity.ts";
@@ -736,6 +738,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		const id = `async-parallel-shared-cwd-mutation-${Date.now().toString(36)}`;
 		let runnerStarted = false;
 		const observer = observeSharedCwdRunner(id);
+		const originalFactoryModule = childSessionFactoryModule();
 		const failures: unknown[] = [];
 		let reported = false;
 		const reportFailure = () => {
@@ -745,6 +748,29 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			catch { t.diagnostic("#1906 failure snapshot unavailable (contents withheld)"); }
 		};
 		try {
+			assert.ok(originalFactoryModule, "expected the installed scripted runner factory");
+			const factoryPath = path.join(tempDir, "shared-cwd-exit-phases.mjs");
+			fs.writeFileSync(factoryPath, `
+import { writeSync } from "node:fs";
+import createFactory from ${JSON.stringify(pathToFileURL(originalFactoryModule).href)};
+export default function() {
+  const factory = createFactory();
+  let invocation = 0;
+  const mark = (phase, call) => writeSync(process.stderr.fd, "#1906 phase=" + phase + " invocation=" + call + " ts=" + Date.now() + " pid=" + process.pid + "\\n");
+  process.once("exit", () => mark("exit", 0));
+  return {
+    create(...args) { return factory.create(...args); },
+    async dispose() {
+      const call = ++invocation;
+      mark("dispose-entry", call);
+      const result = await factory.dispose();
+      mark("dispose-return", call);
+      return result;
+    },
+  };
+}
+`);
+			setChildSessionFactoryModule(factoryPath);
 			const launch = observer.launch(() => executeAsyncChain(id, {
 				chain: [{
 					parallel: [
@@ -792,7 +818,10 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			} catch (error) {
 				failures.push(error);
 				reportFailure();
-			} finally { observer.dispose(); }
+			} finally {
+				setChildSessionFactoryModule(originalFactoryModule);
+				observer.dispose();
+			}
 		}
 		if (failures.length === 1) throw failures[0];
 		if (failures.length > 1) throw new AggregateError(failures, "Primary execution and cleanup/diagnostic failures", { cause: failures[0] });

--- a/test/support/async-execution-fixture.ts
+++ b/test/support/async-execution-fixture.ts
@@ -402,6 +402,7 @@ export function observeSharedCwdRunner(id: string) {
 	const notifications: unknown[] = [];
 	const processes: Array<{ proc: ChildProcess; events: unknown[]; dispose: () => void }> = [];
 	let pid: number | undefined;
+	let signalZero: { at: number; state: string } | undefined;
 	const diagnosticChannel = channel("child_process");
 	const onProcess = (message: unknown) => {
 		const proc = record(message).process;
@@ -443,6 +444,17 @@ export function observeSharedCwdRunner(id: string) {
 		// One bounded read per known file, only after failure. No arbitrary text escapes.
 		snapshot() {
 			const snapshotAt = Date.now();
+			const matched = processes.filter(({ proc }) => pid !== undefined && proc.pid === pid);
+			const processState = matched.map(({ proc }) => ({
+				exitCode: proc.exitCode,
+				signalCode: proc.signalCode === null ? null : known(proc.signalCode, ["SIGTERM", "SIGKILL", "SIGINT", "SIGABRT", "SIGSEGV"]) ?? "other",
+			}));
+			// PID presence is not identity or cleanup authority. Probe at most once.
+			if (!signalZero && matched.length === 1 && pid !== undefined) {
+				const at = Date.now();
+				try { process.kill(pid, 0); signalZero = { at, state: "present" }; }
+				catch (error) { signalZero = { at, state: known(record(error).code, ["ESRCH", "EPERM", "EACCES", "EINVAL"]) ?? "other" }; }
+			}
 			const files = ["process-terminal.json", "process-terminal-candidate.json", "status.json", "result", "events.jsonl", "runner.stdout.log", "runner.stderr.log"].map((name) => {
 				const file = name === "result" ? path.join(RESULTS_DIR, `${id}.json`) : path.join(ASYNC_DIR, id, name);
 				let fd: number | undefined;
@@ -457,7 +469,18 @@ export function observeSharedCwdRunner(id: string) {
 					const buffer = Buffer.alloc(Math.min(size, limit));
 					const text = buffer.subarray(0, fs.readSync(fd, buffer, 0, buffer.length, offset)).toString("utf-8");
 					const base = { name, readAt, size, truncated: offset > 0 };
-					if (name.endsWith(".log")) return { ...base, markers: ["ENOENT", "EACCES", "EPERM", "EBUSY", "ENOSPC", "SyntaxError", "TypeError", "UnhandledPromiseRejection"].filter((marker) => text.includes(marker)) };
+					if (name.endsWith(".log")) {
+						const phases = [];
+						for (const line of text.split("\n").slice(offset > 0 ? 1 : 0)) {
+							const match = /^#1906 phase=(dispose-entry|dispose-return|exit) invocation=(\d{1,16}) ts=(\d{1,16}) pid=(\d{1,16})$/.exec(line);
+							if (!match || matched.length !== 1) continue;
+							const [invocation, ts, markerPid] = match.slice(2).map(Number);
+							if (![invocation, ts, markerPid].every(Number.isSafeInteger) || markerPid !== pid || ts <= 0) continue;
+							if (match[1] === "exit" ? invocation !== 0 : invocation < 1) continue;
+							phases.push({ phase: match[1], invocation, ts, pid: markerPid });
+						}
+						return { ...base, markers: ["ENOENT", "EACCES", "EPERM", "EBUSY", "ENOSPC", "SyntaxError", "TypeError", "UnhandledPromiseRejection"].filter((marker) => text.includes(marker)), phases: phases.slice(-16) };
+					}
 					if (name === "events.jsonl") {
 						let parseErrors = 0;
 						const lifecycle = [];
@@ -474,7 +497,7 @@ export function observeSharedCwdRunner(id: string) {
 				} catch (error) { return { name, readAt, state: error instanceof SyntaxError ? "invalid-json" : errorCode(error) }; }
 				finally { if (fd !== undefined) fs.closeSync(fd); }
 			});
-			return { snapshotAt, finishedAt: Date.now(), waitElapsedMs: typeof marks.waitStartedAt === "number" ? snapshotAt - marks.waitStartedAt : undefined, files };
+			return { snapshotAt, finishedAt: Date.now(), waitElapsedMs: typeof marks.waitStartedAt === "number" ? snapshotAt - marks.waitStartedAt : undefined, processState, signalZero, files };
 		},
 		dispose() { for (const entry of processes) entry.dispose(); },
 	};


### PR DESCRIPTION
## Summary

Follow-up diagnostics for #1906. **This does not close the issue or claim a production fix.**

Two unchanged-main Windows attempts reached completed result assertions but timed out waiting for the shared-cwd runner's terminal event. Existing diagnostics show a matching final candidate and no observed exit/close; they cannot establish when disposal finished or whether JavaScript exit ran.

- Wrap this test's existing scripted factory to timestamp disposal entry/return and synchronous exit without changing delegated behavior.
- Project only bounded, allowlisted, matching-PID phase records on failure, plus public exit fields and one signal-0 observation.
- Preserve the assertions, 10-second deadline, primary failure, factory restoration and cleanup predicate. PID presence is not termination or cleanup authority.

## Validation

- Existing focused integration test passed.
- Disposable real-subprocess checks verified phase/PID correlation and bounded sanitized projection.
- Typecheck and diff hygiene passed.
- Dedicated simplification found no useful changes. Fresh read-only review found no issues.

Local validation was Darwin/Node 25.2.1, not Windows proof. Synchronous markers can perturb timing; bounded logs or abrupt termination can omit evidence.
