### PR TITLE
fix: clear recovered assistant errors on tool-use completion

### DIFF
--- a/src/runs/background/run-child-session.ts
+++ b/src/runs/background/run-child-session.ts
@@ -474,6 +474,10 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 					}
 				}
 				if (event.message.errorMessage) assistantError = event.message.errorMessage;
+				else if (hasToolCall && event.message.stopReason === "toolUse") {
+					// A recovered request can finish via a terminating tool, without a text stop.
+					assistantError = undefined;
+				}
 				const eventUsage = event.message.usage;
 				if (eventUsage) {
 					usage.turns++;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -1105,6 +1105,10 @@ async function runSingleAttempt(
 						}
 					}
 					if (evt.message.errorMessage) assistantError = evt.message.errorMessage;
+					else if (hasToolCall && evt.message.stopReason === "toolUse") {
+						// A recovered request can finish via a terminating tool, without a text stop.
+						assistantError = undefined;
+					}
 					const assistantText = extractTextFromContent(evt.message.content);
 					appendRecentOutput(progress, assistantText.split("\n").slice(-10));
 					// Final assistant message: start the settle drain window.

--- a/test/integration/recovered-assistant-error.test.ts
+++ b/test/integration/recovered-assistant-error.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+import { makeAgent } from "../support/helpers.ts";
+import type { MockPiResponse } from "../support/mock-pi.ts";
+import { runSync } from "../../src/runs/foreground/execution.ts";
+import { createStructuredOutputRuntime } from "../../src/runs/shared/structured-output.ts";
+import type { JsonSchemaObject } from "../../src/shared/types.ts";
+import {
+	available,
+	executeAsyncSingle,
+	installAsyncExecutionHooks,
+	isAsyncAvailable,
+	mockPi,
+	readAsyncPayload,
+	tempDir,
+} from "../support/async-execution-fixture.ts";
+
+const providerError = "provider transport failed";
+const structuredValue = { verdict: "ready" };
+const structuredSchema: JsonSchemaObject = {
+	type: "object",
+	properties: { verdict: { const: "ready" } },
+	required: ["verdict"],
+	additionalProperties: false,
+};
+const usage = { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } };
+
+type Host = "background" | "foreground";
+
+function assistantMessage(stopReason: string, content: unknown[] = [], errorMessage?: string) {
+	const message = {
+		role: "assistant",
+		content,
+		model: "mock/test-model",
+		stopReason,
+		usage,
+	};
+	if (!errorMessage) return { type: "message_end", message };
+	return { type: "message_end", message: { ...message, errorMessage } };
+}
+
+function toolCall(name = "read") {
+	return { type: "toolCall", id: `${name}-call`, name, arguments: name === "structured_output" ? { value: structuredValue } : {} };
+}
+
+function failedAssistantRequest() {
+	return assistantMessage("error", [], providerError);
+}
+
+interface FixtureResult {
+	success: boolean;
+	error?: string;
+	structuredOutput?: unknown;
+}
+
+async function runFixture(host: Host, response: MockPiResponse, withStructuredOutput = false): Promise<FixtureResult> {
+	mockPi.onCall(response);
+	const agent = makeAgent("recovery-fixture", { completionGuard: false });
+	const runId = `recovered-assistant-error-${host}-${randomUUID()}`;
+
+	if (host === "foreground") {
+		const structuredOutput = withStructuredOutput ? createStructuredOutputRuntime(structuredSchema, tempDir) : undefined;
+		const options = { runId, acceptance: false as const, waitToolEnabled: false };
+		const result = structuredOutput
+			? await runSync(tempDir, [agent], agent.name, "Exercise the scripted child lifecycle", { ...options, structuredOutput })
+			: await runSync(tempDir, [agent], agent.name, "Exercise the scripted child lifecycle", options);
+		assert.equal(mockPi.callCount(), 1, "the fixture must not launch a fallback child");
+		return { success: result.exitCode === 0, error: result.error, structuredOutput: result.structuredOutput };
+	}
+
+	const params = {
+		agent: agent.name,
+		task: "Exercise the scripted child lifecycle",
+		agentConfig: agent,
+		ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "recovered-assistant-error-session" },
+		artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+		shareEnabled: false,
+		sessionRoot: path.join(tempDir, "sessions"),
+		maxSubagentDepth: 2,
+		waitToolEnabled: false,
+		acceptance: false as const,
+	};
+	const launch = withStructuredOutput
+		? executeAsyncSingle(runId, { ...params, structuredOutputSchema: structuredSchema })
+		: executeAsyncSingle(runId, params);
+	assert.equal(launch.isError, undefined, launch.content[0]?.text ?? "background launch failed");
+	const payload = await readAsyncPayload(runId);
+	assert.equal(mockPi.callCount(), 1, "the fixture must not launch a fallback child");
+	return {
+		success: payload.success,
+		error: payload.results[0]?.error,
+		structuredOutput: payload.results[0]?.structuredOutput,
+	};
+}
+
+// These cases use only the installed scripted ChildSessionFactory. They do not
+// load a provider, credential, ambient extension, or real child agent.
+describe("recovered assistant errors", { skip: !available ? "pi packages not available" : undefined }, () => {
+	installAsyncExecutionHooks();
+
+	for (const host of ["background", "foreground"] as const) {
+		it(`${host}: recovered request can terminate with structured_output`, { skip: host === "background" && !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+			const result = await runFixture(host, {
+				jsonl: [
+					failedAssistantRequest(),
+					{ type: "auto_retry_start", attempt: 1, maxAttempts: 3, delayMs: 0, errorMessage: providerError },
+					assistantMessage("toolUse", [toolCall("structured_output")]),
+					{ type: "auto_retry_end", success: true, attempt: 1 },
+				],
+				structuredOutput: structuredValue,
+			}, true);
+
+			assert.equal(result.success, true, result.error);
+			assert.equal(result.error, undefined);
+			assert.deepEqual(result.structuredOutput, structuredValue);
+		});
+
+		it(`${host}: retry success and toolUse without a call do not clear the error`, { skip: host === "background" && !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+			const result = await runFixture(host, {
+				jsonl: [
+					failedAssistantRequest(),
+					{ type: "auto_retry_end", success: true, attempt: 1 },
+					assistantMessage("toolUse"),
+				],
+			});
+
+			assert.equal(result.success, false);
+			assert.match(result.error ?? "", new RegExp(providerError));
+		});
+
+		it(`${host}: a tool call with a non-toolUse stop does not clear the error`, { skip: host === "background" && !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+			const result = await runFixture(host, {
+				jsonl: [failedAssistantRequest(), assistantMessage("length", [toolCall()])],
+			});
+
+			assert.equal(result.success, false);
+			assert.match(result.error ?? "", new RegExp(providerError));
+		});
+
+		it(`${host}: an error-bearing toolUse response replaces rather than clears the error`, { skip: host === "background" && !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+			const result = await runFixture(host, {
+				jsonl: [failedAssistantRequest(), assistantMessage("toolUse", [toolCall()], "later provider failure")],
+			});
+
+			assert.equal(result.success, false);
+			assert.match(result.error ?? "", /later provider failure/);
+		});
+	}
+});


### PR DESCRIPTION
## Summary

Clear an earlier `assistantError` when a native child produces an error-free `toolUse` response containing an actual tool call. Apply the same condition in the background and foreground drivers.

A recovered request can finish through terminating `structured_output` without another assistant text response. Currently, both drivers keep the earlier provider error latched in that case, returning a false failure; the background runner consequently skips reading the captured structured output.

```text
assistant error → retry → successful structured_output tool call → capture + terminate → settled
```

This is distinct from #894, which handles recovered tool errors during structured-output validation. This change fixes the assistant-error latch before that validation runs.

## Scope and safety

- Eight runtime lines, plus regressions using the existing scripted child-session integration fixture.
- Do not clear errors on retry-success notifications alone, missing tool calls, non-`toolUse` stops, or error-bearing responses.
- Existing structured-output/acceptance and timeout/cancellation/finalization checks remain unchanged.
- Does not diagnose or change the underlying transport failures.

## Validation

All runtime validation used a network-denied macOS sandbox with isolated HOME, agent, temporary, and model-exclusion storage. No live model/provider or production operations.

- New regression file: baseline **6 passed, 2 failed**; patched **8 passed, 0 failed, 0 skipped**. Both failure cases are recovered structured termination, one per driver.
- Existing affected integration selection: **8 passed**, covering ordinary-text recovery, empty-response failures, structured capture, and missing structured/acceptance evidence.
- `npm run typecheck`: passed.
- Oxlint on the new test: passed (0 warnings/errors).
- `git diff --check`: passed.
- Independent native-agent source review: no blockers (OK with notes). Focused regressions, affected integration selection, typecheck, and new-test lint were rerun successfully after rebasing onto `90ff9369`; all three reviewed files remained byte-identical.

Commands:

```sh
node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/recovered-assistant-error.test.ts
npm run typecheck
./node_modules/.bin/oxlint test/integration/recovered-assistant-error.test.ts
```

Broader unit-suite attempt: **2,827 passed, 5 failed, 3 skipped**. Failures involved process-group/host-command checks (including `spawnSync ps EPERM` under the sandbox) and a worktree setup timeout. The worktree case passed when rerun alone. These failures were not baseline-compared, so the full unit suite is **not claimed green**. The full integration suite was not run.
