### PR TITLE
fix: keep fleet inspector active-run roster stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Keep the fleet inspector roster stable by ordering active runs by start time instead of last activity heartbeat (#1923). Thanks to [@expoli](https://github.com/expoli) for #1924.
 - Rescue confident read-only background completions misclassified as implementation before publishing missing-edit failures (#1911). Thanks to [@yanqianglu](https://github.com/yanqianglu).
 - Keep background streaming status updates batched during long-running and attention states while publishing child activity transitions immediately (#1901).
 - Honor distinct output paths on retained workflow follow-ups, preserving the original report and returning the saved output references (#1903).

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -182,7 +182,8 @@ function asyncItems(run: AsyncRunSummary, description?: string): FleetItem[] {
 function orderFleetAsyncRuns(runs: AsyncRunSummary[], terminalLimit: number): AsyncRunSummary[] {
 	const updatedAt = (run: AsyncRunSummary) => run.lastUpdate ?? run.endedAt ?? run.startedAt;
 	const byNewest = (left: AsyncRunSummary, right: AsyncRunSummary) => updatedAt(right) - updatedAt(left);
-	const active = runs.filter((run) => run.state === "queued" || run.state === "running").sort(byNewest);
+	const byStartedAt = (left: AsyncRunSummary, right: AsyncRunSummary) => left.startedAt - right.startedAt || left.id.localeCompare(right.id);
+	const active = runs.filter((run) => run.state === "queued" || run.state === "running").sort(byStartedAt);
 	const terminal = runs.filter((run) => run.state !== "queued" && run.state !== "running").sort(byNewest);
 	return [...active, ...terminal.slice(0, terminalLimit)];
 }
@@ -208,7 +209,7 @@ export function collectFleetSnapshot(
 		liveWorkflowForegroundControls.add(control);
 		workflowForegroundChildCounts.set(control.parentWorkflowRunId, (workflowForegroundChildCounts.get(control.parentWorkflowRunId) ?? 0) + activeChildCount);
 	}
-	for (const control of [...state.foregroundControls.values()].sort((left, right) => right.updatedAt - left.updatedAt)) {
+	for (const control of [...state.foregroundControls.values()].sort((left, right) => left.startedAt - right.startedAt || left.runId.localeCompare(right.runId))) {
 		activeForegroundIds.add(control.runId);
 		if (control.parentWorkflowRunId && workflowParentIds.has(control.parentWorkflowRunId)
 			&& ((workflowForegroundChildCounts.get(control.parentWorkflowRunId) ?? 0) <= 1 || !liveWorkflowForegroundControls.has(control))) continue;
@@ -249,7 +250,7 @@ export function collectFleetSnapshot(
 		const tracked = [...trackedJobs.values()]
 			.filter((job) => belongsToCurrentSession(job.sessionId, state.currentSessionId));
 		const byUpdate = (left: AsyncJobState, right: AsyncJobState) => (right.updatedAt ?? right.startedAt ?? 0) - (left.updatedAt ?? left.startedAt ?? 0);
-		const active = tracked.filter((job) => job.status === "queued" || job.status === "running").sort(byUpdate);
+		const active = tracked.filter((job) => job.status === "queued" || job.status === "running");
 		const recent = tracked.filter((job) => job.status !== "queued" && job.status !== "running").sort(byUpdate).slice(0, options.limit ?? MAX_RECENT_ASYNC_RUNS);
 		const trackedRuns: AsyncRunSummary[] = [];
 		for (const job of [...active, ...recent]) {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -44,6 +44,7 @@ function writeAsyncRun(root: string, input: {
 	state?: "running" | "complete" | "failed";
 	mode?: "single" | "parallel" | "workflow";
 	lastUpdate?: number;
+	startedAt?: number;
 	agents?: string[];
 	contexts?: Array<"fresh" | "fork">;
 	models?: string[];
@@ -63,7 +64,7 @@ function writeAsyncRun(root: string, input: {
 		sessionId: input.sessionId ?? "session-current",
 		mode: input.mode ?? (agents.length > 1 ? "parallel" : "single"),
 		state,
-		startedAt: 100,
+		startedAt: input.startedAt ?? 100,
 		lastUpdate: input.lastUpdate ?? 200,
 		currentStep: 0,
 		steps: agents.map((agent, index) => ({
@@ -627,8 +628,8 @@ describe("native subagent fleet", () => {
 		});
 		const snapshot = collectFleetSnapshot(state);
 		assert.deepEqual(snapshot.items.map((item) => item.key), [
-			"foreground-active:child-2:0",
 			"foreground-active:child-1:0",
+			"foreground-active:child-2:0",
 			"async:unrelated",
 			"async:workflow-1",
 		]);
@@ -695,6 +696,26 @@ describe("native subagent fleet", () => {
 		assert.equal(snapshot.items[0]?.runId, "active-old");
 		assert.equal(snapshot.items.find((item) => item.runId === "terminal-21")?.state, "complete");
 		assert.ok(!snapshot.items.some((item) => item.runId === "terminal-0"));
+	});
+
+	it("orders active runs by start time so the roster stays stable while they emit", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-active-order-"));
+		try {
+			writeAsyncRun(root, { id: "worker-b", startedAt: 200, lastUpdate: 900 });
+			writeAsyncRun(root, { id: "worker-a", startedAt: 100, lastUpdate: 500 });
+			const state = stateForTest();
+			const keys = () => collectFleetSnapshot(state, { asyncDirRoot: root, resultsDir: path.join(root, "results") }).items.map((item) => item.key);
+			// First refresh: the run created first stays on top, even though worker-b emitted most recently.
+			assert.deepEqual(keys(), ["async:worker-a:0", "async:worker-b:0"]);
+			// Later activity on worker-b must not reorder the roster.
+			writeAsyncRun(root, { id: "worker-b", startedAt: 200, lastUpdate: 1500 });
+			assert.deepEqual(keys(), ["async:worker-a:0", "async:worker-b:0"]);
+			// A run started later still lands after the earlier ones.
+			writeAsyncRun(root, { id: "worker-c", startedAt: 300, lastUpdate: 300 });
+			assert.deepEqual(keys(), ["async:worker-a:0", "async:worker-b:0", "async:worker-c:0"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("accepts default Fleet navigation from Kitty CSI-u input", () => {


### PR DESCRIPTION
## Problem

The fleet inspector roster reorders the *running* rows on almost every refresh when two or more active subagents run concurrently (e.g. parallel workers). Selection is preserved by key, but the selected row itself jumps between positions, making the roster hard to monitor. See #1923.

## Root cause

`orderFleetAsyncRuns` (`src/tui/fleet.ts`) sorted active runs by `lastUpdate` descending, and `lastUpdate` is refreshed on essentially every activity heartbeat. The relative order of two active runs therefore flipped whenever the "other" one emitted output. `collectFleetSnapshot` applied the same unstable rule to foreground controls (`updatedAt`).

## Fix

- Sort active (queued/running) async runs by `startedAt` ascending with an `id` tiebreak — the same stable, creation-order rule the compact fleet status widget already uses (`src/tui/fleet-status.ts`).
- Apply the same `startedAt` + `runId` rule to the foreground-control ordering in `collectFleetSnapshot`.
- Terminal runs keep recency ordering (`lastUpdate` descending, bounded window) so recently finished work stays on top; `recentForeground` history is unchanged.
- Remove the now-redundant pre-sort of tracked active jobs.

## Verification

- New unit test: active roster order is stable when workers emit at different rates, and later-started runs land after earlier ones (exercises the `listAsyncRuns` history path).
- Adjusted one existing foreground-order assertion to the new start-time rule.
- `npm run typecheck` and `npm run test:unit` pass (2833 passed, 0 failed).

Fixes #1923
