### PR TITLE
fix: diagnose empty terminal text responses accurately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).
 - Rescue confident read-only background completions misclassified as implementation before publishing missing-edit failures (#1911). Thanks to [@yanqianglu](https://github.com/yanqianglu).
 - Keep background streaming status updates batched during long-running and attention states while publishing child activity transitions immediately (#1901).
 - Honor distinct output paths on retained workflow follow-ups, preserving the original report and returning the saved output references (#1903).

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -457,8 +457,13 @@ export function hasEmptyTerminalAssistantResponse(messages: Message[]): boolean 
 	const lastAssistant = messages.findLast((message) => message.role === "assistant");
 	return lastAssistant?.role === "assistant"
 		&& Array.isArray(lastAssistant.content)
-		&& lastAssistant.content.length === 0
-		&& lastAssistant.usage.output === 0;
+		&& ((lastAssistant.content.length === 0 && lastAssistant.usage.output === 0)
+			|| (messages.at(-1) === lastAssistant
+				&& lastAssistant.stopReason === "stop"
+				&& !lastAssistant.errorMessage
+				&& lastAssistant.content.length > 0
+				// Token accounting can be nonzero even when no response text was emitted.
+				&& lastAssistant.content.every((part) => part.type === "text" && part.text === "")));
 }
 
 export function formatEmptyTerminalAssistantResponseError(messages: Message[]): string {

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -243,6 +243,51 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.match(payload.results[0]?.error ?? "", /ended during 'bash' tool execution before the tool completed/);
 	});
 
+	for (const terminal of [
+		{ name: "empty text stop", content: [{ type: "text", text: "" }], stopReason: "stop", error: /no output.*empty response/i },
+		{ name: "tool-call-only stop", content: [{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "README.md" } }], stopReason: "toolUse", error: /grep failed.*Path not found/i },
+		{ name: "empty text length limit", content: [{ type: "text", text: "" }], stopReason: "length", error: /grep failed.*Path not found/i },
+	]) {
+		it(`background diagnoses ${terminal.name} after an exploratory tool error`, { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+			mockPi.onCall({
+				stdoutRaw: [
+					events.toolResult("grep", "Path not found", true),
+					events.toolResult("read", "recovered file contents"),
+					{
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: terminal.content,
+							model: "openai/gpt-5-mini",
+							stopReason: terminal.stopReason,
+							usage: { input: 0, output: 4, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+						},
+					},
+				].map((event) => JSON.stringify(event)).join("\n"),
+				exitCode: 0,
+			});
+			const id = `async-terminal-diagnosis-${Date.now().toString(36)}`;
+			executeAsyncSingle(id, {
+				agent: "worker",
+				task: "Do work",
+				agentConfig: makeAgent("worker", { model: "openai/gpt-5-mini" }),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false,
+				maxSubagentDepth: 2,
+			});
+
+			const resultPath = await waitForAsyncResultFile(id);
+			const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
+			assert.equal(payload.success, false);
+			assert.equal(payload.exitCode, 1);
+			assert.match(payload.results[0]?.error ?? "", terminal.error);
+			assert.equal(payload.results[0]?.output, "");
+			const status = await waitForAsyncState(id, (candidate) => candidate.state === "failed");
+			assert.match(status.steps?.[0]?.error ?? "", terminal.error);
+		});
+	}
+
 	it("background runs prefer empty-output fallback over an earlier tool error", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [

--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -2676,20 +2676,20 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 
 	it("prefers empty-output fallback over an earlier tool error", async () => {
 		mockPi.onCall({
-			jsonl: [
+			stdoutRaw: [
 				events.toolResult("read", "ENOENT: no such file or directory", true),
 				events.toolResult("read", "recovered file contents"),
 				{
 					type: "message_end",
 					message: {
 						role: "assistant",
-						content: [],
+						content: [{ type: "text", text: "" }],
 						model: "openai/gpt-5-mini",
 						stopReason: "stop",
-						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+						usage: { input: 0, output: 4, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
 					},
 				},
-			],
+			].map((event) => JSON.stringify(event)).join("\n"),
 			exitCode: 0,
 		});
 		mockPi.onCall({ output: "Recovered on fallback" });


### PR DESCRIPTION
Closes #1921.

Classify the observed final empty-string text `stop` response with reported usage as an empty-response failure, rather than reporting an earlier tool error. This remains a failure and permits the existing fallback policy; saved artifacts do not turn it into success.

Preserves the original zero-block case, genuine errors, useful text, tool-call and other stop-reason exclusions. No whitespace/thinking policy expansion or assistant-error latch changes.

Validation: 23 original focused driver cases and pre-fix red controls; five selected cases after the previous rebase. Retained assessment, separate simplification and fresh source review completed. The latest rebase onto c265 preserves the feature patch/blobs and original evidence attribution; typecheck, hygiene and independent three-way tree comparison passed.

Main CI is healthy after #1929. New-head CI/Greptile and feedback disposition remain required before merge.
