### PR TITLE
fix: preserve lineage for string-ID workflow resumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).
 - Rescue confident read-only background completions misclassified as implementation before publishing missing-edit failures (#1911). Thanks to [@yanqianglu](https://github.com/yanqianglu).

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -115,7 +115,7 @@ import { handleHerdrInspectorAction, HERDR_INSPECTOR_ACTIONS } from "../../inspe
 import { handleHerdrProjectPaneAction, HERDR_PROJECT_PANE_ACTIONS } from "../../inspectors/herdr/project-panes.ts";
 import { previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError, type WorkflowLanePlan, type WorkflowReceiptResumeReference, type WorkflowScriptChildResult, type WorkflowScriptTraceEntry, type WorkflowSteerOptions, type WorkflowSteerResult } from "../../workflows/scripted-workflow.ts";
 import { executeWorkflowHostCommand, resolveWorkflowHostOutputClaimPath, type WorkflowHostCommandParams, type WorkflowHostCommandResult } from "../../workflows/host-command.ts";
-import { buildWorkflowReceipt, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
+import { buildWorkflowReceipt, readWorkflowReceipt, workflowReceiptPath, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
 import { upsertHostStep, validHostStepNodes } from "../shared/host-step-status.ts";
 import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "../shared/lane-metadata.ts";
 import { parseWorkflowChildSummary, workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
@@ -1744,6 +1744,28 @@ async function resumeExternalJobFollowUp(input: {
 	return externalJobFollowUpStarted({ sourceRunId: input.target.runId, runId: result.details.asyncId ?? runId, asyncDir: result.details.asyncDir ?? asyncDir, interactive: input.ctx.hasUI });
 }
 
+function resolveRequestedResumeTarget(params: SubagentParamsLike, deps: ExecutorDeps, parentSessionFile: string | null): ResumeSourceTarget | { kind: "live-nested"; target: ResolvedSubagentRunId & { kind: "nested" } } {
+	const requestedId = params.id ?? params.runId;
+	let resolved: ResolvedSubagentRunId | undefined;
+	try {
+		resolved = requestedId ? resolveSubagentRunId(requestedId, omitUndefinedProperties({ state: deps.state, nested: nestedResolutionScopeForExecutor(deps) })) : undefined;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "";
+		const asyncMatches = message.match(/async:/g)?.length ?? 0;
+		if (!isResumeAmbiguity(error) || !message.includes("foreground:") || asyncMatches !== 1) throw error;
+	}
+	if (resolved?.kind === "nested") {
+		if (params.chain?.length) throw new Error("Attaching a running subagent as a chain root is currently available for top-level async runs only.");
+		if (resolved.match.run.state === "running" || resolved.match.run.state === "queued") return { kind: "live-nested", target: resolved };
+		const trustedSessionRoots = [
+			...(deps.config.defaultSessionDir ? [path.resolve(deps.expandTilde(deps.config.defaultSessionDir))] : []),
+			...(parentSessionFile ? [deps.getSubagentSessionRoot(parentSessionFile)] : []),
+		];
+		return resolveNestedResumeTarget(resolved, trustedSessionRoots);
+	}
+	return resolveResumeTarget(params, deps.state, { asyncRequireSessionFile: false });
+}
+
 async function resumeAsyncRun(input: {
 	params: SubagentParamsLike;
 	requestCwd: string;
@@ -1782,34 +1804,9 @@ async function resumeAsyncRun(input: {
 	let target: ResumeSourceTarget;
 	const parentSessionFile = input.ctx.sessionManager.getSessionFile() ?? null;
 	try {
-		const requestedId = input.params.id ?? input.params.runId;
-		let resolved: ResolvedSubagentRunId | undefined;
-		try {
-			resolved = requestedId ? resolveSubagentRunId(requestedId, omitUndefinedProperties({ state: input.deps.state, nested: nestedResolutionScopeForExecutor(input.deps) })) : undefined;
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "";
-			const asyncMatches = message.match(/async:/g)?.length ?? 0;
-			if (!isResumeAmbiguity(error) || !message.includes("foreground:") || asyncMatches !== 1) throw error;
-		}
-		if (resolved?.kind === "nested") {
-			if (attachChain) {
-				return {
-					content: [{ type: "text", text: "Attaching a running subagent as a chain root is currently available for top-level async runs only." }],
-					isError: true,
-					details: { mode: "management", results: [] },
-				};
-			}
-			if (resolved.match.run.state === "running" || resolved.match.run.state === "queued") {
-				return resumeLiveNestedRun({ target: resolved, message: followUp });
-			}
-			const trustedSessionRoots = [
-				...(input.deps.config.defaultSessionDir ? [path.resolve(input.deps.expandTilde(input.deps.config.defaultSessionDir))] : []),
-				...(parentSessionFile ? [input.deps.getSubagentSessionRoot(parentSessionFile)] : []),
-			];
-			target = resolveNestedResumeTarget(resolved, trustedSessionRoots);
-		} else {
-			target = resolveResumeTarget(input.params, input.deps.state, { asyncRequireSessionFile: false });
-		}
+		const resolved = resolveRequestedResumeTarget(input.params, input.deps, parentSessionFile);
+		if (resolved.kind === "live-nested") return resumeLiveNestedRun({ target: resolved.target, message: followUp });
+		target = resolved;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		return { content: [{ type: "text", text: message }], isError: true, details: { mode: "management", results: [] } };
@@ -4265,8 +4262,6 @@ function workflowChildResult(
 	}
 	const requestedContext = childParams.context === "fresh" || childParams.context === "fork" ? childParams.context : undefined;
 	const resolvedContext = result.details.context ?? (resolvedContexts.length === 1 ? resolvedContexts[0] : resolvedContexts.length > 1 ? "mixed" : undefined);
-	const resumeSourceRunId = typeof childParams.resume === "string" && childParams.resume.trim() ? childParams.resume.trim() : undefined;
-	const continuationRunIds = [...new Set([resumeSourceRunId, runId].filter((value): value is string => Boolean(value)))];
 	const outputReference = result.details.results.find((child) => child.savedOutputPath)?.savedOutputPath
 		?? result.details.results.find((child) => child.outputReference?.path)?.outputReference?.path;
 	const outputPathMapping = typeof childParams.task === "string" ? outputPathMappingFromTask(childParams.task, outputReference) : undefined;
@@ -4299,7 +4294,7 @@ function workflowChildResult(
 		...(outputPathMapping ? { outputPathMapping } : {}),
 		...(externalAdapter ? { externalAdapter } : {}),
 		resumability,
-		continuation: { runIds: continuationRunIds },
+		continuation: { runIds: runId ? [runId] : [] },
 		artifactPaths: [...artifactPaths],
 		results: result.details.results,
 	};
@@ -4412,10 +4407,33 @@ function missingWorkflowReceiptResumeHint(reference: WorkflowReceiptResumeRefere
 	}
 }
 
-function resolveKeyedWorkflowResume(
-	reference: WorkflowReceiptResumeReference,
-	state: SubagentState,
-): { runId: string; runIds: string[] } {
+function resolveWorkflowResume(
+	reference: WorkflowReceiptResumeReference | string,
+	deps: ExecutorDeps,
+	parentSessionFile: string | null,
+	index?: number,
+): string | { runId: string; runIds: string[] } {
+	const state = deps.state;
+	if (typeof reference === "string") {
+		const target = resolveRequestedResumeTarget({ id: reference.trim(), ...(index !== undefined ? { index } : {}) }, deps, parentSessionFile);
+		// Live routing stays with action=resume and does not claim retained lineage.
+		if (target.kind !== "revive") return reference.trim();
+		const runId = target.runId;
+		const status = target.source === "async" && target.asyncDir ? readStatus(target.asyncDir) : undefined;
+		if (status?.runId === runId && status.parentWorkflowRunId && status.workflowKey) {
+			// Only follow the validated child's recorded owner; never search other workflows.
+			const receiptPath = workflowReceiptPath(DIRS.async, status.parentWorkflowRunId);
+			try {
+				fs.statSync(receiptPath);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") return { runId, runIds: [runId] };
+				throw error;
+			}
+			const entry = readWorkflowReceipt(DIRS.async, status.parentWorkflowRunId).entries[status.workflowKey];
+			if (entry?.latestRunId === runId) return { runId, runIds: entry.continuation.runIds };
+		}
+		return { runId, runIds: [runId] };
+	}
 	try {
 		const entry = resolveWorkflowReceiptResumeEntry({
 			reference,
@@ -5468,7 +5486,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								return child;
 							},
 							status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel)),
-							resolveResume: (reference) => resolveKeyedWorkflowResume(reference, deps.state),
+							resolveResume: (reference, _signal, index) => resolveWorkflowResume(reference, deps, ctx.sessionManager.getSessionFile() ?? null, index),
 							steer: (key, message, options, workflowSignal) => steerWorkflowChildByKey({ state: deps.state, workflowRunId, key, message, options, signal: workflowSignal, resolveRunId: () => workflowChildRunIds.get(key) }),
 						});
 						const finalPreflightWarnings = workflowPreflightWarnings(workflowPreflight, workflow.trace, { settled: true });
@@ -5683,7 +5701,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						return child;
 					},
 					status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel)),
-					resolveResume: (reference) => resolveKeyedWorkflowResume(reference, deps.state),
+					resolveResume: (reference, _signal, index) => resolveWorkflowResume(reference, deps, ctx.sessionManager.getSessionFile() ?? null, index),
 					steer: (key, message, options, workflowSignal) => steerWorkflowChildByKey({ state: deps.state, workflowRunId: foregroundWorkflowRunId, key, message, options, signal: workflowSignal, resolveRunId: () => workflowChildRunIds.get(key) }),
 				});
 				const finalPreflightWarnings = workflowPreflightWarnings(workflowPreflight, workflow.trace, { settled: true });

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4443,9 +4443,7 @@ function resolveWorkflowResume(
 				if (target.kind !== "revive") throw new Error(`Workflow receipt child '${reference.key}' latest run '${runId}' is still running.`);
 			},
 		});
-		const runId = entry.latestRunId;
-		if (!runId) throw new Error(`Workflow receipt child '${reference.key}' has no retained run id.`);
-		return { runId, runIds: entry.continuation.runIds };
+		return { runId: entry.latestRunId, runIds: entry.continuation.runIds };
 	} catch (error) {
 		const workflowRunId = reference.workflowRunId.trim();
 		if (isMissingWorkflowReceiptDiagnostic(error, workflowRunId)) {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -1110,7 +1110,7 @@ export interface RunWorkflowScriptOptions {
 	globalConcurrencyLimit?: number;
 	admit?: (calls: Array<{ key: string; params: Record<string, unknown> }>) => void | Promise<void>;
 	launch: (key: string, params: Record<string, unknown>, signal: AbortSignal, admission: { admitted: boolean; batch: boolean }) => Promise<WorkflowScriptChildResult>;
-	resolveResume?: (reference: WorkflowReceiptResumeReference, signal: AbortSignal) => string | WorkflowResolvedResumeReference | Promise<string | WorkflowResolvedResumeReference>;
+	resolveResume?: (reference: WorkflowReceiptResumeReference | string, signal: AbortSignal, index?: number) => string | WorkflowResolvedResumeReference | Promise<string | WorkflowResolvedResumeReference>;
 	status: (keyOrRunId: string, signal: AbortSignal) => Promise<WorkflowScriptChildResult>;
 	steer?: (key: string, message: string, options: WorkflowSteerOptions, signal: AbortSignal) => Promise<WorkflowSteerResult>;
 	host?: (key: string, params: WorkflowHostCommandParams, signal: AbortSignal) => Promise<WorkflowHostCommandResult>;
@@ -2183,10 +2183,11 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				const childStopController = new AbortController();
 				childStopControllers.set(key, childStopController);
 				const childSignal = combinedAbortSignal([childController.signal, childStopController.signal]);
-				const resolvedResumeValue = resumeReference
+				const resumeInput = resumeReference ?? (typeof params.resume === "string" && options.resolveResume ? params.resume : undefined);
+				const resolvedResumeValue = resumeInput
 					? await Promise.resolve().then(() => {
 						if (!options.resolveResume) throw new Error("Keyed workflow receipt resume is unavailable in this host.");
-						return options.resolveResume(resumeReference, childSignal);
+						return options.resolveResume(resumeInput, childSignal, typeof params.index === "number" ? params.index : undefined);
 					})
 					: undefined;
 				const resolvedResume = typeof resolvedResumeValue === "string"
@@ -2202,6 +2203,10 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 						: [];
 					resolvedResumeLineage = [...new Set(lineage.length ? lineage : [resolvedResumeId!])];
 					if (resolvedResumeLineage.at(-1) !== resolvedResumeId) resolvedResumeLineage.push(resolvedResumeId!);
+					if (typeof resumeInput === "string") {
+						const predecessor = [...children.values()].find((child) => child.runId === resolvedResumeId);
+						if (predecessor?.continuation && predecessor.continuation.runIds.at(-1) === resolvedResumeId) resolvedResumeLineage = predecessor.continuation.runIds;
+					}
 				}
 				const launchParams = resolvedResumeId ? { ...params, resume: resolvedResumeId } : params;
 				await launchSemaphore.acquire();

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -905,7 +905,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 		}
 	});
 
-	it("resume action revives completed multi-child async runs by index", async () => {
+	for (const workflow of [false, true]) it(`${workflow ? "workflow string resume" : "resume action"} revives completed multi-child async runs by index`, async () => {
 		mockPi.onCall({ output: "revived async child b" });
 		const runId = `resume-revive-multi-${Date.now()}`;
 		const asyncDir = path.join(ASYNC_DIR, runId);
@@ -933,17 +933,26 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 
 			const result = await executor.execute(
 				"resume-revive-multi",
-				{ action: "resume", id: runId, index: 1, message: "What did b find?" },
+				workflow
+					? { async: false, workflowScript: `return runs.run("indexed", { resume: ${JSON.stringify(runId)}, index: 1, task: "What did b find?", output: false });` }
+					: { action: "resume", id: runId, index: 1, message: "What did b find?" },
 				new AbortController().signal,
 				undefined,
 				makeMinimalCtx(tempDir),
 			);
 
 			assert.equal(result.isError, undefined);
-			assert.match(result.content[0]?.text ?? "", /Revived async subagent from/);
-			assert.match(result.details?.asyncId ?? "", /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
-			assert.match(result.content[0]?.text ?? "", /Agent: b/);
-			assert.match(result.content[0]?.text ?? "", new RegExp(secondSession.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+			if (workflow) {
+				const child = result.details!.workflow!.value as { runId: string; agent: string; continuation: { runIds: string[] } };
+				assert.equal(child.agent, "b");
+				assert.deepEqual(child.continuation.runIds, [runId, child.runId]);
+				assert.deepEqual(result.details!.workflow!.receipt!.entries.indexed.continuation, child.continuation);
+			} else {
+				assert.match(result.content[0]?.text ?? "", /Revived async subagent from/);
+				assert.match(result.details?.asyncId ?? "", /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+				assert.match(result.content[0]?.text ?? "", /Agent: b/);
+				assert.match(result.content[0]?.text ?? "", new RegExp(secondSession.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+			}
 			const args = await readMockCallArgs(0);
 			assert.equal(args[args.indexOf("--session") + 1], secondSession);
 			assert.equal(args[args.indexOf("--model") + 1], "anthropic/claude-sonnet-4:high");

--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -1628,14 +1628,16 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 			const challengeOutput = relative ? "challenge-relative.md" : path.join(tempDir, "challenge-absolute.md");
 			mockPi.onCall({ output: "original writer report" });
 			mockPi.onCall({ output: "retained challenge report" });
+			mockPi.onCall({ output: "repeated challenge report" });
 			const result = await makeExecutor([makeAgent("echo")], {}, true).execute(
 				`workflow-retained-output-${relative}`,
 				{
 					async: false,
 					workflowScript: `
 						const writer = await runs.run("writer", { agent: "echo", task: "Write report", acceptance: false, output: ${JSON.stringify(writerPath)} });
-						const challenge = await runs.run("challenge", { resume: writer.runId, task: "Challenge report", output: ${JSON.stringify(challengeOutput)} });
-						return { writer, challenge };
+						const challenge = await runs.run("challenge", { resume: ${relative ? "writer.runId.slice(0, 12)" : "writer.runId"}, task: "Challenge report", output: ${JSON.stringify(challengeOutput)} });
+						const repeated = await runs.run("repeated", { resume: challenge.runId, task: "Challenge again", output: false });
+						return { writer, challenge, repeated };
 					`,
 				},
 				new AbortController().signal,
@@ -1644,9 +1646,16 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 			);
 
 			assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
-			const { writer, challenge } = result.details.workflow?.value as { writer: { ok: boolean; runId: string; outputReference: string }; challenge: { ok: boolean; runId: string; outputReference: string } };
+			const { writer, challenge, repeated } = result.details.workflow?.value as Record<string, { ok: boolean; runId: string; outputReference: string; continuation: { runIds: string[] } }>;
 			assert.equal(writer.ok, true);
 			assert.equal(challenge.ok, true);
+			assert.equal(repeated.ok, true);
+			assert.deepEqual(challenge.continuation.runIds, [writer.runId, challenge.runId]);
+			assert.deepEqual(repeated.continuation.runIds, [writer.runId, challenge.runId, repeated.runId]);
+			for (const child of [writer, challenge, repeated]) {
+				const entry = Object.values(result.details.workflow!.receipt!.entries).find((entry) => entry.latestRunId === child.runId);
+				assert.deepEqual(entry?.continuation, child.continuation);
+			}
 			assert.notEqual(challenge.runId, writer.runId);
 			assert.equal(writer.outputReference, writerPath);
 			const challengePath = relative ? path.join(TEMP_ARTIFACTS_DIR, "outputs", `workflow-retained-output-${relative}`, challengeOutput) : challengeOutput;
@@ -1654,9 +1663,95 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 			assert.notEqual(challenge.outputReference, writer.outputReference);
 			assert.equal(fs.readFileSync(writer.outputReference, "utf-8"), "original writer report");
 			assert.equal(fs.readFileSync(challenge.outputReference, "utf-8"), "retained challenge report");
-			assert.deepEqual(result.details.results.map((child) => child.savedOutputPath), [writerPath, challengePath]);
+			assert.deepEqual(result.details.results.map((child) => child.savedOutputPath), [writerPath, challengePath, undefined]);
 		}
-		assert.equal(mockPi.callCount(), 4);
+		assert.equal(mockPi.callCount(), 6);
+	});
+
+	it("preserves string resume lineage from the recorded terminal workflow receipt", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "writer" });
+		mockPi.onCall({ output: "challenge" });
+		mockPi.onCall({ output: "repeated" });
+		const executor = makeExecutor([makeAgent("echo")]);
+		const ctx = makeMinimalCtx(tempDir);
+		const started = await executor.execute("lineage-source", {
+			async: true,
+			workflowScript: `
+				const writer = await runs.run("writer", { agent: "echo", task: "Write", async: false, acceptance: false, output: false });
+				const challenge = await runs.run("challenge", { resume: writer.runId, task: "Challenge", output: false });
+				return { writer, challenge };
+			`,
+		}, new AbortController().signal, undefined, ctx);
+		assert.equal(started.isError, undefined);
+		const resultPath = path.join(DIRS.results, `${started.details.asyncId}.json`);
+		for (let attempt = 0; attempt < 500 && !fs.existsSync(resultPath); attempt++) await new Promise((resolve) => setTimeout(resolve, 20));
+		const settled = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+		const { writer, challenge } = settled.workflow.value;
+		assert.equal(challenge.ok, true);
+		assert.deepEqual(challenge.continuation.runIds, [writer.runId, challenge.runId]);
+		assert.deepEqual(settled.workflowReceipt.receipt.entries.challenge.continuation, challenge.continuation);
+		const repeated = await executor.execute("lineage-repeated", {
+			async: false,
+			workflowScript: `return runs.run("repeated", { resume: ${JSON.stringify(challenge.runId)}, task: "Repeat challenge", output: false });`,
+		}, new AbortController().signal, undefined, ctx);
+		assert.equal(repeated.isError, undefined, repeated.content[0]?.text);
+		const child = repeated.details.workflow!.value as { runId: string; continuation: { runIds: string[] } };
+		assert.deepEqual(child.continuation.runIds, [writer.runId, challenge.runId, child.runId]);
+		assert.deepEqual(repeated.details.workflow!.receipt!.entries.repeated.continuation, child.continuation);
+
+		// A recorded but malformed receipt is not the same as an absent older receipt.
+		fs.writeFileSync(settled.workflowReceipt.path, "{broken");
+		const rejected = await executor.execute("lineage-malformed", {
+			async: false,
+			workflowScript: `return runs.run("rejected", { resume: ${JSON.stringify(challenge.runId)}, task: "Do not launch", output: false });`,
+		}, new AbortController().signal, undefined, ctx);
+		assert.equal(rejected.isError, true);
+		assert.match(rejected.content[0]?.text ?? "", /could not be read/);
+		assert.deepEqual(rejected.details.workflow!.receipt!.entries.rejected.continuation.runIds, []);
+		assert.equal(mockPi.callCount(), 3);
+		for (const evidence of ["missing", "mismatched"]) {
+			if (evidence === "missing") fs.rmSync(settled.workflowReceipt.path);
+			else {
+				const receipt = settled.workflowReceipt.receipt;
+				receipt.entries.challenge.latestRunId = "unrelated-run";
+				receipt.entries.challenge.continuation.runIds = ["unrelated-run"];
+				fs.writeFileSync(settled.workflowReceipt.path, JSON.stringify(receipt));
+			}
+			mockPi.onCall({ output: "continued without older evidence" });
+			const fallback = await executor.execute(`lineage-${evidence}`, {
+				async: false,
+				workflowScript: `return runs.run("fallback", { resume: ${JSON.stringify(challenge.runId)}, task: "Continue", output: false });`,
+			}, new AbortController().signal, undefined, ctx);
+			assert.equal(fallback.isError, undefined, fallback.content[0]?.text);
+			const continued = fallback.details.workflow!.value as { runId: string; continuation: { runIds: string[] } };
+			assert.deepEqual(continued.continuation.runIds, [challenge.runId, continued.runId]);
+			assert.deepEqual(fallback.details.workflow!.receipt!.entries.fallback.continuation, continued.continuation);
+		}
+		assert.equal(mockPi.callCount(), 5);
+	});
+
+	it("rejects missing and stale string resume IDs without claiming continuation lineage", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		mockPi.onCall({ output: "writer" });
+		const executor = makeExecutor([makeAgent("echo")]);
+		const ctx = makeMinimalCtx(tempDir);
+		const first = await executor.execute("lineage-stale-source", {
+			async: false,
+			workflowScript: `return runs.run("writer", { agent: "echo", task: "Write", acceptance: false, output: false });`,
+		}, new AbortController().signal, undefined, ctx);
+		assert.equal(first.isError, undefined);
+		const writer = first.details.workflow!.value as { runId: string; results: Array<{ sessionFile: string }> };
+		fs.rmSync(writer.results[0].sessionFile);
+		for (const id of ["missing-retained-run", writer.runId]) {
+			const rejected = await executor.execute("lineage-rejected", {
+				async: false,
+				workflowScript: `return runs.run("rejected", { resume: ${JSON.stringify(id)}, task: "Do not launch" });`,
+			}, new AbortController().signal, undefined, ctx);
+			assert.equal(rejected.isError, true);
+			assert.match(rejected.content[0]?.text ?? "", /not found|does not exist/);
+			assert.equal(rejected.details.workflow!.receipt!.entries.rejected.latestRunId, undefined);
+			assert.deepEqual(rejected.details.workflow!.receipt!.entries.rejected.continuation.runIds, []);
+		}
+		assert.equal(mockPi.callCount(), 1);
 	});
 
 	it("applies explicit structured-output contract fields when resuming a foreground workflow child", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -317,7 +317,7 @@ describe("nested control routing", () => {
 		}
 	});
 
-	it("routes resume for live nested runs through the control inbox", async () => {
+	for (const workflow of [false, true]) it(`routes ${workflow ? "workflow string" : "action"} resume for live nested runs through the control inbox`, async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-nested-live-resume-"));
 		try {
 			const emitted: Array<{ name: string; payload: unknown }> = [];
@@ -332,7 +332,9 @@ describe("nested control routing", () => {
 				writeNestedControlResult(route, { ts: Date.now(), requestId: request.requestId, targetRunId: request.targetRunId, ok: true, message: "nested resume accepted" });
 			}, 50);
 
-			const result = await executor.execute("resume", { action: "resume", id: "nested-live-resume", message: "continue please" }, new AbortController().signal, undefined, ctx(root));
+			const result = await executor.execute("resume", workflow
+				? { async: false, workflowScript: `return runs.run("live", { resume: "nested-live-resume", task: "continue please", output: false });` }
+				: { action: "resume", id: "nested-live-resume", message: "continue please" }, new AbortController().signal, undefined, ctx(root));
 
 			assert.equal(result.isError, undefined);
 			assert.match(text(result), /nested resume accepted/);
@@ -387,13 +389,15 @@ describe("nested control routing", () => {
 		}
 	});
 
-	it("rejects stopped nested runs before attempting revival", async () => {
+	for (const workflow of [false, true]) it(`rejects stopped nested runs before ${workflow ? "workflow string resume" : "action revival"}`, async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-nested-stopped-resume-"));
 		try {
 			const route = createNestedRun("nested-stopped-resume", "stopped", { sessionFile: path.join(root, "missing-session.jsonl") });
 
 			const result = await createExecutor(stateWithNestedRoute(route), [{ name: "worker", description: "Worker", prompt: "Do work" }])
-				.execute("resume", { action: "resume", id: "nested-stopped-resume", message: "continue" }, new AbortController().signal, undefined, ctx(root));
+				.execute("resume", workflow
+					? { async: false, workflowScript: `return runs.run("stopped", { resume: "nested-stopped-resume", task: "continue", output: false });` }
+					: { action: "resume", id: "nested-stopped-resume", message: "continue" }, new AbortController().signal, undefined, ctx(root));
 
 			assert.equal(result.isError, true);
 			assert.match(text(result), /was stopped and cannot be resumed/);

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -324,17 +324,26 @@ describe("nested control routing", () => {
 			const events = { emit(name: string, payload: unknown) { emitted.push({ name, payload }); }, on() { return () => {}; } };
 			const route = createNestedRun("nested-live-resume", "running", { intercomTarget: "attacker-target", leafIntercomTarget: "attacker-leaf" });
 			const executor = createExecutor(stateWithNestedRoute(route), [], true, events);
-			setTimeout(() => {
-				const request = readNestedControlRequests(route)[0];
+			const responder = (async () => {
+				const deadline = Date.now() + 2_000;
+				let request = readNestedControlRequests(route)[0];
+				while (!request && Date.now() < deadline) {
+					await new Promise((resolve) => setTimeout(resolve, 10));
+					request = readNestedControlRequests(route)[0];
+				}
 				assert.ok(request, "expected a nested resume request");
 				assert.equal(request.action, "resume");
 				assert.equal(request.message, "continue please");
 				writeNestedControlResult(route, { ts: Date.now(), requestId: request.requestId, targetRunId: request.targetRunId, ok: true, message: "nested resume accepted" });
-			}, 50);
+			})();
 
-			const result = await executor.execute("resume", workflow
+			const execution = Promise.resolve().then(() => executor.execute("resume", workflow
 				? { async: false, workflowScript: `return runs.run("live", { resume: "nested-live-resume", task: "continue please", output: false });` }
-				: { action: "resume", id: "nested-live-resume", message: "continue please" }, new AbortController().signal, undefined, ctx(root));
+				: { action: "resume", id: "nested-live-resume", message: "continue please" }, new AbortController().signal, undefined, ctx(root)));
+			const [response, executed] = await Promise.allSettled([responder, execution]);
+			if (response.status === "rejected") throw response.reason;
+			if (executed.status === "rejected") throw executed.reason;
+			const result = executed.value;
 
 			assert.equal(result.isError, undefined);
 			assert.match(text(result), /nested resume accepted/);


### PR DESCRIPTION
Closes #1920.

String-ID workflow resumes resolve the canonical predecessor and preserve available recorded ancestry in returned results and receipts. Prefix/index, nested revival and live routing reuse existing selection. Missing older history stays unknown; malformed or unreadable recorded evidence is rejected. No new options, store or history scans.

Original challenge, simplification and fresh review passed with 40 focused cases. The accepted test-only CI correction uses bounded actual-request observation and settled-task cleanup. Refreshed onto main063a after #1927, with only a changelog union. All five candidate source/test blobs are unchanged. Two existing lineage/fallback controls, typecheck and hygiene passed; parent verified complete tree composition and exact contributor-credit union. Original review/test attribution remains attached to its original heads; fixtures are scripted, not live providers.

New-head CI/Greptile and full feedback disposition are required before merge, followed by required main CI.