### PR TITLE
fix: stabilize active Fleet rows including missing start times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Surface structured output in completion notices when text is blank or only a closing think-tag (#1945). Thanks to [@npfedwards](https://github.com/npfedwards).
 - Validate literal workflow `baseRef` values before execution and clarify supported refs (#1934, #1937). Thanks to [@jeanduplessis](https://github.com/jeanduplessis).
 - Use portable boolean tool-schema branches for restricted Gemini function-declaration converters while preserving false-only runtime contracts (#1950). Thanks to [@Biaogo94](https://github.com/Biaogo94).
-- Keep the fleet inspector roster stable by ordering active runs by start time instead of last activity heartbeat (#1923).
+- Keep the fleet inspector roster stable by ordering active runs by start time instead of last activity heartbeat (#1923, #1924). Thanks to [@expoli](https://github.com/expoli).
 - Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Surface structured output in completion notices when text is blank or only a closing think-tag (#1945). Thanks to [@npfedwards](https://github.com/npfedwards).
 - Validate literal workflow `baseRef` values before execution and clarify supported refs (#1934, #1937). Thanks to [@jeanduplessis](https://github.com/jeanduplessis).
 - Use portable boolean tool-schema branches for restricted Gemini function-declaration converters while preserving false-only runtime contracts (#1950). Thanks to [@Biaogo94](https://github.com/Biaogo94).
+- Keep the fleet inspector roster stable by ordering active runs by start time instead of last activity heartbeat (#1923).
 - Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -179,10 +179,15 @@ function asyncItems(run: AsyncRunSummary, description?: string): FleetItem[] {
 	}));
 }
 
-function orderFleetAsyncRuns(runs: AsyncRunSummary[], terminalLimit: number): AsyncRunSummary[] {
+function orderFleetAsyncRuns(runs: AsyncRunSummary[], terminalLimit: number, trackedJobs: Map<string, AsyncJobState>): AsyncRunSummary[] {
 	const updatedAt = (run: AsyncRunSummary) => run.lastUpdate ?? run.endedAt ?? run.startedAt;
 	const byNewest = (left: AsyncRunSummary, right: AsyncRunSummary) => updatedAt(right) - updatedAt(left);
-	const byStartedAt = (left: AsyncRunSummary, right: AsyncRunSummary) => left.startedAt - right.startedAt || left.id.localeCompare(right.id);
+	// Missing tracked starts must not inherit the summary's heartbeat-based display fallback.
+	const startedAt = (run: AsyncRunSummary) => {
+		const job = trackedJobs.get(run.id);
+		return job ? job.startedAt ?? 0 : run.startedAt;
+	};
+	const byStartedAt = (left: AsyncRunSummary, right: AsyncRunSummary) => startedAt(left) - startedAt(right) || left.id.localeCompare(right.id);
 	const active = runs.filter((run) => run.state === "queued" || run.state === "running").sort(byStartedAt);
 	const terminal = runs.filter((run) => run.state !== "queued" && run.state !== "running").sort(byNewest);
 	return [...active, ...terminal.slice(0, terminalLimit)];
@@ -273,7 +278,7 @@ export function collectFleetSnapshot(
 		} else {
 			runs = trackedRuns;
 		}
-		for (const run of orderFleetAsyncRuns(runs, options.limit ?? MAX_RECENT_ASYNC_RUNS)) {
+		for (const run of orderFleetAsyncRuns(runs, options.limit ?? MAX_RECENT_ASYNC_RUNS, trackedJobs)) {
 			items.push(...asyncItems(run, descriptions.get(run.id)));
 		}
 	} catch (cause) {

--- a/src/tui/fleet.ts
+++ b/src/tui/fleet.ts
@@ -182,7 +182,8 @@ function asyncItems(run: AsyncRunSummary, description?: string): FleetItem[] {
 function orderFleetAsyncRuns(runs: AsyncRunSummary[], terminalLimit: number): AsyncRunSummary[] {
 	const updatedAt = (run: AsyncRunSummary) => run.lastUpdate ?? run.endedAt ?? run.startedAt;
 	const byNewest = (left: AsyncRunSummary, right: AsyncRunSummary) => updatedAt(right) - updatedAt(left);
-	const active = runs.filter((run) => run.state === "queued" || run.state === "running").sort(byNewest);
+	const byStartedAt = (left: AsyncRunSummary, right: AsyncRunSummary) => left.startedAt - right.startedAt || left.id.localeCompare(right.id);
+	const active = runs.filter((run) => run.state === "queued" || run.state === "running").sort(byStartedAt);
 	const terminal = runs.filter((run) => run.state !== "queued" && run.state !== "running").sort(byNewest);
 	return [...active, ...terminal.slice(0, terminalLimit)];
 }
@@ -208,7 +209,7 @@ export function collectFleetSnapshot(
 		liveWorkflowForegroundControls.add(control);
 		workflowForegroundChildCounts.set(control.parentWorkflowRunId, (workflowForegroundChildCounts.get(control.parentWorkflowRunId) ?? 0) + activeChildCount);
 	}
-	for (const control of [...state.foregroundControls.values()].sort((left, right) => right.updatedAt - left.updatedAt)) {
+	for (const control of [...state.foregroundControls.values()].sort((left, right) => left.startedAt - right.startedAt || left.runId.localeCompare(right.runId))) {
 		activeForegroundIds.add(control.runId);
 		if (control.parentWorkflowRunId && workflowParentIds.has(control.parentWorkflowRunId)
 			&& ((workflowForegroundChildCounts.get(control.parentWorkflowRunId) ?? 0) <= 1 || !liveWorkflowForegroundControls.has(control))) continue;
@@ -249,7 +250,7 @@ export function collectFleetSnapshot(
 		const tracked = [...trackedJobs.values()]
 			.filter((job) => belongsToCurrentSession(job.sessionId, state.currentSessionId));
 		const byUpdate = (left: AsyncJobState, right: AsyncJobState) => (right.updatedAt ?? right.startedAt ?? 0) - (left.updatedAt ?? left.startedAt ?? 0);
-		const active = tracked.filter((job) => job.status === "queued" || job.status === "running").sort(byUpdate);
+		const active = tracked.filter((job) => job.status === "queued" || job.status === "running");
 		const recent = tracked.filter((job) => job.status !== "queued" && job.status !== "running").sort(byUpdate).slice(0, options.limit ?? MAX_RECENT_ASYNC_RUNS);
 		const trackedRuns: AsyncRunSummary[] = [];
 		for (const job of [...active, ...recent]) {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -44,6 +44,7 @@ function writeAsyncRun(root: string, input: {
 	state?: "running" | "complete" | "failed";
 	mode?: "single" | "parallel" | "workflow";
 	lastUpdate?: number;
+	startedAt?: number;
 	agents?: string[];
 	contexts?: Array<"fresh" | "fork">;
 	models?: string[];
@@ -63,7 +64,7 @@ function writeAsyncRun(root: string, input: {
 		sessionId: input.sessionId ?? "session-current",
 		mode: input.mode ?? (agents.length > 1 ? "parallel" : "single"),
 		state,
-		startedAt: 100,
+		startedAt: input.startedAt ?? 100,
 		lastUpdate: input.lastUpdate ?? 200,
 		currentStep: 0,
 		steps: agents.map((agent, index) => ({
@@ -627,8 +628,8 @@ describe("native subagent fleet", () => {
 		});
 		const snapshot = collectFleetSnapshot(state);
 		assert.deepEqual(snapshot.items.map((item) => item.key), [
-			"foreground-active:child-2:0",
 			"foreground-active:child-1:0",
+			"foreground-active:child-2:0",
 			"async:unrelated",
 			"async:workflow-1",
 		]);
@@ -695,6 +696,26 @@ describe("native subagent fleet", () => {
 		assert.equal(snapshot.items[0]?.runId, "active-old");
 		assert.equal(snapshot.items.find((item) => item.runId === "terminal-21")?.state, "complete");
 		assert.ok(!snapshot.items.some((item) => item.runId === "terminal-0"));
+	});
+
+	it("orders active runs by start time so the roster stays stable while they emit", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-active-order-"));
+		try {
+			writeAsyncRun(root, { id: "worker-b", startedAt: 200, lastUpdate: 900 });
+			writeAsyncRun(root, { id: "worker-a", startedAt: 100, lastUpdate: 500 });
+			const state = stateForTest();
+			const keys = () => collectFleetSnapshot(state, { asyncDirRoot: root, resultsDir: path.join(root, "results") }).items.map((item) => item.key);
+			// First refresh: the run created first stays on top, even though worker-b emitted most recently.
+			assert.deepEqual(keys(), ["async:worker-a:0", "async:worker-b:0"]);
+			// Later activity on worker-b must not reorder the roster.
+			writeAsyncRun(root, { id: "worker-b", startedAt: 200, lastUpdate: 1500 });
+			assert.deepEqual(keys(), ["async:worker-a:0", "async:worker-b:0"]);
+			// A run started later still lands after the earlier ones.
+			writeAsyncRun(root, { id: "worker-c", startedAt: 300, lastUpdate: 300 });
+			assert.deepEqual(keys(), ["async:worker-a:0", "async:worker-b:0", "async:worker-c:0"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("accepts default Fleet navigation from Kitty CSI-u input", () => {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -447,6 +447,29 @@ describe("native subagent fleet", () => {
 		}
 	});
 
+	it("keeps tracked missing-start rows stable across opposing heartbeat updates", () => {
+		const state = stateForTest();
+		state.fleetJobs = new Map();
+		for (const [id, startedAt, status] of [
+			["known", 100, "running"], ["unknown-b", undefined, "running"], ["unknown-a", undefined, "queued"],
+		] as const) {
+			state.fleetJobs.set(id, {
+				asyncId: id, asyncDir: `/tmp/${id}`, sessionId: "session-current", status, startedAt,
+			});
+		}
+		for (const direction of [1, -1]) {
+			let heartbeat = 500;
+			for (const job of state.fleetJobs.values()) job.updatedAt = heartbeat += direction * 10;
+			const snapshot = collectFleetSnapshot(state);
+			assert.equal(snapshot.error, undefined);
+			assert.deepEqual(snapshot.items.map((item) => item.key), ["async:unknown-a", "async:unknown-b", "async:known"]);
+			for (const item of snapshot.items) {
+				const job = state.fleetJobs.get(item.runId)!;
+				assert.equal(item.run?.startedAt, job.startedAt ?? job.updatedAt);
+			}
+		}
+	});
+
 	it("keeps tracked active workflows ahead of older failed terminal history", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fleet-history-"));
 		try {


### PR DESCRIPTION
Closes #1923. Maintainer replacement for #1924, preserving expoli author/date/message and [@expoli](https://github.com/expoli) credit. Active native rows keep stable start/id order; missing tracked start uses zero only for sorting, not display. External rows, terminal history and selection semantics unchanged; no new scans/state/API. Original89tests/typecheck, separate simplification and fresh review remain attributed to their original heads. The previous Windows mission-lock timeout is retained as unrelated unresolved evidence, not rerun or claimed fixed.

Current refresh: base d074 after #1918. The complete candidate patch, all candidate blobs and all original authors/dates/messages/credits are unchanged. Parent verified full-tree composition; no tests/typecheck/reviews were redundantly repeated for the disjoint upstream acceptance-test change. New-head CI/Greptile/full feedback are required. Main health remains blocked by a separately investigated Windows terminal-proof failure; this publication is not merge readiness.