### PR TITLE
docs(skills): document steer delivery modes and scheduledRuns.storeRoot in execution-controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
+### Changed
+
+- Document steer delivery modes and `scheduledRuns.storeRoot` in the bundled skill reference (`execution-controls.md`).
+
 ### Fixed
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -330,7 +330,7 @@ The action waits up to three seconds for the child Pi session to accept the corr
 Steering supports three delivery modes via the `mode` parameter (`steer` is the default):
 
 - `mode: "steer"` — interrupt the child at the next safe point of its current turn and deliver the message.
-- `mode: "follow_up"` — do not interrupt; append to a bounded FIFO queue delivered at the next turn boundary. Completed or paused retained children receive the message as a revival brief (`queueRevivalBrief`) when they are revived.
+- `mode: "follow_up"` — do not interrupt; append to a bounded FIFO queue delivered at the next turn boundary. Completed retained children (single-step runs in state `complete`) receive the message as a revival brief (`queueRevivalBrief`) when they are revived; paused children reject follow-up steering outright.
 - `mode: "auto"` — deliver immediately when the child is between turns; otherwise queue it as `follow_up` would.
 
 ```typescript

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -258,7 +258,7 @@ A cooperating terminal runtime can register read-only external records through `
 
 ### Scheduled subagent runs
 
-Schedules are durable project records under `.pi/subagents/schedules/`. They are enabled by default; set `{ "scheduledRuns": { "enabled": false } }` in `~/.pi/agent/extensions/subagent/config.json` to disable them. Only schedule explicit work the user asked for.
+Schedules are durable project records under `.pi/subagents/schedules/`. They are enabled by default; set `{ "scheduledRuns": { "enabled": false } }` in `~/.pi/agent/extensions/subagent/config.json` to disable them. Only schedule explicit work the user asked for. To keep schedules outside the project repository, set `{ "scheduledRuns": { "storeRoot": "~/.pi/subagent-schedules" } }` in the same config: `storeRoot` accepts an absolute path or a `~/`-prefixed path, and records land under `<storeRoot>/<sha256(cwd) first 20 hex>/<scheduleId>/`.
 
 ```typescript
 // One-shot reviewer
@@ -326,6 +326,19 @@ subagent({ action: "steer", id: "abc123", message: "Focus on the failing test." 
 ```
 
 The action waits up to three seconds for the child Pi session to accept the correlated user input and returns a request id with `delivered`, `scheduled`, `pending`, `partial`, `recovered`, or `failed` plus per-child states. Indexed pending children return `scheduled` immediately. Only a top-level single-child run may automatically interrupt after a missed acknowledgment and recover after confirmed pause within a further 15 seconds. Recovery preserves the original child contract and only its remaining deadline, turn, and tool budgets. If the session is missing, a budget is exhausted, the pause cannot be confirmed, or replacement launch fails, the source remains paused when pausing succeeded and the action returns the exact failure. Chain, parallel, and nested runs never auto-interrupt; inspect their per-child outcomes and handle failures explicitly. A late acknowledgment is recorded and cannot cancel committed recovery.
+
+Steering supports three delivery modes via the `mode` parameter (`steer` is the default):
+
+- `mode: "steer"` — interrupt the child at the next safe point of its current turn and deliver the message.
+- `mode: "follow_up"` — do not interrupt; append to a bounded FIFO queue delivered at the next turn boundary. Completed or paused retained children receive the message as a revival brief (`queueRevivalBrief`) when they are revived.
+- `mode: "auto"` — deliver immediately when the child is between turns; otherwise queue it as `follow_up` would.
+
+```typescript
+subagent({ action: "steer", id: "abc123", mode: "follow_up", message: "After this step, also validate the config file." })
+subagent({ action: "steer", id: "abc123", mode: "auto", message: "Switch to the failing test now." })
+```
+
+Receipts reflect the chosen mode: direct delivery returns `delivered`; a queued message surfaces through the per-child states until it is delivered at the next turn boundary.
 
 ## Watchdog
 

--- a/skills/pi-subagents/references/execution-controls.md
+++ b/skills/pi-subagents/references/execution-controls.md
@@ -331,7 +331,7 @@ Steering supports three delivery modes via the `mode` parameter (`steer` is the 
 
 - `mode: "steer"` — interrupt the child at the next safe point of its current turn and deliver the message.
 - `mode: "follow_up"` — do not interrupt; append to a bounded FIFO queue delivered at the next turn boundary. Completed retained children (single-step runs in state `complete`) receive the message as a revival brief (`queueRevivalBrief`) when they are revived; paused children reject follow-up steering outright.
-- `mode: "auto"` — deliver immediately when the child is between turns; otherwise queue it as `follow_up` would.
+- `mode: "auto"` — same next-safe-point delivery path as `steer`, but without the automatic pause-and-revive recovery after a missed acknowledgment.
 
 ```typescript
 subagent({ action: "steer", id: "abc123", mode: "follow_up", message: "After this step, also validate the config file." })


### PR DESCRIPTION
## Summary
- Document the steer `mode` parameter's three delivery modes (`steer` / `follow_up` / `auto`, shipped in #884) in `skills/pi-subagents/references/execution-controls.md`. `docs/tool-reference.md` already covers them; the bundled skill reference that agents actually read at runtime did not.
- Document `scheduledRuns.storeRoot` (shipped in #892) in the Scheduled subagent runs section of the same file, including the `<storeRoot>/<sha256(cwd) first 20 hex>/<scheduleId>/` record layout.
- Add a CHANGELOG entry under `[Unreleased]` → `### Changed`.

Documentation gap only — no `Fixes`/`Closes` (the features themselves are implemented and released).

## Validation
- `git diff --check` clean
- Markdown fence / inline backtick balance verified for both edited sections
- Semantics verified against source at 063a5ad:
  - steer mode union: `src/shared/types.ts:2112`, `src/runs/background/control-channel.ts:63`
  - revival brief: `queueRevivalBrief` at `src/runs/background/control-channel.ts:311`, called from `src/runs/foreground/async-steering-action.ts:74`
  - storeRoot resolution: `src/extension/config.ts:50-54` (`resolveScheduledStoreRoot`)
  - record layout: `src/runs/background/scheduled-runs.ts:98-103,348,354`
