### PR TITLE
fix(deps): use the official npm registry for undici

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Resolve undici from the official npm registry in the lockfile for npm 12 compatibility (#1935). Thanks to [@chem](https://github.com/chem).
 - Fix background launches on stable Pi 0.85.1 without experimental packages, retaining Pi 0.85.0 support (#1944). Thanks to [@geril07](https://github.com/geril07).
 - Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,7 +2356,7 @@
     },
     "node_modules/undici": {
       "version": "8.10.0",
-      "resolved": "https://registry.npmmirror.com/undici/-/undici-8.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
       "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Closes #1935. Thanks to [@chem](https://github.com/chem) for the report. Changes only the undici resolved URL from the mirror to registry.npmjs.org, plus contributor credit. Official registry metadata matches pinned version 8.10.0 and the existing integrity value. The lockfile is otherwise unchanged; no dependency installation or tarball execution is claimed. Separate simplification and fresh review passed on the original correction; parent verified the identical corrected lock blob and mechanical base/changelog composition.

Prepared on main379a with parent composition and credit verification. New exact-head Ubuntu, Windows, Bun, pi085 and Greptile/full feedback gates remain required, followed by required post-merge main CI. Publication does not clear the existing Windows main-health blocker.

Current refresh: base d074 after #1918. The complete candidate patch, all candidate blobs and all original authors/dates/messages/credits are unchanged. Parent verified full-tree composition; no tests/typecheck/reviews were redundantly repeated for the disjoint upstream acceptance-test change. New-head CI/Greptile/full feedback are required. Main health remains blocked by a separately investigated Windows terminal-proof failure; this publication is not merge readiness.