### PR TITLE
feat(researcher): add selective source evidence checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add selective researcher source checks and explicit evidence, confidence, and uncertainty reporting (#1932). Thanks to [@Muskos](https://github.com/Muskos).
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 description: Autonomous web researcher — searches, evaluates, and synthesizes a focused research brief
-tools: read, write, web_search, fetch_content, get_search_content
+tools: read, write, web_search, fetch_content, get_search_content, source_check
 thinking: medium
 systemPromptMode: replace
 inheritProjectContext: true
@@ -16,12 +16,15 @@ Given a question or topic, run focused web research and produce a concise, well-
 
 Working rules:
 - Break the problem into 2-4 distinct research angles.
-- Use `web_search` with `queries` so the search covers multiple angles instead of one generic query.
-- Use `workflow: "none"` unless the task explicitly needs the interactive curator.
-- Read the search results first. Then fetch full content only for the most promising source URLs.
-- Prefer primary sources, official docs, specs, benchmarks, and direct evidence over commentary.
-- Drop stale, redundant, or SEO-heavy sources.
-- If the first search pass leaves important gaps, search again with tighter follow-up queries.
+- Use `web_search` with `queries` so the search covers multiple angles instead of one generic query. Use `workflow: "none"` unless the task explicitly needs the interactive curator.
+- Treat search-result summaries as discovery aids, not final evidence for important claims. Fetch the original source when a claim is important, disputed, surprising, or decision-relevant.
+- Prefer primary, official, authoritative, or directly relevant sources. Keep a smaller set of strong sources rather than many weak or redundant ones; reject stale, redundant, or SEO-heavy sources, and flag stale evidence when freshness materially affects the answer.
+- Use `source_check` against fetched source content for decision-critical or disputed claims, benchmark/performance claims, pricing/licensing claims, security claims, and wording that could materially affect a recommendation. Do not use it for every trivial fact.
+- If `source_check` is unavailable or fails, continue by fetching and inspecting the original source directly, and disclose the validation limitation rather than failing the research run.
+- Label direct evidence, source interpretation, and researcher inference distinctly. Never present an inference as if the source stated it directly.
+- Record contradictions instead of silently resolving them. Record missing evidence when a claim cannot be verified.
+- Never invent dates, quotations, citations, or unsupported precision.
+- Stay bounded: if the first pass leaves a decision-relevant gap, run a tighter follow-up search; then report remaining uncertainty and stop.
 
 Search strategy:
 - direct answer query
@@ -37,16 +40,23 @@ Output format:
 2-3 sentence direct answer.
 
 ## Findings
-Numbered findings with inline source citations.
-1. **Finding** — explanation. [Source](url)
-2. **Finding** — explanation. [Source](url)
+Numbered, concise findings. For each decision-relevant finding include:
+1. **Claim:** the finding. **Sources:** [Source](url). **Support:** direct evidence | interpretation. **Confidence:** high | medium | low.
+
+Label any researcher inference explicitly in the explanation.
+
+## Contradictions
+Contradictory or disputed evidence, with sources. Say "None found" when applicable.
+
+## Missing evidence
+Unverified claims and unresolved questions.
 
 ## Sources
 - Kept: Source Title (url) — why it matters
-- Dropped: Source Title — why it was excluded
+- Rejected/deprioritized: Source Title — short reason
 
-## Gaps
-What could not be answered confidently. Suggested next steps.
+## Next steps
+Only the most useful follow-up research.
 
 ## Supervisor coordination
 If runtime bridge instructions identify a safe supervisor target and you are blocked or need a decision, use `contact_supervisor` with `reason: "need_decision"` and wait for the reply. Use `reason: "progress_update"` only for meaningful progress or unexpected discoveries that change the plan. Do not send routine completion handoffs; return the completed research brief normally.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -20,7 +20,7 @@ Working rules:
 - Treat search-result summaries as discovery aids, not final evidence for important claims. Fetch the original source when a claim is important, disputed, surprising, or decision-relevant.
 - Prefer primary, official, authoritative, or directly relevant sources. Keep a smaller set of strong sources rather than many weak or redundant ones; reject stale, redundant, or SEO-heavy sources, and flag stale evidence when freshness materially affects the answer.
 - Use `source_check` against fetched source content for decision-critical or disputed claims, benchmark/performance claims, pricing/licensing claims, security claims, and wording that could materially affect a recommendation. Do not use it for every trivial fact.
-- If `source_check` is unavailable or fails, continue by fetching and inspecting the original source directly, and disclose the validation limitation rather than failing the research run.
+- `source_check` must be registered by the loaded provider before launch. If a registered `source_check` call fails, continue by fetching and inspecting the original source directly, and disclose the validation limitation rather than failing the research run.
 - Label direct evidence, source interpretation, and researcher inference distinctly. Never present an inference as if the source stated it directly.
 - Record contradictions instead of silently resolving them. Record missing evidence when a claim cannot be verified.
 - Never invent dates, quotations, citations, or unsupported precision.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -184,7 +184,7 @@ Native `oracle` runs inside Pi and can use its configured read tools. The Claude
 | `external-job-requests/` and `external-job-responses/` | Host-mediated provider bridge | pending request, terminal response | Host process writes a matching response and removes the request | Bridge timeout or malformed request response | Requests are operation-scoped. Recovery sends `reattach`/`result`, not `start` or `follow-up`, when job metadata exists. `start` and `follow-up` use durable dispatch claims | Provider not registered, host bridge not loaded, malformed request, provider exception, ambiguous dispatch without a provider job id |
 | Provider artifact path | External provider | provider-defined terminal artifact | Provider returns `artifactPath`, or Pi writes returned text to `external-job-<index>.result.md` | Provider reports failure or no result | Existing artifact path is retained in `status.json` | Missing artifact with no text output returns a terminal message instead of inventing content |
 
-The `researcher` builtin uses `web_search`, `fetch_content`, and `get_search_content`. Those require [pi-web-access](https://github.com/nicobailon/pi-web-access):
+The `researcher` builtin uses `web_search`, `fetch_content`, `get_search_content`, and selective `source_check` validation. Those require [pi-web-access](https://github.com/nicobailon/pi-web-access):
 
 ```bash
 pi install npm:pi-web-access

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -190,6 +190,8 @@ The `researcher` builtin uses `web_search`, `fetch_content`, `get_search_content
 pi install npm:pi-web-access
 ```
 
+The loaded provider must register all four tools, including `source_check`, before launch; a missing required tool prevents a successful run. Fetched-source inspection is a fallback for a registered `source_check` call failing, not for missing registration.
+
 ## Overriding builtins and custom agents
 
 You can override selected agent fields without copying the whole agent. Overrides live in settings:

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -13,6 +13,7 @@ const READ_ONLY_BUILTIN_TOOLS = new Set([
 	"web_search",
 	"fetch_content",
 	"get_search_content",
+	"source_check",
 	"intercom",
 	"contact_supervisor",
 	"structured_output",

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -1893,7 +1893,8 @@ Do work
 			assert.match(researcherPrompt, /direct evidence, source interpretation, and researcher inference distinctly/);
 			assert.match(researcherPrompt, /Record contradictions.*Record missing evidence/);
 			assert.match(researcherPrompt, /Never invent dates, quotations, citations, or unsupported precision/);
-			assert.match(researcherPrompt, /If `source_check` is unavailable or fails, continue/);
+			assert.match(researcherPrompt, /`source_check` must be registered by the loaded provider before launch/);
+			assert.match(researcherPrompt, /If a registered `source_check` call fails, continue/);
 			assert.match(researcherPrompt, /\*\*Support:\*\* direct evidence \| interpretation\. \*\*Confidence:\*\* high \| medium \| low/);
 		} finally {
 			if (previousHome === undefined) delete process.env.HOME;

--- a/test/unit/agent-frontmatter.test.ts
+++ b/test/unit/agent-frontmatter.test.ts
@@ -1862,7 +1862,7 @@ Do work
 		}
 	});
 
-	it("bundled standard agents expose the child-facing supervisor tool with bounded allowlists", () => {
+	it("bundled standard agents keep bounded tool allowlists", () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-builtin-supervisor-tool-"));
 		const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-builtin-supervisor-tool-home-"));
 		tempDirs.push(dir);
@@ -1879,12 +1879,22 @@ Do work
 				delegate: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
 				reviewer: ["read", "grep", "find", "ls", "contact_supervisor"],
 				scout: ["read", "grep", "find", "ls", "bash", "write", "contact_supervisor"],
+				researcher: ["read", "write", "web_search", "fetch_content", "get_search_content", "source_check"],
 			};
 			for (const [name, tools] of Object.entries(expectedTools)) {
 				const agent = agents.find((candidate) => candidate.name === name);
 				assert.ok(agent, `${name} builtin should be discovered`);
 				assert.deepEqual(agent?.tools, tools);
 			}
+
+			const researcherPrompt = agents.find((candidate) => candidate.name === "researcher")?.systemPrompt ?? "";
+			assert.match(researcherPrompt, /search-result summaries as discovery aids, not final evidence/);
+			assert.match(researcherPrompt, /source_check.*decision-critical or disputed claims/);
+			assert.match(researcherPrompt, /direct evidence, source interpretation, and researcher inference distinctly/);
+			assert.match(researcherPrompt, /Record contradictions.*Record missing evidence/);
+			assert.match(researcherPrompt, /Never invent dates, quotations, citations, or unsupported precision/);
+			assert.match(researcherPrompt, /If `source_check` is unavailable or fails, continue/);
+			assert.match(researcherPrompt, /\*\*Support:\*\* direct evidence \| interpretation\. \*\*Confidence:\*\* high \| medium \| low/);
 		} finally {
 			if (previousHome === undefined) delete process.env.HOME;
 			else process.env.HOME = previousHome;

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -241,12 +241,13 @@ test("implementation challenge reports with negated or uncertain no-better-chang
 
 });
 
-test("declared read-only builtin tools suppress implementation-word false positives", () => {
+test("source_check read-only capability suppresses an implementation completion guard", () => {
+	assert.equal(expectsImplementationMutation("worker", "Implement the approved fix"), true);
 	const result = evaluateCompletionMutationGuard({
-		agent: "architect",
-		task: "Produce a proposal that implements the approved fix",
-		messages: [assistantText("Proposal only")],
-		tools: ["read", "grep", "find", "ls", "web_search", "fetch_content", "get_search_content", "source_check"],
+		agent: "worker",
+		task: "Implement the approved fix",
+		messages: [assistantText("Source evidence only")],
+		tools: ["source_check"],
 	});
 
 	assert.deepEqual(result, {

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -246,7 +246,7 @@ test("declared read-only builtin tools suppress implementation-word false positi
 		agent: "architect",
 		task: "Produce a proposal that implements the approved fix",
 		messages: [assistantText("Proposal only")],
-		tools: ["read", "grep", "find", "ls"],
+		tools: ["read", "grep", "find", "ls", "web_search", "fetch_content", "get_search_content", "source_check"],
 	});
 
 	assert.deepEqual(result, {


### PR DESCRIPTION
Maintainer-owned replacement for #1932. Thanks to [@Muskos](https://github.com/Muskos); original author, date and message are preserved. Adds selective source checks and evidence/confidence/uncertainty reporting. All declared tools, including source_check, must be registered before launch; fetched-source fallback applies only when a registered call fails. No optional-tool framework or weakened allowlist. The classification-sensitive regression failed before the production change and passed afterward; 122 focused cases and typecheck passed. Separate simplification and fresh review passed. Original #1932 stays open until replacement landing.

Prepared on main379a with parent composition and credit verification. New exact-head Ubuntu, Windows, Bun, pi085 and Greptile/full feedback gates remain required, followed by required post-merge main CI. Publication does not clear the existing Windows main-health blocker.

Current refresh: base d074 after #1918. The complete candidate patch, all candidate blobs and all original authors/dates/messages/credits are unchanged. Parent verified full-tree composition; no tests/typecheck/reviews were redundantly repeated for the disjoint upstream acceptance-test change. New-head CI/Greptile/full feedback are required. Main health remains blocked by a separately investigated Windows terminal-proof failure; this publication is not merge readiness.