### PR TITLE
docs: clarify automatic model fallback safety boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Clarify the documented pre-tool safety boundary for automatic model fallback (#1936). Thanks to [@peedrr](https://github.com/peedrr).
+
 ### Added
 - Add selective researcher source checks and explicit evidence, confidence, and uncertainty reporting (#1932). Thanks to [@Muskos](https://github.com/Muskos).
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -310,7 +310,7 @@ Field notes:
 | `extensions` | Omitted means a background child loads the parent's ambient extensions; empty means no ambient extensions; list values load exactly those extensions. Foreground children never load ambient extensions, so for them only listed values apply. |
 | `subagentOnlyExtensions` | Extension paths loaded only in this agent's child sessions. Tools registered there are unavailable to the main agent unless also installed through normal Pi extension configuration. |
 | `model` | Default model. Bare ids prefer the current provider when possible, then unique registry matches. |
-| `fallbackModels` | Ordered backup models for provider/model failures such as quota, auth, provider-reported timeout, or unavailable model. Expiration of the run-level `timeoutMs` / `maxRuntimeMs` deadline is terminal and does not trigger fallback. Ordinary task failures do not trigger fallback. |
+| `fallbackModels` | Ordered backup models for retryable provider/model failures before any tool activity. Once a tool has started, a provider failure (including HTTP 429) fails the run rather than replaying the task on another model. Ordinary task failures and expiration of the run-level `timeoutMs` / `maxRuntimeMs` deadline do not trigger fallback. Retained history alone does not make automatic continuation safe; see [models.md](models.md). |
 | `thinking` | Appended as a `:level` suffix at runtime unless a suffix is already present. |
 | `systemPromptMode` | `replace` by default; `append` keeps Pi's base prompt. |
 | `inheritProjectContext` | Keeps or strips inherited repository instruction blocks. |

--- a/docs/models.md
+++ b/docs/models.md
@@ -100,7 +100,11 @@ A setup that works well in practice: route agents by task shape instead of runni
 
 The routing rule: use the capability tiers (1–3) when the task is well-scoped, and the intent tier (4) when scoping or judging is the task itself.
 
-Give tier-4 agents cross-provider `fallbackModels` so subscription usage limits degrade gracefully instead of failing the run. Fallback triggers on retryable provider/model failures such as rate-limit, overload, unavailable-model, and provider-reported timeout errors. The outer run-level `timeoutMs` / `maxRuntimeMs` deadline is terminal and does not start another fallback attempt:
+Give tier-4 agents `fallbackModels` for retryable provider/model failures such as rate-limit, overload, unavailable-model, and provider-reported timeout errors **before any tool activity**. Once a tool has started, a provider failure (including HTTP 429) fails the run rather than replaying the task on another model. Ordinary task failures and the outer run-level `timeoutMs` / `maxRuntimeMs` deadline do not trigger fallback.
+
+Fallback uses native Pi sessions, not fresh `pi` CLI processes. Even when an exact session file is reopened, normal fallback resubmits the original task; retained history alone does not make automatic continuation after tool work safe.
+
+Example fallback configuration:
 
 ```yaml
 ---


### PR DESCRIPTION
Related to #1936; this documentation change does not resolve or close the requested post-tool continuation feature. Thanks to [@peedrr](https://github.com/peedrr) for the report. Documents the existing pre-tool boundary: a provider failure after tool activity fails the run rather than replaying work. Native retained sessions alone do not make automatic continuation safe; normal fallback resubmits the original task. No runtime, cache or TTL change. Separate simplification and fresh source review passed. #1936 remains open for safe-continuation design.

Prepared on main379a with parent composition and credit verification. New exact-head Ubuntu, Windows, Bun, pi085 and Greptile/full feedback gates remain required, followed by required post-merge main CI. Publication does not clear the existing Windows main-health blocker.

Current refresh: base d074 after #1918. The complete candidate patch, all candidate blobs and all original authors/dates/messages/credits are unchanged. Parent verified full-tree composition; no tests/typecheck/reviews were redundantly repeated for the disjoint upstream acceptance-test change. New-head CI/Greptile/full feedback are required. Main health remains blocked by a separately investigated Windows terminal-proof failure; this publication is not merge readiness.