### PR TITLE
fix(workflows): expose published workflow receipt references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Resolve undici from the official npm registry in the lockfile for npm 12 compatibility (#1935). Thanks to [@chem](https://github.com/chem).
 - Fix background launches on stable Pi 0.85.1 without experimental packages, retaining Pi 0.85.0 support (#1944). Thanks to [@geril07](https://github.com/geril07).
+- Surface the published workflow receipt path in wait completions, notifications, and exact status/debug responses (#1938).
 - Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -96,6 +96,7 @@ subagent({
 - `toolBudget` becomes the default for each child unless that child supplies a narrower value.
 - `usageBudget` accounts for reported usage across completed workflow children. Once exhausted, it rejects later child launches but does not stop children that are already running.
 - Budget and timeout stops return a structured `terminalOutcome` with `state: "partial"` and reason `budget_exhausted` or `timeout`. Workflow receipts keep settled child evidence for recovery.
+- After an async workflow receipt is successfully published, `workflowReceiptPath` exposes its exact path in wait completion details, completion notifications, and exact status/debug details. Text responses also identify the receipt. Pending runs and failed receipt publications omit the reference; older status records are not backfilled. The reference records publication, not a guarantee against later retention cleanup. Raw result files retain `workflowReceipt: { path, receipt }`.
 
 These controls are opt-in. Avoid tight hard budgets for mutation-capable workers unless the workflow has an explicit checkpoint and handoff path.
 

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -34,6 +34,7 @@ export interface SubagentNotifyChildOutput {
 export type SubagentNotifyWatchdogBlocker = Pick<ChildWatchdogWarningSummary, "summary" | "addressed" | "stalemate"> & { agent: string };
 
 export interface SubagentNotifyDetails {
+	workflowReceiptPath?: string;
 	agent: string;
 	status: "completed" | "failed" | "paused" | "stopped";
 	source?: "async" | "foreground";
@@ -250,6 +251,7 @@ function formatChildRun(child: { runId: string; workflowKey?: string; agent?: st
 function formatCorrelationLines(details: SubagentNotifyDetails): string[] {
 	return [
 		details.workflowRunId ? `Workflow run: ${details.workflowRunId}` : undefined,
+		details.workflowReceiptPath ? `Workflow receipt: ${details.workflowReceiptPath}` : undefined,
 		details.childRuns?.length ? `Child runs: ${details.childRuns.map(formatChildRun).join(", ")}` : undefined,
 		details.reconciledFromDetachedChild ? `Reconciled detached child: ${details.reconciledFromDetachedChild}` : undefined,
 	].filter((line): line is string => line !== undefined);
@@ -323,12 +325,14 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 	}
 	const sessionLine = sessionIndex >= 0 ? body[sessionIndex] : undefined;
 	const handoffIndex = body.findIndex((line) => line.startsWith("Parallel handoff: "));
+	const receiptIndex = body.findIndex((line) => line.startsWith("Workflow receipt: "));
+	const workflowReceiptPath = receiptIndex >= 0 ? body[receiptIndex]!.slice("Workflow receipt: ".length).trim() : undefined;
 	const workflowRunIndex = body.findIndex((line) => line.startsWith("Workflow run: "));
 	const childRunsIndex = body.findIndex((line) => line.startsWith("Child runs: "));
 	const reconciledIndex = body.findIndex((line) => line.startsWith("Reconciled detached child: "));
 	const watchdogIndex = body.findIndex((line) => line === WATCHDOG_BLOCKERS_HEADING);
 	const watchdogBlockers = watchdogIndex >= 0 ? parseWatchdogBlockerLines(body.slice(watchdogIndex + 1)) : [];
-	const metadataIndexes = [sessionIndex, handoffIndex, workflowRunIndex, childRunsIndex, reconciledIndex, watchdogIndex].filter((index) => index >= 0);
+	const metadataIndexes = [sessionIndex, handoffIndex, receiptIndex, workflowRunIndex, childRunsIndex, reconciledIndex, watchdogIndex].filter((index) => index >= 0);
 	const firstMetadataIndex = metadataIndexes.length ? Math.min(...metadataIndexes) : body.length;
 	const resultEnd = firstMetadataIndex > 0 && body[firstMetadataIndex - 1]?.trim() === "" ? firstMetadataIndex - 1 : firstMetadataIndex;
 	const resultPreview = body.slice(0, resultEnd).join("\n").trim() || "(no output)";
@@ -359,6 +363,7 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 		...(match[1] === "Detached foreground task" ? { source: "foreground" as const } : {}),
 		...(match[4] ? { taskInfo: match[4] } : {}),
 		...(parsedScheduleOrigin ? { scheduleOrigin: parsedScheduleOrigin } : {}),
+		...(workflowReceiptPath ? { workflowReceiptPath } : {}),
 		resultPreview,
 		...(handoffPath ? { handoffPath } : {}),
 		...(workflowRunId ? { workflowRunId } : {}),
@@ -448,6 +453,10 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 		? result.parallelHandoff as { path?: unknown }
 		: undefined;
 	const handoffPath = typeof parallelHandoff?.path === "string" ? parallelHandoff.path : undefined;
+	const receipt = result.workflowReceipt;
+	const receiptPath = receipt && typeof receipt === "object" && !Array.isArray(receipt)
+		? (receipt as Record<string, unknown>).path : undefined;
+	const workflowReceiptPath = typeof receiptPath === "string" && receiptPath ? receiptPath : undefined;
 	const rawRunId = typeof result.runId === "string" ? result.runId : typeof result.id === "string" ? result.id : undefined;
 	const workflowRunId = (result.mode === "workflow" || agent === "workflow") && rawRunId ? rawRunId : undefined;
 	const directChild = !workflowRunId && result.results?.length === 1 ? result.results[0]! : undefined;
@@ -517,6 +526,7 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 		agent,
 		status,
 		...(scheduleOrigin ? { scheduleOrigin } : {}),
+		...(workflowReceiptPath ? { workflowReceiptPath } : {}),
 		...(result.source ? { source: result.source } : {}),
 		...(taskInfo ? { taskInfo } : {}),
 		resultPreview,

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -251,7 +251,6 @@ function formatChildRun(child: { runId: string; workflowKey?: string; agent?: st
 function formatCorrelationLines(details: SubagentNotifyDetails): string[] {
 	return [
 		details.workflowRunId ? `Workflow run: ${details.workflowRunId}` : undefined,
-		details.workflowReceiptPath ? `Workflow receipt: ${details.workflowReceiptPath}` : undefined,
 		details.childRuns?.length ? `Child runs: ${details.childRuns.map(formatChildRun).join(", ")}` : undefined,
 		details.reconciledFromDetachedChild ? `Reconciled detached child: ${details.reconciledFromDetachedChild}` : undefined,
 	].filter((line): line is string => line !== undefined);
@@ -285,6 +284,7 @@ export function formatSingleCompletion(details: SubagentNotifyDetails): string {
 		: undefined;
 	return [
 		`${taskKind} ${details.status}: **${details.agent}**${details.taskInfo ?? ""}`,
+		details.workflowReceiptPath ? `Workflow receipt: ${details.workflowReceiptPath}` : undefined,
 		"",
 		scheduleLine,
 		scheduleLine ? "" : undefined,
@@ -305,7 +305,11 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 	const lines = content.split("\n");
 	const match = (lines[0] ?? "").match(/^(Background task|Detached foreground task) (completed|failed|paused|stopped): \*\*(.+?)\*\*(?:\s+(\([^)]*\)))?$/);
 	if (!match) return undefined;
-	let body = lines.slice(2);
+	// Only the header slot before the blank separator can carry a receipt.
+	// Identical lines anywhere in model output remain preview text.
+	const receiptHeader = lines[1]?.startsWith("Workflow receipt: ") && lines[2] === "";
+	const workflowReceiptPath = receiptHeader ? lines[1]!.slice("Workflow receipt: ".length) : undefined;
+	let body = lines.slice(receiptHeader ? 3 : 2);
 	// Restore the schedule origin so a re-rendered notice keeps its attribution and
 	// does not fold the line into the result preview.
 	const scheduleMatch = (body[0] ?? "").match(/^Scheduled run from \*\*(.+?)\*\* \(schedule (.+?)\)\.$/);
@@ -325,14 +329,12 @@ export function parseSubagentNotifyContent(content: string): SubagentNotifyDetai
 	}
 	const sessionLine = sessionIndex >= 0 ? body[sessionIndex] : undefined;
 	const handoffIndex = body.findIndex((line) => line.startsWith("Parallel handoff: "));
-	const receiptIndex = body.findIndex((line) => line.startsWith("Workflow receipt: "));
-	const workflowReceiptPath = receiptIndex >= 0 ? body[receiptIndex]!.slice("Workflow receipt: ".length).trim() : undefined;
 	const workflowRunIndex = body.findIndex((line) => line.startsWith("Workflow run: "));
 	const childRunsIndex = body.findIndex((line) => line.startsWith("Child runs: "));
 	const reconciledIndex = body.findIndex((line) => line.startsWith("Reconciled detached child: "));
 	const watchdogIndex = body.findIndex((line) => line === WATCHDOG_BLOCKERS_HEADING);
 	const watchdogBlockers = watchdogIndex >= 0 ? parseWatchdogBlockerLines(body.slice(watchdogIndex + 1)) : [];
-	const metadataIndexes = [sessionIndex, handoffIndex, receiptIndex, workflowRunIndex, childRunsIndex, reconciledIndex, watchdogIndex].filter((index) => index >= 0);
+	const metadataIndexes = [sessionIndex, handoffIndex, workflowRunIndex, childRunsIndex, reconciledIndex, watchdogIndex].filter((index) => index >= 0);
 	const firstMetadataIndex = metadataIndexes.length ? Math.min(...metadataIndexes) : body.length;
 	const resultEnd = firstMetadataIndex > 0 && body[firstMetadataIndex - 1]?.trim() === "" ? firstMetadataIndex - 1 : firstMetadataIndex;
 	const resultPreview = body.slice(0, resultEnd).join("\n").trim() || "(no output)";
@@ -382,6 +384,7 @@ export function formatGroupedCompletion(details: SubagentNotifyDetails[]): strin
 		if (!detail) continue;
 		const sessionLine = formatSessionLine(detail);
 		blocks.push(`${index + 1}. ${detail.agent}${detail.taskInfo ?? ""}${detail.scheduleOrigin ? ` — scheduled run from ${detail.scheduleOrigin.name ?? detail.scheduleOrigin.id} (schedule ${detail.scheduleOrigin.id})` : ""}`);
+		if (detail.workflowReceiptPath) blocks.push(`Workflow receipt: ${detail.workflowReceiptPath}`);
 		blocks.push(formatResultPreview(detail));
 		blocks.push(...formatWatchdogBlockerLines(detail));
 		if (detail.handoffPath) blocks.push(`Parallel handoff: ${detail.handoffPath}`);

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -88,6 +88,7 @@ function formatRunLifecycleDebug(input: { status: AsyncStatus; asyncDir: string;
 		`Run: ${status.runId}`,
 		`Dir: ${asyncDir}`,
 		`Status file: ${path.join(asyncDir, "status.json")}`,
+		status.workflowReceiptPath ? `Workflow receipt: ${status.workflowReceiptPath}` : undefined,
 		`Process terminal file: ${path.join(asyncDir, "process-terminal.json")}`,
 		`Session: ${status.sessionId ?? "unknown"}`,
 		`State: ${status.state}`,
@@ -423,7 +424,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				const capacity = inspectActiveAsyncCapacityOwner({ runId: diskStatus.runId, sessionId: diskStatus.sessionId, asyncDir }, { rootDir: deps.activeCapacityRoot, liveWorkflowRunIds: new Set(deps.state?.workflowControllers?.keys() ?? []), abandonedSlotReleaseAfterMs: deps.abandonedSlotReleaseAfterMs });
 				return {
 					content: [{ type: "text", text: formatRunLifecycleDebug({ status: diskStatus, asyncDir, sidecarProcessTerminal: sidecar, overlayProcessTerminal: overlay, capacity }) }],
-					details: { mode: "single", results: [], ...((sidecar ?? overlay) ? { lifecycleStatus: { processTerminal: sidecar ?? overlay } } : {}) },
+					details: { mode: "single", results: [], ...(diskStatus.workflowReceiptPath ? { workflowReceiptPath: diskStatus.workflowReceiptPath } : {}), ...((sidecar ?? overlay) ? { lifecycleStatus: { processTerminal: sidecar ?? overlay } } : {}) },
 				};
 			}
 			if (params.view === "transcript") {
@@ -450,7 +451,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				const capacity = inspectActiveAsyncCapacityOwner({ runId: status.runId, sessionId: status.sessionId, asyncDir }, { rootDir: deps.activeCapacityRoot, liveWorkflowRunIds: new Set(deps.state?.workflowControllers?.keys() ?? []), abandonedSlotReleaseAfterMs: deps.abandonedSlotReleaseAfterMs });
 				return {
 					content: [{ type: "text", text: formatRunLifecycleDebug({ status, asyncDir, sidecarProcessTerminal: sidecar, overlayProcessTerminal: overlay, capacity }) }],
-					details: { mode: "single", results: [], ...((sidecar ?? overlay) ? { lifecycleStatus: { processTerminal: sidecar ?? overlay } } : {}) },
+					details: { mode: "single", results: [], ...(status.workflowReceiptPath ? { workflowReceiptPath: status.workflowReceiptPath } : {}), ...((sidecar ?? overlay) ? { lifecycleStatus: { processTerminal: sidecar ?? overlay } } : {}) },
 				};
 			}
 			if (params.view === "transcript") {
@@ -626,6 +627,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				}
 			}
 			if (nestedWarning) lines.push(`Warning: ${nestedWarning}`);
+			if (status.workflowReceiptPath) lines.push(`Workflow receipt: ${status.workflowReceiptPath}`);
 			if (status.sessionFile) lines.push(`Session: ${status.sessionFile}`);
 			const allExternal = (status.steps?.length ?? 0) > 0 && status.steps!.every((step) => step.runner?.type === "external-cli" || step.runner?.type === "external-job");
 			if (status.state === "running" && !allExternal && status.mode !== "workflow") lines.push(`Steer running child: subagent({ action: "steer", id: "${status.runId}", message: "..." })`);
@@ -639,7 +641,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 
 			const workflowChildren = parseWorkflowChildSummary(status.workflowChildren);
 			if (workflowChildren && workflowChildren.workflowRunId !== status.runId) throw new Error("workflowChildren.workflowRunId does not match async status runId.");
-			return { content: [{ type: "text", text: lines.join("\n") }], details: { mode: "single", results: [], ...(status.preflight ? { preflight: status.preflight } : {}), ...(status.workflow?.preflightWarnings?.length ? { preflightWarnings: status.workflow.preflightWarnings } : {}), ...(workflowChildren ? { workflowChildren } : {}), ...(runFanoutBudget ? { runFanoutBudget } : {}), ...(processTerminal ? { lifecycleStatus: { processTerminal } } : {}) } };
+			return { content: [{ type: "text", text: lines.join("\n") }], details: { mode: "single", results: [], ...(status.workflowReceiptPath ? { workflowReceiptPath: status.workflowReceiptPath } : {}), ...(status.preflight ? { preflight: status.preflight } : {}), ...(status.workflow?.preflightWarnings?.length ? { preflightWarnings: status.workflow.preflightWarnings } : {}), ...(workflowChildren ? { workflowChildren } : {}), ...(runFanoutBudget ? { runFanoutBudget } : {}), ...(processTerminal ? { lifecycleStatus: { processTerminal } } : {}) } };
 		}
 	}
 
@@ -680,6 +682,11 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			const runId = data.runId ?? data.id ?? resolvedId;
 			const lines = [`Run: ${runId}`, data.toolCallId ? `Tool call: ${data.toolCallId}` : undefined, `State: ${status}`, `Result: ${resultPath}`].filter((line): line is string => Boolean(line));
 			if (data.parallelHandoff?.path) lines.push(`Parallel handoff: ${data.parallelHandoff.path}`);
+			const receipt = (data as Record<string, unknown>).workflowReceipt;
+			const receiptPath = receipt && typeof receipt === "object" && !Array.isArray(receipt)
+				? (receipt as Record<string, unknown>).path : undefined;
+			const workflowReceiptPath = typeof receiptPath === "string" && receiptPath ? receiptPath : undefined;
+			if (workflowReceiptPath) lines.push(`Workflow receipt: ${workflowReceiptPath}`);
 			const children = Array.isArray(data.results) ? data.results : data.agent ? [{ agent: data.agent, sessionFile: data.sessionFile }] : [];
 			lines.push(...formatTimeoutRecoveryLines(data.timeoutRecovery, "  "));
 			for (const [index, child] of children.entries()) {
@@ -694,7 +701,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 			if (data.summary) lines.push("", data.summary);
 			const workflowChildren = parseWorkflowChildSummary((data as unknown as Record<string, unknown>).workflowChildren);
 			if (workflowChildren && workflowChildren.workflowRunId !== runId) throw new Error("workflowChildren.workflowRunId does not match the result run id.");
-			return { content: [{ type: "text", text: lines.join("\n") }], details: { mode: "single", results: [], ...(workflowChildren ? { workflowChildren } : {}) } };
+			return { content: [{ type: "text", text: lines.join("\n") }], details: { mode: "single", results: [], ...(workflowReceiptPath ? { workflowReceiptPath } : {}), ...(workflowChildren ? { workflowChildren } : {}) } };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			return {

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -337,6 +337,9 @@ function completionUsage(completions: WaitCompletion[] | undefined): Usage | und
 
 function result(text: string, isError = false, completions?: WaitCompletion[]): AgentToolResult<Details> {
 	const usage = completionUsage(completions);
+	for (const completion of completions ?? []) {
+		if (completion.workflowReceiptPath) text += `\nWorkflow receipt [${completion.runId}]: ${completion.workflowReceiptPath}`;
+	}
 	return {
 		content: [{ type: "text", text }],
 		...(isError ? { isError: true } : {}),

--- a/src/runs/background/wait-completions.ts
+++ b/src/runs/background/wait-completions.ts
@@ -96,6 +96,9 @@ export function toWaitCompletion(data: Record<string, unknown>, runId: string): 
 		})
 		: undefined;
 	const agent = asNonEmptyString(data.agent);
+	const receipt = data.workflowReceipt;
+	const workflowReceiptPath = receipt && typeof receipt === "object" && !Array.isArray(receipt)
+		? asNonEmptyString((receipt as Record<string, unknown>).path) : undefined;
 	const mode = asNonEmptyString(data.mode);
 	const state = asNonEmptyString(data.state);
 	const workflowChildren = parseWorkflowChildSummary(data.workflowChildren);
@@ -104,6 +107,7 @@ export function toWaitCompletion(data: Record<string, unknown>, runId: string): 
 		runId,
 		...(agent ? { agent } : {}),
 		...(mode ? { mode } : {}),
+		...(workflowReceiptPath ? { workflowReceiptPath } : {}),
 		...(state ? { state } : {}),
 		...(typeof data.success === "boolean" ? { success: data.success } : {}),
 		...(results && results.length > 0 ? { results } : {}),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5498,9 +5498,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const workflowChildren = workflowChildSummary({ parentToolCallId: toolCallId, workflowRunId, workflowState: "completed", inventoryComplete: true, trace: workflow.trace, children: workflow.children, steps: status.steps });
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: finalPreflightTrace, emits: workflow.emits, console: workflow.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}) }, workflowChildren, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
 						const receipt = terminalWorkflowReceipt(workflowRunId, "complete", workflow.children, workflowChildren, undefined, validHostStepNodes(status.workflowGraph), workflowResource?.provenance);
+						delete status.workflowReceiptPath;
 						let workflowReceipt: { path: string; receipt: WorkflowReceipt } | undefined;
 						try {
 							workflowReceipt = { path: writeWorkflowReceipt(asyncDir, receipt), receipt };
+							status.workflowReceiptPath = workflowReceipt.path;
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
@@ -5544,9 +5546,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const receiptState: WorkflowReceiptState = status.state === "complete" ? "complete" : status.state === "paused" ? "paused" : status.state === "stopped" ? "stopped" : "failed";
 						const terminalOutcome = workflowFailureTerminalOutcome(error, partial.children, usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)));
 						const receipt = terminalWorkflowReceipt(workflowRunId, receiptState, partial.children, workflowChildren, terminalOutcome, validHostStepNodes(status.workflowGraph), workflowResource?.provenance);
+						delete status.workflowReceiptPath;
 						let workflowReceipt: { path: string; receipt: WorkflowReceipt } | undefined;
 						try {
 							workflowReceipt = { path: writeWorkflowReceipt(asyncDir, receipt), receipt };
+							status.workflowReceiptPath = workflowReceipt.path;
 						} catch (receiptError) {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -94,7 +94,7 @@ function workflowResultChildren(status: AsyncStatus, childRunId: string, result:
 	}));
 }
 
-function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, resolution: WorkflowTerminalResolution | undefined): WorkflowReceipt | undefined {
+function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, result: SingleResult, asyncDir: string, resolution: WorkflowTerminalResolution | undefined): { receipt: WorkflowReceipt; path: string } | undefined {
 	const receiptRoot = path.dirname(asyncDir);
 	const receiptPath = workflowReceiptPath(receiptRoot, status.runId);
 	if (!fs.existsSync(receiptPath)) return undefined;
@@ -155,8 +155,7 @@ function reconcileWorkflowReceipt(status: AsyncStatus, childRunId: string, resul
 		delete next.workflowResolution;
 		delete next.recovery;
 	}
-	writeWorkflowReceipt(asyncDir, next);
-	return next;
+	return { receipt: next, path: writeWorkflowReceipt(asyncDir, next) };
 }
 
 function appendDetachedWorkflowEvent(asyncDir: string, event: Record<string, unknown>): void {
@@ -209,10 +208,13 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 	}
 	let receipt: WorkflowReceipt | undefined;
+	let receiptPath: string | undefined;
 	let receiptError: string | undefined;
 	const resolution = classifyWorkflowSettlement(next, input.result.interrupted);
 	try {
-		receipt = reconcileWorkflowReceipt(next, input.childRunId, input.result, asyncDir, resolution);
+		const publication = reconcileWorkflowReceipt(next, input.childRunId, input.result, asyncDir, resolution);
+		receipt = publication?.receipt;
+		receiptPath = publication?.path;
 	} catch (error) {
 		receiptError = `Failed to reconcile async workflow receipt: ${error instanceof Error ? error.message : String(error)}`;
 	}
@@ -243,7 +245,7 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 			completionOwnerId: next.completionOwnerId,
 		},
 		receipt,
-		receiptPath: path.join(asyncDir, "workflow-receipt.json"),
+		receiptPath,
 		receiptPersistenceError: receiptError,
 		resolution,
 		terminalOutcome: receipt?.terminalOutcome,

--- a/src/runs/foreground/workflow-detach-reconcile.ts
+++ b/src/runs/foreground/workflow-detach-reconcile.ts
@@ -285,6 +285,7 @@ export function reconcileDetachedWorkflowChildCompletion(input: {
 			agent: "workflow",
 			success: plan.status.state === "complete",
 			state: plan.status.state,
+			...(plan.publicResult.workflowReceipt ? { workflowReceipt: plan.publicResult.workflowReceipt } : {}),
 			...(resolution ? { workflowResolution: resolution } : {}),
 			...(plan.receipt?.terminalOutcome ? { terminalOutcome: plan.receipt.terminalOutcome } : {}),
 			recovery: plan.recovery,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1341,6 +1341,7 @@ export interface WaitCompletionChild {
  */
 export interface WaitCompletion {
 	runId: string;
+	workflowReceiptPath?: string;
 	agent?: string;
 	mode?: string;
 	state?: string;
@@ -1374,6 +1375,7 @@ export interface AgentCapabilityRow {
 
 export interface Details {
 	mode: SubagentResultMode | "management";
+	workflowReceiptPath?: string;
 	runId?: string;
 	/** Host tool-call id retained when it differs from the internal run id. */
 	toolCallId?: string;
@@ -1781,6 +1783,8 @@ export interface ExternalProcessStatus {
 }
 
 export interface AsyncStatus {
+	/** Exact reference returned by successful current workflow receipt publication. */
+	workflowReceiptPath?: string;
 	lifecycleArtifactVersion?: SubagentLifecycleArtifactVersion;
 	runId: string;
 	/** Parent Pi process/window that owns local completion delivery. */

--- a/src/workflows/workflow-settlement.ts
+++ b/src/workflows/workflow-settlement.ts
@@ -209,6 +209,8 @@ export function planWorkflowSettlement(input: {
 		if (!resolution) resolution = classifyWorkflowSettlement(status);
 	}
 	const recovery = workflowRecoveryActions(receipt);
+	delete status.workflowReceiptPath;
+	if (receipt && input.receiptPath) status.workflowReceiptPath = input.receiptPath;
 	if (receipt) {
 		receipt = {
 			...receipt,
@@ -233,6 +235,7 @@ export function planWorkflowSettlement(input: {
 		timestamp: now,
 	};
 	const terminal = status.state === "complete" || status.state === "failed" || status.state === "partial" || status.state === "stopped";
+	if (!status.workflowReceiptPath) delete publicResult.workflowReceipt;
 	const completionEvent = terminal ? {
 		type: "subagent.workflow.completed",
 		state: status.state,

--- a/test/integration/async-execution.part-1.test.ts
+++ b/test/integration/async-execution.part-1.test.ts
@@ -58,6 +58,9 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 				assert.equal(launch.isError, undefined, launch.content[0]?.text);
 				const id = launch.details?.asyncId;
 				assert.ok(id);
+				assert.equal(launch.details?.workflowReceiptPath, undefined);
+				const pendingStatus = await executor.executePublic("pending-receipt-status", { action: "status", id }, new AbortController().signal, undefined, ctx);
+				assert.equal(pendingStatus.details?.workflowReceiptPath, undefined);
 				const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id), "utf8")) as AsyncResultPayload & { workflowReceipt: { path: string; receipt: WorkflowReceipt } };
 				assert.equal(payload.success, true, payload.error);
 				assert.equal((await waitForAsyncState(id, (status) => status.state === "complete")).state, "complete");
@@ -71,6 +74,11 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 				assert.ok(payload.workflowReceipt.receipt.entries.review.latestRunId);
 				assert.deepEqual(payload.workflowReceipt.receipt.hostSteps?.map(({ id, state, exitCode }) => ({ id, state, exitCode })), [{ id: "check", state: "done", exitCode: 0 }]);
 				assert.deepEqual(JSON.parse(fs.readFileSync(payload.workflowReceipt.path, "utf8")), payload.workflowReceipt.receipt);
+				for (const action of ["status", "debug.run"] as const) {
+					const inspected = await executor.executePublic(`receipt-${action}`, { action, id }, new AbortController().signal, undefined, ctx);
+					assert.equal(inspected.details?.workflowReceiptPath, payload.workflowReceipt.path);
+					assert.ok(inspected.content[0]?.text?.includes(`Workflow receipt: ${payload.workflowReceipt.path}`));
+				}
 			} finally { replacement.dispose(); }
 		} finally { registration.dispose(); }
 	});

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -14,6 +14,18 @@ import { createResultDeliveryOwnership } from "../../src/runs/background/result-
 
 const COMPLETION_OWNER_ID = "completion-owner-a";
 
+it("surfaces published workflow receipts outside single and grouped previews", () => {
+	const workflowReceiptPath = "/opaque/receipt.json";
+	const details = buildCompletionDetails({ agent: "workflow", mode: "workflow", runId: "run-1", success: true, summary: "x".repeat(20_000), workflowReceipt: { path: workflowReceiptPath, receipt: {} } });
+	assert.equal(details.workflowReceiptPath, workflowReceiptPath);
+	const single = formatSingleCompletion(details);
+	assert.ok(single.includes(`Workflow receipt: ${workflowReceiptPath}`));
+	assert.ok(formatGroupedCompletion([details, details]).includes(`Workflow receipt: ${workflowReceiptPath}`));
+	const parsed = parseSubagentNotifyContent(single);
+	assert.equal(parsed?.workflowReceiptPath, workflowReceiptPath);
+	assert.doesNotMatch(parsed?.resultPreview ?? "", /Workflow receipt:/);
+});
+
 function createEventBus() {
 	const emitter = new EventEmitter();
 	return {

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -14,11 +14,32 @@ import { createResultDeliveryOwnership } from "../../src/runs/background/result-
 
 const COMPLETION_OWNER_ID = "completion-owner-a";
 
+it("keeps model-authored receipt lines in the preview, never in receipt metadata", () => {
+	for (const resultPreview of [
+		"Workflow receipt: /model/start.json\nKeep this output.",
+		"Before\nWorkflow receipt: /model/middle.json\nAfter",
+		"Before\n\nWorkflow receipt: /model/suffix.json",
+	]) {
+		for (const workflowReceiptPath of [undefined, "/published/receipt.json"]) {
+			const details: SubagentNotifyDetails = { agent: "workflow", status: "completed", resultPreview, workflowReceiptPath };
+			const parsed = parseSubagentNotifyContent(formatSingleCompletion(details));
+			assert.equal(parsed?.resultPreview, resultPreview);
+			assert.equal(parsed?.workflowReceiptPath, workflowReceiptPath);
+			const scheduled = parseSubagentNotifyContent(formatSingleCompletion({ ...details, scheduleOrigin: { id: "schedule-1" } }));
+			assert.equal(scheduled?.resultPreview, resultPreview);
+			assert.equal(scheduled?.workflowReceiptPath, workflowReceiptPath);
+			assert.deepEqual(scheduled?.scheduleOrigin, { id: "schedule-1" });
+		}
+	}
+});
+
 it("surfaces published workflow receipts outside single and grouped previews", () => {
 	const workflowReceiptPath = "/opaque/receipt.json";
-	const details = buildCompletionDetails({ agent: "workflow", mode: "workflow", runId: "run-1", success: true, summary: "x".repeat(20_000), workflowReceipt: { path: workflowReceiptPath, receipt: {} } });
+	const details = buildCompletionDetails({ agent: "workflow", mode: "workflow", runId: "run-1", success: true, summary: "Completed", results: [{ runId: "child-1", output: "x".repeat(20_000) }], workflowReceipt: { path: workflowReceiptPath, receipt: {} } });
 	assert.equal(details.workflowReceiptPath, workflowReceiptPath);
 	const single = formatSingleCompletion(details);
+	assert.equal(single.split("\n")[1], `Workflow receipt: ${workflowReceiptPath}`);
+	assert.match(single, /\[preview truncated\]/);
 	assert.ok(single.includes(`Workflow receipt: ${workflowReceiptPath}`));
 	assert.ok(formatGroupedCompletion([details, details]).includes(`Workflow receipt: ${workflowReceiptPath}`));
 	const parsed = parseSubagentNotifyContent(single);

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -22,6 +22,19 @@ function textContent(result: ReturnType<typeof inspectSubagentStatus>): string {
 }
 
 describe("async run status inspection", () => {
+	it("projects only published receipt references from result-only status", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-receipt-status-"));
+		try {
+			const resultPath = path.join(root, "receipt-run.json");
+			for (const workflowReceipt of [{ path: "/opaque/published.json", receipt: {} }, undefined, { path: 42 }, []]) {
+				fs.writeFileSync(resultPath, JSON.stringify({ runId: "receipt-run", mode: "workflow", success: true, workflowReceipt }));
+				const result = inspectSubagentStatus({ id: "receipt-run" }, { asyncDirRoot: path.join(root, "absent"), resultsDir: root });
+				const expected = workflowReceipt && "path" in workflowReceipt && typeof workflowReceipt.path === "string" ? workflowReceipt.path : undefined;
+				assert.equal(result.details?.workflowReceiptPath, expected);
+				assert.equal(textContent(result).includes("Workflow receipt:"), expected !== undefined);
+			}
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
 	afterEach(() => {
 		delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for(EXTERNAL_JOB_PROVIDER_REGISTRY_KEY)];
 	});

--- a/test/unit/wait-completions.test.ts
+++ b/test/unit/wait-completions.test.ts
@@ -3,10 +3,16 @@ import { describe, it } from "node:test";
 import { toWaitCompletion } from "../../src/runs/background/wait-completions.ts";
 
 describe("workflow wait completion projection", () => {
+	it("omits absent and malformed receipt references", () => {
+		for (const workflowReceipt of [undefined, null, [], "path", { path: "" }, { path: 42 }]) {
+			assert.equal("workflowReceiptPath" in toWaitCompletion({ workflowReceipt }, "run"), false);
+		}
+	});
 	it("retains the bounded workflow-child summary and excludes result output", () => {
 		const completion = toWaitCompletion({
 			agent: "workflow",
 			mode: "workflow",
+			workflowReceipt: { path: "/opaque/published-receipt.json", receipt: { output: "must not be copied" } },
 			state: "complete",
 			success: true,
 			workflowChildren: {
@@ -29,6 +35,7 @@ describe("workflow wait completion projection", () => {
 		}, "workflow-1");
 
 		assert.equal(completion.workflowChildren?.children[0]?.childId, "review");
+		assert.equal(completion.workflowReceiptPath, "/opaque/published-receipt.json");
 		assert.deepEqual(completion.results?.[0]?.usage, { input: 10, output: 2, cacheRead: 30, cacheWrite: 0, cost: 0.04, turns: 1 });
 		assert.equal(completion.results?.[0]?.sessionFile, "/sessions/run-1.jsonl");
 		assert.doesNotMatch(JSON.stringify(completion), /must not be copied/);

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 import { applyDetachedChildToPausedWorkflow, promotePausedWorkflowIfSettled, reconcileDetachedWorkflowChildCompletion } from "../../src/runs/foreground/workflow-detach-reconcile.ts";
 import { DIRS, type AsyncStatus, type IntercomEventBus, type SubagentState } from "../../src/shared/types.ts";
 import { buildWorkflowReceipt, writeWorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
+import { buildCompletionDetails, formatSingleCompletion, parseSubagentNotifyContent, type CompletionNotification } from "../../src/runs/background/notify.ts";
 
 function pausedWorkflow(childRunId: string, extra?: Partial<NonNullable<AsyncStatus["steps"]>[number]>): AsyncStatus {
 	return {
@@ -176,10 +177,12 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		const state = {
 			asyncJobs: new Map([[workflowRunId, { asyncId: workflowRunId, asyncDir, status: "paused" as const }]]),
 		} as SubagentState;
+		let emitted: CompletionNotification | undefined;
 		assert.equal(reconcileDetachedWorkflowChildCompletion({
 			state,
 			workflowRunId,
 			childRunId: "child-1",
+			events: { emit: (_name, payload) => { emitted = payload as CompletionNotification; } } as IntercomEventBus,
 			result: { index: 0, agent: "worker", task: `Write your findings to exactly this path: ${requestedPath}`, exitCode: 0, sessionFile, savedOutputPath: savedPath, usage: { input: 100, output: 50, cacheRead: 25, cacheWrite: 5, cost: 0.001, turns: 1 } },
 		}), true);
 		const published = JSON.parse(fs.readFileSync(path.join(DIRS.results, `${workflowRunId}.json`), "utf-8")) as { state?: string; success?: boolean; summary?: string; error?: string; sessionId?: string; workflowResolution?: string; recovery?: unknown[]; results?: Array<{ outputReference?: string; outputPathMapping?: unknown }>; workflowReceipt?: { receipt?: { state?: string; workflowResolution?: string; recovery?: unknown[]; entries?: Record<string, { resumability?: { state?: string; reason?: string } }> } } };
@@ -200,6 +203,11 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		assert.equal(published.workflowReceipt?.receipt?.workflowResolution, "settled-awaiting-resume");
 		assert.deepEqual(published.workflowReceipt?.receipt?.recovery, published.recovery);
 		assert.equal(published.workflowReceipt?.receipt?.entries?.detaches?.resumability?.state, "resumable");
+		assert.ok(emitted);
+		const notification = parseSubagentNotifyContent(formatSingleCompletion(buildCompletionDetails(emitted)));
+		const publishedPath = (published.workflowReceipt as { path: string }).path;
+		assert.equal(notification?.workflowReceiptPath, publishedPath);
+		assert.deepEqual(JSON.parse(fs.readFileSync(notification.workflowReceiptPath!, "utf8")), published.workflowReceipt?.receipt);
 		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
 		assert.match(events, /"type":"subagent.workflow.completed"/);
 		assert.match(events, /"state":"failed"/);

--- a/test/unit/workflow-detach-reconcile.test.ts
+++ b/test/unit/workflow-detach-reconcile.test.ts
@@ -578,7 +578,8 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		const asyncDir = path.join(DIRS.async, workflowRunId);
 		fs.mkdirSync(asyncDir, { recursive: true });
 		fs.mkdirSync(DIRS.results, { recursive: true });
-		const status = { ...pausedWorkflow("child-1"), runId: workflowRunId, sessionId: "session-1" };
+		const status = { ...pausedWorkflow("child-1"), runId: workflowRunId, sessionId: "session-1", workflowReceiptPath: "/stale/receipt.json" };
+		fs.writeFileSync(path.join(DIRS.results, `${workflowRunId}.json`), JSON.stringify({ workflowReceipt: { path: status.workflowReceiptPath, receipt: {} } }));
 		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify(status), "utf-8");
 		fs.writeFileSync(path.join(asyncDir, "workflow-receipt.json"), JSON.stringify({ version: 1, workflowRunId, state: "paused", createdAt: 1, entries: { detaches: { key: "wrong" } } }), "utf-8");
 		const state = {
@@ -597,6 +598,7 @@ describe("reconcileDetachedWorkflowChildCompletion", () => {
 		assert.equal(published.success, false);
 		assert.match(published.error ?? "", /evidence-persistence-failed/);
 		assert.equal(published.workflowReceipt, undefined);
+		assert.equal(JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8")).workflowReceiptPath, undefined);
 		const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
 		assert.match(events, /"type":"subagent.workflow.receipt_write_failed"/);
 		assert.match(events, /"type":"subagent.workflow.completed"/);


### PR DESCRIPTION
Closes #1938.

Expose the existing successfully published receipt path as workflowReceiptPath in async completion/wait and exact status/debug surfaces. Pending or unsuccessful current publication has no reference; stale replacement references are cleared. Existing raw receipt shape, direct/detached outcome policies and retention limits remain unchanged. No guessed consumer paths, new filesystem operations, scans, backfill, store or Fleet/intercom expansion.

Original implementation: sensitive wait regression failed before the change;117 focused unit and41 integration cases plus typecheck passed. Retained challenge and separate simplification were unchanged. Fresh review found a detached-event omission that could win notification dedupe; one event field plus an actual-event notification regression fixes it. That regression failed before the correction; all27 affected-file cases and typecheck passed. Parent verified complete rebase composition and the narrow final-fix delta, preserving original review/test attribution.

Prepared on d074 after #1918. Required new-head CI/Greptile/full feedback and healthy main remain gates; no release or installation claim.

Final receipt-prefix correction: fixed-position metadata header prevents model-authored Workflow receipt lines from spoofing metadata or truncating preview. Sensitive public format/parse RED then41 affected-file tests and typecheck passed. Targeted fresh review of7a93f47b found no findings. No general parser redesign or structured-preview policy change; previous review/test attribution preserved. New exact-head gates remain required.
