### PR TITLE
fix: support stable Pi 0.85.1 background launches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,13 +58,19 @@ jobs:
         with:
           node-version: 22.19.0
       - name: Real Pi 0.85.0 background child smoke
-        run: node --experimental-strip-types test/smoke/pi085-clean-install.mjs "${{ runner.temp }}/pi085-smoke"
+        run: node --experimental-strip-types test/smoke/pi085-clean-install.mjs "${{ runner.temp }}/pi0850-smoke" 0.85.0
+      - name: Real Pi 0.85.1 background child smoke
+        run: node --experimental-strip-types test/smoke/pi085-clean-install.mjs "${{ runner.temp }}/pi0851-smoke" 0.85.1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: pi085-smoke-logs
           path: |
-            ${{ runner.temp }}/pi085-smoke/*.log
-            ${{ runner.temp }}/pi085-smoke/aliases.json
-            ${{ runner.temp }}/pi085-smoke/host/package-lock.json
-            ${{ runner.temp }}/pi085-smoke/extension/package-lock.json
+            ${{ runner.temp }}/pi0850-smoke/*.log
+            ${{ runner.temp }}/pi0850-smoke/aliases.json
+            ${{ runner.temp }}/pi0850-smoke/host/package-lock.json
+            ${{ runner.temp }}/pi0850-smoke/extension/package-lock.json
+            ${{ runner.temp }}/pi0851-smoke/*.log
+            ${{ runner.temp }}/pi0851-smoke/aliases.json
+            ${{ runner.temp }}/pi0851-smoke/host/package-lock.json
+            ${{ runner.temp }}/pi0851-smoke/extension/package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Fix background launches on stable Pi 0.85.1 without experimental packages, retaining Pi 0.85.0 support (#1944). Thanks to [@geril07](https://github.com/geril07).
 - Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).

--- a/src/runs/background/runner-aliases.ts
+++ b/src/runs/background/runner-aliases.ts
@@ -23,9 +23,6 @@ export const HOST_PEER_ALIASES: ReadonlyArray<{ specifier: string; pkg: string; 
 	{ specifier: "@earendil-works/pi-agent-core/node", pkg: "@earendil-works/pi-agent-core", subpath: "./node" },
 	{ specifier: "@earendil-works/chord", pkg: "@earendil-works/chord", subpath: "." },
 	{ specifier: "@earendil-works/chord/context", pkg: "@earendil-works/chord", subpath: "./context" },
-	{ specifier: "@earendil-works/pi-server", pkg: "@earendil-works/pi-server", subpath: "." },
-	{ specifier: "@earendil-works/pi-server/unix", pkg: "@earendil-works/pi-server", subpath: "./unix" },
-	{ specifier: "@earendil-works/pi-client/unix", pkg: "@earendil-works/pi-client", subpath: "./unix" },
 	{ specifier: "@earendil-works/pi-tui", pkg: "@earendil-works/pi-tui", subpath: "." },
 	{ specifier: "@earendil-works/pi-ai", pkg: "@earendil-works/pi-ai", subpath: "./compat" },
 	{ specifier: "@earendil-works/pi-ai/compat", pkg: "@earendil-works/pi-ai", subpath: "./compat" },
@@ -34,6 +31,13 @@ export const HOST_PEER_ALIASES: ReadonlyArray<{ specifier: string; pkg: string; 
 	{ specifier: "typebox", pkg: "typebox", subpath: "." },
 	{ specifier: "typebox/compile", pkg: "typebox", subpath: "./compile" },
 	{ specifier: "typebox/value", pkg: "typebox", subpath: "./value" },
+];
+
+/** Experimental dependencies accidentally published in exactly Pi 0.85.0. */
+const PI0850_PEER_ALIASES = [
+	{ specifier: "@earendil-works/pi-server", pkg: "@earendil-works/pi-server", subpath: "." },
+	{ specifier: "@earendil-works/pi-server/unix", pkg: "@earendil-works/pi-server", subpath: "./unix" },
+	{ specifier: "@earendil-works/pi-client/unix", pkg: "@earendil-works/pi-client", subpath: "./unix" },
 ];
 
 interface PackageManifest {
@@ -103,7 +107,11 @@ export function resolvePackageSubpath(packageDir: string, subpath: string): stri
 
 /** Find `pkg` as the pi package itself, one of its dependencies, or a sibling in a hoisted install. */
 export function findHostPeerPackageDir(piPackageRoot: string, pkg: string): string | undefined {
-	if (readManifest(piPackageRoot)?.name === pkg) return piPackageRoot;
+	return findPeerPackageDir(piPackageRoot, pkg, readManifest(piPackageRoot)?.name);
+}
+
+function findPeerPackageDir(piPackageRoot: string, pkg: string, hostName: unknown): string | undefined {
+	if (hostName === pkg) return piPackageRoot;
 	const candidates = [path.join(piPackageRoot, "node_modules", pkg)];
 	let dir = piPackageRoot;
 	for (;;) {
@@ -127,14 +135,17 @@ export function resolveHostPeerAliases(
 	const aliases: Record<string, string> = {};
 	const missing: string[] = [];
 	const supplemental: string[] = [];
-	for (const { specifier, pkg, subpath } of HOST_PEER_ALIASES) {
-		const packageDir = findHostPeerPackageDir(piPackageRoot, pkg);
+	const hostManifest = readManifest(piPackageRoot);
+	const isPi0850 = hostManifest?.version === "0.85.0";
+	const required = isPi0850 ? [...HOST_PEER_ALIASES, ...PI0850_PEER_ALIASES] : HOST_PEER_ALIASES;
+	for (const { specifier, pkg, subpath } of required) {
+		const packageDir = findPeerPackageDir(piPackageRoot, pkg, hostManifest?.name);
 		let target = packageDir ? resolvePackageSubpath(packageDir, subpath) : undefined;
 		// Pi 0.85.0 omitted this runtime dependency. Never replace working host
 		// exports or extend this exact version contract to other peers/hosts.
 		if ((!target || !fs.existsSync(target))
 			&& (specifier === "@earendil-works/pi-server" || specifier === "@earendil-works/pi-server/unix")
-			&& readManifest(piPackageRoot)?.version === "0.85.0"
+			&& isPi0850
 			&& (!packageDir || readManifest(packageDir)?.version === "0.85.0")) {
 			const localDir = findHostPeerPackageDir(extensionRoot, pkg);
 			if (localDir && readManifest(localDir)?.version === "0.85.0") {

--- a/test/smoke/pi085-clean-install.mjs
+++ b/test/smoke/pi085-clean-install.mjs
@@ -1,4 +1,4 @@
-// Run with Node >=22.19.0: node --experimental-strip-types test/smoke/pi085-clean-install.mjs [artifact-dir]
+// Run with Node >=22.19.0: node --experimental-strip-types test/smoke/pi085-clean-install.mjs [artifact-dir] [0.85.0|0.85.1]
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -7,6 +7,9 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const source = fileURLToPath(new URL("../../", import.meta.url));
+const version = process.argv[3] ?? "0.85.0";
+assert.ok(["0.85.0", "0.85.1"].includes(version), "requires an explicitly supported smoke version");
+const isPi0850 = version === "0.85.0";
 const root = process.argv[2] ? path.resolve(process.argv[2]) : fs.mkdtempSync(path.join(os.tmpdir(), "pi085-smoke-"));
 fs.mkdirSync(root, { recursive: true });
 const host = path.join(root, "host");
@@ -32,7 +35,7 @@ function run(name, command, args, workdir, extra = {}, success = true) {
 	else assert.notEqual(result.status, 0, `${name} unexpectedly passed`);
 	return result;
 }
-fs.writeFileSync(path.join(host, "package.json"), JSON.stringify({ private: true, dependencies: { "@earendil-works/pi-coding-agent": "0.85.0" } }));
+fs.writeFileSync(path.join(host, "package.json"), JSON.stringify({ private: true, dependencies: { "@earendil-works/pi-coding-agent": version } }));
 run("host-install", "npm", ["install", "--no-audit", "--no-fund"], host);
 const packed = JSON.parse(run("pack", "npm", ["pack", "--json", "--pack-destination", root], source).stdout)[0];
 assert.ok(packed.files.some(file => file.path === "runner-server-preload.mjs"), "preload must ship");
@@ -44,21 +47,28 @@ const { createJiti } = await import(pathToFileURL(path.join(extension, "node_mod
 const jitiLoader = createJiti(import.meta.url, { fsCache: false });
 const { resolveHostPeerAliases, findHostPeerPackageDir, resolvePackageSubpath } = await jitiLoader.import(path.join(installed, "src/runs/background/runner-aliases.ts"));
 assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-server"), undefined, "host must remain missing server");
-const pristine = run("pristine-public-sdk", process.execPath, ["--input-type=module", "-e", `await import(${JSON.stringify(pathToFileURL(resolvePackageSubpath(pi, ".")).href)})`], cwd, {}, false);
-assert.match(pristine.stderr, /Cannot find package '@earendil-works\/pi-server'/);
+if (!isPi0850) assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-client"), undefined, "stable host must remain missing client");
+const pristine = run("pristine-public-sdk", process.execPath, ["--input-type=module", "-e", `await import(${JSON.stringify(pathToFileURL(resolvePackageSubpath(pi, ".")).href)})`], cwd, {}, !isPi0850);
+if (isPi0850) assert.match(pristine.stderr, /Cannot find package '@earendil-works\/pi-server'/);
 const resolved = resolveHostPeerAliases(pi);
 assert.deepEqual(resolved.missing, []);
-assert.deepEqual(resolved.supplemental, ["@earendil-works/pi-server", "@earendil-works/pi-server/unix"]);
+assert.deepEqual(resolved.supplemental, isPi0850 ? ["@earendil-works/pi-server", "@earendil-works/pi-server/unix"] : []);
+if (!isPi0850) {
+	for (const specifier of ["@earendil-works/pi-server", "@earendil-works/pi-server/unix", "@earendil-works/pi-client/unix"]) assert.equal(resolved.aliases[specifier], undefined);
+}
 fs.writeFileSync(path.join(root, "aliases.json"), JSON.stringify(resolved, null, 2));
 for (const file of ["pi085-child.ts", "pi085-extension.ts"]) fs.copyFileSync(new URL(file, import.meta.url), path.join(cwd, file));
 const childEnv = { SMOKE_EXTENSION: installed, JITI_ALIAS: JSON.stringify(resolved.aliases) };
 const jiti = path.join(extension, "node_modules/jiti/lib/jiti-cli.mjs");
 const args = [jiti, path.join(cwd, "pi085-child.ts")];
 // The real file-extension gate must fail with aliases alone, not just an import mock.
-const negative = run("without-preload", process.execPath, args, cwd, childEnv, false);
-assert.match(negative.stderr, /Model "pi085-smoke\/local" not found/);
+if (isPi0850) {
+	const negative = run("without-preload", process.execPath, args, cwd, childEnv, false);
+	assert.match(negative.stderr, /Model "pi085-smoke\/local" not found/);
+}
 const preload = resolved.supplemental.length ? ["--import", pathToFileURL(path.join(installed, "runner-server-preload.mjs")).href] : [];
 const positive = run("child", process.execPath, [...preload, ...args], cwd, childEnv);
 assert.match(positive.stdout, /PASS public SDK\/default child factory/);
 assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-server"), undefined);
+if (!isPi0850) assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-client"), undefined);
 console.log(`${positive.stdout.trim()}\nArtifacts: ${root}`);

--- a/test/unit/async-spawn-preload.test.ts
+++ b/test/unit/async-spawn-preload.test.ts
@@ -5,7 +5,6 @@ import { syncBuiltinESMExports } from "node:module";
 import * as path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { HOST_PEER_ALIASES } from "../../src/runs/background/runner-aliases.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
 import { createTempDir, makeAgent, removeTempDir } from "../support/helpers.ts";
 
@@ -14,21 +13,32 @@ test("executeAsyncSingle preloads supplemental server aliases before jiti, but n
 	const host = path.join(root, "host");
 	const server = "@earendil-works/pi-server";
 	const expectedAliases: Record<string, string> = {};
+	const hostExports: Record<string, string[]> = {
+		"@earendil-works/pi-coding-agent": ["."],
+		"@earendil-works/pi-agent-core": [".", "./node"],
+		"@earendil-works/chord": [".", "./context"],
+		"@earendil-works/pi-tui": ["."],
+		"@earendil-works/pi-ai": ["./compat", "./oauth", "./providers/all"],
+		"typebox": [".", "./compile", "./value"],
+		[server]: [".", "./unix"],
+		"@earendil-works/pi-client": ["./unix"],
+	};
 	// Use real package manifests/targets, as in host-peer-runtime-imports.test.ts.
 	function writeHostPackage(pkg: string) {
 		const dir = pkg === "@earendil-works/pi-coding-agent" ? host : path.join(host, "node_modules", pkg);
 		fs.mkdirSync(dir, { recursive: true });
-		const exports = Object.fromEntries(HOST_PEER_ALIASES.filter(entry => entry.pkg === pkg).map(entry => {
-			const target = `./${entry.subpath === "." ? "index" : entry.subpath.slice(2).replaceAll("/", "-")}.mjs`;
+		const exports = Object.fromEntries(hostExports[pkg]!.map(subpath => {
+			const target = `./${subpath === "." ? "index" : subpath.slice(2).replaceAll("/", "-")}.mjs`;
 			fs.writeFileSync(path.join(dir, target), "export {};\n");
-			expectedAliases[entry.specifier] = path.join(dir, target);
-			return [entry.subpath, target];
+			expectedAliases[subpath === "." ? pkg : `${pkg}/${subpath.slice(2)}`] = path.join(dir, target);
+			if (pkg === "@earendil-works/pi-ai" && subpath === "./compat") expectedAliases[pkg] = path.join(dir, target);
+			return [subpath, target];
 		}));
 		fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: pkg, version: "0.85.0", exports }));
 	}
 	const originalArgv1 = process.argv[1];
 	try {
-		for (const pkg of new Set(HOST_PEER_ALIASES.map(entry => entry.pkg))) {
+		for (const pkg of Object.keys(hostExports)) {
 			if (pkg !== server) writeHostPackage(pkg);
 		}
 		for (const specifier of [server, `${server}/unix`]) {
@@ -42,23 +52,35 @@ test("executeAsyncSingle preloads supplemental server aliases before jiti, but n
 			throw new Error("spawn boundary captured");
 		});
 		syncBuiltinESMExports();
-		for (const complete of [false, true]) {
-			if (complete) writeHostPackage(server);
-			const result = executeAsyncSingle(`spawn-preload-${complete}`, {
+		for (const scenario of ["supplemental", "complete", "stable", "missing-stable"]) {
+			if (scenario === "complete") writeHostPackage(server);
+			if (scenario === "stable") {
+				fs.writeFileSync(path.join(host, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent", version: "0.85.1", exports: { ".": "./index.mjs" } }));
+				for (const pkg of [server, "@earendil-works/pi-client"]) fs.rmSync(path.join(host, "node_modules", pkg), { recursive: true });
+				for (const specifier of [server, `${server}/unix`, "@earendil-works/pi-client/unix"]) delete expectedAliases[specifier];
+			}
+			if (scenario === "missing-stable") fs.unlinkSync(expectedAliases["@earendil-works/pi-agent-core/node"]!);
+			const result = executeAsyncSingle(`spawn-preload-${scenario}`, {
 				agent: "worker", task: "Inspect launch wiring", agentConfig: makeAgent("worker"),
 				ctx: { pi: { events: { emit() {} } }, cwd: root, currentSessionId: "spawn-preload-session" },
 				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
 				shareEnabled: false, sessionRoot: path.join(root, "sessions"), maxSubagentDepth: 1, acceptance: false,
 			});
 			assert.equal(result.isError, true);
+			if (scenario === "missing-stable") {
+				assert.match(result.content[0]!.text, /@earendil-works\/pi-agent-core\/node/);
+				assert.equal(spawn.mock.callCount(), 3);
+				continue;
+			}
 			assert.match(result.content[0]!.text, /spawn boundary captured/);
-			assert.equal(spawn.mock.callCount(), complete ? 2 : 1);
+			assert.equal(spawn.mock.callCount(), scenario === "supplemental" ? 1 : scenario === "complete" ? 2 : 3);
 			const [command, args, options] = spawn.mock.calls.at(-1)!.arguments;
 			assert.ok(path.isAbsolute(command));
 			assert.equal(options.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV], host);
-			assert.deepEqual(JSON.parse(options.env.JITI_ALIAS), expectedAliases);
-			const jitiIndex = complete ? 0 : 2;
-			if (complete) assert.ok(!args.includes("--import"));
+			const actualAliases = JSON.parse(options.env.JITI_ALIAS) as Record<string, string>;
+			assert.deepEqual(Object.fromEntries(Object.entries(actualAliases).map(([key, target]) => [key, fs.realpathSync(target)])), expectedAliases);
+			const jitiIndex = scenario === "supplemental" ? 2 : 0;
+			if (scenario !== "supplemental") assert.ok(!args.includes("--import"));
 			else {
 				assert.equal(args[0], "--import");
 				assert.equal(args[1], new URL("../../runner-server-preload.mjs", import.meta.url).href);

--- a/test/unit/host-peer-runtime-imports.test.ts
+++ b/test/unit/host-peer-runtime-imports.test.ts
@@ -222,7 +222,13 @@ test("server supplementation is host-first, missing-only, and restricted to matc
 
 		for (const version of ["0.84.0", "0.85.1", "0.85.0-test"]) {
 			writePackage(host, "@earendil-works/pi-coding-agent", version, { ".": "./sdk.mjs" });
-			assert.deepEqual(resolveHostPeerAliases(host, extension).supplemental, []);
+			result = resolveHostPeerAliases(host, extension);
+			assert.deepEqual(result.supplemental, []);
+			for (const specifier of [server, `${server}/unix`, "@earendil-works/pi-client/unix"]) {
+				assert.ok(!result.missing.includes(specifier));
+				assert.equal(result.aliases[specifier], undefined);
+			}
+			assert.ok(result.missing.includes("@earendil-works/pi-agent-core/node"));
 		}
 		writePackage(host, "@earendil-works/pi-coding-agent", "0.85.0", { ".": "./sdk.mjs" });
 		writePackage(localServer, server, "0.85.1", exports);
@@ -231,20 +237,12 @@ test("server supplementation is host-first, missing-only, and restricted to matc
 		fs.unlinkSync(path.join(localServer, "unix.mjs"));
 		assert.ok(resolveHostPeerAliases(host, extension).missing.includes(`${server}/unix`));
 
-		// Complete hosts retain wildcard support and never need the preload.
+		// Non-exception hosts ignore experimental packages even when installed.
 		writePackage(host, "@earendil-works/pi-coding-agent", "0.86.0", { ".": "./sdk.mjs" });
 		writePackage(hostServer, server, "0.86.0", exports);
 		result = resolveHostPeerAliases(host, extension);
 		assert.deepEqual(result.supplemental, []);
-		assert.equal(result.aliases[`${server}/unix`], path.join(hostServer, "unix.mjs"));
-		for (const pkg of new Set(HOST_PEER_ALIASES.map(entry => entry.pkg))) {
-			const entries = HOST_PEER_ALIASES.filter(entry => entry.pkg === pkg);
-			const targets = Object.fromEntries(entries.map((entry, index) => [entry.subpath, `./export-${index}.mjs`]));
-			writePackage(pkg === "@earendil-works/pi-coding-agent" ? host : path.join(host, "node_modules", pkg), pkg, "0.86.0", targets);
-		}
-		result = resolveHostPeerAliases(host, extension);
-		assert.deepEqual(result.missing, []);
-		assert.deepEqual(result.supplemental, []);
+		assert.equal(result.aliases[`${server}/unix`], undefined);
 	} finally {
 		fs.rmSync(root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
Closes #1944. Thanks to [@geril07](https://github.com/geril07) for the report.

Require stable host peers by default and retain the experimental peer exception only for exact Pi0.85.0. Existing host identity, host-first/version-matched server supplementation, preload and pinned dependencies are unchanged. Reuse existing root manifest work rather than add launch I/O.

The existing pi085-clean-install check now exercises pinned0.85.0 and0.85.1 in separate pristine roots with retained lock artifacts. No local installation or published-package runtime success is claimed. Focused regression failed before the change and passed7/7 afterward; typecheck, smoke syntax, YAML and hygiene passed. Retained challenge and separate simplification were unchanged; fresh source review found no findings. Required exact-head CI and Greptile remain pending. Main Windows health remains a separate merge gate.
