### PR TITLE
fix(notify): surface structured output hidden by trivial text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Resolve undici from the official npm registry in the lockfile for npm 12 compatibility (#1935). Thanks to [@chem](https://github.com/chem).
 - Fix background launches on stable Pi 0.85.1 without experimental packages, retaining Pi 0.85.0 support (#1944). Thanks to [@geril07](https://github.com/geril07).
 - Surface the published workflow receipt path in wait completions, notifications, and exact status/debug responses (#1938).
+- Surface structured output in completion notices when text is blank or only a closing think-tag (#1945). Thanks to [@npfedwards](https://github.com/npfedwards).
 - Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -190,11 +190,17 @@ function structuredOutputText(value: unknown): string | undefined {
 	}
 }
 
+function isDegenerateOutput(text: string): boolean {
+	return !text.trim() || text.trim() === "</think>";
+}
+
 function childInlinePreview(child: CompletionChild): { preview?: string; truncated?: boolean; unavailableReason?: string } {
 	const output = typeof child.output === "string" ? child.output : "";
 	const outputReference = childSavedOutputPath(child);
 	const referenceOnly = Boolean(outputReference && output.trim().startsWith("Output saved to:"));
-	const raw = child.outputState === "absent" || referenceOnly ? structuredOutputText(child.structuredOutput) : output || structuredOutputText(child.structuredOutput);
+	const raw = child.outputState === "absent" || referenceOnly
+		? structuredOutputText(child.structuredOutput)
+		: isDegenerateOutput(output) ? structuredOutputText(child.structuredOutput) ?? output : output;
 	if (!raw?.trim()) {
 		return { unavailableReason: referenceOnly ? "saved output is file-only" : "no safe inline output" };
 	}
@@ -468,10 +474,17 @@ export function buildCompletionDetails(result: CompletionNotification): Subagent
 		: undefined;
 	const directSummary = summary.trim();
 	const directAgent = typeof directChild?.agent === "string" ? directChild.agent : agent;
+	const directSummaryBody = directAgent && summary.trimStart().startsWith(`${directAgent}:\n`)
+		? summary.trimStart().slice(directAgent.length + 2)
+		: directSummary;
+	const directDegenerateSummary = directChild
+		&& isDegenerateOutput(typeof directChild.output === "string" ? directChild.output : "")
+		&& isDegenerateOutput(directSummaryBody)
+		&& structuredOutputText(directChild.structuredOutput) !== undefined;
 	const directNoOutputSummary = directChild && (!directSummary
 		|| directSummary === "(no output)"
 		|| (directAgent && directSummary === `${directAgent}:\n(no output)`));
-	const resultPreview = directStructuredPreview && directNoOutputSummary
+	const resultPreview = directStructuredPreview && (directNoOutputSummary || directDegenerateSummary)
 		? `Structured output:\n${directStructuredPreview}`
 		: summary;
 	const childRuns = result.results?.flatMap((child) => {

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -747,58 +747,27 @@ describe("completion formatting helpers", () => {
 		assert.equal(details.status, "completed");
 	});
 
-	it("surfaces structured output in workflow child previews when text is only a closing think-tag", () => {
+	it("surfaces structured output in workflow previews and direct notices for degenerate text", () => {
 		const summary = "Workflow completed with 1 child run(s). Return: { answer: 42 } Emitted: ready Trace: 2 event(s).";
-		const details = buildCompletionDetails({
-			id: "workflow-think-tag",
-			runId: "workflow-think-tag",
-			mode: "workflow",
-			agent: "workflow",
-			success: true,
-			summary,
-			results: [{
-				workflowKey: "review",
-				runId: "child-review",
-				agent: "delegate",
-				success: true,
-				outputState: "present",
-				outputReference: "/tmp/review.json",
-				output: "</think>",
-				structuredOutput: { ok: true },
-			}],
-		});
-
-		const content = formatSingleCompletion(details);
-		assert.equal(details.resultPreview, summary);
-		assert.ok(content.includes(summary));
-		assert.match(content, /key=review run=child-review status=completed/);
-		assert.match(content, /Saved output: \/tmp\/review\.json/);
-		assert.match(content, /Workflow run: workflow-think-tag/);
-		assert.match(content, /Child runs: review=child-review \(completed\)/);
-		assert.match(content, /    \|   "ok": true/);
-	});
-
-	it("surfaces structured output in direct notices when text is only a closing think-tag", () => {
-		const details = buildCompletionDetails({
-			id: "direct-think-tag",
-			agent: "delegate",
-			success: true,
-			summary: "delegate:\n</think>",
-			results: [{ agent: "delegate", success: true, outputState: "present", output: "</think>", structuredOutput: { ok: true } }],
-		});
-
-		assert.match(formatSingleCompletion(details), /"ok": true/);
-	});
-
-	it("uses structured output for whitespace and padded closing think-tags", () => {
-		for (const output of [" \n\t", " \n</think> \n"]) {
-			for (const agent of ["delegate", "workflow"]) {
-				const details = buildCompletionDetails({
-					id: "degenerate-run", agent, success: true, summary: `delegate:\n${output}`,
-					results: [{ agent: "delegate", success: true, output, structuredOutput: false }],
-				});
-				assert.match(formatSingleCompletion(details), /(?:Structured output:\n|    \| )false/);
-			}
+		for (const output of ["</think>", " \n\t", " \n</think> \n"]) {
+			const result = {
+				id: "workflow-think-tag", agent: "workflow", success: true, summary,
+				results: [{
+					workflowKey: "review", runId: "child-review", agent: "delegate", success: true,
+					outputState: "present" as const, outputReference: "/tmp/review.json", output, structuredOutput: false,
+				}],
+			};
+			const details = buildCompletionDetails(result);
+			const content = formatSingleCompletion(details);
+			assert.equal(details.resultPreview, summary);
+			assert.ok(content.includes(summary));
+			assert.match(content, /key=review run=child-review status=completed/);
+			assert.match(content, /Saved output: \/tmp\/review\.json/);
+			assert.match(content, /Workflow run: workflow-think-tag/);
+			assert.match(content, /Child runs: review=child-review \(completed\)/);
+			assert.match(content, /    \| false/);
+			const direct = buildCompletionDetails({ ...result, agent: "delegate", summary: `delegate:\n${output}` });
+			assert.match(formatSingleCompletion(direct), /Structured output:\nfalse/);
 		}
 	});
 

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -747,6 +747,84 @@ describe("completion formatting helpers", () => {
 		assert.equal(details.status, "completed");
 	});
 
+	it("surfaces structured output in workflow child previews when text is only a closing think-tag", () => {
+		const summary = "Workflow completed with 1 child run(s). Return: { answer: 42 } Emitted: ready Trace: 2 event(s).";
+		const details = buildCompletionDetails({
+			id: "workflow-think-tag",
+			runId: "workflow-think-tag",
+			mode: "workflow",
+			agent: "workflow",
+			success: true,
+			summary,
+			results: [{
+				workflowKey: "review",
+				runId: "child-review",
+				agent: "delegate",
+				success: true,
+				outputState: "present",
+				outputReference: "/tmp/review.json",
+				output: "</think>",
+				structuredOutput: { ok: true },
+			}],
+		});
+
+		const content = formatSingleCompletion(details);
+		assert.equal(details.resultPreview, summary);
+		assert.ok(content.includes(summary));
+		assert.match(content, /key=review run=child-review status=completed/);
+		assert.match(content, /Saved output: \/tmp\/review\.json/);
+		assert.match(content, /Workflow run: workflow-think-tag/);
+		assert.match(content, /Child runs: review=child-review \(completed\)/);
+		assert.match(content, /    \|   "ok": true/);
+	});
+
+	it("surfaces structured output in direct notices when text is only a closing think-tag", () => {
+		const details = buildCompletionDetails({
+			id: "direct-think-tag",
+			agent: "delegate",
+			success: true,
+			summary: "delegate:\n</think>",
+			results: [{ agent: "delegate", success: true, outputState: "present", output: "</think>", structuredOutput: { ok: true } }],
+		});
+
+		assert.match(formatSingleCompletion(details), /"ok": true/);
+	});
+
+	it("uses structured output for whitespace and padded closing think-tags", () => {
+		for (const output of [" \n\t", " \n</think> \n"]) {
+			for (const agent of ["delegate", "workflow"]) {
+				const details = buildCompletionDetails({
+					id: "degenerate-run", agent, success: true, summary: `delegate:\n${output}`,
+					results: [{ agent: "delegate", success: true, output, structuredOutput: false }],
+				});
+				assert.match(formatSingleCompletion(details), /(?:Structured output:\n|    \| )false/);
+			}
+		}
+	});
+
+	it("preserves meaningful prose and direct diagnostics alongside structured output", () => {
+		const output = "Review complete </think> with notes.";
+		const child = { agent: "delegate", success: true, output, structuredOutput: { ok: true } };
+		const workflow = buildCompletionDetails({ id: "prose-run", agent: "workflow", success: true, results: [child] });
+		assert.equal(workflow.childOutputs?.[0]?.preview, output);
+		const direct = buildCompletionDetails({ id: "prose-run", agent: "delegate", success: true, summary: `delegate:\n${output}`, results: [child] });
+		assert.equal(direct.resultPreview, `delegate:\n${output}`);
+		const diagnostic = "delegate:\n</think>\nError: validation failed.";
+		const failed = buildCompletionDetails({ id: "error-run", agent: "delegate", success: false, summary: diagnostic, results: [{ ...child, success: false, output: "</think>" }] });
+		assert.equal(failed.resultPreview, diagnostic);
+		assert.match(formatSingleCompletion(failed), /Background task failed/);
+	});
+
+	it("retains tag text when structured output is unavailable or unserializable", () => {
+		for (const structuredOutput of [undefined, 1n]) {
+			const child = { agent: "delegate", success: true, output: "</think>", structuredOutput };
+			const workflow = buildCompletionDetails({ id: "fallback-run", agent: "workflow", success: true, results: [child] });
+			assert.equal(workflow.childOutputs?.[0]?.preview, "</think>");
+			const direct = buildCompletionDetails({ id: "fallback-run", agent: "delegate", success: true, summary: "delegate:\n</think>", results: [child] });
+			assert.equal(direct.resultPreview, "delegate:\n</think>");
+		}
+	});
+
 	it("surfaces direct structured output when the completion has no text output", () => {
 		const details = buildCompletionDetails({
 			id: "structured-run",


### PR DESCRIPTION
Closes #1945. Thanks to [@npfedwards](https://github.com/npfedwards) for the report.

Prevent blank text or a standalone closing think-tag from masking serializable structured output in workflow child previews and direct completion notices. Preserve meaningful prose priority, meaningful error summaries, workflow summaries, correlation and raw/persisted output. This is not a broad JSON-first policy or shared tag parser.

Two original public notification regressions failed before the fix. The combined retained-writer challenge/cleanup reduced the tests by 31 lines without changing the production correction. All 42 notification tests, typecheck and diff hygiene pass; fresh source review found no actionable findings. Three files, +63/-2, with no new I/O, dependency, API, lifecycle or delivery-ownership change.

Prepared on d0745ae4. Required exact-head CI and Greptile remain gates; main Windows shutdown health is being investigated separately. Publication is not merge readiness or a release.
