### PR TITLE
fix: make false-only tool schemas portable for Gemini converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Surface the published workflow receipt path in wait completions, notifications, and exact status/debug responses (#1938).
 - Surface structured output in completion notices when text is blank or only a closing think-tag (#1945). Thanks to [@npfedwards](https://github.com/npfedwards).
 - Validate literal workflow `baseRef` values before execution and clarify supported refs (#1934, #1937). Thanks to [@jeanduplessis](https://github.com/jeanduplessis).
+- Use portable boolean tool-schema branches for restricted Gemini function-declaration converters while preserving false-only runtime contracts (#1950). Thanks to [@Biaogo94](https://github.com/Biaogo94).
 - Preserve retained predecessor lineage in string-ID workflow continuations and receipts (#1920).
 - Clear recovered assistant errors on successful tool-use completion, including terminating structured output (#1919). Thanks to [@Jonathanm10](https://github.com/Jonathanm10).
 - Diagnose empty terminal text responses as empty-output failures rather than earlier exploratory tool errors (#1921).

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -77,6 +77,8 @@ const AcceptanceEvidenceKinds = [
 	"manual-notes",
 ];
 
+// Provider boolean branches intentionally overapproximate false-only runtime inputs.
+// Restricted function-declaration converters only support string enum members.
 const AcceptanceOverride = Type.Unsafe({
 	anyOf: [
 		{ type: "string", enum: ["auto", "attested", "checked"] },
@@ -89,10 +91,10 @@ const AcceptanceOverride = Type.Unsafe({
 		{
 			type: "string",
 		},
-		{ type: "boolean", enum: [false] },
+		{ type: "boolean" },
 		{ type: "object", additionalProperties: true },
 	],
-	description: `Optional acceptance policy. Prefer an inline JSON object. JSON-encoded object strings are tolerated only during input normalization; invalid strings fail closed. Reviewer/read-only calls, omit acceptance. { level: "checked", evidence: ["commands-run", "changed-files"] }. Supported evidence kinds: ${AcceptanceEvidenceKinds.join(",")}. acceptance.review.required.`,
+	description: `Optional acceptance policy. false disables acceptance; true is invalid. Prefer an inline JSON object. JSON-encoded object strings are tolerated only during input normalization; invalid strings fail closed. Reviewer/read-only calls, omit acceptance. { level: "checked", evidence: ["commands-run", "changed-files"] }. Supported evidence kinds: ${AcceptanceEvidenceKinds.join(",")}. acceptance.review.required.`,
 });
 
 const AgentContractOverride = Type.Object({
@@ -257,7 +259,7 @@ export const ChainItem = Type.Object({
 const MissionLaunchOverride = Type.Unsafe({
 	anyOf: [
 		{ type: "object", additionalProperties: true },
-		{ type: "boolean", enum: [false] },
+		{ type: "boolean" },
 	],
 });
 const MissionUpdateOverride = Type.Unsafe({ type: "object", additionalProperties: true });
@@ -317,7 +319,7 @@ const SubagentParamProperties = {
 	scope: Type.Optional(Type.String({ enum: ["session", "user", "project"], description: "Scope for action='watchdog.configure'. Defaults to session to avoid persistent settings writes unless user/project is explicit." })),
 	target: Type.Optional(Type.String({ enum: ["main", "children", "child"], description: "Target for watchdog actions." })),
 	focus: Type.Optional(Type.Boolean({ description: "Focus the new Herdr pane for inspector.open or project.open." })),
-	thinking: Type.Optional(Type.Unsafe({ anyOf: [{ type: "string" }, { type: "boolean", enum: [false] }], description: "Thinking level for action='watchdog.configure' only (off/minimal/low/medium/high/xhigh/max, inherit, or false for off). Ignored on dispatch; set per-run child thinking with a suffix on the model string, e.g. model: 'provider/id:high'." })),
+	thinking: Type.Optional(Type.Unsafe({ anyOf: [{ type: "string" }, { type: "boolean" }], description: "Thinking level for action='watchdog.configure' only (off/minimal/low/medium/high/xhigh/max, inherit, or false for off; true is invalid). Ignored on dispatch; set per-run child thinking with a suffix on the model string, e.g. model: 'provider/id:high'." })),
 	at: Type.Optional(Type.String({ description: "One-shot trigger for action='schedule.create': a relative delay such as '+10m' or an ISO timestamp with timezone." })),
 	every: Type.Optional(Type.String({ description: "Fixed recurring interval for action='schedule.create', such as '30m', '6h', '2d', or '2w'." })),
 	sessionOnly: Type.Optional(Type.Boolean()),
@@ -326,7 +328,7 @@ const SubagentParamProperties = {
 	overlap: Type.Optional(Type.String({ enum: ["skip"], description: "Overlap policy. This slice supports skip only." })),
 	catchUp: Type.Optional(Type.String({ enum: ["none", "latest"], description: "Missed occurrence policy for recurring schedules. Defaults to latest." })),
 	missionId: Type.Optional(Type.String({ description: "Mission id." })),
-	mission: Type.Optional(Type.Unsafe({ ...MissionLaunchOverride, description: "Mission object, or false for no mission. Set exactly one non-empty title or summary; objective and labels are optional. goal may only be true and then requires budget.tokens." })),
+	mission: Type.Optional(Type.Unsafe({ ...MissionLaunchOverride, description: "Mission object, or false for no mission; true is invalid. Set exactly one non-empty title or summary; objective and labels are optional. goal may only be true and then requires budget.tokens." })),
 	missionUpdate: Type.Optional(Type.Unsafe({ ...MissionUpdateOverride, description: "Mission update: objective, goal false or {paused:boolean}, budget, summary, labels, decisions, artifacts, or delivery receipts." })),
 	missionStatus: Type.Optional(Type.String({ description: "Mission status." })),
 	missionScope: Type.Optional(Type.String({ description: "Mission list scope: project (default) or global pointer index." })),

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -52,7 +52,7 @@ import { isScheduledRunAction } from "../background/scheduled-runs.ts";
 import { encodeIndexSegment } from "../background/index-segment.ts";
 import { enqueueChainAppendRequest, readPendingChainAppendRequests, runnerStepOutputNames } from "../background/chain-append.ts";
 import { ChainOutputValidationError, validateChainOutputBindingsWithContext } from "../shared/chain-outputs.ts";
-import { normalizeGateAcceptance, resolveAcceptanceReportMode, validateExecutionAcceptance } from "../shared/acceptance.ts";
+import { normalizeGateAcceptance, resolveAcceptanceReportMode, validateAcceptanceInput, validateExecutionAcceptance } from "../shared/acceptance.ts";
 import { canPreferFork, createForkContextResolver, forkedChildRequiresThinkingOff, resolveSubagentLaunchContext } from "../../shared/fork-context.ts";
 import { createPrunedForkSessionWriter } from "../../shared/pruned-fork.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
@@ -4917,6 +4917,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			workflowResource = { permit: workflowResourcePermit, ...consumed };
 		}
 		if (requestParams.workflowScript !== undefined && normalizedAction === undefined) {
+			const acceptanceErrors = validateAcceptanceInput(requestParams.acceptance);
+			if (acceptanceErrors.length > 0) return buildRequestedModeError(requestParams, acceptanceErrors.join(" "));
 			const foregroundWorkflowRunId = encodeIndexSegment(_id);
 			if (delegatedWorkflowPermit) {
 				const permitError = validateWorkflowChildPermitRoot(delegatedWorkflowPermit, foregroundWorkflowRunId);

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -579,6 +579,24 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
 	});
 
+	it("rejects invalid public workflow acceptance defaults before mission or script work", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const executor = makeExecutor([makeAgent("echo")]);
+		const ctx = makeMinimalCtx(tempDir);
+		const params = { async: false, workflowScript: `return "workflow-default-ran";` };
+		const projectBefore = fs.readdirSync(tempDir, { recursive: true });
+		const agentBefore = fs.readdirSync(agentDir, { recursive: true });
+		const rejected = await executor.executePublic("invalid-workflow-default", { ...params, acceptance: true }, new AbortController().signal, undefined, ctx);
+		assert.equal(rejected.isError, true);
+		assert.match(rejected.content[0]?.text ?? "", /acceptance must be a string level, false, or an object/);
+		assert.equal(rejected.details.workflow, undefined, "invalid default must not execute the workflow");
+		assert.deepEqual(fs.readdirSync(tempDir, { recursive: true }), projectBefore, "invalid default must not create mission or workflow files");
+		assert.deepEqual(fs.readdirSync(agentDir, { recursive: true }), agentBefore, "invalid default must not create mission index files");
+		const accepted = await executor.executePublic("false-workflow-default", { ...params, acceptance: false }, new AbortController().signal, undefined, ctx);
+		assert.equal(accepted.isError, undefined, accepted.content[0]?.text);
+		assert.match(accepted.content[0]?.text ?? "", /workflow-default-ran/);
+		assert.equal(mockPi.callCount(), 0);
+	});
+
 	it("runs a workflow host command without launching a child", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const scriptPath = path.join(tempDir, "host-command.cjs");
 		fs.writeFileSync(scriptPath, `process.stdout.write("host command passed\\n");`);

--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -87,6 +87,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			const address = server.address() as { port: number };
 			const hook = path.join(tempDir, ".git", "setup-hook.cjs");
 			fs.writeFileSync(hook, `#!${process.execPath}\nconst fs = require('node:fs');
+process.stdin.resume();
 if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
  const socket = require('node:net').connect(${address.port}, '127.0.0.1', () => socket.write('ready'));
  socket.on('data', data => { if (data.toString() === 'release') { socket.end(); console.log('{}'); } else socket.write('ack'); });

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -1220,6 +1220,17 @@ describe("acceptance gates", () => {
 		assert.match(errors.join("\n"), /acceptance\.review\.required/);
 	});
 
+	it("rejects transport-permitted true acceptance before execution, including nested inputs", () => {
+		const errors = validateExecutionAcceptance({
+			acceptance: true,
+			tasks: [{ acceptance: true }],
+			chain: [{ acceptance: true }, { parallel: [{ acceptance: true }] }, { parallel: { acceptance: true } }],
+		});
+		const paths = ["acceptance", "tasks[0].acceptance", "chain[0].acceptance", "chain[1].parallel[0].acceptance", "chain[2].parallel.acceptance"];
+		assert.equal(errors.length, paths.length);
+		paths.forEach((path, index) => assert.ok(errors[index]?.startsWith(`${path} must be a string level, false, or an object.`)));
+	});
+
 	it("requires outputSchema for explicit structured acceptance report mode", () => {
 		const schema = { type: "object" as const };
 		const errors = validateExecutionAcceptance({

--- a/test/unit/mission-lifecycle.test.ts
+++ b/test/unit/mission-lifecycle.test.ts
@@ -36,6 +36,8 @@ describe("mission launch lifecycle", () => {
 			labels: ["review"],
 		});
 		assert.throws(() => validateMissionLaunch({}), /title or mission\.summary/);
+		assert.throws(() => validateMissionLaunch(true), /mission must be an object/);
+		assert.throws(() => validateMissionLaunch(false), /mission must be an object/);
 		assert.throws(() => validateMissionLaunch({ title: "Title", summary: "Summary" }), /cannot both be set/);
 		assert.throws(() => validateMissionLaunch({ title: " " }), /non-empty string/);
 		assert.throws(() => validateMissionLaunch({ title: "Title", goal: false }), /must be true/);
@@ -45,6 +47,13 @@ describe("mission launch lifecycle", () => {
 	it("creates missions by default for task launches and honors explicit opt-out", () => {
 		const test = projectFixture();
 		try {
+			assert.throws(() => prepareMissionLaunch({
+				params: { mission: true, task: "Invalid mission" },
+				projectRoot: test.projectRoot,
+				config: test.missionConfig,
+			}), /mission must be an object/);
+			assert.deepEqual(fs.readdirSync(test.projectRoot), [], "invalid mission must not create records");
+			assert.equal(fs.existsSync(test.missionConfig.globalIndexDir), false);
 			const binding = prepareMissionLaunch({
 				params: { task: "Map the auth flow" },
 				projectRoot: test.projectRoot,

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -535,6 +535,10 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 				if (!current.value || typeof current.value !== "object") continue;
 
 				const node = current.value as JsonSchemaNode;
+				// oxlint-disable-next-line anti-slop/no-runtime-typeof -- Inspecting JSON Schema enum representation is the portability contract under test.
+				if (Array.isArray(node.enum) && node.enum.some((value) => typeof value !== "string")) {
+					rejectedPaths.push(`${current.path}.enum`);
+				}
 				if (Array.isArray(node.type)) {
 					rejectedPaths.push(`${current.path}.type`);
 				}
@@ -606,6 +610,13 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		assert.ok(SubagentParams, "SubagentParams schema should exist");
 		assert.ok(CompileSchema, "TypeBox compiler should exist");
 		const validator = CompileSchema(SubagentParams);
+		// Transport accepts both booleans; semantic boundaries still reject unsupported true.
+		for (const field of ["acceptance", "mission", "thinking"]) {
+			assert.deepEqual(anyOfBranches(SubagentParams.properties[field]).find((branch) => branch.type === "boolean"), { type: "boolean" });
+			assert.equal(validator.Check({ [field]: false }), true);
+			assert.equal(validator.Check({ [field]: true }), true);
+			assert.equal(validator.Check({ [field]: 123 }), false);
+		}
 		const validValues = [
 			{ skill: "review" },
 			{ workflowScript: "return await runs.run(\"one\", {agent: \"reviewer\", task: \"check\"})" },
@@ -626,7 +637,6 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			{ output: 123 },
 			{ timeoutMs: 0 },
 			{ maxRuntimeMs: -1 },
-			{ agent: "worker", task: "Fix", acceptance: true },
 			{ config: [] },
 			{ config: null },
 			{ agent: "worker", task: "Fix", toolBudget: { hard: 0 } },

--- a/test/unit/watchdog-tool-actions.test.ts
+++ b/test/unit/watchdog-tool-actions.test.ts
@@ -77,6 +77,24 @@ describe("watchdog tool actions", () => {
 		assert.equal(result.isError, undefined);
 		assert.equal(runtime.getSnapshot(tempProject).config.main.model, "anthropic/claude-opus-4-8");
 		assert.equal(runtime.getSnapshot(tempProject).config.main.thinking, "low");
+		const off = handleWatchdogToolAction("watchdog.configure", { thinking: false }, ctx, runtime);
+		assert.equal(off.isError, undefined);
+		assert.equal(runtime.getSnapshot(tempProject).config.main.thinking, false);
+	});
+
+	it("rejects transport-permitted true thinking without changing session or settings", () => {
+		const runtime = new MainWatchdogRuntime({ cwd: tempProject });
+		const ctx = createCtx({ provider: "openai-codex", id: "gpt-5.5" });
+		const before = runtime.getSnapshot(tempProject).config.main;
+		for (const scope of ["session", "user"]) {
+			// SAFETY: Deliberately pass invalid tool JSON to prove the false-only runtime contract.
+			const result = handleWatchdogToolAction("watchdog.configure", { scope, thinking: true as never }, ctx, runtime);
+			assert.equal(result.isError, true);
+			assert.match(text(result), /Unsupported watchdog thinking 'true'/);
+			assert.deepEqual(runtime.getSnapshot(tempProject).config.main, before);
+		}
+		assert.equal(fs.existsSync(path.join(tempHome, ".pi", "agent", "settings.json")), false);
+		assert.equal(fs.existsSync(path.join(tempProject, ".pi", "settings.json")), false);
 	});
 
 	it("persists the recommended model when user scope is explicit", () => {


### PR DESCRIPTION
## Summary
- Remove three boolean-literal enums rejected by restricted Gemini function-declaration converters. Keep the false-only semantic contracts; this does not enable `true` as a supported option.
- Validate workflow acceptance defaults before mission/storage/script execution, including childless workflows.
- Credit [@Biaogo94](https://github.com/Biaogo94) for the report and local reproduction.

Closes #1950.

## Validation
- 109 focused schema/acceptance/mission/watchdog tests and typecheck passed on the original implementation.
- Public workflow-default regression reproduced the gap, then passed with the guard; three targeted integration cases, gate normalization and typecheck passed.
- Combined challenge/cleanup and independent review completed. The review's workflow-default finding was fixed and independently re-reviewed.
- Current-main refresh preserves the non-changelog patch byte-for-byte and contributor credit. New exact-head CI remains required.

Compatibility claim is limited to restricted function-declaration converters; native Gemini's `parametersJsonSchema` path is not claimed universally broken. No live provider run. Existing lint debt is unchanged: 124 baseline diagnostics, none added. Validation precedes executor launch effects, not trusted resource resolution or raw-file reads.
