### PR TITLE
fix: await Orca creation before observer test teardown

### DIFF
--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -53,6 +53,8 @@ const ORCA_CLEANUP_WATCHDOG_SCRIPT = [
 ].join("");
 
 export interface OrcaProgressTab {
+	/** Resolves when the terminal-create watchdog closes, after its final manifest/queue writes (success or failure). Not viewer completion. */
+	readonly creationSettled: Promise<void>;
 	append(text: string): void;
 	section(input: { agent: string; index: number; count: number }): void;
 	event(event: { type?: string; message?: Message; toolName?: string; args?: unknown }): void;
@@ -402,6 +404,8 @@ export function createOrcaProgressTab(input: {
 		}
 	};
 	let createSettled = false;
+	let resolveCreationSettled!: () => void;
+	const creationSettled = new Promise<void>((resolve) => { resolveCreationSettled = resolve; });
 	let cleanupPaths: string[] | undefined;
 	const scheduleDeferredCleanup = () => {
 		if (!createSettled || cleanupPaths === undefined) return;
@@ -434,6 +438,7 @@ export function createOrcaProgressTab(input: {
 			createSettled = true;
 			if (code !== 0) failObserver();
 			scheduleDeferredCleanup();
+			resolveCreationSettled();
 		});
 		watchdog.once("error", () => {
 			markCreateReady();
@@ -450,6 +455,7 @@ export function createOrcaProgressTab(input: {
 
 	let finished = false;
 	return {
+		creationSettled,
 		append(text) {
 			if (finished) return;
 			writeProgress(text);

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -193,11 +193,19 @@ test("malformed optional observer metadata cannot break child execution", { skip
 		env: { ...process.env, ORCA_TEST_CAPTURE: capture },
 	} as never);
 	assert.ok(tab);
-	tab.finish("completed");
-	await waitForFile(capture);
+	await tab.finish("completed");
+	// Capture precedes the watchdog's final manifest/queue writes; wait for its close.
+	await tab.creationSettled;
 	const args = JSON.parse(fs.readFileSync(capture, "utf-8")) as string[];
 	assert.equal(args[args.indexOf("--title") + 1], "subagents · subagent · 1");
-	removeProgressFiles("run-0-");
+	const manifestDir = path.join(dir, ".pi", "subagents", "views", "orca");
+	const [manifestName] = fs.readdirSync(manifestDir);
+	const manifest = JSON.parse(fs.readFileSync(path.join(manifestDir, manifestName!), "utf-8"));
+	assert.equal(manifest.state, "open");
+	const viewer = args[args.indexOf("--command") + 1]!;
+	assert.match(await captureCommand(viewer, dir), /completed/);
+	assert.equal(fs.existsSync(manifest.logPath), false);
+	assert.equal(fs.existsSync(manifest.logPath.replace(/\.log$/, ".done")), false);
 });
 
 test("disabled Orca progress tabs do not invoke Orca", async () => {


### PR DESCRIPTION
## Fix
The observer test treated the fake Orca capture file as completion, but the terminal-create watchdog could still rewrite project metadata during teardown.

Expose the existing watchdog's settlement promise and await it in the failing test. Then run and await the captured viewer cleanup before removing the test directory. Normal child execution remains nonblocking; no extra I/O, timers, polling, retries, or larger timeout.

Fixes the Ubuntu cleanup failure in [main run 33981344539](https://github.com/nicobailon/pi-subagents/actions/runs/33981344539/job/101347000526).

## Validation
- Corrected test: passed in about **0.5 seconds**.
- Existing observer test file: 14 passed, one existing platform skip. Its pre-existing queue-timeout case accounts for most of the 34-second file run.
- Typecheck and diff hygiene passed.
- Independent exact-head source review found no issues, including failure settlement and remaining write ownership.

Two files, +17/-3. No user-visible runtime behavior change or unrelated cleanup. New exact-head CI remains required; the original failed run was not retried.
