### PR TITLE
fix(workflows): await workflow-owned result publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).
 - Resolve undici from the official npm registry in the lockfile for npm 12 compatibility (#1935). Thanks to [@chem](https://github.com/chem).
 - Fix background launches on stable Pi 0.85.1 without experimental packages, retaining Pi 0.85.0 support (#1944). Thanks to [@geril07](https://github.com/geril07).
 - Surface the published workflow receipt path in wait completions, notifications, and exact status/debug responses (#1938).

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -123,6 +123,11 @@ function selectedStatusStep(status: AsyncStatus | null, index: number): NonNulla
 
 function isTerminalStatus(status: AsyncStatus | null, index: number): boolean {
 	if (!status) return false;
+	// A workflow-owned single runner publishes its result after completing its
+	// step. Keep that window open while root process proof is absent or pending;
+	// explicit terminal/unavailable proof retains the existing step fallback.
+	if (status.mode === "single" && status.parentWorkflowRunId
+		&& (!status.processTerminal || status.processTerminal.state === "pending")) return TERMINAL_STATES.has(status.state);
 	const step = selectedStatusStep(status, index);
 	if (step && TERMINAL_STEP_STATUSES.has(step.status)) return true;
 	return TERMINAL_STATES.has(status.state);

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -941,7 +941,7 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 				makeMinimalCtx(tempDir),
 			);
 
-			assert.equal(result.isError, undefined);
+			assert.equal(result.isError, undefined, result.content[0]?.text);
 			if (workflow) {
 				const child = result.details!.workflow!.value as { runId: string; agent: string; continuation: { runIds: string[] } };
 				assert.equal(child.agent, "b");

--- a/test/unit/chain-root-attachment.test.ts
+++ b/test/unit/chain-root-attachment.test.ts
@@ -149,68 +149,6 @@ describe("async chain root attachment", () => {
 		assert.equal(result.output, "published after step completion");
 	});
 
-	for (const state of ["complete", "failed", "partial", "paused", "stopped"]) {
-		it(`fails closed for a workflow-owned single root in ${state} without a result`, async () => {
-			const importedRoot = { ...root(), resultPath: path.join(tempDir, "root-run", "workflow-result.json") };
-			writeJson(path.join(importedRoot.asyncDir, "status.json"), {
-				runId: importedRoot.runId,
-				mode: "single",
-				parentWorkflowRunId: "workflow-parent",
-				state,
-				startedAt: 1,
-				steps: [{ agent: "worker", status: "complete" }],
-			});
-			const result = await waitForImportedAsyncRoot(importedRoot, { terminalResultGraceMs: 0 });
-			assert.equal(result.success, false);
-			assert.equal(result.exitCode, 1);
-			assert.match(result.error ?? "", state === "stopped" ? /stopped by user/ : /ended without a result file/);
-		});
-	}
-
-	for (const proofState of ["observed", "unknown", "not-started"]) {
-		it(`preserves missing-result failure with completed step and ${proofState} root proof`, async () => {
-			const importedRoot = { ...root(), resultPath: path.join(tempDir, "root-run", "workflow-result.json") };
-			writeJson(path.join(importedRoot.asyncDir, "status.json"), {
-				runId: importedRoot.runId,
-				mode: "single",
-				parentWorkflowRunId: "workflow-parent",
-				state: "running",
-				startedAt: 1,
-				processTerminal: {
-					version: 1,
-					runId: importedRoot.runId,
-					runnerProcessInstanceId: "runner-instance",
-					state: proofState,
-					...(proofState === "observed" ? { observedAt: 2, instances: [{ kind: "runner", processInstanceId: "runner-instance", closeObservedAt: 2, exitCode: 1, signal: null }] } : {}),
-					...(proofState === "unknown" ? { reason: "runner-candidate-missing" } : {}),
-				},
-				steps: [{ agent: "worker", status: "complete" }],
-			});
-			const result = await waitForImportedAsyncRoot(importedRoot, { terminalResultGraceMs: 0 });
-			assert.equal(result.success, false);
-			assert.equal(result.exitCode, 1);
-			assert.match(result.error ?? "", /ended without a result file/);
-		});
-	}
-
-	for (const mode of ["chain", "parallel"]) {
-		it(`preserves selected-index terminal fallback for a running workflow-owned ${mode} root`, async () => {
-			const importedRoot = root("root-run", 1);
-			writeJson(path.join(importedRoot.asyncDir, "status.json"), {
-				runId: importedRoot.runId,
-				mode,
-				parentWorkflowRunId: "workflow-parent",
-				state: "running",
-				startedAt: 1,
-				steps: [{ agent: "first", status: "running" }, { agent: "selected", status: "complete" }],
-			});
-			const result = await waitForImportedAsyncRoot(importedRoot, { terminalResultGraceMs: 0 });
-			assert.equal(result.agent, "selected");
-			assert.equal(result.success, false);
-			assert.match(result.error ?? "", /ended without a result file/);
-		});
-	}
-
 	it("imports a failed root as a failed first chain step", async () => {
 		const importedRoot = root();
 		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
@@ -284,14 +222,21 @@ describe("async chain root attachment", () => {
 		assert.deepEqual(result.effects?.fileMutation?.evidence?.changedFiles, ["input.md"]);
 	});
 
-	it("fails a terminal root that never produced a result file", async () => {
-		const importedRoot = root();
+	for (const fixture of [
+		{ name: "terminal root", status: { mode: "single", state: "complete" } },
+		{ name: "terminal workflow-owned single", status: { mode: "single", state: "complete", parentWorkflowRunId: "workflow-parent" } },
+		{ name: "running workflow-owned single with unavailable root proof", status: {
+			mode: "single", state: "running", parentWorkflowRunId: "workflow-parent",
+			processTerminal: { version: 1, runId: "root-run", runnerProcessInstanceId: "runner-instance", state: "unknown", reason: "runner-candidate-missing" },
+		} },
+		{ name: "selected child of running workflow-owned parallel root", index: 1, status: { mode: "parallel", state: "running", parentWorkflowRunId: "workflow-parent" } },
+	]) it(`fails closed without a result for ${fixture.name}`, async () => {
+		const importedRoot = root("root-run", fixture.index ?? 0);
 		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
 			runId: importedRoot.runId,
-			mode: "single",
-			state: "complete",
+			...fixture.status,
 			startedAt: 1,
-			steps: [{ agent: "worker", status: "complete" }],
+			steps: [...(fixture.index ? [{ agent: "first", status: "running" }] : []), { agent: "worker", status: "complete" }],
 		});
 
 		const result = await waitForImportedAsyncRoot(importedRoot, {
@@ -299,6 +244,7 @@ describe("async chain root attachment", () => {
 			terminalResultGraceMs: 0,
 		});
 
+		assert.equal(result.agent, "worker");
 		assert.equal(result.exitCode, 1);
 		assert.match(result.error ?? "", /ended without a result file/);
 	});

--- a/test/unit/chain-root-attachment.test.ts
+++ b/test/unit/chain-root-attachment.test.ts
@@ -115,6 +115,102 @@ describe("async chain root attachment", () => {
 		assert.equal(result.exitCode, 0);
 	});
 
+	for (const proofState of [undefined, "pending"]) it(`waits past the terminal grace for workflow-owned single publication with ${proofState ?? "absent"} root proof`, async (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 });
+		const importedRoot = { ...root(), resultPath: path.join(tempDir, "root-run", "workflow-result.json") };
+		writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+			runId: importedRoot.runId,
+			mode: "single",
+			parentWorkflowRunId: "workflow-parent",
+			state: "running",
+			pid: process.pid,
+			startedAt: 1,
+			...(proofState ? { processTerminal: { version: 1, runId: importedRoot.runId, runnerProcessInstanceId: "runner-instance", state: proofState } } : {}),
+			steps: [{ agent: "worker", status: "complete" }],
+		});
+
+		// The live publisher is this process; advance only the waiter's clock,
+		// leaving the real completed-step evidence intact until publication.
+		const waiting = waitForImportedAsyncRoot(importedRoot);
+		for (let poll = 0; poll < 3; poll++) {
+			t.mock.timers.tick(500);
+			await Promise.resolve();
+		}
+		assert.equal(Date.now(), 1_500);
+		assert.equal(fs.existsSync(importedRoot.resultPath), false);
+		writeJson(importedRoot.resultPath, {
+			state: "complete",
+			success: true,
+			results: [{ agent: "worker", output: "published after step completion", success: true }],
+		});
+		t.mock.timers.tick(500);
+		const result = await waiting;
+		assert.equal(result.success, true, result.error);
+		assert.equal(result.output, "published after step completion");
+	});
+
+	for (const state of ["complete", "failed", "partial", "paused", "stopped"]) {
+		it(`fails closed for a workflow-owned single root in ${state} without a result`, async () => {
+			const importedRoot = { ...root(), resultPath: path.join(tempDir, "root-run", "workflow-result.json") };
+			writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+				runId: importedRoot.runId,
+				mode: "single",
+				parentWorkflowRunId: "workflow-parent",
+				state,
+				startedAt: 1,
+				steps: [{ agent: "worker", status: "complete" }],
+			});
+			const result = await waitForImportedAsyncRoot(importedRoot, { terminalResultGraceMs: 0 });
+			assert.equal(result.success, false);
+			assert.equal(result.exitCode, 1);
+			assert.match(result.error ?? "", state === "stopped" ? /stopped by user/ : /ended without a result file/);
+		});
+	}
+
+	for (const proofState of ["observed", "unknown", "not-started"]) {
+		it(`preserves missing-result failure with completed step and ${proofState} root proof`, async () => {
+			const importedRoot = { ...root(), resultPath: path.join(tempDir, "root-run", "workflow-result.json") };
+			writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+				runId: importedRoot.runId,
+				mode: "single",
+				parentWorkflowRunId: "workflow-parent",
+				state: "running",
+				startedAt: 1,
+				processTerminal: {
+					version: 1,
+					runId: importedRoot.runId,
+					runnerProcessInstanceId: "runner-instance",
+					state: proofState,
+					...(proofState === "observed" ? { observedAt: 2, instances: [{ kind: "runner", processInstanceId: "runner-instance", closeObservedAt: 2, exitCode: 1, signal: null }] } : {}),
+					...(proofState === "unknown" ? { reason: "runner-candidate-missing" } : {}),
+				},
+				steps: [{ agent: "worker", status: "complete" }],
+			});
+			const result = await waitForImportedAsyncRoot(importedRoot, { terminalResultGraceMs: 0 });
+			assert.equal(result.success, false);
+			assert.equal(result.exitCode, 1);
+			assert.match(result.error ?? "", /ended without a result file/);
+		});
+	}
+
+	for (const mode of ["chain", "parallel"]) {
+		it(`preserves selected-index terminal fallback for a running workflow-owned ${mode} root`, async () => {
+			const importedRoot = root("root-run", 1);
+			writeJson(path.join(importedRoot.asyncDir, "status.json"), {
+				runId: importedRoot.runId,
+				mode,
+				parentWorkflowRunId: "workflow-parent",
+				state: "running",
+				startedAt: 1,
+				steps: [{ agent: "first", status: "running" }, { agent: "selected", status: "complete" }],
+			});
+			const result = await waitForImportedAsyncRoot(importedRoot, { terminalResultGraceMs: 0 });
+			assert.equal(result.agent, "selected");
+			assert.equal(result.success, false);
+			assert.match(result.error ?? "", /ended without a result file/);
+		});
+	}
+
 	it("imports a failed root as a failed first chain step", async () => {
 		const importedRoot = root();
 		writeJson(path.join(importedRoot.asyncDir, "status.json"), {


### PR DESCRIPTION
Refs #1906. Fixes the workflow-owned root result publication boundary that made retained workflow resume tests fail before the root result file appeared on Windows.\n\nValidation:\n- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/chain-root-attachment.test.ts\n- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern 'waits for retained workflow resume loops and returns each completed revived child|workflow string resume revives completed multi-child async runs by index' test/integration/intercom-result-delivery.test.ts\n- npm run typecheck\n- git diff --check