### PR TITLE
fix(models): classify provider request-limit failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).
+- Recognize raw `REQUEST_LIMIT_EXCEEDED` rate limits and keep context-overflow errors out of the model exclusion cache (#1955, #1957). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).
 - Resolve undici from the official npm registry in the lockfile for npm 12 compatibility (#1935). Thanks to [@chem](https://github.com/chem).
 - Fix background launches on stable Pi 0.85.1 without experimental packages, retaining Pi 0.85.0 support (#1944). Thanks to [@geril07](https://github.com/geril07).
 - Surface the published workflow receipt path in wait completions, notifications, and exact status/debug responses (#1938).

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -537,6 +537,7 @@ export function buildModelCandidates(
 }
 
 const RETRYABLE_MODEL_FAILURE_PATTERNS = [
+	/^REQUEST_LIMIT_EXCEEDED$/,
 	/rate\s*limit/i,
 	/usage\s*limit/i,
 	/too many requests/i,
@@ -609,7 +610,7 @@ export function isRetryableModelFailureAttempt(input: { error: string | undefine
 }
 
 export function recordRetryableModelFailure(model: string | undefined, error: string | undefined): void {
-	if (!model || !isRetryableModelFailure(error)) return;
+	if (!model || !isRetryableModelFailure(error) || isContextOverflow(error)) return;
 	const { provider, modelId } = parseModelKey(model);
 	recordModelFailure({ modelId, reason: error, ...(provider ? { provider } : {}) });
 }

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -13,7 +13,7 @@ import {
 	resolveModelCandidate,
 	resolveSubagentModelOverride,
 } from "../../src/runs/shared/model-fallback.ts";
-import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
+import { clearExclusions, findModelExclusion, getExcludedCount, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 import { resolveModelScopesForAgent } from "../../src/runs/shared/model-scope.ts";
 
 beforeEach(() => clearExclusions());
@@ -202,6 +202,27 @@ describe("model fallback helpers", () => {
 			buildModelCandidates("gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
 			["openai/gpt-5-mini", "anthropic/claude-sonnet-4"],
 		);
+	});
+
+	it("does not cache context overflow even when upstream makes it retryable", () => {
+		const error = "upstream: maximum context length exceeded";
+		assert.equal(isRetryableModelFailure(error), true);
+		assert.equal(isContextOverflow(error), true);
+		recordRetryableModelFailure("openai/gpt-5-mini", error);
+		assert.equal(getExcludedCount(), 0);
+	});
+
+	it("still caches raw request limits and per-minute input-token rate quotas", () => {
+		for (const error of [
+			"REQUEST_LIMIT_EXCEEDED",
+			'{"error_code":"REQUEST_LIMIT_EXCEEDED","message":"REQUEST_LIMIT_EXCEEDED: Exceeded workspace input tokens per minute rate limit for <model>."}',
+		]) {
+			clearExclusions();
+			assert.equal(isContextOverflow(error), false);
+			recordRetryableModelFailure("openai/gpt-5-mini", error);
+			assert.equal(findModelExclusion("gpt-5-mini", "openai")?.reason, error);
+			assert.equal(getExcludedCount(), 1);
+		}
 	});
 
 	it("applies the current provider preference to fallback candidates too", () => {
@@ -449,6 +470,25 @@ describe("model fallback helpers", () => {
 		assert.equal(isRetryableModelFailure("bash failed (exit 1): command not found"), false);
 		assert.equal(isRetryableModelFailure("read failed (exit 1): no such file or directory"), false);
 		assert.equal(isRetryableModelFailure(undefined), false);
+	});
+
+	it("recognizes only the exact raw request-limit code without broadening limit families", () => {
+		assert.equal(isRetryableModelFailure("REQUEST_LIMIT_EXCEEDED"), true);
+		for (const error of ["TOKEN_LIMIT_EXCEEDED", "INPUT_LIMIT_EXCEEDED", "OUTPUT_LIMIT_EXCEEDED", "RESOURCE_EXHAUSTED", "NOT_REQUEST_LIMIT_EXCEEDED", "REQUEST_LIMIT_EXCEEDED_OTHER", "400"]) {
+			assert.equal(isRetryableModelFailure(error), false, error);
+		}
+	});
+
+	it("preserves attempt and tool-failure guards for request-limit errors", () => {
+		const error = "REQUEST_LIMIT_EXCEEDED";
+		assert.equal(isRetryableModelFailureAttempt({ error, messages: [], toolCount: 0 }), true);
+		assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ errorMessage: error }], toolCount: 0 }), true);
+		assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ errorMessage: "different error" }], toolCount: 0 }), false);
+		assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ errorMessage: error }], toolCount: 1 }), false);
+		const toolError = `bash failed (exit 1): ${error}`;
+		assert.equal(isRetryableModelFailure(toolError), false);
+		recordRetryableModelFailure("openai/gpt-5-mini", toolError);
+		assert.equal(getExcludedCount(), 0);
 	});
 
 	it("does not treat network-flavored tool failures as retryable model failures", () => {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -220,7 +220,7 @@ describe("model fallback helpers", () => {
 			clearExclusions();
 			assert.equal(isContextOverflow(error), false);
 			recordRetryableModelFailure("openai/gpt-5-mini", error);
-			assert.equal(findModelExclusion("gpt-5-mini", "openai")?.reason, error);
+			assert.equal(findModelExclusion("openai/gpt-5-mini")?.reason, error);
 			assert.equal(getExcludedCount(), 1);
 		}
 	});
@@ -477,18 +477,6 @@ describe("model fallback helpers", () => {
 		for (const error of ["TOKEN_LIMIT_EXCEEDED", "INPUT_LIMIT_EXCEEDED", "OUTPUT_LIMIT_EXCEEDED", "RESOURCE_EXHAUSTED", "NOT_REQUEST_LIMIT_EXCEEDED", "REQUEST_LIMIT_EXCEEDED_OTHER", "400"]) {
 			assert.equal(isRetryableModelFailure(error), false, error);
 		}
-	});
-
-	it("preserves attempt and tool-failure guards for request-limit errors", () => {
-		const error = "REQUEST_LIMIT_EXCEEDED";
-		assert.equal(isRetryableModelFailureAttempt({ error, messages: [], toolCount: 0 }), true);
-		assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ errorMessage: error }], toolCount: 0 }), true);
-		assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ errorMessage: "different error" }], toolCount: 0 }), false);
-		assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ errorMessage: error }], toolCount: 1 }), false);
-		const toolError = `bash failed (exit 1): ${error}`;
-		assert.equal(isRetryableModelFailure(toolError), false);
-		recordRetryableModelFailure("openai/gpt-5-mini", toolError);
-		assert.equal(getExcludedCount(), 0);
 	});
 
 	it("does not treat network-flavored tool failures as retryable model failures", () => {


### PR DESCRIPTION
Closes #1957. Addresses the request-limit/cacheable-overflow slice of #1955; #1955 remains open for the broader malformed-request TTL policy.\n\nRecognizes exact REQUEST_LIMIT_EXCEEDED provider machine codes as retryable and keeps context-overflow errors out of the model exclusion cache.\n\nValidation:\n- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts\n- npm run typecheck\n- git diff --check