### PR TITLE
fix(workflows): emit rpc workflow progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).
 - Recognize raw `REQUEST_LIMIT_EXCEEDED` rate limits and keep context-overflow errors out of the model exclusion cache (#1955, #1957). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).
+- Emit synchronous workflow progress updates for RPC/headless and cross-repository hosts even when the live chat card is off (#1951). Thanks to [@yanqianglu](https://github.com/yanqianglu).
 - Resolve undici from the official npm registry in the lockfile for npm 12 compatibility (#1935). Thanks to [@chem](https://github.com/chem).
 - Fix background launches on stable Pi 0.85.1 without experimental packages, retaining Pi 0.85.0 support (#1944). Thanks to [@geril07](https://github.com/geril07).
 - Surface the published workflow receipt path in wait completions, notifications, and exact status/debug responses (#1938).

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -356,6 +356,8 @@ known, or for explicit emergency hotfix lanes.
 
 For watched same-repo workflows, pass `async:false` only when the parent must block until completion. That blocking mode also shows the live in-chat workflow card. `chatProgress` can force `off` or `live-card` when the automatic policy is not what you want. Blocking workflows default to a 30-minute timeout; async workflows have no default timeout. See the [tool reference](tool-reference.md) for the full parameter list.
 
+Synchronous workflows publish trace and `emit(...)` updates through the tool update callback regardless of `chatProgress`, including RPC/headless and cross-repository runs. These updates include `details.workflow` and `details.workflowChildren`; `chatProgress: "off"` disables the live card, not transport progress. This is workflow lifecycle progress, not a live child transcript.
+
 The legacy `/chain`, `/parallel`, and `/run-chain` commands are not registered.
 
 ## Direct commands

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4759,14 +4759,14 @@ function applyWorkflowLaneTrace(graph: WorkflowGraphSnapshot, trace: WorkflowScr
 	else delete graph.currentNodeId;
 }
 
-function workflowChatProgressUpdate(
+function workflowProgressUpdate(
 	runId: string,
 	chatProgress: WorkflowChatProgressProjection,
 	workflow: NonNullable<Details["workflow"]>,
 	workflowChildren?: Details["workflowChildren"],
 	preflight?: import("../../shared/types.ts").WorkflowPreflightV1,
-): AgentToolResult<Details> | undefined {
-	if (chatProgress.mode !== "live-card") return undefined;
+): AgentToolResult<Details> {
+	// chatProgress controls the TUI projection, not transport-level progress.
 	return {
 		content: [{ type: "text", text: "Workflow running." }],
 		details: { mode: "workflow", runId, results: [], workflow, ...(preflight ? { preflight } : {}), ...(workflowChildren ? { workflowChildren } : {}), chatProgress },
@@ -5601,8 +5601,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const workflowDeadlineAt = timeout === undefined ? undefined : Date.now() + timeout;
 			const workflowCapabilityCeiling = intersectSubagentCapabilityCeilings(requestParams.capabilityCeiling, resolveCurrentSubagentCapabilityCeiling(resolveCurrentSessionId(ctx.sessionManager)));
 			const sendWorkflowProgress = () => {
-				const update = workflowChatProgressUpdate(foregroundWorkflowRunId, chatProgress, liveWorkflow, liveWorkflowChildren, workflowPreflight);
-				if (update) onUpdate?.(update);
+				onUpdate?.(workflowProgressUpdate(foregroundWorkflowRunId, chatProgress, liveWorkflow, liveWorkflowChildren, workflowPreflight));
 			};
 			try {
 				const workflow = await runWorkflowScript({

--- a/test/unit/workflow-chat-progress.test.ts
+++ b/test/unit/workflow-chat-progress.test.ts
@@ -111,6 +111,68 @@ describe("workflow chat progress policy", () => {
 });
 
 describe("workflow chat progress rendering", () => {
+	for (const scenario of ["explicit off", "non-repository auto", "cross-repository auto"] as const) {
+		it(`emits foreground lifecycle updates before settlement with ${scenario}`, async () => {
+			const root = scenario === "non-repository auto"
+				? fs.mkdtempSync(path.join(os.tmpdir(), "pi-workflow-progress-headless-"))
+				: createRepo("pi-workflow-progress-off-");
+			const other = scenario === "cross-repository auto" ? createRepo("pi-workflow-progress-cross-") : undefined;
+			try {
+				const updates: Details[] = [];
+				let settled = false;
+				const result = await createExecutor().execute(
+					"wf-headless",
+					{
+						workflowScript: `return await runs.run("scout", { agent: "missing-agent", task: "scan" });`,
+						async: false,
+						chatProgress: scenario === "explicit off" ? "off" : "auto",
+						...(other ? { cwd: other } : {}),
+					},
+					new AbortController().signal,
+					(update) => {
+						assert.equal(settled, false);
+						updates.push(structuredClone(update.details));
+					},
+					ctx(root),
+				).then((result) => { settled = true; return result; });
+				assert.equal(result.isError, true);
+				assert.ok(updates.every((details) => details.chatProgress?.mode === "off"));
+				const started = updates.find((details) => details.workflowChildren?.children[0]?.state === "running");
+				assert.ok(started, "expected running child inventory before failure");
+				assert.equal(started.mode, "workflow");
+				assert.equal(started.runId, result.details.runId);
+				assert.equal(started.workflowChildren?.parentToolCallId, "wf-headless");
+				assert.equal(started.workflowChildren?.workflowRunId, result.details.runId);
+				assert.equal(started.workflowChildren?.inventoryComplete, false);
+				assert.equal(started.workflow?.trace[0]?.key, "scout");
+				assert.ok(updates.some((details) => details.workflow?.trace.some((entry) => entry.state === "failed")));
+				assert.equal(result.details.workflowChildren?.inventoryComplete, true);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+				if (other) fs.rmSync(other, { recursive: true, force: true });
+			}
+		});
+	}
+
+	it("emits headless workflow values before returning final output without an update callback requirement", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-workflow-progress-emits-"));
+		try {
+			const updates: Details[] = [];
+			const params = { workflowScript: `emit({ phase: "checking" }); return "done";`, async: false, chatProgress: "off" as const };
+			const result = await createExecutor().execute("wf-emits", params, undefined, (update) => {
+				assert.equal(update.details.workflow?.value, undefined);
+				updates.push(structuredClone(update.details));
+			}, ctx(root));
+			assert.ok(updates.some((details) => details.workflow?.emits.some((value) => (value as { phase?: string }).phase === "checking")));
+			assert.equal(result.details.workflow?.value, "done");
+			assert.equal(result.isError, undefined);
+			const withoutCallback = await createExecutor().execute("wf-no-callback", params, undefined, undefined, ctx(root));
+			assert.equal(withoutCallback.details.workflow?.value, "done");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("emits live-card updates with bounded workflow ids", async () => {
 		const repo = createRepo("pi-workflow-progress-executor-");
 		const toolCallId = `wf-live-${"x".repeat(300)}`;


### PR DESCRIPTION
## Summary
- emit synchronous workflow lifecycle updates through the foreground callback even when the live chat card is off
- keep live-card rendering policy separate from RPC/headless transport
- document lifecycle-only scope and credit @yanqianglu for #1951

Closes #1951.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-chat-progress.test.ts`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-chat-progress.test.ts test/unit/scripted-workflow.test.ts test/unit/workflow-preflight.test.ts test/unit/workflow-receipt.test.ts`
- `npm run typecheck`
- `git diff --check`