### PR TITLE
fix(tui): keep async widget order stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Document steer delivery modes and `scheduledRuns.storeRoot` in the bundled skill reference (`execution-controls.md`) (#1933). Thanks to [@G0-0000](https://github.com/G0-0000).
 
 ### Fixed
+- Keep the async status widget in place across progress updates instead of re-registering it behind other extensions' widgets (#1931). Thanks to [@DraconDev](https://github.com/DraconDev).
 - Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).
 - Recognize raw `REQUEST_LIMIT_EXCEEDED` rate limits and keep context-overflow errors out of the model exclusion cache (#1955, #1957). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).
 - Emit synchronous workflow progress updates for RPC/headless and cross-repository hosts even when the live chat card is off (#1951). Thanks to [@yanqianglu](https://github.com/yanqianglu).

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -2722,16 +2722,29 @@ function fitAdaptiveWidgetLines(jobs: AsyncJobState[], buildLines: () => string[
 	return rendered.lines;
 }
 
-function buildWidgetComponent(jobs: AsyncJobState[], isExpanded: () => boolean): (_tui: unknown, theme: Theme) => Component {
-	return (_tui, theme) => {
+const asyncWidgetUpdates = new WeakMap<ExtensionContext["ui"], (jobs: AsyncJobState[]) => void>();
+
+function buildWidgetComponent(jobs: AsyncJobState[], ui: ExtensionContext["ui"]): (tui: { requestRender(): void }, theme: Theme) => Component {
+	return (tui, theme) => {
 		const container = new Container();
 		let cachedRenderWidth: number | undefined;
 		let cachedFrame: number | undefined;
 		let cachedExpanded: boolean | undefined;
 		let cachedLines: string[] | undefined;
+		const update = (nextJobs: AsyncJobState[]): void => {
+			jobs = nextJobs;
+			cachedLines = undefined;
+			tui.requestRender();
+		};
+		asyncWidgetUpdates.set(ui, update);
+		const component = Object.assign(container, {
+			dispose(): void {
+				if (asyncWidgetUpdates.get(ui) === update) asyncWidgetUpdates.delete(ui);
+			},
+		});
 		container.render = (renderWidth: number): string[] => {
 			const frame = Math.floor(Date.now() / WIDGET_ANIMATION_INTERVAL_MS);
-			const expanded = isExpanded();
+			const expanded = ui.getToolsExpanded?.() ?? false;
 			if (cachedLines && cachedRenderWidth === renderWidth && cachedFrame === frame && cachedExpanded === expanded) return cachedLines;
 			const width = Math.max(0, renderWidth - 2);
 			const projectionFor = workflowWidgetProjectionLookup();
@@ -2746,7 +2759,7 @@ function buildWidgetComponent(jobs: AsyncJobState[], isExpanded: () => boolean):
 			cachedLines = fitAdaptiveWidgetLines(jobs, buildLines, theme, width, expanded, frame, projectionFor).map((line) => paddedWidgetLine(line, renderWidth));
 			return cachedLines;
 		};
-		return container;
+		return component;
 	};
 }
 
@@ -2841,6 +2854,7 @@ export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = ge
 export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void {
 	if (jobs.length === 0) {
 		resetWidgetLayoutSession();
+		asyncWidgetUpdates.delete(ctx.ui);
 		if (ctx.hasUI) ctx.ui.setWidget(WIDGET_KEY, undefined);
 		return;
 	}
@@ -2849,7 +2863,11 @@ export function renderWidget(ctx: ExtensionContext, jobs: AsyncJobState[]): void
 		ctx.ui.setWidget(WIDGET_KEY, encodeAsyncStatusSnapshotWidget(jobs));
 		return;
 	}
-	ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, () => ctx.ui.getToolsExpanded?.() ?? false));
+	// Pi replaces a widget by deleting and reinserting its key. Update the mounted
+	// component instead so progress cannot move it past other extensions' widgets.
+	const update = asyncWidgetUpdates.get(ctx.ui);
+	if (update) update(jobs);
+	else ctx.ui.setWidget(WIDGET_KEY, buildWidgetComponent(jobs, ctx.ui));
 }
 
 function renderSingleCompact(

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -91,6 +91,56 @@ function resetWidgetLayout(): void {
 }
 
 describe("subagent async widget rendering", () => {
+	it("updates the mounted async widget without changing host insertion order", () => {
+		type Widget = { render(width: number): string[]; dispose?(): void };
+		const widgets = new Map<string, Widget>();
+		let registrations = 0;
+		let renderRequests = 0;
+		const tui = { requestRender: () => { renderRequests += 1; } };
+		const ctx = {
+			hasUI: true,
+			ui: {
+				// Pi 0.85 setExtensionWidget disposes/deletes before inserting.
+				setWidget(key: string, factory: ((tui: typeof tui, theme: typeof theme) => Widget) | undefined) {
+					widgets.get(key)?.dispose?.();
+					widgets.delete(key);
+					if (factory) {
+						registrations += 1;
+						widgets.set(key, factory(tui, theme));
+					}
+				},
+			},
+		};
+		const job = { asyncId: "same-run", asyncDir: "/tmp/run", status: "running", agents: ["before-update"] };
+		const originalNow = Date.now;
+		try {
+			Date.now = () => 1_000;
+			renderWidget(ctx, [job]);
+			const mounted = widgets.get("subagent-async")!;
+			assert.match(mounted.render(180).join("\n"), /before-update/);
+			ctx.ui.setWidget("other-extension", () => ({ render: () => ["other"] }));
+			for (const agent of ["after-update", "latest-update"]) {
+				renderWidget({ ...ctx }, [{ ...job, agents: [agent] }]);
+				assert.deepEqual([...widgets.keys()], ["subagent-async", "other-extension"]);
+				assert.equal(widgets.get("subagent-async"), mounted);
+				assert.match(mounted.render(180).join("\n"), new RegExp(agent), "same-frame cache must be invalidated");
+			}
+			assert.equal(registrations, 2, "progress must not re-register either widget");
+			assert.equal(renderRequests, 2, "each update requests a repaint without a timer");
+
+			ctx.ui.setWidget("subagent-async", undefined);
+			renderWidget(ctx, [job]);
+			assert.notEqual(widgets.get("subagent-async"), mounted, "host disposal allows remounting");
+			renderWidget(ctx, []);
+			assert.deepEqual([...widgets.keys()], ["other-extension"]);
+			renderWidget(ctx, [job]);
+			assert.ok(widgets.has("subagent-async"), "cleared widgets can mount again");
+		} finally {
+			Date.now = originalNow;
+			renderWidget(ctx, []);
+		}
+	});
+
 	it("renders compact workflow lanes by default and keeps details expanded", () => {
 		const job = {
 			asyncId: "a6b9aa6b-workflow",


### PR DESCRIPTION
Refs #1931. Partial bounded fix: keep the async status widget mounted across progress updates so Pi 0.85 does not delete/reinsert `subagent-async` behind unrelated extension widgets.

This does not claim to fix the separate unproven duplicate transcript panel report; #1931 should remain open for screenshot/tool-call identity evidence on that part.

Thanks to [@DraconDev](https://github.com/DraconDev) for reporting the widget reorder symptom.

Validation:
- `node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/render-widget.test.ts test/integration/render-fork-badge.test.ts test/integration/async-job-tracker.test.ts`
- `npm run typecheck`
- `git diff --check`