### PR TITLE
fix(models): avoid caching request-shape failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Keep the async status widget in place across progress updates instead of re-registering it behind other extensions' widgets (#1931). Thanks to [@DraconDev](https://github.com/DraconDev).
+- Avoid caching request-shape provider errors as unhealthy model exclusions (#1955). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).
 - Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).
 - Recognize raw `REQUEST_LIMIT_EXCEEDED` rate limits and keep context-overflow errors out of the model exclusion cache (#1955, #1957). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).
 - Emit synchronous workflow progress updates for RPC/headless and cross-repository hosts even when the live chat card is off (#1951). Thanks to [@yanqianglu](https://github.com/yanqianglu).

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -609,8 +609,13 @@ export function isRetryableModelFailureAttempt(input: { error: string | undefine
 	return Boolean(error && input.messages?.some((message) => messageError(message)?.trim() === error));
 }
 
+// Request-shape failures can match broad fallback signals such as "upstream",
+// but do not establish that the model is unhealthy for subsequent requests.
+const REQUEST_SHAPE_FAILURE_PATTERN = /\b(?:bad[ _]request|invalid[ _]argument|invalid_request_error)\b/i;
+
 export function recordRetryableModelFailure(model: string | undefined, error: string | undefined): void {
-	if (!model || !isRetryableModelFailure(error) || isContextOverflow(error)) return;
+	if (!model || !error || !isRetryableModelFailure(error) || isContextOverflow(error)) return;
+	if (REQUEST_SHAPE_FAILURE_PATTERN.test(error)) return;
 	const { provider, modelId } = parseModelKey(model);
 	recordModelFailure({ modelId, reason: error, ...(provider ? { provider } : {}) });
 }

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -212,6 +212,39 @@ describe("model fallback helpers", () => {
 		assert.equal(getExcludedCount(), 0);
 	});
 
+	it("does not cache the reported Databricks tool-message request error (issue #1955)", () => {
+		const model = "databricks/databricks-kimi-k3";
+		const error = 'Databricks error: {"error_code":"BAD_REQUEST","message":"{\\"error\\":\\"Upstream error: INVALID_ARGUMENT: Kimi K3 tool messages need a resolvable tool name: carry `tool`/`name`, or match a preceding assistant tool_call by order.\\"}"}';
+		assert.equal(isRetryableModelFailure(error), true);
+		const messages = [{ role: "assistant", errorMessage: error }];
+		assert.equal(isRetryableModelFailureAttempt({ error, messages, toolCount: 0 }), true);
+		assert.equal(isRetryableModelFailureAttempt({ error, messages, toolCount: 1 }), false);
+		recordRetryableModelFailure(model, error);
+		assert.equal(findModelExclusion(model), undefined);
+		assert.equal(getExcludedCount(), 0);
+		assert.deepEqual(buildModelCandidates(model, undefined, undefined), [model]);
+	});
+
+	it("does not cache request-shape errors despite retryable upstream prose", () => {
+		for (const error of [
+			"Bad Request: upstream rejected the request",
+			"BAD_REQUEST: upstream rejected the request",
+			"INVALID_ARGUMENT: upstream rejected the request",
+			"invalid_request_error: upstream rejected the request",
+		]) {
+			assert.equal(isRetryableModelFailure(error), true, error);
+			recordRetryableModelFailure("openai/gpt-5-mini", error);
+			assert.equal(getExcludedCount(), 0, error);
+		}
+	});
+
+	it("still caches rate limits that mention numeric request quotas", () => {
+		const error = "rate limit exceeded: 400 requests per minute";
+		recordRetryableModelFailure("openai/gpt-5-mini", error);
+		assert.equal(findModelExclusion("openai/gpt-5-mini")?.reason, error);
+		assert.equal(getExcludedCount(), 1);
+	});
+
 	it("still caches raw request limits and per-minute input-token rate quotas", () => {
 		for (const error of [
 			"REQUEST_LIMIT_EXCEEDED",


### PR DESCRIPTION
Closes #1955.

Stop recording request-shape provider failures as unhealthy model exclusions when the error is a BAD_REQUEST / INVALID_ARGUMENT / invalid_request_error envelope whose only retryable signal is broad upstream prose.

This is cache-only. It does not change runtime fallback-after-tools policy, TTL defaults/configuration, provider serialization, or existing persisted exclusions.

Thanks to [@slyons-vamp](https://github.com/slyons-vamp) for the exact Databricks/Kimi failure payload and classification report.

Validation:
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts test/unit/model-exclusions.test.ts`
- `npm run typecheck`
- `git diff --check`

Review:
- Fresh review found one valid numeric-400 overreach; fixed by removing the bare numeric 400 guard and adding a positive rate-limit quota regression.
