### PR TITLE
fix(status): inspect live foreground transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 - Return `invalid_state` instead of queuing unreachable workflow stop requests when live workflow controllers are unavailable (#1965).
 - Forward bounded live tool activity, timing, model/effort, and counters for synchronous workflow children without forwarding transcripts (#1964).
+- Allow `action: "status", view: "transcript"` to inspect bounded live foreground child artifacts on demand (#1963).
 - Keep the async status widget in place across progress updates instead of re-registering it behind other extensions' widgets (#1931). Thanks to [@DraconDev](https://github.com/DraconDev).
 - Avoid caching request-shape provider errors as unhealthy model exclusions (#1955). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).
 - Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -2,12 +2,14 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { safeTerminalText } from "../../shared/display-text.ts";
+import { getArtifactPaths, getArtifactsDir } from "../../shared/artifacts.ts";
+import { readFleetTranscript } from "../../tui/fleet-transcript.ts";
 import { formatAsyncRunList, formatAsyncRunOutputPath, formatAsyncRunProgressLabel, formatWorkflowStageLine, listAsyncRuns } from "./async-status.ts";
 import { formatAsyncResultTranscript, formatAsyncRunTranscript, formatNestedRunTranscript, inspectSubagentFleet } from "./fleet-view.ts";
 import { formatNestedRunStatusLines } from "../shared/nested-render.ts";
 import { formatModelThinking } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
-import { DIRS, type AsyncStatus, type Details, type ForegroundResumeRun, type NestedRunSummary, type SteeringStatus, type SubagentState } from "../../shared/types.ts";
+import { DIRS, type AsyncStatus, type Details, type ForegroundRunControl, type ForegroundResumeRun, type NestedRunSummary, type SteeringStatus, type SubagentState } from "../../shared/types.ts";
 import { inspectActiveAsyncCapacityOwner, type ActiveAsyncCapacityInspection } from "./active-async-capacity.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { resolveSubagentIntercomTarget } from "../../intercom/intercom-bridge.ts";
@@ -242,6 +244,54 @@ function formatRememberedForegroundStatus(run: ForegroundResumeRun): string {
 	return lines.join("\n");
 }
 
+/** Request-only snapshot of the same artifact used by Fleet; no session or output fallback. */
+function formatLiveForegroundTranscript(control: ForegroundRunControl, state: SubagentState, options: { index?: number; lines?: number }): string {
+	if (!state.currentSessionId || control.sessionId !== state.currentSessionId) {
+		throw new Error(`Foreground run '${control.runId}' is not owned by the current session.`);
+	}
+	if (options.index !== undefined && (!Number.isInteger(options.index) || options.index < 0)) {
+		throw new Error("Transcript index must be a non-negative integer.");
+	}
+	const children = control.activeChildren
+		? [...control.activeChildren.values()]
+		: control.currentAgent ? [{ index: control.currentIndex ?? 0, agent: control.currentAgent, sessionName: control.sessionName }] : [];
+	const header = [`Run: ${control.runId}`, "State: live foreground"];
+	if (children.length === 0) return `${header.map((line) => safeTerminalText(line)).join("\n")}\nTranscript unavailable: no active foreground child.`;
+	if (options.index === undefined && children.length > 1) {
+		throw new Error(`Transcript view requires index for foreground run '${control.runId}'. Active child indexes: ${children.map((child) => child.index).join(", ")}.`);
+	}
+	const child = options.index === undefined ? children[0]! : children.find((child) => child.index === options.index);
+	if (!child) throw new Error(`Transcript index ${options.index} is not an active foreground child of '${control.runId}'.`);
+	const root = getArtifactsDir(state.parentSessionFile ?? null, control.cwd ?? state.baseCwd, state.artifactDirPreference);
+	const transcriptPath = getArtifactPaths(root, control.runId, child.agent, child.index).transcriptPath;
+	const transcript = readFleetTranscript(transcriptPath, { trustedRoots: [root] });
+	const lineLimit = Number.isFinite(options.lines) ? Math.max(1, Math.min(500, Math.trunc(options.lines!))) : 80;
+	const allLines = transcript.events.flatMap((event) => {
+		const text = event.kind === "tool"
+			? [`Tool: ${event.name} (${event.status})`, event.argsPayload ?? event.args, event.output ?? event.error].filter(Boolean).join("\n")
+			: event.kind === "notice" ? event.text : `${event.kind === "assistant" ? "Assistant" : "Supervisor"}: ${event.text}`;
+		return text.split(/\r?\n/);
+	});
+	let body = allLines.slice(-lineLimit).join("\n");
+	let truncated = transcript.truncated || allLines.length > lineLimit
+		|| transcript.events.some((event) => event.kind === "tool" && event.outputTruncated)
+		|| body.includes("… message truncated");
+	const maxOutputBytes = 32 * 1024;
+	const bytes = Buffer.from(body);
+	if (bytes.length > maxOutputBytes) {
+		// Skip UTF-8 continuation bytes at the beginning of the bounded tail.
+		let start = bytes.length - maxOutputBytes;
+		while ((bytes[start]! & 0xc0) === 0x80) start++;
+		body = bytes.subarray(start).toString("utf-8");
+		truncated = true;
+	}
+	header.push(`Child: ${child.index} (${child.sessionName?.trim() || child.agent})`, `Transcript: ${transcriptPath}`);
+	if (transcript.warning) header.push(`Transcript warning: ${transcript.warning}`);
+	header.push(`Live transcript tail${truncated ? " (tail truncated)" : ""}:`);
+	if (!body) header.push("Transcript unavailable: no readable activity in the bounded artifact tail yet.");
+	return [...header.map((line) => safeTerminalText(line)), body].filter(Boolean).join("\n");
+}
+
 function formatRememberedForegroundTranscript(run: ForegroundResumeRun, options: { index?: number; lines?: number }): string {
 	let index = options.index;
 	if (index !== undefined && !Number.isInteger(index)) throw new Error("Transcript index must be an integer.");
@@ -314,6 +364,12 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 		return inspectSubagentFleet(params, { asyncDirRoot, resultsDir, kill: deps.kill, now: deps.now, state: deps.state, childSafe: Boolean(deps.nested) });
 	}
 	if (!params.id && !params.runId && !params.dir) {
+		if (params.view === "transcript" && deps.state?.currentSessionId) {
+			const controls = [...deps.state.foregroundControls.values()].filter((control) => control.sessionId === currentSessionId);
+			const foreground = controls.find((control) => control.runId === deps.state?.lastForegroundControlId)
+				?? controls.sort((left, right) => right.updatedAt - left.updatedAt)[0];
+			if (foreground) return inspectSubagentStatus({ ...params, id: foreground.runId }, deps);
+		}
 		if (deps.nested) {
 			return {
 				content: [{ type: "text", text: "Child-safe subagent status requires an id when no foreground run is active." }],
@@ -354,6 +410,13 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 		} else if (!params.dir && requestedId) {
 			const resolved = resolveSubagentRunId(requestedId, { asyncDirRoot, resultsDir, state: deps.state, nested: deps.nested });
 			if (resolved?.kind === "foreground") {
+				const control = deps.state?.foregroundControls.get(resolved.id);
+				if (control && deps.state && params.view === "transcript") {
+					return {
+						content: [{ type: "text", text: formatLiveForegroundTranscript(control, deps.state, params) }],
+						details: { mode: "management", results: [] },
+					};
+				}
 				const run = deps.state?.foregroundRuns?.get(resolved.id);
 				if (run) {
 					try {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -6123,7 +6123,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					}
 					return withBudget(inspectSubagentStatus(paramsWithResolvedCwd, omitUndefinedProperties({ state: deps.state, nested: nestedScope, sessionRoots, abandonedSlotReleaseAfterMs: resolveAbandonedSlotReleaseAfterMs(deps.config.capacity?.abandonedSlotReleaseAfterMs) })));
 				}
-				if (paramsWithResolvedCwd.view === "fleet") {
+				if (paramsWithResolvedCwd.view === "fleet" || paramsWithResolvedCwd.view === "transcript") {
 					return withBudget(inspectSubagentStatus(paramsWithResolvedCwd, omitUndefinedProperties({ state: deps.state, nested: nestedScope, sessionRoots, abandonedSlotReleaseAfterMs: resolveAbandonedSlotReleaseAfterMs(deps.config.capacity?.abandonedSlotReleaseAfterMs) })));
 				}
 				if (targetRunId) {
@@ -6132,12 +6132,6 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						if (resolved?.kind === "foreground") {
 							const foreground = getForegroundControl(deps.state, resolved.id);
 							if (foreground) {
-								if (paramsWithResolvedCwd.view === "transcript") {
-									return withBudget({
-										content: [{ type: "text", text: "Live foreground transcript is already visible in the expanded running subagent result. Persisted session transcript becomes inspectable after the foreground run completes when sessions are enabled." }],
-										details: { mode: "management", results: [] },
-									});
-								}
 								return withBudget(foregroundStatusResult(foreground));
 							}
 						}
@@ -6147,13 +6141,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					}
 				} else if (!hasDirectoryTarget) {
 					const foreground = getForegroundControl(deps.state, undefined);
-					if (foreground && paramsWithResolvedCwd.view !== "transcript") return withBudget(foregroundStatusResult(foreground));
-					if (foreground && paramsWithResolvedCwd.view === "transcript") {
-						return withBudget({
-							content: [{ type: "text", text: "Live foreground transcript is already visible in the expanded running subagent result. Pass an async run id to inspect a background transcript." }],
-							details: { mode: "management", results: [] },
-						});
-					}
+					if (foreground) return withBudget(foregroundStatusResult(foreground));
 				}
 				return withBudget(inspectSubagentStatus(paramsWithResolvedCwd, omitUndefinedProperties({ state: deps.state, nested: nestedScope, sessionRoots, abandonedSlotReleaseAfterMs: resolveAbandonedSlotReleaseAfterMs(deps.config.capacity?.abandonedSlotReleaseAfterMs) })));
 			}

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -9,6 +9,7 @@ import { createNestedRoute, findNestedControlResult, projectNestedEvents, readNe
 import type { ChildRuntimeConfig } from "../../src/runs/shared/child-runtime-config.ts";
 import { ASYNC_DIR, type SubagentState } from "../../src/shared/types.ts";
 import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
+import { getArtifactPaths, getArtifactsDir } from "../../src/shared/artifacts.ts";
 
 const routeRoots: string[] = [];
 const fanoutListenerCleanupKey = "__piSubagentFanoutChildNestedControlInboxCleanups";
@@ -164,8 +165,15 @@ describe("nested control routing", () => {
 		try {
 			const route = createNestedRun("nested-foreground");
 			const state = createState();
+			state.artifactDirPreference = "project";
+			const artifactRoot = getArtifactsDir(null, root, "project");
+			fs.mkdirSync(artifactRoot, { recursive: true });
+			fs.writeFileSync(getArtifactPaths(artifactRoot, "root-control", "orchestrator", 0).transcriptPath,
+				`${JSON.stringify({ recordType: "message", role: "assistant", text: "LIVE_FOREGROUND_ACTIVITY" })}\n`);
 			state.foregroundControls.set("root-control", {
 				runId: "root-control",
+				sessionId: "session",
+				cwd: root,
 				mode: "single",
 				startedAt: 1,
 				updatedAt: 1,
@@ -186,6 +194,12 @@ describe("nested control routing", () => {
 			const transcript = await createExecutor(state).execute("transcript", { action: "status", id: "root-control", index: 0, view: "transcript" }, new AbortController().signal, undefined, ctx(root));
 			assert.equal(transcript.isError, undefined);
 			assert.match(text(transcript), /^Transcript target: run root-control · child 0\nSpawn budget:/);
+			assert.match(text(transcript), /LIVE_FOREGROUND_ACTIVITY/);
+			for (const hasUI of [false, true]) {
+				const implicit = await createExecutor(state).execute("implicit-transcript", { action: "status", view: "transcript" }, new AbortController().signal, undefined, { ...ctx(root), hasUI });
+				assert.equal(implicit.isError, undefined);
+				assert.match(text(implicit), /LIVE_FOREGROUND_ACTIVITY/);
+			}
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -9,6 +9,7 @@ import { inspectSubagentStatus } from "../../src/runs/background/run-status.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 import { claimRunFanoutBatch, createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../../src/runs/shared/run-fanout-budget.ts";
 import { TEMP_ROOT_DIR, type SubagentState } from "../../src/shared/types.ts";
+import { getArtifactPaths, getArtifactsDir } from "../../src/shared/artifacts.ts";
 
 function errno(code: string): NodeJS.ErrnoException {
 	const error = new Error(code) as NodeJS.ErrnoException;
@@ -22,6 +23,80 @@ function textContent(result: ReturnType<typeof inspectSubagentStatus>): string {
 }
 
 describe("async run status inspection", () => {
+	it("inspects live foreground artifacts on demand with child selection, ownership and bounded tails", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-live-foreground-transcript-"));
+		try {
+			const artifactRoot = getArtifactsDir(null, root, "project");
+			fs.mkdirSync(artifactRoot, { recursive: true });
+			const control = {
+				runId: "live-foreground", sessionId: "current", mode: "parallel" as const, cwd: root, startedAt: 1, updatedAt: 1,
+				activeChildren: new Map([2, 5].map((index) => [index, { index, agent: "worker", startedAt: 1, updatedAt: 1 }])),
+			};
+			const state = {
+				baseCwd: root, currentSessionId: "current", artifactDirPreference: "project", asyncJobs: new Map(),
+				foregroundControls: new Map([[control.runId, control]]), lastForegroundControlId: control.runId,
+			} as unknown as SubagentState;
+			const deps = { state, asyncDirRoot: path.join(root, "runs"), resultsDir: path.join(root, "results") };
+			const file = getArtifactPaths(artifactRoot, control.runId, "worker", 5).transcriptPath;
+			const record = (text: string) => `${JSON.stringify({ recordType: "message", role: "assistant", text })}\n`;
+			fs.writeFileSync(file, record("first\nsecond\nthird"));
+			const inspect = (params = {}) => inspectSubagentStatus({ view: "transcript", ...params }, deps);
+			assert.match(textContent(inspect()), /requires index.*Active child indexes: 2, 5/);
+			const selected = inspect({ id: "live-fore", index: 5, lines: 2 });
+			assert.equal(selected.isError, undefined);
+			assert.match(textContent(selected), /Child: 5 \(worker\)/);
+			assert.match(textContent(selected), /tail truncated/);
+			assert.match(textContent(selected), /second\nthird$/);
+			assert.doesNotMatch(textContent(selected), /first/);
+			fs.appendFileSync(file, record("fresh activity"));
+			assert.match(textContent(inspect({ index: 5 })), /fresh activity/);
+			fs.appendFileSync(file, [
+				{ recordType: "tool_start", toolName: "bash", toolCallId: "tool-1", argsPreview: "pwd" },
+				{ recordType: "message", role: "toolResult", toolCallId: "tool-1", text: "tool output" },
+				{ recordType: "message", role: "user", text: "supervisor guidance" },
+			].map((event) => JSON.stringify(event) + "\n").join(""));
+			assert.match(textContent(inspect({ index: 5 })), /Tool: bash \(complete\)\npwd\ntool output\nSupervisor: supervisor guidance/);
+			assert.match(textContent(inspect({ index: 2 })), /Transcript unavailable/);
+			assert.doesNotMatch(textContent(inspect({ index: 2 })), /fresh activity/);
+			for (const index of [-1, 1.5, 99]) assert.equal(inspect({ index }).isError, true);
+			control.sessionId = "other";
+			assert.match(textContent(inspect({ id: control.runId, index: 5 })), /not owned by the current session/);
+			assert.doesNotMatch(textContent(inspect({ id: control.runId, index: 5 })), /fresh activity/);
+			state.currentSessionId = null;
+			assert.equal(inspect({ id: control.runId, index: 5 }).isError, true);
+			state.currentSessionId = control.sessionId = "current";
+			fs.writeFileSync(file, record("界".repeat(30_000)));
+			const bytes = textContent(inspect({ index: 5, lines: 500 }));
+			assert.match(bytes, /tail truncated/);
+			assert.ok(Buffer.byteLength(bytes.split("(tail truncated):\n")[1]!) <= 32 * 1024);
+			assert.doesNotMatch(bytes, /\uFFFD/);
+			fs.writeFileSync(file, Array.from({ length: 600 }, (_, index) => record(`record-${index}`)).join(""));
+			const records = textContent(inspect({ index: 5, lines: 100_000 }));
+			assert.match(records, /tail truncated/);
+			assert.equal(records.split("(tail truncated):\n")[1]!.split("\n").length, 240);
+			assert.doesNotMatch(records, /record-0\b/);
+			assert.match(records, /record-599/);
+			fs.writeFileSync(file, record("界\n".repeat(600)));
+			const lines = textContent(inspect({ index: 5, lines: 100_000 }));
+			assert.equal(lines.split("(tail truncated):\n")[1]!.split("\n").length, 500);
+			fs.writeFileSync(file, record("x".repeat(2 * 1024 * 1024)) + record("latest\u001b\u202e") + '{"partial":');
+			const tail = textContent(inspect({ index: 5 }));
+			assert.match(tail, /tail truncated/);
+			assert.match(tail, /latest/);
+			assert.doesNotMatch(tail, /[\u001b\u202e]/u);
+			fs.unlinkSync(file);
+			const outside = path.join(root, "outside.jsonl");
+			fs.writeFileSync(outside, record("OUTSIDE_SECRET"));
+			fs.symlinkSync(outside, file);
+			const refused = textContent(inspect({ index: 5 }));
+			assert.match(refused, /refused a symlink/);
+			assert.match(refused, /Transcript unavailable/);
+			assert.doesNotMatch(refused, /OUTSIDE_SECRET/);
+			control.activeChildren.clear();
+			assert.match(textContent(inspect()), /no active foreground child/);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
 	it("projects only published receipt references from result-only status", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-receipt-status-"));
 		try {


### PR DESCRIPTION
Closes #1963.

Adds bounded request-only transcript inspection for live foreground children through status transcript view. It reuses the Fleet transcript artifact reader, preserves current-session ownership checks, requires explicit child selection when needed, and removes the old TUI-only refusal path.

Validation:
- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/run-status.test.ts test/unit/nested-control.test.ts test/unit/fleet-transcript.test.ts test/unit/child-transcript.test.ts
- npm run typecheck
- git diff --check
