### PR TITLE
fix(rpc): fail closed for unreachable workflow stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Return `invalid_state` instead of queuing unreachable workflow stop requests when live workflow controllers are unavailable (#1965).
 - Keep the async status widget in place across progress updates instead of re-registering it behind other extensions' widgets (#1931). Thanks to [@DraconDev](https://github.com/DraconDev).
 - Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).
 - Recognize raw `REQUEST_LIMIT_EXCEEDED` rate limits and keep context-overflow errors out of the model exclusion cache (#1955, #1957). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).

--- a/src/extension/rpc.ts
+++ b/src/extension/rpc.ts
@@ -643,27 +643,10 @@ function stopAsyncRun(
 				message: `Stop requested for async run ${initialRunId}.`,
 			};
 		}
-		try {
-			deliverStopRequest({
-				asyncDir: location.asyncDir,
-				pid: initialStatus.pid,
-				kill: options.kill,
-				now: options.now,
-				source: "rpc-stop",
-				...(child ? { targetIndex: child.index, childId: child.id } : {}),
-			});
-		} catch (error) {
-			throw new SubagentRpcError("execution_failed", error instanceof Error ? error.message : String(error));
-		}
-		if (child) emitChildStopping(initialRunId, location.asyncDir, child);
-		return {
-			runId: initialRunId,
-			asyncDir: location.asyncDir,
-			previousState: initialStatus.state,
-			state: "stopping",
-			...(child ? { childId: child.id } : {}),
-			message: child ? `Stop requested for child ${child.id} in async run ${initialRunId}.` : `Stop requested for async run ${initialRunId}.`,
-		};
+		// Workflow controls live in-process; a persisted run directory cannot restore them.
+		throw new SubagentRpcError("invalid_state", child
+			? `Child '${child.id}' in workflow ${initialRunId} has no live stop callback available.`
+			: `Workflow ${initialRunId} has no live run controller available to stop.`);
 	}
 
 	let status;

--- a/test/unit/rpc.test.ts
+++ b/test/unit/rpc.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { consumeStopRequestPayload, stopRequestPath } from "../../src/runs/background/control-channel.ts";
+import { consumeStopRequestPayload, stopRequestPath, stopRequestsDir } from "../../src/runs/background/control-channel.ts";
 import {
 	SUBAGENT_RPC_PROTOCOL_VERSION,
 	SUBAGENT_RPC_READY_EVENT,
@@ -1037,7 +1037,7 @@ describe("subagent extension RPC bridge", () => {
 		}
 	});
 
-	it("stops reload-recovered workflows through the durable control channel", async () => {
+	for (const scenario of ["no-state", "empty-maps", "child-no-state", "child-controller-only", "child-callback-false", "run-callback-only"] as const) it(`rejects workflow stop without the required live control: ${scenario}`, async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-rpc-stop-workflow-"));
 		try {
 			const events = new FakeEvents();
@@ -1045,6 +1045,14 @@ describe("subagent extension RPC bridge", () => {
 			const resultsDir = path.join(root, "results");
 			const asyncDir = path.join(asyncRoot, "workflow-run");
 			let killCalls = 0;
+			const controller = new AbortController();
+			const calls: string[] = [];
+			const stopChild = (childId: string) => { calls.push(childId); return false; };
+			const childId = scenario.startsWith("child-") ? "worker" : undefined;
+			const state = scenario === "no-state" || scenario === "child-no-state" ? undefined : {
+				workflowControllers: new Map(scenario === "child-controller-only" || scenario === "child-callback-false" ? [["workflow-run", controller]] : []),
+				workflowChildStops: new Map(scenario === "child-callback-false" || scenario === "run-callback-only" ? [["workflow-run", stopChild]] : []),
+			} as SubagentState;
 			fs.mkdirSync(asyncDir, { recursive: true });
 			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
 				runId: "workflow-run",
@@ -1054,10 +1062,15 @@ describe("subagent extension RPC bridge", () => {
 				pid: 4242,
 				startedAt: 100,
 				lastUpdate: 100,
-				steps: [{ agent: "worker", status: "running", startedAt: 100 }],
+				steps: [
+					{ workflowKey: "worker", agent: "worker", status: "running", startedAt: 100 },
+					{ workflowKey: "sibling", agent: "worker", status: "running", startedAt: 100 },
+				],
 			}, null, 2), "utf-8");
+			const statusBefore = fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8");
 			const bridge = registerSubagentRpcBridge({
 				events,
+				state,
 				getContext: () => ctx(),
 				execute: async () => assert.fail("stop should not call executor"),
 				asyncDirRoot: asyncRoot,
@@ -1069,13 +1082,18 @@ describe("subagent extension RPC bridge", () => {
 				now: () => 150,
 			});
 
-			const reply = await request(events, "stop-workflow", "stop", { id: "workflow-run" });
+			const reply = await request(events, "stop-workflow", "stop", { id: "workflow-run", ...(childId ? { childId } : {}) });
 
-			assert.equal(reply.success, true);
-			assert.equal((reply as { data: { runId?: string; state?: string; message?: string } }).data.runId, "workflow-run");
-			assert.equal((reply as { data: { state?: string } }).data.state, "stopping");
-			assert.match((reply as { data: { message?: string } }).data.message ?? "", /Stop requested for async run workflow-run/);
-			assert.equal(consumeStopRequestPayload(asyncDir)?.type, "stop");
+			assert.equal(reply.success, false);
+			assert.equal((reply as { error: { code: string } }).error.code, "invalid_state");
+			assert.match((reply as { error: { message: string } }).error.message,
+				scenario === "child-callback-false" ? /not available to stop/ : childId ? /no live stop callback/ : /no live run controller/);
+			assert.equal(fs.existsSync(stopRequestPath(asyncDir)), false);
+			assert.equal(fs.existsSync(stopRequestsDir(asyncDir)), false);
+			assert.equal(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8"), statusBefore);
+			assert.equal(events.emitted.some(({ event }) => event === SUBAGENT_CHILD_STATUS_EVENT), false);
+			assert.equal(controller.signal.aborted, false);
+			assert.deepEqual(calls, scenario === "child-callback-false" ? ["worker"] : []);
 			assert.equal(killCalls, 0);
 
 			bridge.dispose();


### PR DESCRIPTION
Refs #1965.

Returns `invalid_state` when RPC workflow stop handling no longer has the required live callback or controller, instead of queuing an unreachable stop request and reporting false success. This intentionally does not implement durable restart recovery for orphaned workflow work.

Validation:
- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/rpc.test.ts test/unit/control-channel.test.ts
- npm run typecheck
- git diff --check
