### PR TITLE
fix(workflows): stream live child activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Return `invalid_state` instead of queuing unreachable workflow stop requests when live workflow controllers are unavailable (#1965).
+- Forward bounded live tool activity, timing, model/effort, and counters for synchronous workflow children without forwarding transcripts (#1964).
 - Keep the async status widget in place across progress updates instead of re-registering it behind other extensions' widgets (#1931). Thanks to [@DraconDev](https://github.com/DraconDev).
 - Avoid caching request-shape provider errors as unhealthy model exclusions (#1955). Thanks to [@slyons-vamp](https://github.com/slyons-vamp).
 - Wait for workflow-owned root result publication before declaring retained workflow resumes missing on Windows (#1906).

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -356,7 +356,7 @@ known, or for explicit emergency hotfix lanes.
 
 For watched same-repo workflows, pass `async:false` only when the parent must block until completion. That blocking mode also shows the live in-chat workflow card. `chatProgress` can force `off` or `live-card` when the automatic policy is not what you want. Blocking workflows default to a 30-minute timeout; async workflows have no default timeout. See the [tool reference](tool-reference.md) for the full parameter list.
 
-Synchronous workflows publish trace and `emit(...)` updates through the tool update callback regardless of `chatProgress`, including RPC/headless and cross-repository runs. These updates include `details.workflow` and `details.workflowChildren`; `chatProgress: "off"` disables the live card, not transport progress. This is workflow lifecycle progress, not a live child transcript.
+Synchronous workflows publish trace and `emit(...)` updates through the tool update callback regardless of `chatProgress`, including RPC/headless and cross-repository runs. These updates include `details.workflow` and `details.workflowChildren`; `chatProgress: "off"` disables the live card, not transport progress. Running foreground child rows additionally expose bounded `activity` (current tool, timing, and counters), plus resolved model/thinking when available, keyed by `childId`. Activity-only updates coalesce over 100 ms; lifecycle updates remain immediate. Activity clears when children settle, and is not persisted for async workflows. Tool names are limited to 256 UTF-8 bytes and each activity object is below 2 KiB (including JSON escaping); arguments and transcripts are not forwarded.
 
 The legacy `/chain`, `/parallel`, and `/run-chain` commands are not registered.
 

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -118,7 +118,7 @@ import { executeWorkflowHostCommand, resolveWorkflowHostOutputClaimPath, type Wo
 import { buildWorkflowReceipt, readWorkflowReceipt, workflowReceiptPath, resolveWorkflowReceiptResumeEntry, writeWorkflowReceipt, type WorkflowReceipt, type WorkflowReceiptState } from "../../workflows/workflow-receipt.ts";
 import { upsertHostStep, validHostStepNodes } from "../shared/host-step-status.ts";
 import { assertWorkflowLaneKey, normalizeWorkflowLaneMetadata } from "../shared/lane-metadata.ts";
-import { parseWorkflowChildSummary, workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
+import { parseWorkflowChildSummary, workflowChildProgress, workflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { resolveWorkflowChatProgress, type WorkflowChatProgressProjection } from "../../workflows/chat-progress.ts";
 import { annotateWorkflowPreflightTrace, formatWorkflowPreflight, formatWorkflowPreflightWarnings, normalizeWorkflowPreflight, workflowPreflightWarnings } from "../../workflows/workflow-preflight.ts";
 import {
@@ -5599,10 +5599,18 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					: publicExecution ? undefined : runHostCommand;
 			const workflowHostSteps = new Map<string, HostStepNode>();
 			let liveWorkflow: NonNullable<Details["workflow"]> = { trace: [], emits: [], console: [], ...(workflowResource ? { resource: workflowResource.provenance } : {}) };
-			let liveWorkflowChildren = workflowChildSummary({ parentToolCallId: _id, workflowRunId: foregroundWorkflowRunId, workflowState: "running", inventoryComplete: false });
+			const childProgress = new Map<string, ReturnType<typeof workflowChildProgress>>();
+			let activityTimer: ReturnType<typeof setTimeout> | undefined;
+			let lastProgressAt = 0;
+			let workflowProgressClosed = false;
 			const workflowDeadlineAt = timeout === undefined ? undefined : Date.now() + timeout;
 			const workflowCapabilityCeiling = intersectSubagentCapabilityCeilings(requestParams.capabilityCeiling, resolveCurrentSubagentCapabilityCeiling(resolveCurrentSessionId(ctx.sessionManager)));
 			const sendWorkflowProgress = () => {
+				if (workflowProgressClosed) return;
+				if (activityTimer) clearTimeout(activityTimer);
+				activityTimer = undefined;
+				lastProgressAt = Date.now();
+				const liveWorkflowChildren = workflowChildSummary({ parentToolCallId: _id, workflowRunId: foregroundWorkflowRunId, workflowState: "running", inventoryComplete: false, trace: liveWorkflow.trace, progress: childProgress });
 				onUpdate?.(workflowProgressUpdate(foregroundWorkflowRunId, chatProgress, liveWorkflow, liveWorkflowChildren, workflowPreflight));
 			};
 			try {
@@ -5621,7 +5629,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const projectedTrace = annotateWorkflowPreflightTrace(trace, workflowPreflight);
 						const preflightWarnings = workflowPreflightWarnings(workflowPreflight, trace);
 						liveWorkflow = { ...liveWorkflow, trace: projectedTrace, ...(preflightWarnings.length ? { preflightWarnings } : {}) };
-						liveWorkflowChildren = workflowChildSummary({ parentToolCallId: _id, workflowRunId: foregroundWorkflowRunId, workflowState: "running", inventoryComplete: false, trace });
+						for (const entry of trace) {
+							if (entry.operation === "run" && ["completed", "failed", "stopped", "detached"].includes(entry.state)) childProgress.delete(entry.key);
+						}
 						sendWorkflowProgress();
 					},
 					admit: (calls) => {
@@ -5677,6 +5687,15 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							return execute(randomUUID(), childRequest, workflowSignal, (update) => {
 								const progress = update.details.progress?.[0];
 								if (!progress) return;
+								if (onUpdate && !workflowProgressClosed) {
+									if (progress.status === "running") childProgress.set(key, workflowChildProgress(progress));
+									else childProgress.delete(key);
+									if (!activityTimer) {
+										const delay = 100 - (Date.now() - lastProgressAt);
+										if (delay <= 0) sendWorkflowProgress();
+										else activityTimer = setTimeout(sendWorkflowProgress, delay);
+									}
+								}
 								const progressStatus = progress.status === "completed" ? "completed" : progress.status === "failed" ? "failed" : "running";
 								recordMissionWorkflowChild(missionBinding, foregroundWorkflowRunId, key, {
 									status: progressStatus,
@@ -5757,6 +5776,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					isError: true,
 					details: compactOptional<Details>({ mode: "workflow", runId: foregroundWorkflowRunId, results: workflowDetailsResults(partial.children), ...(workflowPreflight ? { preflight: workflowPreflight } : {}), workflowChildren, totalChildUsage: sumResultsUsage(workflowResults), totalCost: sumResultsCost(workflowResults), usageBudget: usageBudgetState(workflowUsageBudget.budget, sumResultsCost(workflowResults)), workflow: { trace: finalPreflightTrace, emits: partial.emits, console: partial.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}), receipt }, chatProgress }),
 				}, workflowFanoutBudget));
+			} finally {
+				workflowProgressClosed = true;
+				if (activityTimer) clearTimeout(activityTimer);
+				childProgress.clear();
 			}
 		}
 		const directParams = requestParams;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -174,6 +174,19 @@ export interface WorkflowLaneMetadata {
 	outputPaths?: string[];
 }
 
+/** Bounded foreground activity; excludes tool arguments and transcript content. */
+export interface WorkflowChildActivity {
+	currentTool?: string;
+	currentToolStartedAt?: number;
+	lastActivityAt?: number;
+	durationMs?: number;
+	toolCount?: number;
+	turnCount?: number;
+	tokens?: number;
+	inputTokens?: number;
+	outputTokens?: number;
+}
+
 export interface WorkflowChildSummary {
 	version: 1;
 	parentToolCallId: string;
@@ -188,6 +201,8 @@ export interface WorkflowChildSummary {
 		sessionName?: string;
 		model?: string;
 		thinking?: string;
+		/** Present only while a synchronous foreground child is running. */
+		activity?: WorkflowChildActivity;
 		state: "pending" | "running" | "completed" | "failed" | "paused" | "stopped" | "rejected" | "detached";
 	}>;
 }

--- a/src/workflows/workflow-child-summary.ts
+++ b/src/workflows/workflow-child-summary.ts
@@ -1,9 +1,42 @@
-import type { AsyncStatus, WorkflowChildSummary } from "../shared/types.ts";
+import type { AgentProgress, AsyncStatus, WorkflowChildActivity, WorkflowChildSummary } from "../shared/types.ts";
 import type { WorkflowScriptChildResult, WorkflowScriptTraceEntry } from "./scripted-workflow.ts";
 
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const TERMINAL_STATES = new Set(["completed", "failed", "paused", "stopped", "rejected", "detached"]);
 const MAX_REQUIRED_ID_BYTES = 4_096;
+const ACTIVITY_COUNTERS = ["currentToolStartedAt", "lastActivityAt", "durationMs", "toolCount", "turnCount", "tokens", "inputTokens", "outputTokens"] as const;
+type WorkflowChildLiveProgress = WorkflowChildActivity & Pick<AgentProgress, "agent" | "sessionName" | "model" | "thinking">;
+
+export function workflowChildProgress(progress: AgentProgress): WorkflowChildLiveProgress {
+	return {
+		...workflowChildActivity(progress),
+		agent: bounded(progress.agent, 256) ?? "",
+		...(bounded(progress.sessionName, 256) ? { sessionName: progress.sessionName } : {}),
+		...(bounded(progress.model, 256) ? { model: progress.model } : {}),
+		...(bounded(progress.thinking, 32) ? { thinking: progress.thinking } : {}),
+	};
+}
+
+/** Fixed field count and a 256 UTF-8 byte tool name keep JSON activity below 2 KiB, including escaping. */
+export function workflowChildActivity(progress: WorkflowChildActivity): WorkflowChildActivity {
+	const activity: WorkflowChildActivity = {};
+	if (bounded(progress.currentTool, 256)) activity.currentTool = progress.currentTool;
+	for (const field of ACTIVITY_COUNTERS) {
+		const value = progress[field];
+		if (typeof value === "number" && Number.isFinite(value) && value >= 0) activity[field] = value;
+	}
+	return activity;
+}
+
+function parseActivity(value: unknown): WorkflowChildActivity | undefined {
+	if (value === undefined) return undefined;
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("workflowChildren child activity is invalid.");
+	const input = value as Record<string, unknown>;
+	for (const [key, value] of Object.entries(input)) {
+		if (key === "currentTool" ? !bounded(value, 256) : !ACTIVITY_COUNTERS.includes(key as typeof ACTIVITY_COUNTERS[number]) || typeof value !== "number" || !Number.isFinite(value) || value < 0) throw new Error("workflowChildren child activity is invalid.");
+	}
+	return { ...input } as WorkflowChildActivity;
+}
 
 function bounded(value: unknown, maxBytes: number): string | undefined {
 	if (typeof value !== "string" || !value.trim() || Buffer.byteLength(value, "utf8") > maxBytes) return undefined;
@@ -24,6 +57,8 @@ export function workflowChildSummary(input: {
 	trace?: WorkflowScriptTraceEntry[];
 	children?: WorkflowScriptChildResult[];
 	steps?: NonNullable<AsyncStatus["steps"]>;
+	/** In-memory snapshots from synchronous child callbacks, keyed by workflow key. */
+	progress?: ReadonlyMap<string, WorkflowChildLiveProgress>;
 }): WorkflowChildSummary {
 	const rows = new Map<string, WorkflowChildSummary["children"][number]>();
 	for (const entry of input.trace ?? []) {
@@ -83,6 +118,18 @@ export function workflowChildSummary(input: {
 			if (!TERMINAL_STATES.has(row.state)) rows.set(key, { ...row, state: input.workflowState === "stopped" ? "stopped" : "failed" });
 		}
 	}
+	for (const [key, progress] of input.progress ?? []) {
+		const row = rows.get(key);
+		if (!row || row.state !== "running") continue;
+		rows.set(key, {
+			...row,
+			...(bounded(progress.agent, 256) ? { agent: progress.agent } : {}),
+			...(bounded(progress.sessionName, 256) ? { sessionName: progress.sessionName } : {}),
+			...(bounded(progress.model, 256) ? { model: progress.model } : {}),
+			...(bounded(progress.thinking, 32) ? { thinking: progress.thinking } : {}),
+			activity: workflowChildActivity(progress),
+		});
+	}
 	return {
 		version: 1,
 		parentToolCallId: requiredId(input.parentToolCallId, "parentToolCallId"),
@@ -105,14 +152,16 @@ export function parseWorkflowChildSummary(value: unknown): WorkflowChildSummary 
 	const children = input.children.map((row): WorkflowChildSummary["children"][number] => {
 		if (!row || typeof row !== "object" || Array.isArray(row)) throw new Error("workflowChildren child row is invalid.");
 		const child = row as Record<string, unknown>;
-		if (Object.keys(child).some((key) => !["childId", "runId", "agent", "sessionName", "model", "thinking", "state"].includes(key))) throw new Error("workflowChildren child row has unsupported fields.");
+		if (Object.keys(child).some((key) => !["childId", "runId", "agent", "sessionName", "model", "thinking", "state", "activity"].includes(key))) throw new Error("workflowChildren child row has unsupported fields.");
 		if (typeof child.childId !== "string" || !KEY_PATTERN.test(child.childId)) throw new Error("workflowChildren childId is invalid.");
 		const state = child.state;
 		if (state !== "pending" && state !== "running" && state !== "completed" && state !== "failed" && state !== "paused" && state !== "stopped" && state !== "rejected" && state !== "detached") throw new Error("workflowChildren child state is invalid.");
 		for (const [field, maxBytes] of [["runId", 256], ["agent", 256], ["sessionName", 256], ["model", 256], ["thinking", 32]] as const) {
 			if (child[field] !== undefined && bounded(child[field], maxBytes) === undefined) throw new Error(`workflowChildren child ${field} is invalid.`);
 		}
-		return { childId: child.childId, state, ...(child.runId ? { runId: child.runId as string } : {}), ...(child.agent ? { agent: child.agent as string } : {}), ...(child.sessionName ? { sessionName: child.sessionName as string } : {}), ...(child.model ? { model: child.model as string } : {}), ...(child.thinking ? { thinking: child.thinking as string } : {}) };
+		const activity = parseActivity(child.activity);
+		if (activity && state !== "running") throw new Error("workflowChildren child activity requires running state.");
+		return { childId: child.childId, state, ...(activity ? { activity } : {}), ...(child.runId ? { runId: child.runId as string } : {}), ...(child.agent ? { agent: child.agent as string } : {}), ...(child.sessionName ? { sessionName: child.sessionName as string } : {}), ...(child.model ? { model: child.model as string } : {}), ...(child.thinking ? { thinking: child.thinking as string } : {}) };
 	});
 	if (new Set(children.map((child) => child.childId)).size !== children.length) throw new Error("workflowChildren has duplicate childId values.");
 	if (typeof input.parentToolCallId !== "string") throw new Error("workflowChildren.parentToolCallId is invalid.");

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -62,6 +62,36 @@ import { registerSubagentCapabilityCeiling } from "../../src/api/capability-ceil
 describe("single sync execution", { skip: !available ? "pi packages not available" : undefined }, () => {
 	installSingleExecutionHooks();
 
+	it("streams bounded concurrent synchronous workflow activity with chatProgress off", async () => {
+		for (const [task, tool] of [["Child A", "read"], ["Child B", "bash"]]) {
+			mockPi.onCall({ matchArgIncludes: task, steps: [
+				{ jsonl: Array.from({ length: 100 }, () => ({ type: "tool_execution_start", toolCallId: tool, toolName: tool, args: { secret: "not-forwarded" } })) },
+				{ delay: 450, jsonl: [events.toolEnd(tool)] },
+				{ delay: 250, jsonl: [events.assistantMessage("done")] },
+			] });
+		}
+		const updates: any[] = [];
+		const result = await makeExecutor([makeAgent("worker")]).execute("wf-activity", {
+			workflowScript: `return await runs.all([{ key: "a", agent: "worker", task: "Child A", async: false }, { key: "b", agent: "worker", task: "Child B", async: false }]);`,
+			async: false, chatProgress: "off",
+		}, undefined, (update) => updates.push(structuredClone(update.details)), makeMinimalCtx(tempDir));
+		assert.equal(result.isError, undefined, JSON.stringify(result.content));
+		for (const [key, tool] of [["a", "read"], ["b", "bash"]]) {
+			const row = updates.flatMap((update) => update.workflowChildren?.children ?? []).find((row) => row.childId === key && row.activity?.currentTool === tool);
+			assert.ok(row, `missing mid-run activity for ${key}`);
+			assert.equal(row.agent, "worker");
+			assert.ok(row.activity.durationMs >= 0);
+			assert.ok(row.activity.toolCount >= 1);
+			assert.equal(JSON.stringify(row).includes("not-forwarded"), false);
+		}
+		assert.ok(result.details.workflowChildren.children.every((row) => row.activity === undefined));
+		assert.ok(updates.length < 25, `burst was not coalesced: ${updates.length} updates`);
+		assert.ok(updates.some((update) => update.workflowChildren?.children.some((row) => row.activity && !row.activity.currentTool && row.activity.toolCount > 0)), "tool completion clears currentTool while running");
+		const count = updates.length;
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		assert.equal(updates.length, count, "no trailing timer after settlement");
+	});
+
 	it("spawns agent and captures output", async () => {
 		mockPi.onCall({ output: "Hello from mock agent" });
 		const agents = makeAgentConfigs(["echo"]);

--- a/test/unit/workflow-child-summary.test.ts
+++ b/test/unit/workflow-child-summary.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import { workflowChildActivity, workflowChildProgress, workflowChildSummary, parseWorkflowChildSummary } from "../../src/workflows/workflow-child-summary.ts";
+import type { AgentProgress } from "../../src/shared/types.ts";
+
+const progress = { agent: "worker", status: "running", model: "provider/model", thinking: "high", currentTool: "read", currentToolStartedAt: 100, lastActivityAt: 120, durationMs: 20, toolCount: 1, turnCount: 2, tokens: 10, inputTokens: 8, outputTokens: 2, task: "private", currentToolArgs: "private", recentOutput: ["private"] } as AgentProgress;
+const input = { parentToolCallId: "tool", workflowRunId: "wf", workflowState: "running" as const, inventoryComplete: false, trace: ["a", "b"].map((key) => ({ operation: "run" as const, key, state: "started" as const })) };
+
+it("projects independent bounded snapshots by stable key and clears terminal activity", () => {
+	const snapshots = new Map([["b", workflowChildProgress(progress)], ["a", workflowChildProgress({ ...progress, currentTool: "bash", toolCount: 9 })]]);
+	const summary = workflowChildSummary({ ...input, progress: snapshots });
+	assert.deepEqual(summary.children.map((row) => [row.childId, row.activity?.currentTool, row.activity?.toolCount]), [["a", "bash", 9], ["b", "read", 1]]);
+	assert.equal(summary.children[0].model, progress.model);
+	assert.equal(summary.children[0].thinking, "high");
+	assert.equal(JSON.stringify(summary).includes("private"), false);
+	assert.deepEqual(parseWorkflowChildSummary(summary), summary);
+	snapshots.set("a", workflowChildProgress({ ...progress, currentTool: undefined, currentToolStartedAt: undefined }));
+	assert.equal(workflowChildSummary({ ...input, progress: snapshots }).children[0].activity?.currentTool, undefined);
+	assert.equal(summary.children[0].activity?.currentTool, "bash", "published snapshots stay immutable");
+	assert.ok(workflowChildSummary({ ...input, inventoryComplete: true, workflowState: "failed", progress: snapshots }).children.every((row) => row.activity === undefined));
+});
+
+it("bounds UTF-8 and JSON bytes and rejects malformed activity strictly", () => {
+	assert.equal(workflowChildActivity({ currentTool: "界".repeat(86) }).currentTool, undefined);
+	assert.equal(workflowChildActivity({ currentTool: "界".repeat(85) }).currentTool?.length, 85);
+	const activity = workflowChildActivity({ ...progress, currentTool: "\u0000".repeat(256), tokens: Number.MAX_VALUE });
+	assert.ok(Buffer.byteLength(JSON.stringify(activity)) < 2048);
+	assert.deepEqual(workflowChildActivity({ tokens: NaN, toolCount: -1, durationMs: Infinity }), {});
+	const summary = workflowChildSummary({ ...input, progress: new Map([["a", workflowChildProgress(progress)]]) });
+	for (const invalid of [null, [], { tokens: -1 }, { tokens: Infinity }, { tokens: "1" }, { currentTool: "界".repeat(86) }, { recentOutput: [] }, { currentToolArgs: "secret" }]) {
+		assert.throws(() => parseWorkflowChildSummary({ ...summary, children: [{ ...summary.children[0], activity: invalid }] }), /activity/);
+	}
+	assert.throws(() => parseWorkflowChildSummary({ ...summary, children: [{ ...summary.children[0], state: "completed" }] }), /running state/);
+});


### PR DESCRIPTION
Closes #1964.

Streams bounded live activity snapshots for foreground children inside synchronous workflows. Rows stay keyed by workflow child id, expose current tool/timing/model/thinking/counters only, coalesce activity-only updates, and do not forward arguments, transcripts, polling, or async persistence.

Validation:
- node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/workflow-child-summary.test.ts test/unit/workflow-chat-progress.test.ts test/unit/rpc.test.ts test/unit/inspect-rpc.test.ts
- node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='streams bounded concurrent' test/integration/single-execution.part-1.test.ts
- npm run typecheck
- git diff --check
