### PR TITLE
test(ci): isolate Windows terminal-event control (temporary experiment)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,15 @@ jobs:
           node-version: 24
       - name: Install devDependencies
         run: npm ci --ignore-scripts
+      - name: Temporary Windows isolated control for issue 1906
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          NODE_DISABLE_COMPILE_CACHE: '1'
+        run: |
+          node -e 'console.log(JSON.stringify({node:process.version,platform:process.platform,arch:process.arch,commit:process.env.GITHUB_SHA,runnerOS:process.env.RUNNER_OS,runnerArch:process.env.RUNNER_ARCH,imageOS:process.env.ImageOS,imageVersion:process.env.ImageVersion}))'
+          Write-Output "Checkout commit: $(git rev-parse HEAD)"
+          node --experimental-strip-types --import ./test/support/register-loader.mjs --test --test-name-pattern='does not use shared-cwd sibling tracked edits as parallel completion-guard proof' test/integration/async-execution.part-3.test.ts
       - name: Typecheck
         run: npm run typecheck
       - name: Unit tests


### PR DESCRIPTION
Refs #1906. **Temporary diagnostic experiment. Do not merge.**

Run the existing shared-cwd terminal-event regression once on Windows before other test suites, with compile cache disabled. Record Node, runner image, and actual checkout identity. Existing checks, assertions, and timeouts remain unchanged.

Current main already passes this test in the full Windows suite. This isolated control compares the execution context; success does not establish a root cause or resolve #1906. No retries or production changes are included. Retain the CI evidence, then close this experiment without merging unless new evidence warrants a separately reviewed change.

Validation: fresh read-only review, YAML parsing and baseline structure comparison, exact single-test selection, and git diff --check. Native PowerShell execution is deferred to this CI run.
