### PR TITLE
fix: tolerate unconfigured prompt runtime loads

### DIFF
--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -441,7 +441,12 @@ function registerStructuredOutputTool(pi: ExtensionAPI, structured: NonNullable<
 }
 
 /** Register every child-side hook the prompt runtime owns for one child session. */
-export default function registerSubagentPromptRuntime(pi: ExtensionAPI, config: ChildRuntimeConfig): void {
+export default function registerSubagentPromptRuntime(pi: ExtensionAPI, config?: ChildRuntimeConfig): void {
+	// A path-based load has no ChildRuntimeConfig. This can happen if an
+	// ambient-extension discovery path finds the runtime module in addition to
+	// the configured inline factory. It must be inert rather than crashing the
+	// child before startup; the inline factory remains the real registration path.
+	if (!config) return;
 	registerRuntimeExtensionAcknowledgements(pi, config.runtimeAcknowledgements);
 	registerPermissionGate(pi, config.permissions, config.childWatchdog);
 	registerToolBudget(pi, config.toolBudget);

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -71,6 +71,10 @@ const PROMPT_WITH_EXPLICIT_SKILL = [
 const CONFIGURED_SKILLS_SECTION = "\n\nThe following configured skills are available to this subagent.\nUse the read tool to load a skill's file when the task matches its description.\nWhen a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.\n\n<available_skills>\n  <skill>\n    <name>configured-skill</name>\n    <description>explicit agent skill</description>\n    <location>/tmp/configured-skill/SKILL.md</location>\n  </skill>\n</available_skills>";
 
 describe("subagent prompt runtime", () => {
+	it("ignores an unconfigured path-based load", () => {
+		assert.doesNotThrow(() => registerSubagentPromptRuntime({} as never));
+	});
+
 	it("registers no permission hook by default and routes ask only to the watchdog arbiter", async () => {
 		const handlers: Array<(event: { toolName?: string; input?: unknown }, ctx?: unknown) => unknown> = [];
 		const pi = { on(event: string, handler: (event: { toolName?: string; input?: unknown }, ctx?: unknown) => unknown) { if (event === "tool_call") handlers.push(handler); } };


### PR DESCRIPTION
## Summary

- Make the child prompt-runtime extension tolerate being loaded without a `ChildRuntimeConfig`.
- Add a regression test for an unconfigured path-based load.

## Context

An async in-process child on Pi 0.85.0 with pi-subagents 0.65.1 failed before its first tool call with:

```
Cannot read properties of undefined (reading 'runtimeAcknowledgements')
```

The runtime is normally installed through the configured inline child hook. However, if extension discovery or reload also invokes the module as a path-based extension, that invocation has no runtime config. Returning without registering hooks keeps the accidental invocation inert while preserving the normal configured path.

This is intentionally defense-in-depth. The exact ambient-extension discovery/reload path still needs confirmation; the existing `child-launch.ts` filtering of known runtime paths remains unchanged.

Closes #1973.

## Validation

- `npm run typecheck`
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/subagent-prompt-runtime.test.ts` (50 passed)
- `git diff --check`
