### PR TITLE
fix(intercom): register supervisor asks that arrive while nothing polls

### DIFF
--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -563,7 +563,14 @@ function appendSupervisorReplyEntry(pi: ExtensionAPI, request: PendingSupervisor
 // would be a far wider change to the run-control surface.
 interface SupervisorAskResolver {
 	pending: Map<string, PendingSupervisorRequest>;
-	resolve: (request: PendingSupervisorRequest, message: string) => void;
+	/**
+	 * Publishes the reply the blocked child is polling for. Once this returns, the message HAS been
+	 * delivered, so it is kept separate from the bookkeeping that follows: a bookkeeping failure must
+	 * not make the caller believe the message still needs sending.
+	 */
+	publish: (request: PendingSupervisorRequest, message: string) => SupervisorReply;
+	/** Journal, dequeue, and attention updates. Safe to fail after the reply is already published. */
+	finalize: (request: PendingSupervisorRequest, reply: SupervisorReply) => void;
 }
 
 const supervisorAskResolvers = new Set<SupervisorAskResolver>();
@@ -588,13 +595,23 @@ export function resolvePendingSupervisorAskWithSteer(input: { runId: string; chi
 			&& candidate.childIndex === input.childIndex,
 		);
 		if (!request) continue;
+		let reply: SupervisorReply;
 		try {
-			resolver.resolve(request, message);
+			reply = resolver.publish(request, message);
 		} catch (error) {
-			// Fail closed and loud: report no resolution so the caller keeps its own delivery receipt
-			// (queued/failed) rather than claiming a delivery that did not happen.
+			// The reply was not published, so nothing was delivered. Fail closed and loud: report no
+			// resolution so the caller keeps its own delivery receipt (queued/failed) rather than
+			// claiming a delivery that did not happen.
 			console.error(`Failed to answer supervisor request ${request.id} from a steer:`, error);
 			return undefined;
+		}
+		// Past this point the child can already read the reply, so the steer HAS been delivered.
+		// A bookkeeping failure must not return undefined: the caller would fall back to child.steer
+		// and deliver the same instruction a second time.
+		try {
+			resolver.finalize(request, reply);
+		} catch (error) {
+			console.error(`Answered supervisor request ${request.id} from a steer, but failed to record it:`, error);
 		}
 		return { requestId: request.id, reason: request.reason };
 	}
@@ -760,8 +777,8 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	// consistent resolution.
 	const askResolver: SupervisorAskResolver = {
 		pending,
-		resolve: (request, message) => {
-			const reply = writeReply(request, message);
+		publish: (request, message) => writeReply(request, message),
+		finalize: (request, reply) => {
 			appendSupervisorReplyEntry(pi, request, reply);
 			observeRequestLifecycle(request, "resolved");
 			pending.delete(request.id);

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -391,8 +391,11 @@ function currentContextSessionId(state: Pick<SubagentState, "currentSessionId">,
 	return state.currentSessionId ?? undefined;
 }
 
-function requestMatchesContext(request: SupervisorRequest, state: Pick<SubagentState, "currentSessionId">, ctx: ExtensionContext): boolean {
-	const currentSessionId = currentContextSessionId(state, ctx);
+// `ctx` is optional: session ownership is a property of `state.currentSessionId`, not of the UI
+// context. A null or stale `lastUiContext` must never make an ask from this session look like it
+// belongs to another one, because that silently drops the ask instead of queueing it.
+function requestMatchesContext(request: SupervisorRequest, state: Pick<SubagentState, "currentSessionId">, ctx?: ExtensionContext): boolean {
+	const currentSessionId = ctx ? currentContextSessionId(state, ctx) : state.currentSessionId ?? undefined;
 	return Boolean(currentSessionId && request.orchestratorSessionId === currentSessionId);
 }
 
@@ -547,6 +550,57 @@ function appendSupervisorReplyEntry(pi: ExtensionAPI, request: PendingSupervisor
 	}
 }
 
+// A child parked in `contact_supervisor` is inside a tool call, so it has no turn boundary. An
+// in-memory steer for such a child can only be QUEUED, and that queue drains at a turn boundary
+// which never comes: the steer receipt claims delivery, the child never sees the message, and
+// `action:"stop"` cannot checkpoint a blocked tool call either. The supervisor channel is the one
+// path that reaches a child inside that tool call, because the child is already polling its reply
+// file. So when a steer targets a child that has a pending ask, deliver the steer AS the reply.
+//
+// This is a registry rather than a parameter because the only convergence point for the
+// workflow-child steer routes (`steerWorkflowForegroundTarget`) has no access to the channel
+// closure, and threading the pending map through every steer call site in subagent-executor.ts
+// would be a far wider change to the run-control surface.
+interface SupervisorAskResolver {
+	pending: Map<string, PendingSupervisorRequest>;
+	resolve: (request: PendingSupervisorRequest, message: string) => void;
+}
+
+const supervisorAskResolvers = new Set<SupervisorAskResolver>();
+
+export interface SupervisorAskSteerOutcome {
+	requestId: string;
+	reason: SupervisorReason;
+}
+
+/**
+ * If `runId`/`childIndex` names a child blocked on a supervisor ask, answer that ask with
+ * `message` and return the resolved request. Returns undefined when no ask is pending, in which
+ * case the caller must fall back to its normal steer delivery, so this never swallows a steer.
+ */
+export function resolvePendingSupervisorAskWithSteer(input: { runId: string; childIndex: number; message: string }): SupervisorAskSteerOutcome | undefined {
+	const message = input.message.trim();
+	if (!message) return undefined;
+	for (const resolver of supervisorAskResolvers) {
+		const request = [...resolver.pending.values()].find((candidate) =>
+			candidate.expectsReply
+			&& candidate.runId === input.runId
+			&& candidate.childIndex === input.childIndex,
+		);
+		if (!request) continue;
+		try {
+			resolver.resolve(request, message);
+		} catch (error) {
+			// Fail closed and loud: report no resolution so the caller keeps its own delivery receipt
+			// (queued/failed) rather than claiming a delivery that did not happen.
+			console.error(`Failed to answer supervisor request ${request.id} from a steer:`, error);
+			return undefined;
+		}
+		return { requestId: request.id, reason: request.reason };
+	}
+	return undefined;
+}
+
 function resolvePendingRequest(pending: Map<string, PendingSupervisorRequest>, params: IntercomParams): PendingSupervisorRequest {
 	if (params.replyTo) {
 		const request = pending.get(params.replyTo);
@@ -580,13 +634,20 @@ function publicPendingRequests(pending: Map<string, PendingSupervisorRequest>): 
 	}));
 }
 
-function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
+function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver, discover: () => void): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
 	return {
 		name: NATIVE_SUPERVISOR_TOOL_NAME,
 		label: "Subagent Supervisor",
 		description: "Native pi-subagents supervisor channel. Use reply/pending/status to answer child subagent requests without overriding pi-intercom.",
 		parameters: IntercomParamsSchema,
 		async execute(_id, params) {
+			// Scan the channel root before answering. `refreshPendingRequests` only re-evaluates asks
+			// ALREADY in `pending`; it never reads the filesystem. Because no fs watcher is installed on
+			// darwin and the 500ms poller is demand-gated and self-cancelling, an ask written while
+			// nothing was polling stayed invisible and every `action:"pending"` reported "No pending
+			// supervisor requests" while the child blocked in contact_supervisor. An explicit supervisor
+			// query must always be authoritative against disk.
+			discover();
 			refreshPendingRequests(pending, state, state.lastUiContext ?? undefined, onLifecycle);
 			const input = params as IntercomParams;
 			if (input.action === "status") {
@@ -690,7 +751,22 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 
 	const registerParentTools = (): void => {
-		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pi, pending, state, observeRequestLifecycle));
+		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pi, pending, state, observeRequestLifecycle, () => poll()));
+	};
+
+	// Expose this channel's ask queue to the steer routes so a steer can answer a child blocked
+	// inside contact_supervisor. Uses the same writeReply/journal/attention sequence as
+	// `action:"reply"` so the child, the transcript, and the attention state all see one
+	// consistent resolution.
+	const askResolver: SupervisorAskResolver = {
+		pending,
+		resolve: (request, message) => {
+			const reply = writeReply(request, message);
+			appendSupervisorReplyEntry(pi, request, reply);
+			observeRequestLifecycle(request, "resolved");
+			pending.delete(request.id);
+			clearForegroundSupervisorAttention(request, pending, state);
+		},
 	};
 
 	const cleanupStaleChannelsIfDue = (): void => {
@@ -706,8 +782,11 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 
 	const poll = (): void => {
 		cleanupStaleChannelsIfDue();
-		const ctx = state.lastUiContext;
-		if (!ctx) return;
+		// Registration must not require a live UI context. Returning early whenever
+		// `state.lastUiContext` was null (never set yet, or nulled by a stale-context error) meant an
+		// ask written by a child was never read off disk, so `subagent_supervisor({action:"pending"})`
+		// reported nothing. The queue is authoritative; only the display notification needs the context.
+		const ctx = state.lastUiContext ?? undefined;
 		refreshPendingRequests(pending, state, ctx, observeRequestLifecycle);
 		const now = Date.now();
 		for (const { channelDir, file } of listRequestFiles()) {
@@ -730,24 +809,30 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			else {
 				removeRequestFile(request.requestFile);
 			}
-			pi.sendMessage({
-				customType: SUPERVISOR_REQUEST_MESSAGE_TYPE,
-				content: requestVisibleText(request),
-				display: true,
-				details: {
-					id: request.id,
-					requestId: request.id,
-					reason: request.reason,
-					expectsReply: request.expectsReply,
-					runId: request.runId,
-					agent: request.agent,
-					childIndex: request.childIndex,
-					...(request.childTarget ? { childTarget: request.childTarget } : {}),
-					...(request.interview !== undefined ? { interview: request.interview } : {}),
-					requestBody: request.message,
-					...(request.expectsReply ? { replyHint: supervisorReplyHint(request.id) } : {}),
-				},
-			}, { triggerTurn: true });
+			// The ask is already queued above. A sendMessage failure (no UI, stale context) must not
+			// lose it, and must not abort the loop before the remaining asks register.
+			try {
+				pi.sendMessage({
+					customType: SUPERVISOR_REQUEST_MESSAGE_TYPE,
+					content: requestVisibleText(request),
+					display: true,
+					details: {
+						id: request.id,
+						requestId: request.id,
+						reason: request.reason,
+						expectsReply: request.expectsReply,
+						runId: request.runId,
+						agent: request.agent,
+						childIndex: request.childIndex,
+						...(request.childTarget ? { childTarget: request.childTarget } : {}),
+						...(request.interview !== undefined ? { interview: request.interview } : {}),
+						requestBody: request.message,
+						...(request.expectsReply ? { replyHint: supervisorReplyHint(request.id) } : {}),
+					},
+				}, { triggerTurn: true });
+			} catch (error) {
+				console.error(`Failed to surface supervisor request ${request.id} as a user turn:`, error);
+			}
 			if (request.expectsReply) {
 				(pi as { events?: IntercomEventBus }).events?.emit(INTERCOM_DETACH_REQUEST_EVENT, {
 					requestId: request.id,
@@ -827,6 +912,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		start: () => {
 			if (started) return;
 			started = true;
+			supervisorAskResolvers.add(askResolver);
 			registerParentTools();
 			poll();
 			try {
@@ -850,6 +936,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		},
 		dispose: () => {
 			started = false;
+			supervisorAskResolvers.delete(askResolver);
 			try {
 				rootWatcher?.close();
 			} catch {

--- a/src/runs/foreground/workflow-foreground-steering.ts
+++ b/src/runs/foreground/workflow-foreground-steering.ts
@@ -4,6 +4,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Details, ForegroundRunControl, SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { steeringReceipt } from "../background/steering.ts";
+import { resolvePendingSupervisorAskWithSteer } from "../../intercom/native-supervisor-channel.ts";
 import type { SteerDeliveryMode } from "../background/control-channel.ts";
 
 export interface WorkflowForegroundSteeringTarget {
@@ -91,6 +92,26 @@ export async function steerWorkflowForegroundTarget(input: {
 
 	const message = input.message.trim();
 	const requestId = randomUUID();
+
+	// A child blocked inside `contact_supervisor` has no turn boundary, so `child.steer` can only
+	// queue and that queue never drains. The supervisor channel is the only path into an open tool
+	// call, so if this child has a pending ask, answer the ask with the steer text. Checked BEFORE
+	// `child.steer` so the message is delivered exactly once.
+	const askOutcome = resolvePendingSupervisorAskWithSteer({ runId: control.runId, childIndex: index, message });
+	if (askOutcome) {
+		const steering = {
+			requestId,
+			state: "delivered" as const,
+			deliveryStatus: "delivered" as const,
+			sourceRunId,
+			targets: [{ index, state: "delivered" as const, deliveredAt: Date.now() }],
+		};
+		return {
+			content: [{ type: "text", text: steeringReceipt(message, `Steering delivered for foreground run ${control.runId} (request ${requestId}) by answering its open supervisor request ${askOutcome.requestId}; the child is unblocked.`) }],
+			details: { mode: "management", results: [], steering },
+		};
+	}
+
 	const outcome = await child.steer({ message, ...(input.mode && input.mode !== "steer" ? { mode: input.mode } : {}) });
 	const target = outcome.state === "delivered"
 		? { index, state: "delivered" as const, deliveredAt: Date.now() }

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -77,12 +77,13 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 	return requestId;
 }
 
-function makePi(options: { tools: Map<string, SupervisorTool>; onSend?: () => void }): Record<string, unknown> {
+function makePi(options: { tools: Map<string, SupervisorTool>; onSend?: () => void; onAppendEntry?: () => void }): Record<string, unknown> {
 	return {
 		getAllTools: () => [...options.tools.keys()].map((name) => ({ name })),
 		registerTool: (tool: { name: string } & SupervisorTool) => { options.tools.set(tool.name, tool); },
 		sendMessage: () => { options.onSend?.(); },
 		getSessionName: () => "shared-name",
+		...(options.onAppendEntry ? { appendEntry: () => { options.onAppendEntry!(); } } : {}),
 	};
 }
 
@@ -255,6 +256,57 @@ describe("supervisor ask registration", () => {
 			assert.equal(JSON.parse(fs.readFileSync(reply, "utf-8")).message, "RULING VIA STEER: proceed with option A.");
 			assert.equal(channel.pending.has(requestId), false, "the answered ask must leave the pending queue");
 		} finally {
+			channel.dispose();
+		}
+	});
+
+	// Once the reply file exists the child can read it, so the steer HAS been delivered. A failure in
+	// the bookkeeping that follows must not report "no resolution", because the caller would then also
+	// send the same instruction through child.steer and the child would receive it twice.
+	it("reports the delivery even when post-reply bookkeeping fails, and does not steer twice", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const queued: string[] = [];
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
+			queued.push(input.message);
+			return { state: "queued" as const };
+		});
+		// `clearForegroundSupervisorAttention` reads this map after the reply is already on disk.
+		// (`appendSupervisorReplyEntry` swallows its own errors, so it cannot stand in for this.)
+		// Armed only after registration, because the same map is read while the ask is being queued.
+		let failForegroundLookup = false;
+		state.foregroundRuns = {
+			get: () => {
+				if (failForegroundLookup) throw new Error("foreground state unavailable");
+				return undefined;
+			},
+		} as never;
+		const pi = makePi({ tools });
+		const channel = createNativeSupervisorChannel(pi as never, state, { platform: "darwin" });
+		const originalError = console.error;
+		console.error = () => {};
+
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId, runId: workflowRunId });
+			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+			assert.equal(channel.pending.has(requestId), true, "precondition: the child is blocked on a registered ask");
+			failForegroundLookup = true;
+
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const result = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "RULING VIA STEER: proceed.",
+			});
+
+			const reply = path.join(resolveSupervisorChannelDir(workflowRunId, "worker", 0), "replies", `${requestId}.json`);
+			assert.equal(fs.existsSync(reply), true, "precondition: the reply was published");
+			assert.equal(result.details.steering?.state, "delivered", "a published reply is a real delivery");
+			assert.deepEqual(queued, [], "the child must not also receive the message through child.steer");
+		} finally {
+			console.error = originalError;
 			channel.dispose();
 		}
 	});

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -1,0 +1,381 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, it } from "node:test";
+import {
+	NATIVE_SUPERVISOR_TOOL_NAME,
+	createNativeSupervisorChannel,
+	ensureSupervisorChannelDir,
+	registerNativeSupervisorClient,
+	resolveSupervisorChannelDir,
+} from "../../src/intercom/native-supervisor-channel.ts";
+import { steerWorkflowForegroundTarget } from "../../src/runs/foreground/workflow-foreground-steering.ts";
+import type { ForegroundSteerInput, SubagentState } from "../../src/shared/types.ts";
+
+const createdChannels: string[] = [];
+
+interface SupervisorTool {
+	execute: (id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }>;
+}
+
+function makeState(sessionId: string | null, ctx: unknown): SubagentState {
+	return {
+		baseCwd: process.cwd(),
+		currentSessionId: sessionId,
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: ctx as SubagentState["lastUiContext"],
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
+function makeCtx(sessionId: string): { cwd: string; hasUI: boolean; sessionManager: { getSessionId: () => string; getSessionFile: () => null; getEntries: () => [] } } {
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => null,
+			getEntries: () => [],
+		},
+	};
+}
+
+/**
+ * Write an ask directly to the channel the way a child's `contact_supervisor` call does, without
+ * going through a live poller. This is the state the wave-11 incident was in: the request file was
+ * on disk and no scan had happened yet.
+ */
+function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; reason?: "need_decision" | "progress_update" }): string {
+	const agent = input.agent ?? "worker";
+	const index = input.index ?? 0;
+	const channelDir = resolveSupervisorChannelDir(input.runId, agent, index);
+	createdChannels.push(channelDir);
+	ensureSupervisorChannelDir(channelDir);
+	const requestId = randomUUID();
+	const reason = input.reason ?? "need_decision";
+	fs.writeFileSync(path.join(channelDir, "requests", `${requestId}.json`), JSON.stringify({
+		type: "subagent.supervisor.request",
+		id: requestId,
+		createdAt: Date.now(),
+		reason,
+		message: input.message ?? "Need a decision",
+		expectsReply: reason !== "progress_update",
+		orchestratorSessionId: input.sessionId,
+		orchestratorTarget: "shared-name",
+		runId: input.runId,
+		agent,
+		childIndex: index,
+	}, null, "\t"));
+	return requestId;
+}
+
+function makePi(options: { tools: Map<string, SupervisorTool>; onSend?: () => void }): Record<string, unknown> {
+	return {
+		getAllTools: () => [...options.tools.keys()].map((name) => ({ name })),
+		registerTool: (tool: { name: string } & SupervisorTool) => { options.tools.set(tool.name, tool); },
+		sendMessage: () => { options.onSend?.(); },
+		getSessionName: () => "shared-name",
+	};
+}
+
+function registerWorkflowChild(state: SubagentState, workflowRunId: string, childRunId: string, steer: (input: ForegroundSteerInput) => Promise<{ state: "delivered" | "queued" | "failed"; reason?: string }>): void {
+	state.workflowControllers ??= new Map();
+	state.workflowControllers.set(workflowRunId, new AbortController());
+	state.foregroundControls.set(childRunId, {
+		runId: childRunId,
+		parentWorkflowRunId: workflowRunId,
+		workflowKey: childRunId,
+		sessionId: "session",
+		mode: "single",
+		startedAt: 100,
+		updatedAt: 100,
+		activeChildren: new Map([[0, { index: 0, agent: "worker", startedAt: 100, updatedAt: 100, steer }]]),
+		schedulingOwners: 1,
+	} as never);
+}
+
+function text(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content[0]?.type === "text" ? result.content[0].text ?? "" : "";
+}
+
+afterEach(() => {
+	delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+	for (const channel of createdChannels.splice(0)) fs.rmSync(channel, { recursive: true, force: true });
+});
+
+describe("supervisor ask registration", () => {
+	// D1: `refreshPendingRequests` only re-evaluates asks already in `pending`; it never reads the
+	// filesystem. With no watcher installed and the demand-gated poller stopped, an ask written by
+	// a child was unfindable by ANY number of `action:"pending"` calls.
+	it("discovers an ask written while nothing was polling", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, {
+			platform: "darwin",
+			watch: (() => { throw new Error("darwin must not install a supervisor fs watcher"); }) as never,
+			timers: {
+				setInterval: (() => ({ unref() {} }) as NodeJS.Timeout) as typeof setInterval,
+				clearInterval: (() => {}) as typeof clearInterval,
+				setImmediate,
+				clearImmediate,
+			},
+		});
+
+		try {
+			channel.start();
+			// The ask lands AFTER start(), so the start-time poll cannot have seen it.
+			const requestId = writeRequest({ sessionId, runId });
+			assert.equal(channel.pending.has(requestId), false, "precondition: nothing has scanned the ask yet");
+
+			const result = await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+
+			assert.equal(channel.pending.has(requestId), true, "an explicit supervisor query must be authoritative against disk");
+			assert.match(text(result), new RegExp(requestId), "the ask must be listed with its reply id");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("accepts a reply to an ask that was never seen by a poller", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, makeCtx(sessionId)), { platform: "darwin" });
+
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId, runId });
+
+			const result = await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", {
+				action: "reply",
+				replyTo: requestId,
+				message: "Approved",
+			});
+
+			assert.notEqual(result.isError, true, text(result));
+			const reply = path.join(resolveSupervisorChannelDir(runId, "worker", 0), "replies", `${requestId}.json`);
+			assert.equal(fs.existsSync(reply), true, "the child's reply file must be written");
+			assert.equal(JSON.parse(fs.readFileSync(reply, "utf-8")).message, "Approved");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	// D3: `poll()` returned early whenever `state.lastUiContext` was null, which blinded the QUEUE
+	// and not just the display. Session ownership is carried by `state.currentSessionId`.
+	it("registers an ask with a null UI context", () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId, runId });
+		const tools = new Map<string, SupervisorTool>();
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, null), { platform: "darwin" });
+
+		try {
+			channel.start();
+			assert.equal(channel.pending.has(requestId), true, "a null lastUiContext must not drop the ask");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("still refuses an ask that belongs to another session when the UI context is null", () => {
+		const sessionId = `session-${randomUUID()}`;
+		const foreignSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const foreignId = writeRequest({ sessionId: foreignSessionId, runId });
+		const tools = new Map<string, SupervisorTool>();
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, null), { platform: "darwin" });
+
+		try {
+			channel.start();
+			assert.equal(channel.pending.has(foreignId), false, "session-ownership filtering must survive the null-context path");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("keeps a queued ask when the user-turn notification throws", () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId, runId });
+		const tools = new Map<string, SupervisorTool>();
+		const pi = makePi({ tools, onSend: () => { throw new Error("no UI attached"); } });
+		const channel = createNativeSupervisorChannel(pi as never, makeState(sessionId, makeCtx(sessionId)), { platform: "darwin" });
+
+		try {
+			channel.start();
+			assert.equal(channel.pending.has(requestId), true, "a display failure must not lose an already-queued ask");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	// D4: a child inside `contact_supervisor` has no turn boundary, so `child.steer` can only
+	// return "queued" into a queue that never drains. The steer must instead answer the open ask.
+	it("answers a blocked child's open ask when a steer targets it", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const queued: string[] = [];
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
+			queued.push(input.message);
+			return { state: "queued" as const };
+		});
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId, runId: workflowRunId });
+			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+			assert.equal(channel.pending.has(requestId), true, "precondition: the child is blocked on a registered ask");
+
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const result = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "RULING VIA STEER: proceed with option A.",
+			});
+
+			assert.equal(result.details.steering?.state, "delivered", "the steer must report a real delivery, not a queue");
+			assert.match(text(result), new RegExp(`open supervisor request ${requestId}`));
+			assert.match(text(result), /the child is unblocked/);
+			assert.deepEqual(queued, [], "the message must be delivered exactly once, not also queued in the dead queue");
+
+			const reply = path.join(resolveSupervisorChannelDir(workflowRunId, "worker", 0), "replies", `${requestId}.json`);
+			assert.equal(JSON.parse(fs.readFileSync(reply, "utf-8")).message, "RULING VIA STEER: proceed with option A.");
+			assert.equal(channel.pending.has(requestId), false, "the answered ask must leave the pending queue");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("falls back to the normal steer route and reports its real state when no ask is pending", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const queued: string[] = [];
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
+			queued.push(input.message);
+			return { state: "queued" as const };
+		});
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const result = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "No ask is open here.",
+			});
+
+			// A queued in-memory steer reports `state: "pending"` with a queued target: the honest
+			// receipt for a message that has not reached the child yet.
+			assert.equal(result.details.steering?.state, "pending", "without a pending ask the receipt must stay honest");
+			assert.equal(result.details.steering?.targets[0]?.state, "queued");
+			assert.deepEqual(queued, ["No ask is open here."]);
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("does not answer an ask that belongs to a different child index", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const queued: string[] = [];
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
+			queued.push(input.message);
+			return { state: "queued" as const };
+		});
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			const otherIndexAsk = writeRequest({ sessionId, runId: workflowRunId, index: 3 });
+			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+			assert.equal(channel.pending.has(otherIndexAsk), true, "precondition: index 3 has the open ask");
+
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const result = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "Meant for index 0.",
+			});
+
+			assert.equal(result.details.steering?.state, "pending", "index 0 has no ask, so the normal route must be used");
+			assert.equal(result.details.steering?.targets[0]?.state, "queued");
+			assert.deepEqual(queued, ["Meant for index 0."]);
+			assert.equal(channel.pending.has(otherIndexAsk), true, "index 3's ask must be left untouched");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	// The end-to-end seam: drive the real child-side `contact_supervisor` tool and prove the
+	// blocked child actually receives the steer text as its tool result.
+	it("unblocks the real contact_supervisor tool call through a steer", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const channelDir = resolveSupervisorChannelDir(workflowRunId, "worker", 0);
+		createdChannels.push(channelDir);
+		const supervisorTools = new Map<string, SupervisorTool>();
+		const childTools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async () => ({ state: "queued" as const }));
+		const channel = createNativeSupervisorChannel(makePi({ tools: supervisorTools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			registerNativeSupervisorClient(makePi({ tools: childTools }) as never, {
+				channelDir,
+				runId: workflowRunId,
+				agent: "worker",
+				childIndex: 0,
+				orchestratorSessionId: sessionId,
+			});
+
+			// The child blocks here exactly as it does in production: inside an open tool call,
+			// polling its reply file.
+			const blocked = childTools.get("contact_supervisor")!.execute("ask", {
+				action: "ask",
+				reason: "need_decision",
+				message: "Which option should I take?",
+			} as never);
+
+			await waitForCondition(() => fs.readdirSync(path.join(channelDir, "requests")).length > 0, "the child's ask to reach disk");
+			await supervisorTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const steerResult = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "RULING VIA STEER: take option A.",
+			});
+			assert.equal(steerResult.details.steering?.state, "delivered");
+
+			const childResult = await blocked;
+			assert.notEqual(childResult.isError, true, text(childResult));
+			assert.match(text(childResult), /RULING VIA STEER: take option A\./, "the blocked child must receive the steer as its answer");
+		} finally {
+			channel.dispose();
+		}
+	});
+});
+
+async function waitForCondition(condition: () => boolean, description: string): Promise<void> {
+	const deadline = Date.now() + 2000;
+	while (!condition()) {
+		if (Date.now() > deadline) assert.fail(`Timed out waiting for ${description}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}


### PR DESCRIPTION
Fixes #1975.

A child blocked in `contact_supervisor` could be invisible to its supervisor, and a steer could not reach it. #1975 has the full analysis; this is the summary of what changes and what is proven.

I am filing this because #980 was closed with an explicit invitation to open a fresh issue if the hang still reproduced on a current version. It does, on `e0c1a433`.

## What changes

Three independent defects, each sufficient on its own to lose an ask.

**1. An explicit supervisor query is now authoritative against disk.** `buildParentSupervisorTool.execute` called only `refreshPendingRequests`, which re-evaluates entries already in the `pending` map and never reads the filesystem. `listRequestFiles()` was reachable only from `poll()`. So an ask written while nothing was polling could not be found by any number of `action:"pending"` calls, which is the "pending stayed empty" symptom in #980. The tool now scans the channel root before answering.

**2. Registration no longer requires a live UI context.** `poll()` returned early whenever `state.lastUiContext` was null, which blinded the queue and not just the display. Session ownership is carried by `state.currentSessionId`, so `requestMatchesContext` now takes the UI context as optional and falls back to the session id. Ownership filtering is unchanged: an ask from another session is still refused. `pi.sendMessage` is also wrapped so a display failure cannot lose an already-queued ask or abort the scan of the remaining asks.

**3. A steer can unblock a child inside an open tool call.** A child inside `contact_supervisor` has no turn boundary, so `child.steer` can only queue, and that queue drains at a boundary that never comes: the receipt claimed delivery, the child saw nothing, and `action:"stop"` could not checkpoint the blocked tool call. The supervisor channel is the one path that reaches into an open tool call, because the child is already polling its reply file. `steerWorkflowForegroundTarget` now answers a pending ask with the steer text when one exists for that child, using the same write, journal, and attention-clear sequence as `action:"reply"`.

The third point uses a module-level resolver registry rather than a parameter, because `steerWorkflowForegroundTarget` is the only convergence point for the workflow-child steer routes and has no access to the channel closure. Threading the pending map through every steer call site in `subagent-executor.ts` would be a much wider change to the run-control surface.

## What this does NOT do

**It does not touch the darwin idle-watcher behaviour from #1220/#1228.** There is a third defect in the same module: on darwin no fs watcher is installed and the 5s safety sweep exists only on the native-watcher path, so the proactive notification can be dormant for the entire life of a blocked ask. The obvious patch is to install that sweep on the non-native-watcher path too. I tested it and it works, and I am deliberately not sending it, because it is an always-on interval that contradicts #1220 and breaks the two tests added in a2d3c0f5 for #1228 asserting an idle darwin session installs no timers. I am not going to revert a named, tested, credited fix or rewrite those tests to make my patch pass. I filed that gap as #1977 instead, with a demand-gated-but-durable direction for you to accept or reject.

This PR makes an explicit query authoritative, which closes the "an ask can never be found" hole on darwin. It does not restore a proactive notification there. That distinction is deliberate.

Also not covered, filed separately with no fix: #1979 (steer by child run id resolving to "No async run found"), #1980 (a `mode:single` child blocked in `contact_supervisor` has only the reply path, since the change here is workflow-foreground-specific), #1981 (completion-notification unreliability, which I verified does NOT share the `lastUiContext` dependency and did not root-cause).

## Fail-closed properties

- No pending ask: the steer route falls through and reports its real `queued` state, never a fabricated delivery.
- A throwing resolver: logged, returns undefined, and the caller keeps its own honest receipt.
- Delivered exactly once: the in-memory `child.steer` is not also called when the ask route wins.
- An unanswered ask still times out loudly with `Timed out waiting for supervisor reply`.
- Foreign-session and expired asks still never register.

## Testing

`test/unit/supervisor-ask-registration.test.ts`, nine cases. Seven fail on `main` and pass here. The two pure negatives, foreign-session refusal and the honest queued receipt when no ask is pending, pass in both directions, so no negative is weakened. The last case drives the real child-side `contact_supervisor` tool through `registerNativeSupervisorClient` and awaits its blocked promise, so the unblock is proven end to end rather than asserted about the queue.

Run on `e0c1a433`, macOS 26.3, node v24.4.0:

- `npm run typecheck`: clean
- `npm test` (unit): 2887 tests, 2884 pass, 0 fail, 3 skipped. Baseline on unpatched `main` was 2878 pass, so this is baseline plus exactly the 9 new cases.
- `npm run test:integration`: 965 tests, 959 pass, 0 fail, 6 skipped, identical to the unpatched baseline.

## Live validation

Beyond the harness, this is running on my machine. The full loop was exercised twice against a real detached workflow child: the child called `contact_supervisor`, the ask registered and the notification fired without any `action:"pending"` call, a supervisor reply reached the blocked child, and the child unblocked and completed with the exact reply text. That last step is the mechanism that never worked before the fix.

To be precise about what that does and does not prove: the local build I validated live also carries the darwin notification-floor change described above, which is NOT in this PR. So the "notification fired with no explicit query" part of that observation is attributable to that change, not to this one. Everything in this PR is covered by the deterministic tests above, and the ask-registration and reply-unblock halves of the live run exercise this PR's code paths.
