### PR TITLE
fix(workflows): consume the durable steer inbox for async workflow runs

### DIFF
--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -479,11 +479,18 @@ export function deliverStopRequest(input: {
  * as the runner inbox (native `fs.watch` plus a safety poll, interval polling as
  * the fallback) and the same up-front `check()` for a request that landed before
  * the watcher was installed. Returns a disposer.
+ *
+ * A scan failure keeps its requests on disk for the next tick, matching
+ * `consumeSteerRequests`. Because a persistent failure would otherwise be
+ * indistinguishable from an idle inbox, `onUnavailable` reports the first error
+ * of an unbroken run of failures so the caller can journal it; the next
+ * successful scan re-arms that report.
  */
 export function watchAsyncSteerInbox(
 	asyncDir: string,
 	opts: {
 		onSteer: (request: SteerRequest) => void;
+		onUnavailable?: (error: unknown) => void;
 		pollIntervalMs?: number;
 		safetyPollIntervalMs?: number;
 		platform?: NodeJS.Platform;
@@ -501,12 +508,30 @@ export function watchAsyncSteerInbox(
 	}
 
 	let disposed = false;
+	let reportedUnavailable = false;
 	const check = (): void => {
 		if (disposed) return;
+		let requests: SteerRequest[];
 		try {
-			for (const request of consumeSteerRequests(asyncDir, fsImpl)) opts.onSteer(request);
-		} catch {
-			// Never let inbox errors crash the workflow.
+			requests = consumeSteerRequests(asyncDir, fsImpl);
+		} catch (error) {
+			// Never let inbox errors crash the workflow, but do not let a persistent failure look like
+			// an idle inbox either: a writer that was told its steer was queued would otherwise wait on
+			// a request nothing can read.
+			if (!reportedUnavailable) {
+				reportedUnavailable = true;
+				opts.onUnavailable?.(error);
+			}
+			return;
+		}
+		reportedUnavailable = false;
+		// A throwing consumer must not strand the requests already read off disk.
+		for (const request of requests) {
+			try {
+				opts.onSteer(request);
+			} catch (error) {
+				opts.onUnavailable?.(error);
+			}
 		}
 	};
 

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -471,6 +471,86 @@ export function deliverStopRequest(input: {
 }
 
 /**
+ * Workflow side: watch ONLY `steer-requests/` and route each request into
+ * `onSteer`. Deliberately narrower than `watchAsyncControlInbox`: workflow-mode
+ * runs handle interrupt, stop, and timeout through their in-memory controller,
+ * and nothing else consumes those inbox files for a workflow run, so consuming
+ * them here would silently discard a stop request. Uses the same watch strategy
+ * as the runner inbox (native `fs.watch` plus a safety poll, interval polling as
+ * the fallback) and the same up-front `check()` for a request that landed before
+ * the watcher was installed. Returns a disposer.
+ */
+export function watchAsyncSteerInbox(
+	asyncDir: string,
+	opts: {
+		onSteer: (request: SteerRequest) => void;
+		pollIntervalMs?: number;
+		safetyPollIntervalMs?: number;
+		platform?: NodeJS.Platform;
+		fs?: ControlChannelFs;
+		timers?: ControlChannelTimers;
+	},
+): () => void {
+	const fsImpl = opts.fs ?? fs;
+	const timers = opts.timers ?? { setInterval, clearInterval };
+	const dir = steerRequestsDir(asyncDir);
+	try {
+		fsImpl.mkdirSync(dir, { recursive: true });
+	} catch {
+		// Best effort, because the poll and watch paths below tolerate a missing dir.
+	}
+
+	let disposed = false;
+	const check = (): void => {
+		if (disposed) return;
+		try {
+			for (const request of consumeSteerRequests(asyncDir, fsImpl)) opts.onSteer(request);
+		} catch {
+			// Never let inbox errors crash the workflow.
+		}
+	};
+
+	// Handle a request that may have arrived before the watcher started.
+	check();
+
+	const watchers: fs.FSWatcher[] = [];
+	let interval: ReturnType<typeof setInterval> | undefined;
+	let safetyInterval: ReturnType<typeof setInterval> | undefined;
+	const startPolling = (): void => {
+		if (interval || disposed) return;
+		interval = timers.setInterval(check, opts.pollIntervalMs ?? POLL_INTERVAL_MS);
+		interval.unref?.();
+	};
+	try {
+		if (shouldUseNativeFsWatch("runner-control-inbox", opts.platform)) {
+			const watcher = fsImpl.watch(resolveWatchPath(dir, fsImpl.realpathSync.native), () => check());
+			watcher.on?.("error", startPolling);
+			watchers.push(watcher);
+			safetyInterval = timers.setInterval(check, opts.safetyPollIntervalMs ?? CONTROL_SAFETY_POLL_INTERVAL_MS);
+			safetyInterval.unref?.();
+		} else {
+			startPolling();
+		}
+	} catch {
+		startPolling();
+	}
+
+	return () => {
+		if (disposed) return;
+		disposed = true;
+		for (const watcher of watchers) {
+			try {
+				watcher.close();
+			} catch {
+				// ignore
+			}
+		}
+		if (interval) timers.clearInterval(interval);
+		if (safetyInterval) timers.clearInterval(safetyInterval);
+	};
+}
+
+/**
  * Runner side: watch the control inbox and route interrupt requests into
  * `onInterrupt`. Uses `fs.watch` when available and starts interval polling
  * only when native watching is unavailable or fails. Fires once per distinct

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -2738,6 +2738,11 @@ function applySingleAgentLaunchDefaults(params: SubagentParamsLike, agents: Agen
 
 export const DEFAULT_FOREGROUND_TIMEOUT_MS = 30 * 60 * 1000;
 
+// How long workflow teardown waits for a steer delivery that was consumed just before the run
+// settled. Long enough for an in-process child to answer, short enough that a wedged child session
+// cannot hold controller cleanup and active-capacity reconciliation open.
+const WORKFLOW_STEER_DRAIN_GRACE_MS = 2000;
+
 // Async single-agent runs also need a wall-clock backstop: a child whose bash
 // tool blocks forever (e.g. a background process inheriting the terminal with
 // no bash `timeout` arg) would otherwise hang the parent indefinitely with
@@ -5253,7 +5258,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				// A consumed request whose delivery is still in flight has a `routed` receipt and no terminal
 				// one. Teardown must settle these before closing persistence, or the terminal update is
 				// dropped by `persist()` and the request stays at `routed` forever.
-				const inFlightWorkflowSteers = new Set<Promise<void>>();
+				// The teardown wait is bounded: `child.steer` is another session's promise, and a wedged child
+				// must not hold controller cleanup or capacity reconciliation open. A delivery that outlives
+				// the grace period gets an explicit failed receipt instead.
+				const inFlightWorkflowSteers = new Set<{ settled: Promise<void>; expire: () => void }>();
 				const deliverWorkflowSteerRequest = (request: SteerRequest): void => {
 					const index = request.targetIndex ?? request.targetIndexes?.[0] ?? 0;
 					if (status.state !== "running") {
@@ -5283,7 +5291,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets: [{ index, state: "routed" }] });
 					emitWorkflowSteerEvent("subagent.steer.routed", request.id, index);
 					persist({ tolerateStatusWriteFailure: true });
+					// The delivery result and the teardown expiry race, so whichever lands first owns the receipt.
+					let deliveryRecorded = false;
 					const applyWorkflowSteerDelivery = (state: "delivered" | "queued" | "failed", reason?: string): void => {
+						if (deliveryRecorded) return;
+						deliveryRecorded = true;
 						const now = Date.now();
 						updateSteeringTarget(steeringStatus(status), request.id, index, state === "delivered" ? "delivered" : state === "queued" ? "queued" : "failed", now, reason ? { reason } : {});
 						if (state === "failed") {
@@ -5305,8 +5317,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						},
 						(error) => applyWorkflowSteerDelivery("failed", error instanceof Error ? error.message : String(error)),
 					);
-					inFlightWorkflowSteers.add(delivery);
-					void delivery.finally(() => inFlightWorkflowSteers.delete(delivery));
+					const inFlight = {
+						settled: delivery,
+						expire: () => applyWorkflowSteerDelivery("failed", "steering delivery did not settle before the run finished"),
+					};
+					inFlightWorkflowSteers.add(inFlight);
+					void delivery.finally(() => inFlightWorkflowSteers.delete(inFlight));
 				};
 				let disposeWorkflowSteerInbox: (() => void) | undefined;
 				try {
@@ -5668,7 +5684,22 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							// already closed it, and dropping the update would leave the request stuck at `routed`.
 							if (inFlightWorkflowSteers.size > 0) {
 								persistClosed = false;
-								await Promise.allSettled([...inFlightWorkflowSteers]);
+								const draining = [...inFlightWorkflowSteers];
+								let graceTimer: ReturnType<typeof setTimeout> | undefined;
+								const grace = new Promise<void>((resolve) => {
+									graceTimer = setTimeout(resolve, WORKFLOW_STEER_DRAIN_GRACE_MS);
+									graceTimer.unref?.();
+								});
+								try {
+									await Promise.race([Promise.allSettled(draining.map((entry) => entry.settled)), grace]);
+								} finally {
+									if (graceTimer) clearTimeout(graceTimer);
+								}
+								// Anything still unsettled is failed explicitly now, so a wedged child cannot strand a
+								// request at `routed` and cannot hold teardown open.
+								for (const entry of draining) {
+									if (inFlightWorkflowSteers.has(entry)) entry.expire();
+								}
 							}
 							const undelivered = consumeSteerRequests(asyncDir);
 							if (undelivered.length > 0) {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5250,6 +5250,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					emitWorkflowSteerEvent("subagent.steer.failed", request.id, index, { reason });
 					persist({ tolerateStatusWriteFailure: true });
 				};
+				// A consumed request whose delivery is still in flight has a `routed` receipt and no terminal
+				// one. Teardown must settle these before closing persistence, or the terminal update is
+				// dropped by `persist()` and the request stays at `routed` forever.
+				const inFlightWorkflowSteers = new Set<Promise<void>>();
 				const deliverWorkflowSteerRequest = (request: SteerRequest): void => {
 					const index = request.targetIndex ?? request.targetIndexes?.[0] ?? 0;
 					if (status.state !== "running") {
@@ -5290,7 +5294,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						emitWorkflowSteerEvent(`subagent.steer.${state}`, request.id, index, state === "failed" ? { reason } : { deliveryStatus: state, message: request.message });
 						persist({ tolerateStatusWriteFailure: true });
 					};
-					void steerWorkflowForegroundTarget({
+					const delivery = steerWorkflowForegroundTarget({
 						target: { control, workflowRunId, sourceRunId: workflowRunId },
 						message: request.message,
 						...(request.mode ? { mode: request.mode } : {}),
@@ -5301,10 +5305,15 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						},
 						(error) => applyWorkflowSteerDelivery("failed", error instanceof Error ? error.message : String(error)),
 					);
+					inFlightWorkflowSteers.add(delivery);
+					void delivery.finally(() => inFlightWorkflowSteers.delete(delivery));
 				};
 				let disposeWorkflowSteerInbox: (() => void) | undefined;
 				try {
-					disposeWorkflowSteerInbox = watchAsyncSteerInbox(asyncDir, { onSteer: deliverWorkflowSteerRequest });
+					disposeWorkflowSteerInbox = watchAsyncSteerInbox(asyncDir, {
+						onSteer: deliverWorkflowSteerRequest,
+						onUnavailable: (error) => appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", error: error instanceof Error ? error.message : String(error) }),
+					});
 				} catch (error) {
 					// Steering is an optional control surface, so a watcher that cannot install must not fail the run.
 					appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", error: error instanceof Error ? error.message : String(error) });
@@ -5654,6 +5663,13 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						try {
 							disposeWorkflowSteerInbox?.();
 							closeSteerInbox(asyncDir, status.state);
+							// Settle deliveries consumed just before the run finished. Their terminal receipt is written
+							// by a `.then` handler, so persistence has to be reopened for it: the terminal write above
+							// already closed it, and dropping the update would leave the request stuck at `routed`.
+							if (inFlightWorkflowSteers.size > 0) {
+								persistClosed = false;
+								await Promise.allSettled([...inFlightWorkflowSteers]);
+							}
 							const undelivered = consumeSteerRequests(asyncDir);
 							if (undelivered.length > 0) {
 								persistClosed = false;

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -82,8 +82,8 @@ import {
 	stripDetailsOutputsForIntercomReceipt,
 } from "../../intercom/result-intercom.ts";
 import { applySteeringRecoveryAgentConfig, asyncReviveRequiresRecoveryDescriptor, buildRevivedAsyncTask, readAsyncRecoveryDescriptor, resolveAsyncResumeTarget, resolveAsyncRunLocation } from "../background/async-resume.ts";
-import { deliverInterruptRequest, readRevivalBriefs, requestAsyncSteer, type SteerDeliveryMode } from "../background/control-channel.ts";
-import { updateSteeringTarget, waitForSteeringAction } from "../background/steering.ts";
+import { closeSteerInbox, consumeSteerRequests, deliverInterruptRequest, readRevivalBriefs, requestAsyncSteer, watchAsyncSteerInbox, type SteerDeliveryMode, type SteerRequest } from "../background/control-channel.ts";
+import { createSteeringStatus, recordSteeringRequest, steeringStatus, updateSteeringTarget, waitForSteeringAction } from "../background/steering.ts";
 import { canQueueRetainedAsyncFollowUp, steerAsyncRun } from "./async-steering-action.ts";
 import {
 	resolveWorkflowForegroundSteeringTarget,
@@ -196,6 +196,7 @@ import {
 	resolveMaxSubagentSpawnsPerRun,
 	wrapForkTask,
 	type ScheduleOrigin,
+	type SteeringTargetState,
 } from "../../shared/types.ts";
 import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 
@@ -5223,6 +5224,91 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					return { content: [{ type: "text", text: `Failed to create async workflow storage: ${error instanceof Error ? error.message : String(error)}` }], isError: true, details: { mode: "workflow", results: [] } };
 				}
 				appendWorkflowEvent({ type: "subagent.workflow.started" });
+				// Consume the durable steer inbox for async workflow runs. `watchAsyncControlInbox` is
+				// installed only by subagent-runner.ts, and the runner never executes workflow scripts
+				// (`runWorkflowScript` is called only from this file), so no process was watching
+				// `control/steer-requests/` for a workflow run and a queued request file sat on disk until
+				// the run ended. A workflow's children are in-process foreground children of THIS process,
+				// so deliver through their in-memory controls and write the same status.steering and
+				// subagent.steer.* receipts that the requesting side already reads.
+				const emitWorkflowSteerEvent = (type: string, requestId: string, index?: number, extra: Record<string, unknown> = {}): void => {
+					appendWorkflowEvent({ type, requestId, ...(index !== undefined ? { index } : {}), ...extra });
+				};
+				const recordWorkflowSteerTargets = (request: SteerRequest, targets: Array<{ index: number; state: SteeringTargetState; reason?: string }>): void => {
+					status.steering ??= createSteeringStatus();
+					recordSteeringRequest(steeringStatus(status), {
+						id: request.id,
+						requestedAt: request.ts,
+						...(request.source ? { source: request.source } : {}),
+						message: request.message,
+						targets,
+					});
+				};
+				const failWorkflowSteer = (request: SteerRequest, index: number, reason: string): void => {
+					recordWorkflowSteerTargets(request, [{ index, state: "failed", reason }]);
+					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets: [{ index, state: "failed", reason }] });
+					emitWorkflowSteerEvent("subagent.steer.failed", request.id, index, { reason });
+					persist({ tolerateStatusWriteFailure: true });
+				};
+				const deliverWorkflowSteerRequest = (request: SteerRequest): void => {
+					const index = request.targetIndex ?? request.targetIndexes?.[0] ?? 0;
+					if (status.state !== "running") {
+						failWorkflowSteer(request, index, `run became ${status.state} before steering request was consumed`);
+						return;
+					}
+					// Resolve the workflow step the requester addressed, then that step's live in-process control.
+					const step = status.steps?.[index];
+					// An addressed index beyond the projected steps is a caller error, not a race: fail it
+					// explicitly rather than falling back and steering an unrelated child.
+					if (step === undefined && (status.steps?.length ?? 0) > 0) {
+						failWorkflowSteer(request, index, "child index out of range");
+						return;
+					}
+					const liveControls = [...deps.state.foregroundControls.values()].filter((candidate) => candidate.parentWorkflowRunId === workflowRunId && (candidate.activeChildren?.size ?? 0) > 0);
+					// Prefer the keyed control, then fall back to the sole live child, which covers a step whose
+					// control registered before its workflowKey was projected into status.steps.
+					const control = (step?.workflowKey ? liveControls.find((candidate) => candidate.workflowKey === step.workflowKey) : undefined)
+						?? (liveControls.length === 1 ? liveControls[0] : undefined);
+					if (!control) {
+						failWorkflowSteer(request, index, liveControls.length > 1
+							? `workflow has ${liveControls.length} live children; steer a child run id instead`
+							: "workflow child is not live in this process");
+						return;
+					}
+					recordWorkflowSteerTargets(request, [{ index, state: "routed" }]);
+					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets: [{ index, state: "routed" }] });
+					emitWorkflowSteerEvent("subagent.steer.routed", request.id, index);
+					persist({ tolerateStatusWriteFailure: true });
+					const applyWorkflowSteerDelivery = (state: "delivered" | "queued" | "failed", reason?: string): void => {
+						const now = Date.now();
+						updateSteeringTarget(steeringStatus(status), request.id, index, state === "delivered" ? "delivered" : state === "queued" ? "queued" : "failed", now, reason ? { reason } : {});
+						if (state === "failed") {
+							const failedStep = status.steps?.[index];
+							if (failedStep) failedStep.activityState = "needs_attention";
+							status.activityState = "needs_attention";
+						}
+						emitWorkflowSteerEvent(`subagent.steer.${state}`, request.id, index, state === "failed" ? { reason } : { deliveryStatus: state, message: request.message });
+						persist({ tolerateStatusWriteFailure: true });
+					};
+					void steerWorkflowForegroundTarget({
+						target: { control, workflowRunId, sourceRunId: workflowRunId },
+						message: request.message,
+						...(request.mode ? { mode: request.mode } : {}),
+					}).then(
+						(result) => {
+							const target = result.details.steering?.targets[0];
+							applyWorkflowSteerDelivery(target?.state === "delivered" ? "delivered" : target?.state === "queued" ? "queued" : "failed", target?.reason ?? (target ? undefined : "steering produced no target receipt"));
+						},
+						(error) => applyWorkflowSteerDelivery("failed", error instanceof Error ? error.message : String(error)),
+					);
+				};
+				let disposeWorkflowSteerInbox: (() => void) | undefined;
+				try {
+					disposeWorkflowSteerInbox = watchAsyncSteerInbox(asyncDir, { onSteer: deliverWorkflowSteerRequest });
+				} catch (error) {
+					// Steering is an optional control surface, so a watcher that cannot install must not fail the run.
+					appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", error: error instanceof Error ? error.message : String(error) });
+				}
 				const { workflowScript, async: _workflowAsync, chatProgress: _chatProgress, ...workflowRequest } = requestParams;
 				void Promise.resolve().then(async () => {
 					const workflowDeadlineAt = timeout === undefined ? undefined : Date.now() + timeout;
@@ -5562,6 +5648,21 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(terminalOutcome ? { terminalOutcome } : {}), ...(status.error ? { error: status.error } : {}), ...(status.activityState ? { activityState: status.activityState } : {}) });
 					} finally {
+						// Stop watching, close the inbox so the requesting side cannot queue into a dead run, then
+						// drain in-flight requests to a terminal receipt (mirroring the runner teardown) so a late
+						// steer fails visibly instead of vanishing.
+						try {
+							disposeWorkflowSteerInbox?.();
+							closeSteerInbox(asyncDir, status.state);
+							const undelivered = consumeSteerRequests(asyncDir);
+							if (undelivered.length > 0) {
+								persistClosed = false;
+								const reason = `run became ${status.state} before steering request was consumed`;
+								for (const request of undelivered) failWorkflowSteer(request, request.targetIndex ?? request.targetIndexes?.[0] ?? 0, reason);
+							}
+						} catch (error) {
+							console.error(`Failed to close async workflow steer inbox '${asyncDir}':`, error);
+						}
 						persistClosed = true;
 						deps.state.workflowControllers?.delete(workflowRunId);
 						deps.state.workflowChildStops?.delete(workflowRunId);

--- a/test/integration/workflow-steer-inbox.test.ts
+++ b/test/integration/workflow-steer-inbox.test.ts
@@ -124,6 +124,49 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 		}
 	});
 
+	it("does not let a wedged steer delivery hold teardown open", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const childRelease = path.join(tempDir, "wedged-child-release");
+		// steerWaitForPath is never created, so the child's steer() promise never settles.
+		const neverReleased = path.join(tempDir, "wedged-steer-never");
+		mockPi.onCall({ steerWaitForPath: neverReleased, steps: [{ waitForPath: childRelease, jsonl: [events.assistantMessage("done")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-workflow-steer-wedged";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+
+		const launch = await executor.execute(
+			`workflow-steer-wedged-${Date.now().toString(36)}`,
+			{ workflowScript: `return await runs.run("waits", { agent: "worker", task: "Wait for guidance" });`, async: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(launch.isError, undefined, launch.content[0]?.text);
+		const runId = launch.details?.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+
+		try {
+			await waitForMockPiCall(mockPi, 0, 10_000);
+			requestAsyncSteer(asyncDir, { message: "Never settles.", id: "workflow-steer-wedged", ts: Date.now() });
+			await waitForAsyncState(runId, (candidate) => recentSteering(candidate, "workflow-steer-wedged")?.state === "routed", 15_000);
+
+			fs.writeFileSync(childRelease, "go");
+
+			// Teardown must complete on its own within the drain grace period, giving the unsettled
+			// delivery an explicit failed receipt rather than waiting on it forever.
+			const settled = await waitForAsyncState(
+				runId,
+				(candidate) => recentSteering(candidate, "workflow-steer-wedged")?.state === "failed",
+				20_000,
+			);
+			assert.match(recentSteering(settled, "workflow-steer-wedged")?.reason ?? "", /did not settle before the run finished/);
+			// Capacity and controller cleanup happen after the drain, so a terminal state proves teardown ran.
+			assert.equal(settled.state === "complete" || settled.state === "failed", true, `expected a terminal run state, got ${settled.state}`);
+		} finally {
+			if (!fs.existsSync(childRelease)) fs.writeFileSync(childRelease, "go");
+			fs.writeFileSync(neverReleased, "go");
+		}
+	});
+
 	it("closes the inbox and fails a late steer request when the workflow ends", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		const ctx = makeMinimalCtx(tempDir);
 		ctx.sessionManager.getSessionId = () => "session-workflow-steer-closed";

--- a/test/integration/workflow-steer-inbox.test.ts
+++ b/test/integration/workflow-steer-inbox.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration tests for the durable steer inbox of async WORKFLOW runs.
+ *
+ * `watchAsyncControlInbox` is installed only by subagent-runner.ts, and the runner never executes
+ * workflow scripts, so before this fix no process consumed `control/steer-requests/` for a
+ * workflow run: a queued request file sat on disk until the run ended and the requester's
+ * "delivered" receipt was never backed by a delivery.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { events, makeAgent, makeMinimalCtx } from "../support/helpers.ts";
+import { requestAsyncSteer, steerInboxClosedPath, steerRequestsDir } from "../../src/runs/background/control-channel.ts";
+import type { AsyncStatusPayload } from "../support/async-execution-fixture.ts";
+import {
+	installAsyncExecutionHooks, available, isAsyncAvailable, ASYNC_DIR,
+	createSubagentExecutor, waitForMockPiCall, waitForAsyncState, tempDir, mockPi,
+	makeAsyncExecutor, readAsyncPayload,
+} from "../support/async-execution-fixture.ts";
+
+type SteeringTargets = { steering?: { recent: Array<{ id: string; targets: Array<{ index: number; state: string; reason?: string }> }> } };
+
+function recentSteering(status: AsyncStatusPayload, requestId: string): { index: number; state: string; reason?: string } | undefined {
+	return (status as SteeringTargets).steering?.recent?.find((request) => request.id === requestId)?.targets[0];
+}
+
+describe("async workflow steer inbox", { skip: !available ? "pi packages not available" : undefined }, () => {
+	installAsyncExecutionHooks();
+
+	it("delivers an inbox steer request to a live async workflow child", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const release = path.join(tempDir, "workflow-steer-release");
+		mockPi.onCall({ steps: [{ waitForPath: release, jsonl: [events.assistantMessage("steered workflow child")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-workflow-steer";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+
+		const launch = await executor.execute(
+			`workflow-steer-inbox-${Date.now().toString(36)}`,
+			{ workflowScript: `return await runs.run("waits", { agent: "worker", task: "Wait for guidance" });`, async: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(launch.isError, undefined, launch.content[0]?.text);
+		const runId = launch.details?.asyncId as string;
+		assert.ok(runId, "expected an async workflow run id");
+		const asyncDir = path.join(ASYNC_DIR, runId);
+
+		try {
+			// The child is now live and parked on the release path, so the workflow run is genuinely
+			// steerable: the only question is whether anything consumes its inbox.
+			await waitForMockPiCall(mockPi, 0, 10_000);
+			requestAsyncSteer(asyncDir, { message: "Focus on the failing test.", id: "workflow-steer-1", ts: Date.now() });
+
+			const status = await waitForAsyncState(runId, (candidate) => recentSteering(candidate, "workflow-steer-1") !== undefined, 15_000);
+			const target = recentSteering(status, "workflow-steer-1");
+			assert.equal(target?.state, "delivered", `expected a real delivery, got ${JSON.stringify(target)}`);
+			// The request file must be consumed, not left on disk for the life of the run.
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), []);
+
+			const steers = fs.readFileSync(path.join(mockPi.dir, "steers.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line) as { text: string });
+			assert.match(steers[0]?.text ?? "", /Focus on the failing test\./, "the live child must receive the steer text");
+
+			const eventsText = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
+			assert.match(eventsText, /"type":"subagent\.steer\.routed"[^\n]*"requestId":"workflow-steer-1"/);
+			assert.match(eventsText, /"type":"subagent\.steer\.delivered"[^\n]*"requestId":"workflow-steer-1"/);
+		} finally {
+			fs.writeFileSync(release, "go");
+		}
+
+		const payload = await readAsyncPayload(runId);
+		assert.equal(payload.success, true);
+	});
+
+	it("closes the inbox and fails a late steer request when the workflow ends", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-workflow-steer-closed";
+		const executor = makeAsyncExecutor([]);
+
+		const launch = await executor.execute(
+			`workflow-steer-closed-${Date.now().toString(36)}`,
+			{ workflowScript: "return 'done'", async: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(launch.isError, undefined, launch.content[0]?.text);
+		const runId = launch.details?.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+
+		await waitForAsyncState(runId, (candidate) => candidate.state === "complete", 15_000);
+		// A terminal run must refuse new steering rather than accept a request nothing will read.
+		assert.equal(fs.existsSync(steerInboxClosedPath(asyncDir)), true, "the steer inbox must be closed at teardown");
+		assert.throws(
+			() => requestAsyncSteer(asyncDir, { message: "Too late.", id: "workflow-steer-late", ts: Date.now() }),
+			/no longer accepts steering requests/,
+		);
+	});
+});

--- a/test/integration/workflow-steer-inbox.test.ts
+++ b/test/integration/workflow-steer-inbox.test.ts
@@ -74,6 +74,56 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 		assert.equal(payload.success, true);
 	});
 
+	it("settles a delivery still in flight when the workflow ends, instead of leaving it at routed", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const childRelease = path.join(tempDir, "inflight-child-release");
+		const steerRelease = path.join(tempDir, "inflight-steer-release");
+		// The child finishes as soon as childRelease appears, but its steer() stays unresolved until
+		// steerRelease appears, so the delivery is guaranteed to still be in flight at teardown.
+		mockPi.onCall({ steerWaitForPath: steerRelease, steps: [{ waitForPath: childRelease, jsonl: [events.assistantMessage("done")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-workflow-steer-inflight";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+
+		const launch = await executor.execute(
+			`workflow-steer-inflight-${Date.now().toString(36)}`,
+			{ workflowScript: `return await runs.run("waits", { agent: "worker", task: "Wait for guidance" });`, async: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(launch.isError, undefined, launch.content[0]?.text);
+		const runId = launch.details?.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+
+		try {
+			await waitForMockPiCall(mockPi, 0, 10_000);
+			requestAsyncSteer(asyncDir, { message: "Held in flight.", id: "workflow-steer-inflight", ts: Date.now() });
+			// Wait for the request to be consumed and routed, so the delivery is genuinely in flight.
+			await waitForAsyncState(runId, (candidate) => recentSteering(candidate, "workflow-steer-inflight")?.state === "routed", 15_000);
+
+			// Let the workflow finish while that delivery is still pending.
+			fs.writeFileSync(childRelease, "go");
+			await waitForAsyncState(runId, (candidate) => candidate.state === "complete", 15_000);
+
+			// Now release the delivery. Teardown must still be holding persistence open for it.
+			fs.writeFileSync(steerRelease, "go");
+			const settled = await waitForAsyncState(
+				runId,
+				(candidate) => {
+					const state = recentSteering(candidate, "workflow-steer-inflight")?.state;
+					return state === "delivered" || state === "queued" || state === "failed";
+				},
+				15_000,
+			);
+			// The receipt must reach a terminal state. Left at "routed" it claims the steer is still being
+			// delivered to a run that has already ended.
+			assert.notEqual(recentSteering(settled, "workflow-steer-inflight")?.state, "routed");
+		} finally {
+			if (!fs.existsSync(childRelease)) fs.writeFileSync(childRelease, "go");
+			if (!fs.existsSync(steerRelease)) fs.writeFileSync(steerRelease, "go");
+		}
+	});
+
 	it("closes the inbox and fails a late steer request when the workflow ends", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		const ctx = makeMinimalCtx(tempDir);
 		ctx.sessionManager.getSessionId = () => "session-workflow-steer-closed";

--- a/test/support/fake-child-session.ts
+++ b/test/support/fake-child-session.ts
@@ -21,6 +21,8 @@ export interface FakeChildResponse {
 	exitCode?: number;
 	delay?: number;
 	waitForPath?: string;
+	/** Holds a `steer()` call unresolved until this path exists, so a test can keep a steer delivery in flight. */
+	steerWaitForPath?: string;
 	keepAliveAfterFinalMessageMs?: number;
 	jsonl?: unknown[];
 	/** Raw JSON lines; parsed into events for the in-process child without acceptance-report injection. */
@@ -329,6 +331,8 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 					throw new Error(response.stderr?.trim() || `mock child exited with code ${response.exitCode}`);
 				}
 			};
+			// Retained so `steer()` can honour `steerWaitForPath` from the response this child claimed.
+			let activeResponse: FakeChildResponse | undefined;
 			const session: ChildSession = {
 				subscribe(listener) {
 					listeners.add(listener);
@@ -339,6 +343,7 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 					const systemPrompt = launch.systemPrompt ?? launch.appendSystemPrompt ?? "";
 					const args = fakeChildArgs(launch, text);
 					const response = claimNextResponse(queueDir(), `${args.join("\n")}\n${systemPrompt}`);
+					activeResponse = response;
 					const dir = queueDir();
 					fs.mkdirSync(dir, { recursive: true });
 					const callPath = path.join(dir, `call-${Date.now()}-${process.pid}-${Math.random().toString(16).slice(2)}.json`);
@@ -377,6 +382,7 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 				async steer(text) {
 					record.steers.push({ text, mode: "steer" });
 					recordSteer(text, "steer");
+					await waitForReleasePath(activeResponse?.steerWaitForPath);
 				},
 				async followUp(text) {
 					record.steers.push({ text, mode: "followUp" });

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -23,6 +23,7 @@ import {
 	stopRequestPath,
 	steerRequestsDir,
 	watchAsyncControlInbox,
+	watchAsyncSteerInbox,
 } from "../../src/runs/background/control-channel.ts";
 
 function tmpAsyncDir(label: string): string {
@@ -559,6 +560,176 @@ describe("control channel: watchAsyncControlInbox", () => {
 
 			assert.deepEqual(steers, ["first", "second"]);
 			assert.deepEqual(h.intervalDelays(), [5000]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+});
+
+describe("control channel: watchAsyncSteerInbox", () => {
+	type SteerWatchHarness = {
+		fsImpl: import("../../src/runs/background/control-channel.ts").ControlChannelFs;
+		timers: import("../../src/runs/background/control-channel.ts").ControlChannelTimers;
+		trigger: () => void;
+		triggerError: () => void;
+		closed: () => boolean;
+		intervalDelays: () => number[];
+		watchedDir: () => string | undefined;
+	};
+
+	function steerHarness(): SteerWatchHarness {
+		const listeners = new Map<string, () => void>();
+		const errorListeners = new Map<string, () => void>();
+		let closed = false;
+		const intervalDelays: number[] = [];
+		let watchedDir: string | undefined;
+		const realpathSync = ((target: fs.PathLike, options?: unknown) => fs.realpathSync(target, options as BufferEncoding)) as typeof fs.realpathSync;
+		realpathSync.native = ((target: fs.PathLike) => fs.realpathSync.native(target)) as typeof fs.realpathSync.native;
+		const fsImpl = {
+			mkdirSync: fs.mkdirSync,
+			existsSync: fs.existsSync,
+			rmSync: fs.rmSync,
+			readdirSync: fs.readdirSync,
+			readFileSync: fs.readFileSync,
+			realpathSync,
+			watch: ((dir: string, cb: () => void) => {
+				watchedDir = dir;
+				listeners.set(dir, cb);
+				return {
+					close: () => { closed = true; },
+					on: (event: string, handler: () => void) => {
+						if (event === "error") errorListeners.set(dir, handler);
+					},
+				};
+			}),
+		} as unknown as SteerWatchHarness["fsImpl"];
+		const timers = {
+			setInterval: ((_handler: Parameters<typeof setInterval>[0], delay?: number) => {
+				intervalDelays.push(delay ?? 0);
+				return { unref() {} };
+			}) as unknown as typeof setInterval,
+			clearInterval: (() => {}) as unknown as typeof clearInterval,
+		};
+		return {
+			fsImpl,
+			timers,
+			trigger: () => { for (const listener of listeners.values()) listener(); },
+			triggerError: () => { for (const listener of errorListeners.values()) listener(); },
+			closed: () => closed,
+			intervalDelays: () => [...intervalDelays],
+			watchedDir: () => watchedDir,
+		};
+	}
+
+	it("consumes a steer request that arrived before the watcher started", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-early-");
+		try {
+			requestAsyncSteer(asyncDir, { message: "queued before install", id: "s1", ts: 1 });
+			const steers: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			assert.deepEqual(steers, ["queued before install"]);
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), []);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("consumes later requests via the watch event and stops after dispose", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-event-");
+		try {
+			const steers: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			assert.deepEqual(steers, []);
+
+			requestAsyncSteer(asyncDir, { message: "first", id: "s1", ts: 1 });
+			h.trigger();
+			assert.deepEqual(steers, ["first"]);
+
+			// A spurious event with nothing queued is a no-op.
+			h.trigger();
+			assert.deepEqual(steers, ["first"]);
+
+			dispose();
+			assert.equal(h.closed(), true);
+
+			requestAsyncSteer(asyncDir, { message: "after dispose", id: "s2", ts: 2 });
+			h.trigger();
+			assert.deepEqual(steers, ["first"], "a disposed watcher must not consume further requests");
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("watches only the steer directory, so a stop request stays for its own consumer", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-scope-");
+		try {
+			requestAsyncStop(asyncDir, { source: "test" });
+			const steers: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			h.trigger();
+			assert.deepEqual(steers, []);
+			assert.equal(h.watchedDir(), fs.realpathSync.native(steerRequestsDir(asyncDir)));
+			assert.equal(fs.readdirSync(stopRequestsDir(asyncDir)).length, 1, "a stop request must not be consumed by the steer watcher");
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("uses portable polling without native watchers on Darwin", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-darwin-");
+		try {
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer() {}, fs: h.fsImpl, timers: h.timers, platform: "darwin" });
+			assert.equal(h.watchedDir(), undefined);
+			assert.deepEqual(h.intervalDelays(), [250]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("starts portable polling once when the native watcher fails", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-fallback-");
+		try {
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer() {}, fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			assert.deepEqual(h.intervalDelays(), [5000], "the native path installs only the safety poll");
+			h.triggerError();
+			h.triggerError();
+			assert.deepEqual(h.intervalDelays(), [5000, 250], "polling starts once, not per error");
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("keeps watching when a consumer throws", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-throws-");
+		try {
+			const seen: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, {
+				onSteer: (request) => {
+					seen.push(request.message);
+					if (request.message === "boom") throw new Error("consumer failed");
+				},
+				fs: h.fsImpl,
+				timers: h.timers,
+				platform: "linux",
+			});
+
+			requestAsyncSteer(asyncDir, { message: "boom", id: "s1", ts: 1 });
+			h.trigger();
+			requestAsyncSteer(asyncDir, { message: "still delivered", id: "s2", ts: 2 });
+			h.trigger();
+
+			assert.deepEqual(seen, ["boom", "still delivered"], "a throwing consumer must not kill the watcher");
 			dispose();
 		} finally {
 			cleanup(asyncDir);

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -709,27 +709,79 @@ describe("control channel: watchAsyncSteerInbox", () => {
 		}
 	});
 
-	it("keeps watching when a consumer throws", () => {
+	it("reports an inbox error that escapes the shared consumer instead of looking idle", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-unavailable-");
+		try {
+			const h = steerHarness();
+			let failProbe = true;
+			// `consumeSteerRequests` deliberately swallows a readdir failure and retains the requests for
+			// the next tick, which its own test asserts. An error that escapes it, though, previously
+			// vanished: the watcher caught everything and returned as if the inbox were empty.
+			const failingFs = {
+				...h.fsImpl,
+				existsSync: ((target: fs.PathLike) => {
+					if (failProbe) throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+					return fs.existsSync(target);
+				}) as typeof fs.existsSync,
+			} as SteerWatchHarness["fsImpl"];
+			const steers: string[] = [];
+			const unavailable: string[] = [];
+			const dispose = watchAsyncSteerInbox(asyncDir, {
+				onSteer: (request) => steers.push(request.message),
+				onUnavailable: (error) => unavailable.push(error instanceof Error ? error.message : String(error)),
+				fs: failingFs,
+				timers: h.timers,
+				platform: "linux",
+			});
+
+			assert.deepEqual(steers, []);
+			assert.deepEqual(unavailable, ["permission denied"], "the caller must be told, not left to assume idle");
+
+			// An unbroken run of failures reports once, not once per tick.
+			h.trigger();
+			assert.deepEqual(unavailable, ["permission denied"]);
+
+			// Recovery still delivers, and the report re-arms for the next unbroken run of failures.
+			failProbe = false;
+			requestAsyncSteer(asyncDir, { message: "after recovery", id: "s1", ts: 1 });
+			h.trigger();
+			assert.deepEqual(steers, ["after recovery"]);
+			failProbe = true;
+			h.trigger();
+			assert.deepEqual(unavailable, ["permission denied", "permission denied"]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("keeps watching when a consumer throws, and does not strand its batch siblings", () => {
 		const asyncDir = tmpAsyncDir("pi-steer-watch-throws-");
 		try {
 			const seen: string[] = [];
+			const unavailable: string[] = [];
 			const h = steerHarness();
 			const dispose = watchAsyncSteerInbox(asyncDir, {
 				onSteer: (request) => {
 					seen.push(request.message);
 					if (request.message === "boom") throw new Error("consumer failed");
 				},
+				onUnavailable: (error) => unavailable.push(error instanceof Error ? error.message : String(error)),
 				fs: h.fsImpl,
 				timers: h.timers,
 				platform: "linux",
 			});
 
+			// Both are consumed off disk in one scan, so a throw on the first must not swallow the second.
 			requestAsyncSteer(asyncDir, { message: "boom", id: "s1", ts: 1 });
+			requestAsyncSteer(asyncDir, { message: "sibling in same batch", id: "s2", ts: 2 });
 			h.trigger();
-			requestAsyncSteer(asyncDir, { message: "still delivered", id: "s2", ts: 2 });
-			h.trigger();
+			assert.deepEqual(seen, ["boom", "sibling in same batch"]);
+			assert.deepEqual(unavailable, ["consumer failed"], "a failed delivery must be reported, not silent");
 
-			assert.deepEqual(seen, ["boom", "still delivered"], "a throwing consumer must not kill the watcher");
+			requestAsyncSteer(asyncDir, { message: "still delivered", id: "s3", ts: 3 });
+			h.trigger();
+			assert.deepEqual(seen, ["boom", "sibling in same batch", "still delivered"], "a throwing consumer must not kill the watcher");
 			dispose();
 		} finally {
 			cleanup(asyncDir);


### PR DESCRIPTION
Fixes #1976. This is the on-disk half of #988, which #994 closed by fixing the in-memory route.

#994 made a workflow-owned foreground child steerable through `resolveWorkflowForegroundSteeringTarget`, but the second bullet of #988's problem statement is still true on `e0c1a433`:

> Steering the owning workflow ID or directory writes to the workflow's async control inbox and can report the request as queued, but the in-process workflow owner does not consume that request for its foreground child.

## The bug

`watchAsyncControlInbox` is installed only by `subagent-runner.ts`, and the runner never executes workflow scripts: `runWorkflowScript` is called only from `subagent-executor.ts`. So for an async `mode: "workflow"` run, no process watches `control/steer-requests/` at all. A request file written there sits on disk for the life of the run and is discarded silently when it ends.

## The reachable writer in stock upstream

This is not reachable only through the `subagent` tool. The Herdr inspector writes to that inbox from its own process:

- `src/inspectors/herdr/actions.ts` spawns `inspector-runner.mjs` into a Herdr pane, so it is a separate process from the pi host.
- `queueInspectorSteer` in `src/inspectors/herdr/inspector-runner.ts` calls `requestAsyncSteer(options.asyncDir, ...)` gated only on the run being non-terminal, with no `mode` gate.

Point a Herdr inspector at an async workflow run, type `steer <message>`, and it replies `Steering queued for run <id>.` The file is written, the operator is told the steer is queued, and nothing ever consumes it. That is an operator-visible receipt for a control action that never happened, which is the opposite of what "Background work stays visible" asks for.

## What changes

Adds `watchAsyncSteerInbox` to `control-channel.ts`. It is deliberately narrower than `watchAsyncControlInbox`: it watches only `steer-requests/`, because a workflow handles interrupt, stop, and timeout through its in-memory controller, and consuming those inbox files in the workflow path would silently discard a stop request. It reuses the runner inbox watch strategy (native `fs.watch` plus a 5s safety poll, 250ms interval polling as the fallback) and the same up-front check for a request that landed before install.

The async workflow path installs it and delivers each request to the addressed step's live in-process control, writing the same `status.steering` targets and `subagent.steer.*` events the requesting side already reads, so an inspector or a `subagent` caller sees the normal receipts.

At teardown it stops watching, closes the inbox so nothing can queue into a dead run, then drains anything in flight to a terminal failed receipt, mirroring the runner teardown, so a late steer fails visibly instead of vanishing.

## Fail-closed properties

- An index beyond the projected steps fails explicitly rather than falling back and steering an unrelated child.
- A run that is no longer running fails its request with the state it actually reached.
- More than one live child asks the caller to address a child run id instead of guessing.
- A watcher that cannot install journals `subagent.workflow.steer_inbox_unavailable` rather than failing the run, since steering is an optional control surface.
- A throwing consumer cannot kill the watcher.

## Scope note

I kept this to one invariant: a steer request written to a workflow run's durable inbox is consumed and answered by its owner.

While building it I had a second change that made the `subagent` tool's `action:"steer"` fall through to the disk route when a live workflow run could not be resolved in the current process. I am NOT including it. The broad version of that gate turns `test/unit/async-interrupt-action.test.ts` "rejects ambiguous workflow steering without choosing a foreground child" from a fail-closed refusal into a disk write, and that guard is correct: ambiguity means the controls are present here and the request is underspecified, which is not a foreign-owner situation. I filed the gap as #1978 with a narrowed direction, including why the narrowed path needs a cross-process fixture to test honestly. No upstream test is modified by this PR.

## Testing

`test/integration/workflow-steer-inbox.test.ts`, two cases. The first launches an async workflow, holds its child live, calls `requestAsyncSteer` on the run directory, and asserts the live child receives the steer text and the run records `routed` then `delivered`. On `main` it times out after 15s with the request file still in `control/steer-requests/` and no `subagent.steer.*` event, which is the defect verbatim. The second asserts the inbox is closed at teardown so a late request is refused; on `main` the inbox is never closed and the request is accepted into a completed run.

`test/unit/control-channel.test.ts`, six `watchAsyncSteerInbox` cases following the existing `watchAsyncControlInbox` harness: the pre-install request, watch-event consumption and dispose, the stop-request scope boundary, the Darwin polling path, the single polling fallback, and the throwing consumer.

Run on `e0c1a433`, macOS 26.3, node v24.4.0:

- `npm run typecheck`: clean
- `npm test` (unit): 2887 tests, 2884 pass, 0 fail, 3 skipped. Unpatched baseline was 2878 pass, so this is baseline plus the 6 new cases.
- `npm run test:integration`: 967 tests, 961 pass, 0 fail, 6 skipped. Unpatched baseline was 959 pass, so baseline plus the 2 new cases.

The integration test is the behavioural discriminator: it fails on `main` for the right reason and passes here. The unit tests cannot run on `main` at all, since the export does not exist there.

## Provenance

Found while running a long multi-agent session on macOS where steers aimed at workflow children were reported queued and never arrived. The Herdr inspector path above is the stock-upstream route that makes it reproducible without any local modification.
