### PR TITLE
fix(supervisor): discover asks with explicit reply authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Keep unconfigured prompt-runtime loads inert. Thanks to [@lertian](https://github.com/lertian) for #1973.
+- Discover supervisor asks on demand even without a UI context, isolate notification failures, and keep answers explicit (#1975, #1982). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Return `invalid_state` instead of queuing unreachable workflow stop requests when live workflow controllers are unavailable (#1965).
 - Forward bounded live tool activity, timing, model/effort, and counters for synchronous workflow children without forwarding transcripts (#1964).
 - Allow `action: "status", view: "transcript"` to inspect bounded live foreground child artifacts on demand (#1963).

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -912,6 +912,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		const previousRuntimeSessionId = state.currentSessionId;
 		resultDeliveryOwnership.claimPredecessor(previousSessionFile, previousRuntimeSessionId);
 		state.currentSessionId = resolveCurrentSessionId(ctx.sessionManager);
+		state.supervisorOwnerSessionId = ctx.sessionManager.getSessionId() || null;
 		transitionResultDelivery();
 		state.parentSessionFile = ctx.sessionManager.getSessionFile();
 		state.trustedSessionFileRoot = state.parentSessionFile ? path.join(getAgentDir(), "sessions") : undefined;
@@ -1029,6 +1030,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			promptTemplateBridge.dispose();
 			state.widgetsSuspended = false;
 			state.currentSessionId = null;
+			state.supervisorOwnerSessionId = null;
 			state.statusProjectionSessionId = null;
 			state.parentSessionFile = null;
 			parentSessionEnvValue = null;

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -727,9 +727,6 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 				pending.set(request.id, request);
 				markForegroundSupervisorAttention(request, state);
 			}
-			else {
-				removeRequestFile(request.requestFile);
-			}
 			// The ask is already queued above. A sendMessage failure (no UI, stale context) must not
 			// lose it, and must not abort the loop before the remaining asks register.
 			try {
@@ -751,7 +748,11 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 						...(request.expectsReply ? { replyHint: supervisorReplyHint(request.id) } : {}),
 					},
 				}, { triggerTurn: true });
+				// sendMessage accepts synchronously; one-way updates stay on disk until it returns.
+				if (!request.expectsReply) removeRequestFile(request.requestFile);
 			} catch (error) {
+				// Allow an existing later scan to retry an unaccepted one-way update.
+				if (!request.expectsReply) seenFiles.delete(file);
 				console.error(`Failed to surface supervisor request ${request.id} as a user turn:`, error);
 			}
 			if (request.expectsReply) {

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import type { ChildSupervisorMetadata } from "../runs/shared/child-runtime-config.ts";
 import { INTERCOM_DETACH_REQUEST_EVENT, POLL_INTERVAL_MS, TEMP_ROOT_DIR, type ControlEvent, type IntercomEventBus, type SubagentState } from "../shared/types.ts";
@@ -381,21 +381,8 @@ function cleanupStaleEmptySupervisorChannels(nowMs = Date.now()): number {
 	return removed;
 }
 
-function currentContextSessionId(state: Pick<SubagentState, "currentSessionId">, ctx: ExtensionContext): string | undefined {
-	try {
-		const sessionId = ctx.sessionManager.getSessionId();
-		if (sessionId) return sessionId;
-	} catch {
-		// Fall through to the last known identity.
-	}
-	return state.currentSessionId ?? undefined;
-}
-
-// `ctx` is optional: session ownership is a property of `state.currentSessionId`, not of the UI
-// context. A null or stale `lastUiContext` must never make an ask from this session look like it
-// belongs to another one, because that silently drops the ask instead of queueing it.
-function requestMatchesContext(request: SupervisorRequest, state: Pick<SubagentState, "currentSessionId">, ctx?: ExtensionContext): boolean {
-	const currentSessionId = ctx ? currentContextSessionId(state, ctx) : state.currentSessionId ?? undefined;
+function requestMatchesOwner(request: SupervisorRequest, state: Pick<SubagentState, "supervisorOwnerSessionId">): boolean {
+	const currentSessionId = state.supervisorOwnerSessionId;
 	return Boolean(currentSessionId && request.orchestratorSessionId === currentSessionId);
 }
 
@@ -465,8 +452,8 @@ function requestRunInactive(request: SupervisorRequest, state: SubagentState): b
 	return stepStatus === "complete" || stepStatus === "completed" || stepStatus === "failed" || stepStatus === "paused";
 }
 
-function requestLifecycle(request: PendingSupervisorRequest, state: SubagentState, ctx: ExtensionContext | undefined, now: number): SupervisorRequestLifecycle {
-	if (ctx && !requestMatchesContext(request, state, ctx)) return "wrong-session";
+function requestLifecycle(request: PendingSupervisorRequest, state: SubagentState, now: number): SupervisorRequestLifecycle {
+	if (!requestMatchesOwner(request, state)) return "wrong-session";
 	if (!fs.existsSync(request.requestFile)) return "missing";
 	if (request.expectsReply && fs.existsSync(replyPath(request.channelDir, request.id))) return "resolved";
 	if (request.expectsReply && now > requestExpiresAt(request, now)) return "expired";
@@ -478,10 +465,10 @@ function cleanupRequestLifecycle(request: PendingSupervisorRequest, lifecycle: S
 	if (lifecycle === "resolved" || lifecycle === "expired" || lifecycle === "inactive") removeRequestFile(request.requestFile);
 }
 
-function refreshPendingRequests(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, ctx: ExtensionContext | undefined, onLifecycle: SupervisorRequestLifecycleObserver): void {
+function refreshPendingRequests(pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver): void {
 	const now = Date.now();
 	for (const request of pending.values()) {
-		const lifecycle = requestLifecycle(request, state, ctx, now);
+		const lifecycle = requestLifecycle(request, state, now);
 		if (lifecycle === "pending") continue;
 		pending.delete(request.id);
 		onLifecycle(request, lifecycle);
@@ -550,57 +537,6 @@ function appendSupervisorReplyEntry(pi: ExtensionAPI, request: PendingSupervisor
 	}
 }
 
-// A child parked in `contact_supervisor` is inside a tool call, so it has no turn boundary. An
-// in-memory steer for such a child can only be QUEUED, and that queue drains at a turn boundary
-// which never comes: the steer receipt claims delivery, the child never sees the message, and
-// `action:"stop"` cannot checkpoint a blocked tool call either. The supervisor channel is the one
-// path that reaches a child inside that tool call, because the child is already polling its reply
-// file. So when a steer targets a child that has a pending ask, deliver the steer AS the reply.
-//
-// This is a registry rather than a parameter because the only convergence point for the
-// workflow-child steer routes (`steerWorkflowForegroundTarget`) has no access to the channel
-// closure, and threading the pending map through every steer call site in subagent-executor.ts
-// would be a far wider change to the run-control surface.
-interface SupervisorAskResolver {
-	pending: Map<string, PendingSupervisorRequest>;
-	resolve: (request: PendingSupervisorRequest, message: string) => void;
-}
-
-const supervisorAskResolvers = new Set<SupervisorAskResolver>();
-
-export interface SupervisorAskSteerOutcome {
-	requestId: string;
-	reason: SupervisorReason;
-}
-
-/**
- * If `runId`/`childIndex` names a child blocked on a supervisor ask, answer that ask with
- * `message` and return the resolved request. Returns undefined when no ask is pending, in which
- * case the caller must fall back to its normal steer delivery, so this never swallows a steer.
- */
-export function resolvePendingSupervisorAskWithSteer(input: { runId: string; childIndex: number; message: string }): SupervisorAskSteerOutcome | undefined {
-	const message = input.message.trim();
-	if (!message) return undefined;
-	for (const resolver of supervisorAskResolvers) {
-		const request = [...resolver.pending.values()].find((candidate) =>
-			candidate.expectsReply
-			&& candidate.runId === input.runId
-			&& candidate.childIndex === input.childIndex,
-		);
-		if (!request) continue;
-		try {
-			resolver.resolve(request, message);
-		} catch (error) {
-			// Fail closed and loud: report no resolution so the caller keeps its own delivery receipt
-			// (queued/failed) rather than claiming a delivery that did not happen.
-			console.error(`Failed to answer supervisor request ${request.id} from a steer:`, error);
-			return undefined;
-		}
-		return { requestId: request.id, reason: request.reason };
-	}
-	return undefined;
-}
-
 function resolvePendingRequest(pending: Map<string, PendingSupervisorRequest>, params: IntercomParams): PendingSupervisorRequest {
 	if (params.replyTo) {
 		const request = pending.get(params.replyTo);
@@ -617,6 +553,7 @@ function resolvePendingRequest(pending: Map<string, PendingSupervisorRequest>, p
 		);
 		if (matches.length === 1) return matches[0]!;
 		if (matches.length > 1) throw new Error(`Multiple pending supervisor requests match '${params.to}'. Use replyTo.`);
+		throw new Error(`No pending supervisor request matches '${params.to}'. Use replyTo.`);
 	}
 	if (requests.length === 1) return requests[0]!;
 	if (requests.length === 0) throw new Error("No pending supervisor requests need a reply.");
@@ -648,7 +585,7 @@ function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, Pendin
 			// supervisor requests" while the child blocked in contact_supervisor. An explicit supervisor
 			// query must always be authoritative against disk.
 			discover();
-			refreshPendingRequests(pending, state, state.lastUiContext ?? undefined, onLifecycle);
+			refreshPendingRequests(pending, state, onLifecycle);
 			const input = params as IntercomParams;
 			if (input.action === "status") {
 				return { content: [{ type: "text", text: `Native supervisor channel active. Pending replies: ${pending.size}.` }], details: { active: true, pending: pending.size, root: SUPERVISOR_CHANNEL_ROOT } };
@@ -754,21 +691,6 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pi, pending, state, observeRequestLifecycle, () => poll()));
 	};
 
-	// Expose this channel's ask queue to the steer routes so a steer can answer a child blocked
-	// inside contact_supervisor. Uses the same writeReply/journal/attention sequence as
-	// `action:"reply"` so the child, the transcript, and the attention state all see one
-	// consistent resolution.
-	const askResolver: SupervisorAskResolver = {
-		pending,
-		resolve: (request, message) => {
-			const reply = writeReply(request, message);
-			appendSupervisorReplyEntry(pi, request, reply);
-			observeRequestLifecycle(request, "resolved");
-			pending.delete(request.id);
-			clearForegroundSupervisorAttention(request, pending, state);
-		},
-	};
-
 	const cleanupStaleChannelsIfDue = (): void => {
 		const nowMs = Date.now();
 		if (nowMs - lastStaleCleanupAt < STALE_EMPTY_CHANNEL_CLEANUP_INTERVAL_MS) return;
@@ -786,14 +708,13 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		// `state.lastUiContext` was null (never set yet, or nulled by a stale-context error) meant an
 		// ask written by a child was never read off disk, so `subagent_supervisor({action:"pending"})`
 		// reported nothing. The queue is authoritative; only the display notification needs the context.
-		const ctx = state.lastUiContext ?? undefined;
-		refreshPendingRequests(pending, state, ctx, observeRequestLifecycle);
+		refreshPendingRequests(pending, state, observeRequestLifecycle);
 		const now = Date.now();
 		for (const { channelDir, file } of listRequestFiles()) {
 			if (seenFiles.has(file)) continue;
 			const request = parseRequestFile(file, channelDir);
-			if (!request || !requestMatchesContext(request, state, ctx)) continue;
-			const lifecycle = requestLifecycle(request, state, undefined, now);
+			if (!request || !requestMatchesOwner(request, state)) continue;
+			const lifecycle = requestLifecycle(request, state, now);
 			if (lifecycle !== "pending") {
 				seenFiles.add(file);
 				observeRequestLifecycle(request, lifecycle);
@@ -912,7 +833,6 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		start: () => {
 			if (started) return;
 			started = true;
-			supervisorAskResolvers.add(askResolver);
 			registerParentTools();
 			poll();
 			try {
@@ -936,7 +856,6 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		},
 		dispose: () => {
 			started = false;
-			supervisorAskResolvers.delete(askResolver);
 			try {
 				rootWatcher?.close();
 			} catch {

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -391,8 +391,11 @@ function currentContextSessionId(state: Pick<SubagentState, "currentSessionId">,
 	return state.currentSessionId ?? undefined;
 }
 
-function requestMatchesContext(request: SupervisorRequest, state: Pick<SubagentState, "currentSessionId">, ctx: ExtensionContext): boolean {
-	const currentSessionId = currentContextSessionId(state, ctx);
+// `ctx` is optional: session ownership is a property of `state.currentSessionId`, not of the UI
+// context. A null or stale `lastUiContext` must never make an ask from this session look like it
+// belongs to another one, because that silently drops the ask instead of queueing it.
+function requestMatchesContext(request: SupervisorRequest, state: Pick<SubagentState, "currentSessionId">, ctx?: ExtensionContext): boolean {
+	const currentSessionId = ctx ? currentContextSessionId(state, ctx) : state.currentSessionId ?? undefined;
 	return Boolean(currentSessionId && request.orchestratorSessionId === currentSessionId);
 }
 
@@ -547,6 +550,57 @@ function appendSupervisorReplyEntry(pi: ExtensionAPI, request: PendingSupervisor
 	}
 }
 
+// A child parked in `contact_supervisor` is inside a tool call, so it has no turn boundary. An
+// in-memory steer for such a child can only be QUEUED, and that queue drains at a turn boundary
+// which never comes: the steer receipt claims delivery, the child never sees the message, and
+// `action:"stop"` cannot checkpoint a blocked tool call either. The supervisor channel is the one
+// path that reaches a child inside that tool call, because the child is already polling its reply
+// file. So when a steer targets a child that has a pending ask, deliver the steer AS the reply.
+//
+// This is a registry rather than a parameter because the only convergence point for the
+// workflow-child steer routes (`steerWorkflowForegroundTarget`) has no access to the channel
+// closure, and threading the pending map through every steer call site in subagent-executor.ts
+// would be a far wider change to the run-control surface.
+interface SupervisorAskResolver {
+	pending: Map<string, PendingSupervisorRequest>;
+	resolve: (request: PendingSupervisorRequest, message: string) => void;
+}
+
+const supervisorAskResolvers = new Set<SupervisorAskResolver>();
+
+export interface SupervisorAskSteerOutcome {
+	requestId: string;
+	reason: SupervisorReason;
+}
+
+/**
+ * If `runId`/`childIndex` names a child blocked on a supervisor ask, answer that ask with
+ * `message` and return the resolved request. Returns undefined when no ask is pending, in which
+ * case the caller must fall back to its normal steer delivery, so this never swallows a steer.
+ */
+export function resolvePendingSupervisorAskWithSteer(input: { runId: string; childIndex: number; message: string }): SupervisorAskSteerOutcome | undefined {
+	const message = input.message.trim();
+	if (!message) return undefined;
+	for (const resolver of supervisorAskResolvers) {
+		const request = [...resolver.pending.values()].find((candidate) =>
+			candidate.expectsReply
+			&& candidate.runId === input.runId
+			&& candidate.childIndex === input.childIndex,
+		);
+		if (!request) continue;
+		try {
+			resolver.resolve(request, message);
+		} catch (error) {
+			// Fail closed and loud: report no resolution so the caller keeps its own delivery receipt
+			// (queued/failed) rather than claiming a delivery that did not happen.
+			console.error(`Failed to answer supervisor request ${request.id} from a steer:`, error);
+			return undefined;
+		}
+		return { requestId: request.id, reason: request.reason };
+	}
+	return undefined;
+}
+
 function resolvePendingRequest(pending: Map<string, PendingSupervisorRequest>, params: IntercomParams): PendingSupervisorRequest {
 	if (params.replyTo) {
 		const request = pending.get(params.replyTo);
@@ -580,13 +634,20 @@ function publicPendingRequests(pending: Map<string, PendingSupervisorRequest>): 
 	}));
 }
 
-function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
+function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, PendingSupervisorRequest>, state: SubagentState, onLifecycle: SupervisorRequestLifecycleObserver, discover: () => void): ToolDefinition<typeof IntercomParamsSchema, Record<string, unknown>> {
 	return {
 		name: NATIVE_SUPERVISOR_TOOL_NAME,
 		label: "Subagent Supervisor",
 		description: "Native pi-subagents supervisor channel. Use reply/pending/status to answer child subagent requests without overriding pi-intercom.",
 		parameters: IntercomParamsSchema,
 		async execute(_id, params) {
+			// Scan the channel root before answering. `refreshPendingRequests` only re-evaluates asks
+			// ALREADY in `pending`; it never reads the filesystem. Because no fs watcher is installed on
+			// darwin and the 500ms poller is demand-gated and self-cancelling, an ask written while
+			// nothing was polling stayed invisible and every `action:"pending"` reported "No pending
+			// supervisor requests" while the child blocked in contact_supervisor. An explicit supervisor
+			// query must always be authoritative against disk.
+			discover();
 			refreshPendingRequests(pending, state, state.lastUiContext ?? undefined, onLifecycle);
 			const input = params as IntercomParams;
 			if (input.action === "status") {
@@ -690,7 +751,22 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 
 	const registerParentTools = (): void => {
-		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pi, pending, state, observeRequestLifecycle));
+		if (!hasTool(pi, NATIVE_SUPERVISOR_TOOL_NAME)) pi.registerTool(buildParentSupervisorTool(pi, pending, state, observeRequestLifecycle, () => poll()));
+	};
+
+	// Expose this channel's ask queue to the steer routes so a steer can answer a child blocked
+	// inside contact_supervisor. Uses the same writeReply/journal/attention sequence as
+	// `action:"reply"` so the child, the transcript, and the attention state all see one
+	// consistent resolution.
+	const askResolver: SupervisorAskResolver = {
+		pending,
+		resolve: (request, message) => {
+			const reply = writeReply(request, message);
+			appendSupervisorReplyEntry(pi, request, reply);
+			observeRequestLifecycle(request, "resolved");
+			pending.delete(request.id);
+			clearForegroundSupervisorAttention(request, pending, state);
+		},
 	};
 
 	const cleanupStaleChannelsIfDue = (): void => {
@@ -706,8 +782,11 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 
 	const poll = (): void => {
 		cleanupStaleChannelsIfDue();
-		const ctx = state.lastUiContext;
-		if (!ctx) return;
+		// Registration must not require a live UI context. Returning early whenever
+		// `state.lastUiContext` was null (never set yet, or nulled by a stale-context error) meant an
+		// ask written by a child was never read off disk, so `subagent_supervisor({action:"pending"})`
+		// reported nothing. The queue is authoritative; only the display notification needs the context.
+		const ctx = state.lastUiContext ?? undefined;
 		refreshPendingRequests(pending, state, ctx, observeRequestLifecycle);
 		const now = Date.now();
 		for (const { channelDir, file } of listRequestFiles()) {
@@ -730,24 +809,30 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			else {
 				removeRequestFile(request.requestFile);
 			}
-			pi.sendMessage({
-				customType: SUPERVISOR_REQUEST_MESSAGE_TYPE,
-				content: requestVisibleText(request),
-				display: true,
-				details: {
-					id: request.id,
-					requestId: request.id,
-					reason: request.reason,
-					expectsReply: request.expectsReply,
-					runId: request.runId,
-					agent: request.agent,
-					childIndex: request.childIndex,
-					...(request.childTarget ? { childTarget: request.childTarget } : {}),
-					...(request.interview !== undefined ? { interview: request.interview } : {}),
-					requestBody: request.message,
-					...(request.expectsReply ? { replyHint: supervisorReplyHint(request.id) } : {}),
-				},
-			}, { triggerTurn: true });
+			// The ask is already queued above. A sendMessage failure (no UI, stale context) must not
+			// lose it, and must not abort the loop before the remaining asks register.
+			try {
+				pi.sendMessage({
+					customType: SUPERVISOR_REQUEST_MESSAGE_TYPE,
+					content: requestVisibleText(request),
+					display: true,
+					details: {
+						id: request.id,
+						requestId: request.id,
+						reason: request.reason,
+						expectsReply: request.expectsReply,
+						runId: request.runId,
+						agent: request.agent,
+						childIndex: request.childIndex,
+						...(request.childTarget ? { childTarget: request.childTarget } : {}),
+						...(request.interview !== undefined ? { interview: request.interview } : {}),
+						requestBody: request.message,
+						...(request.expectsReply ? { replyHint: supervisorReplyHint(request.id) } : {}),
+					},
+				}, { triggerTurn: true });
+			} catch (error) {
+				console.error(`Failed to surface supervisor request ${request.id} as a user turn:`, error);
+			}
 			if (request.expectsReply) {
 				(pi as { events?: IntercomEventBus }).events?.emit(INTERCOM_DETACH_REQUEST_EVENT, {
 					requestId: request.id,
@@ -827,6 +912,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		start: () => {
 			if (started) return;
 			started = true;
+			supervisorAskResolvers.add(askResolver);
 			registerParentTools();
 			poll();
 			try {
@@ -850,6 +936,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		},
 		dispose: () => {
 			started = false;
+			supervisorAskResolvers.delete(askResolver);
 			try {
 				rootWatcher?.close();
 			} catch {

--- a/src/runs/foreground/workflow-foreground-steering.ts
+++ b/src/runs/foreground/workflow-foreground-steering.ts
@@ -4,7 +4,6 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Details, ForegroundRunControl, SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { steeringReceipt } from "../background/steering.ts";
-import { resolvePendingSupervisorAskWithSteer } from "../../intercom/native-supervisor-channel.ts";
 import type { SteerDeliveryMode } from "../background/control-channel.ts";
 
 export interface WorkflowForegroundSteeringTarget {
@@ -92,25 +91,6 @@ export async function steerWorkflowForegroundTarget(input: {
 
 	const message = input.message.trim();
 	const requestId = randomUUID();
-
-	// A child blocked inside `contact_supervisor` has no turn boundary, so `child.steer` can only
-	// queue and that queue never drains. The supervisor channel is the only path into an open tool
-	// call, so if this child has a pending ask, answer the ask with the steer text. Checked BEFORE
-	// `child.steer` so the message is delivered exactly once.
-	const askOutcome = resolvePendingSupervisorAskWithSteer({ runId: control.runId, childIndex: index, message });
-	if (askOutcome) {
-		const steering = {
-			requestId,
-			state: "delivered" as const,
-			deliveryStatus: "delivered" as const,
-			sourceRunId,
-			targets: [{ index, state: "delivered" as const, deliveredAt: Date.now() }],
-		};
-		return {
-			content: [{ type: "text", text: steeringReceipt(message, `Steering delivered for foreground run ${control.runId} (request ${requestId}) by answering its open supervisor request ${askOutcome.requestId}; the child is unblocked.`) }],
-			details: { mode: "management", results: [], steering },
-		};
-	}
 
 	const outcome = await child.steer({ message, ...(input.mode && input.mode !== "steer" ? { mode: input.mode } : {}) });
 	const target = outcome.state === "delivered"

--- a/src/runs/foreground/workflow-foreground-steering.ts
+++ b/src/runs/foreground/workflow-foreground-steering.ts
@@ -4,6 +4,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Details, ForegroundRunControl, SubagentState } from "../../shared/types.ts";
 import { readStatus } from "../../shared/utils.ts";
 import { steeringReceipt } from "../background/steering.ts";
+import { resolvePendingSupervisorAskWithSteer } from "../../intercom/native-supervisor-channel.ts";
 import type { SteerDeliveryMode } from "../background/control-channel.ts";
 
 export interface WorkflowForegroundSteeringTarget {
@@ -91,6 +92,26 @@ export async function steerWorkflowForegroundTarget(input: {
 
 	const message = input.message.trim();
 	const requestId = randomUUID();
+
+	// A child blocked inside `contact_supervisor` has no turn boundary, so `child.steer` can only
+	// queue and that queue never drains. The supervisor channel is the only path into an open tool
+	// call, so if this child has a pending ask, answer the ask with the steer text. Checked BEFORE
+	// `child.steer` so the message is delivered exactly once.
+	const askOutcome = resolvePendingSupervisorAskWithSteer({ runId: control.runId, childIndex: index, message });
+	if (askOutcome) {
+		const steering = {
+			requestId,
+			state: "delivered" as const,
+			deliveryStatus: "delivered" as const,
+			sourceRunId,
+			targets: [{ index, state: "delivered" as const, deliveredAt: Date.now() }],
+		};
+		return {
+			content: [{ type: "text", text: steeringReceipt(message, `Steering delivered for foreground run ${control.runId} (request ${requestId}) by answering its open supervisor request ${askOutcome.requestId}; the child is unblocked.`) }],
+			details: { mode: "management", results: [], steering },
+		};
+	}
+
 	const outcome = await child.steer({ message, ...(input.mode && input.mode !== "steer" ? { mode: input.mode } : {}) });
 	const target = outcome.state === "delivered"
 		? { index, state: "delivered" as const, deliveredAt: Date.now() }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2206,6 +2206,8 @@ export interface ActiveAsyncCapacitySnapshot {
 export interface SubagentState {
 	baseCwd: string;
 	currentSessionId: string | null;
+	/** Exact SDK runtime session ID for supervisor ownership; never a session file path. */
+	supervisorOwnerSessionId?: string | null;
 	/** Session for which active status projections were restored successfully. */
 	statusProjectionSessionId?: string | null;
 	/** Reload-stable identity for this parent Pi process/window. */

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -146,6 +146,7 @@ function writeRunningAsyncStatus(runDir: string, runId: string, sessionId: strin
 function createNativeSupervisorHarness(sessionId: string) {
 	const nativeState = createState();
 	(nativeState as { currentSessionId: string; lastUiContext: unknown }).currentSessionId = sessionId;
+	(nativeState as { supervisorOwnerSessionId: string }).supervisorOwnerSessionId = sessionId;
 	(nativeState as { currentSessionId: string; lastUiContext: unknown }).lastUiContext = {
 		hasUI: false,
 		sessionManager: {

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -20,6 +20,7 @@ function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	return {
 		baseCwd: process.cwd(),
 		currentSessionId: sessionId,
+		supervisorOwnerSessionId: (ctx as SubagentState["lastUiContext"])?.sessionManager.getSessionId() ?? null,
 		asyncJobs: new Map(),
 		foregroundControls: new Map(),
 		lastForegroundControlId: null,

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { afterEach, describe, it } from "node:test";
 import {
 	NATIVE_SUPERVISOR_TOOL_NAME,
@@ -11,18 +12,19 @@ import {
 	resolveSupervisorChannelDir,
 } from "../../src/intercom/native-supervisor-channel.ts";
 import { steerWorkflowForegroundTarget } from "../../src/runs/foreground/workflow-foreground-steering.ts";
-import type { ForegroundSteerInput, SubagentState } from "../../src/shared/types.ts";
+import type { ForegroundRunControl, ForegroundSteerInput, SubagentState } from "../../src/shared/types.ts";
 
 const createdChannels: string[] = [];
 
 interface SupervisorTool {
-	execute: (id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }>;
+	execute: (id: string, params: { action: string; replyTo?: string; to?: string; message?: string }) => Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }>;
 }
 
 function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	return {
 		baseCwd: process.cwd(),
 		currentSessionId: sessionId,
+		supervisorOwnerSessionId: (ctx as SubagentState["lastUiContext"])?.sessionManager.getSessionId() ?? null,
 		asyncJobs: new Map(),
 		foregroundControls: new Map(),
 		lastForegroundControlId: null,
@@ -36,13 +38,13 @@ function makeState(sessionId: string | null, ctx: unknown): SubagentState {
 	};
 }
 
-function makeCtx(sessionId: string): { cwd: string; hasUI: boolean; sessionManager: { getSessionId: () => string; getSessionFile: () => null; getEntries: () => [] } } {
+function makeCtx(sessionId: string, sessionFile: string | null = null): { cwd: string; hasUI: boolean; sessionManager: { getSessionId: () => string; getSessionFile: () => string | null; getEntries: () => [] } } {
 	return {
 		cwd: process.cwd(),
 		hasUI: false,
 		sessionManager: {
 			getSessionId: () => sessionId,
-			getSessionFile: () => null,
+			getSessionFile: () => sessionFile,
 			getEntries: () => [],
 		},
 	};
@@ -53,7 +55,7 @@ function makeCtx(sessionId: string): { cwd: string; hasUI: boolean; sessionManag
  * going through a live poller. This is the state the wave-11 incident was in: the request file was
  * on disk and no scan had happened yet.
  */
-function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; reason?: "need_decision" | "progress_update" }): string {
+function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; reason?: "need_decision" | "progress_update"; expiresAt?: number }): string {
 	const agent = input.agent ?? "worker";
 	const index = input.index ?? 0;
 	const channelDir = resolveSupervisorChannelDir(input.runId, agent, index);
@@ -65,6 +67,7 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 		type: "subagent.supervisor.request",
 		id: requestId,
 		createdAt: Date.now(),
+		...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
 		reason,
 		message: input.message ?? "Need a decision",
 		expectsReply: reason !== "progress_update",
@@ -86,32 +89,172 @@ function makePi(options: { tools: Map<string, SupervisorTool>; onSend?: () => vo
 	};
 }
 
-function registerWorkflowChild(state: SubagentState, workflowRunId: string, childRunId: string, steer: (input: ForegroundSteerInput) => Promise<{ state: "delivered" | "queued" | "failed"; reason?: string }>): void {
-	state.workflowControllers ??= new Map();
-	state.workflowControllers.set(workflowRunId, new AbortController());
-	state.foregroundControls.set(childRunId, {
-		runId: childRunId,
-		parentWorkflowRunId: workflowRunId,
-		workflowKey: childRunId,
-		sessionId: "session",
-		mode: "single",
-		startedAt: 100,
-		updatedAt: 100,
-		activeChildren: new Map([[0, { index: 0, agent: "worker", startedAt: 100, updatedAt: 100, steer }]]),
-		schedulingOwners: 1,
-	} as never);
-}
-
 function text(result: { content: Array<{ type: string; text?: string }> }): string {
 	return result.content[0]?.type === "text" ? result.content[0].text ?? "" : "";
 }
 
 afterEach(() => {
-	delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
 	for (const channel of createdChannels.splice(0)) fs.rmSync(channel, { recursive: true, force: true });
 });
 
 describe("supervisor ask registration", () => {
+	it("caches runtime ownership at extension session_start and clears it at shutdown despite stale UI", () => {
+		const script = String.raw`
+			import assert from "node:assert/strict";
+			import fs from "node:fs";
+			import os from "node:os";
+			import path from "node:path";
+			import { randomUUID } from "node:crypto";
+			import registerExtension from "./index.ts";
+			import { resolveSupervisorChannelDir, ensureSupervisorChannelDir } from "./src/intercom/native-supervisor-channel.ts";
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "supervisor-owner-"));
+			const channels = [];
+			function start(owner) {
+				const handlers = new Map();
+				const tools = new Map();
+				const pi = new Proxy({
+					events: { on() { return () => {}; }, emit() {} },
+					on(name, handler) { handlers.set(name, handler); },
+					getAllTools() { return [...tools.keys()].map(name => ({ name })); },
+					registerTool(tool) { tools.set(tool.name, tool); },
+					registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
+				}, { get(target, key) { return key in target ? target[key] : () => undefined; } });
+				const sessionFile = path.join(root, owner + ".jsonl");
+				fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", version: 3, id: owner, timestamp: new Date().toISOString(), cwd: root }) + "\n");
+				let stale = false;
+				const ctx = {
+					cwd: root,
+					get hasUI() { if (stale) throw new Error("This extension ctx is stale after session replacement or reload."); return false; },
+					ui: { setWidget() {}, requestRender() {}, onTerminalInput() { return () => {}; }, notify() {}, theme: { fg(_name, text) { return text; }, bold(text) { return text; } } },
+					sessionManager: {
+						getSessionId() { if (stale) throw new Error("stale session manager"); return owner; },
+						getSessionFile() { return sessionFile; }, getEntries() { return []; },
+					},
+					modelRegistry: { getAvailable() { return []; } },
+				};
+				registerExtension(pi);
+				handlers.get("session_start")({ reason: "startup" }, ctx);
+				stale = true;
+				// Exercise the production stale-context clearing path, not direct state assignment.
+				handlers.get("session_before_compact")({ reason: "threshold", signal: new AbortController().signal });
+				return { tool: tools.get("subagent_supervisor"), shutdown: () => handlers.get("session_shutdown")() };
+			}
+			function ask(owner) {
+				const id = randomUUID();
+				const runId = randomUUID();
+				const dir = resolveSupervisorChannelDir(runId, "worker", 0);
+				channels.push(dir);
+				ensureSupervisorChannelDir(dir);
+				fs.writeFileSync(path.join(dir, "requests", id + ".json"), JSON.stringify({ type: "subagent.supervisor.request", id, createdAt: Date.now(), reason: "need_decision", message: "Decision?", expectsReply: true, orchestratorSessionId: owner, runId, agent: "worker", childIndex: 0 }));
+				return id;
+			}
+			let runtime;
+			try {
+				const owner = randomUUID();
+				runtime = start(owner);
+				const first = ask(owner);
+				assert.match(JSON.stringify(await runtime.tool.execute("pending", { action: "pending" })), new RegExp(first));
+				await runtime.shutdown();
+				const afterShutdown = ask(owner);
+				await assert.rejects(runtime.tool.execute("reply", { action: "reply", replyTo: afterShutdown, message: "No authority" }), /No pending supervisor request found/);
+				runtime = undefined;
+				const replacement = randomUUID();
+				runtime = start(replacement);
+				await assert.rejects(runtime.tool.execute("reply", { action: "reply", replyTo: first, message: "Foreign" }), /No pending supervisor request found/);
+				const next = ask(replacement);
+				assert.match(JSON.stringify(await runtime.tool.execute("reply", { action: "reply", replyTo: next, message: "Approved" })), new RegExp(next));
+			} finally {
+				await runtime?.shutdown();
+				for (const dir of channels) fs.rmSync(dir, { recursive: true, force: true });
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		`;
+		const env = { ...process.env };
+		delete env.PI_SUBAGENT_CHILD;
+		execFileSync(process.execPath, ["--experimental-strip-types", "--import", "./test/support/register-loader.mjs", "--input-type=module", "--eval", script], { cwd: process.cwd(), env, stdio: "pipe", timeout: 30_000 });
+	});
+
+	it("fails closed for explicit mistargets and ambiguity without UI, then answers only the exact ask", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(`/sessions/${sessionId}.jsonl`, makeCtx(sessionId));
+		state.lastUiContext = null;
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+		try {
+			channel.start();
+			const first = writeRequest({ sessionId, runId });
+			const tool = tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!;
+			await assert.rejects(tool.execute("wrong", { action: "reply", to: "different-agent", message: "Approved" }), /No pending supervisor request matches/);
+			await assert.rejects(tool.execute("unknown", { action: "reply", replyTo: "unknown", message: "Approved" }), /No pending supervisor request found/);
+			assert.equal(channel.pending.has(first), true);
+			const second = writeRequest({ sessionId, runId });
+			await assert.rejects(tool.execute("ambiguous", { action: "reply", message: "Approved" }), /Multiple pending supervisor requests/);
+			await assert.rejects(tool.execute("agent", { action: "reply", to: "worker", message: "Approved" }), /Multiple pending supervisor requests match/);
+			const replies = path.join(resolveSupervisorChannelDir(runId, "worker", 0), "replies");
+			assert.deepEqual(fs.readdirSync(replies), []);
+			await tool.execute("exact", { action: "reply", replyTo: second, message: "Only second" });
+			assert.deepEqual(fs.readdirSync(replies), [`${second}.json`]);
+			assert.equal(JSON.parse(fs.readFileSync(path.join(replies, `${second}.json`), "utf8")).message, "Only second");
+			assert.equal(channel.pending.has(first), true);
+			assert.equal(channel.pending.has(second), false);
+		} finally { channel.dispose(); }
+	});
+
+	it("rejects stale discovered and cached asks with no UI", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(`/sessions/${sessionId}.jsonl`, makeCtx(sessionId));
+		state.lastUiContext = null;
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+		try {
+			channel.start();
+			const tool = tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!;
+			const expired = writeRequest({ sessionId, runId, expiresAt: Date.now() - 1 });
+			await assert.rejects(tool.execute("expired", { action: "reply", replyTo: expired, message: "Too late" }), /No pending supervisor request found/);
+			const missing = writeRequest({ sessionId, runId });
+			const resolved = writeRequest({ sessionId, runId });
+			await tool.execute("pending", { action: "pending" });
+			assert.equal(channel.pending.size, 2);
+			const dir = resolveSupervisorChannelDir(runId, "worker", 0);
+			fs.rmSync(path.join(dir, "requests", `${missing}.json`));
+			const replyFile = path.join(dir, "replies", `${resolved}.json`);
+			fs.writeFileSync(replyFile, JSON.stringify({ message: "Already answered" }));
+			for (const replyTo of [missing, resolved]) {
+				await assert.rejects(tool.execute("stale", { action: "reply", replyTo, message: "Must not overwrite" }), /No pending supervisor request found/);
+			}
+			assert.equal(channel.pending.size, 0);
+			assert.deepEqual(fs.readdirSync(path.join(dir, "replies")), [`${resolved}.json`]);
+			assert.equal(JSON.parse(fs.readFileSync(replyFile, "utf8")).message, "Already answered");
+		} finally { channel.dispose(); }
+	});
+
+	it("rechecks cached ownership without UI and never uses the persisted identity as authority", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId, runId });
+			const tool = tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!;
+			await tool.execute("pending", { action: "pending" });
+			assert.equal(channel.pending.has(requestId), true);
+			state.lastUiContext = null;
+			state.supervisorOwnerSessionId = `replacement-${randomUUID()}`;
+			await assert.rejects(tool.execute("foreign", { action: "reply", replyTo: requestId, message: "Wrong owner" }), /No pending supervisor request found/);
+			assert.equal(channel.pending.size, 0);
+			state.supervisorOwnerSessionId = null;
+			const uncached = writeRequest({ sessionId, runId });
+			await assert.rejects(tool.execute("no-owner", { action: "reply", replyTo: uncached, message: "No authority" }), /No pending supervisor request found/);
+			const dir = resolveSupervisorChannelDir(runId, "worker", 0);
+			assert.equal(fs.existsSync(path.join(dir, "requests", `${requestId}.json`)), true, "foreign requests are not ours to delete");
+			assert.deepEqual(fs.readdirSync(path.join(dir, "replies")), []);
+		} finally { channel.dispose(); }
+	});
+
 	// D1: `refreshPendingRequests` only re-evaluates asks already in `pending`; it never reads the
 	// filesystem. With no watcher installed and the demand-gated poller stopped, an ask written by
 	// a child was unfindable by ANY number of `action:"pending"` calls.
@@ -171,18 +314,21 @@ describe("supervisor ask registration", () => {
 		}
 	});
 
-	// D3: `poll()` returned early whenever `state.lastUiContext` was null, which blinded the QUEUE
-	// and not just the display. Session ownership is carried by `state.currentSessionId`.
-	it("registers an ask with a null UI context", () => {
+	it("discovers a runtime-owned ask with a persisted session path and null UI context", async () => {
 		const sessionId = `session-${randomUUID()}`;
 		const runId = `run-${randomUUID()}`;
-		const requestId = writeRequest({ sessionId, runId });
 		const tools = new Map<string, SupervisorTool>();
-		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, null), { platform: "darwin" });
+		const sessionFile = path.join(process.cwd(), `${sessionId}.jsonl`);
+		const state = makeState(sessionFile, makeCtx(sessionId, sessionFile));
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
 
 		try {
 			channel.start();
+			state.lastUiContext = null;
+			const requestId = writeRequest({ sessionId, runId });
+			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
 			assert.equal(channel.pending.has(requestId), true, "a null lastUiContext must not drop the ask");
+			assert.equal(state.currentSessionId, sessionFile, "global session identity must remain unchanged");
 		} finally {
 			channel.dispose();
 		}
@@ -194,7 +340,9 @@ describe("supervisor ask registration", () => {
 		const runId = `run-${randomUUID()}`;
 		const foreignId = writeRequest({ sessionId: foreignSessionId, runId });
 		const tools = new Map<string, SupervisorTool>();
-		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, null), { platform: "darwin" });
+		const state = makeState(`/sessions/${sessionId}.jsonl`, makeCtx(sessionId));
+		state.lastUiContext = null;
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
 
 		try {
 			channel.start();
@@ -204,127 +352,26 @@ describe("supervisor ask registration", () => {
 		}
 	});
 
-	it("keeps a queued ask when the user-turn notification throws", () => {
+	it("registers both asks even when every user-turn notification throws", () => {
 		const sessionId = `session-${randomUUID()}`;
 		const runId = `run-${randomUUID()}`;
 		const requestId = writeRequest({ sessionId, runId });
 		const tools = new Map<string, SupervisorTool>();
 		const pi = makePi({ tools, onSend: () => { throw new Error("no UI attached"); } });
+		const secondId = writeRequest({ sessionId, runId });
 		const channel = createNativeSupervisorChannel(pi as never, makeState(sessionId, makeCtx(sessionId)), { platform: "darwin" });
 
 		try {
 			channel.start();
 			assert.equal(channel.pending.has(requestId), true, "a display failure must not lose an already-queued ask");
+			assert.equal(channel.pending.has(secondId), true, "a display failure must not abort discovery of remaining asks");
 		} finally {
 			channel.dispose();
 		}
 	});
 
-	// D4: a child inside `contact_supervisor` has no turn boundary, so `child.steer` can only
-	// return "queued" into a queue that never drains. The steer must instead answer the open ask.
-	it("answers a blocked child's open ask when a steer targets it", async () => {
-		const sessionId = `session-${randomUUID()}`;
-		const workflowRunId = `workflow-${randomUUID()}`;
-		const tools = new Map<string, SupervisorTool>();
-		const state = makeState(sessionId, makeCtx(sessionId));
-		const queued: string[] = [];
-		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
-			queued.push(input.message);
-			return { state: "queued" as const };
-		});
-		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
-
-		try {
-			channel.start();
-			const requestId = writeRequest({ sessionId, runId: workflowRunId });
-			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
-			assert.equal(channel.pending.has(requestId), true, "precondition: the child is blocked on a registered ask");
-
-			const control = state.foregroundControls.get(workflowRunId)!;
-			const result = await steerWorkflowForegroundTarget({
-				target: { control, workflowRunId, sourceRunId: workflowRunId },
-				message: "RULING VIA STEER: proceed with option A.",
-			});
-
-			assert.equal(result.details.steering?.state, "delivered", "the steer must report a real delivery, not a queue");
-			assert.match(text(result), new RegExp(`open supervisor request ${requestId}`));
-			assert.match(text(result), /the child is unblocked/);
-			assert.deepEqual(queued, [], "the message must be delivered exactly once, not also queued in the dead queue");
-
-			const reply = path.join(resolveSupervisorChannelDir(workflowRunId, "worker", 0), "replies", `${requestId}.json`);
-			assert.equal(JSON.parse(fs.readFileSync(reply, "utf-8")).message, "RULING VIA STEER: proceed with option A.");
-			assert.equal(channel.pending.has(requestId), false, "the answered ask must leave the pending queue");
-		} finally {
-			channel.dispose();
-		}
-	});
-
-	it("falls back to the normal steer route and reports its real state when no ask is pending", async () => {
-		const sessionId = `session-${randomUUID()}`;
-		const workflowRunId = `workflow-${randomUUID()}`;
-		const tools = new Map<string, SupervisorTool>();
-		const state = makeState(sessionId, makeCtx(sessionId));
-		const queued: string[] = [];
-		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
-			queued.push(input.message);
-			return { state: "queued" as const };
-		});
-		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
-
-		try {
-			channel.start();
-			const control = state.foregroundControls.get(workflowRunId)!;
-			const result = await steerWorkflowForegroundTarget({
-				target: { control, workflowRunId, sourceRunId: workflowRunId },
-				message: "No ask is open here.",
-			});
-
-			// A queued in-memory steer reports `state: "pending"` with a queued target: the honest
-			// receipt for a message that has not reached the child yet.
-			assert.equal(result.details.steering?.state, "pending", "without a pending ask the receipt must stay honest");
-			assert.equal(result.details.steering?.targets[0]?.state, "queued");
-			assert.deepEqual(queued, ["No ask is open here."]);
-		} finally {
-			channel.dispose();
-		}
-	});
-
-	it("does not answer an ask that belongs to a different child index", async () => {
-		const sessionId = `session-${randomUUID()}`;
-		const workflowRunId = `workflow-${randomUUID()}`;
-		const tools = new Map<string, SupervisorTool>();
-		const state = makeState(sessionId, makeCtx(sessionId));
-		const queued: string[] = [];
-		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
-			queued.push(input.message);
-			return { state: "queued" as const };
-		});
-		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
-
-		try {
-			channel.start();
-			const otherIndexAsk = writeRequest({ sessionId, runId: workflowRunId, index: 3 });
-			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
-			assert.equal(channel.pending.has(otherIndexAsk), true, "precondition: index 3 has the open ask");
-
-			const control = state.foregroundControls.get(workflowRunId)!;
-			const result = await steerWorkflowForegroundTarget({
-				target: { control, workflowRunId, sourceRunId: workflowRunId },
-				message: "Meant for index 0.",
-			});
-
-			assert.equal(result.details.steering?.state, "pending", "index 0 has no ask, so the normal route must be used");
-			assert.equal(result.details.steering?.targets[0]?.state, "queued");
-			assert.deepEqual(queued, ["Meant for index 0."]);
-			assert.equal(channel.pending.has(otherIndexAsk), true, "index 3's ask must be left untouched");
-		} finally {
-			channel.dispose();
-		}
-	});
-
-	// The end-to-end seam: drive the real child-side `contact_supervisor` tool and prove the
-	// blocked child actually receives the steer text as its tool result.
-	it("unblocks the real contact_supervisor tool call through a steer", async () => {
+	// Drive the real child-side disk protocol: steering cannot resolve asks, explicit reply can.
+	it("only unblocks the real contact_supervisor tool through an explicit reply, not steer or follow_up", async () => {
 		const sessionId = `session-${randomUUID()}`;
 		const workflowRunId = `workflow-${randomUUID()}`;
 		const channelDir = resolveSupervisorChannelDir(workflowRunId, "worker", 0);
@@ -332,7 +379,15 @@ describe("supervisor ask registration", () => {
 		const supervisorTools = new Map<string, SupervisorTool>();
 		const childTools = new Map<string, SupervisorTool>();
 		const state = makeState(sessionId, makeCtx(sessionId));
-		registerWorkflowChild(state, workflowRunId, workflowRunId, async () => ({ state: "queued" as const }));
+		const queued: ForegroundSteerInput[] = [];
+		const control: ForegroundRunControl = {
+			runId: workflowRunId, mode: "single", startedAt: 100, updatedAt: 100,
+			activeChildren: new Map([[0, {
+				index: 0, agent: "worker", startedAt: 100, updatedAt: 100,
+				steer: async (input) => { queued.push(input); return { state: "queued" }; },
+			}]]),
+		};
+		state.foregroundControls.set(workflowRunId, control);
 		const channel = createNativeSupervisorChannel(makePi({ tools: supervisorTools }) as never, state, { platform: "darwin" });
 
 		try {
@@ -344,6 +399,11 @@ describe("supervisor ask registration", () => {
 				childIndex: 0,
 				orchestratorSessionId: sessionId,
 			});
+			const target = { control, workflowRunId, sourceRunId: workflowRunId };
+			const ordinary = await steerWorkflowForegroundTarget({ target, message: "No ask is open here." });
+			assert.equal(ordinary.details.steering?.state, "pending");
+			assert.equal(ordinary.details.steering?.targets[0]?.state, "queued");
+			assert.deepEqual(queued.splice(0), [{ message: "No ask is open here." }]);
 
 			// The child blocks here exactly as it does in production: inside an open tool call,
 			// polling its reply file.
@@ -356,16 +416,32 @@ describe("supervisor ask registration", () => {
 			await waitForCondition(() => fs.readdirSync(path.join(channelDir, "requests")).length > 0, "the child's ask to reach disk");
 			await supervisorTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
 
-			const control = state.foregroundControls.get(workflowRunId)!;
-			const steerResult = await steerWorkflowForegroundTarget({
-				target: { control, workflowRunId, sourceRunId: workflowRunId },
-				message: "RULING VIA STEER: take option A.",
+			const requestId = [...channel.pending.keys()][0]!;
+			assert.ok(requestId);
+			const otherIndexAsk = writeRequest({ sessionId, runId: workflowRunId, index: 3 });
+			await supervisorTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+			for (const mode of ["steer", "follow_up"] as const) {
+				const result = await steerWorkflowForegroundTarget({ target, message: "After this is resolved, update the docs.", mode });
+				assert.equal(result.details.steering?.state, "pending");
+				assert.equal(result.details.steering?.targets[0]?.state, "queued");
+				assert.doesNotMatch(text(result), /the child is unblocked/);
+				assert.equal(channel.pending.has(requestId), true);
+				assert.equal(channel.pending.has(otherIndexAsk), true);
+				assert.equal(fs.existsSync(path.join(channelDir, "replies", `${requestId}.json`)), false);
+				assert.equal(fs.existsSync(path.join(channelDir, "requests", `${requestId}.json`)), true);
+			}
+			assert.deepEqual(queued, [
+				{ message: "After this is resolved, update the docs." },
+				{ message: "After this is resolved, update the docs.", mode: "follow_up" },
+			]);
+			await supervisorTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", {
+				action: "reply", replyTo: requestId, message: "Take option A.",
 			});
-			assert.equal(steerResult.details.steering?.state, "delivered");
 
 			const childResult = await blocked;
 			assert.notEqual(childResult.isError, true, text(childResult));
-			assert.match(text(childResult), /RULING VIA STEER: take option A\./, "the blocked child must receive the steer as its answer");
+			assert.match(text(childResult), /Take option A\./);
+			assert.doesNotMatch(text(childResult), /update the docs/);
 		} finally {
 			channel.dispose();
 		}

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -352,6 +352,43 @@ describe("supervisor ask registration", () => {
 		}
 	});
 
+	it("retains a failed progress update until a later query accepts it without duplicate notifications", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(`/sessions/${sessionId}.jsonl`, makeCtx(sessionId));
+		state.lastUiContext = null;
+		let attempts = 0;
+		let accepted = 0;
+		let requestFile = "";
+		const pi = makePi({ tools, onSend: () => {
+			attempts++;
+			assert.equal(fs.existsSync(requestFile), true, "retain the update until sendMessage returns");
+			if (attempts === 1) throw new Error("notification not accepted");
+			accepted++;
+		} });
+		const channel = createNativeSupervisorChannel(pi as never, state, { platform: "darwin" });
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId, runId, reason: "progress_update" });
+			requestFile = path.join(resolveSupervisorChannelDir(runId, "worker", 0), "requests", `${requestId}.json`);
+			const tool = tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!;
+			await tool.execute("failed", { action: "pending" });
+			assert.equal(attempts, 1);
+			assert.equal(accepted, 0);
+			assert.equal(fs.existsSync(requestFile), true);
+			assert.equal(channel.pending.size, 0, "a progress update must not become a blocking ask");
+			await tool.execute("retry", { action: "pending" });
+			assert.equal(attempts, 2);
+			assert.equal(accepted, 1);
+			assert.equal(fs.existsSync(requestFile), false);
+			await tool.execute("after-acceptance", { action: "pending" });
+			assert.equal(attempts, 2);
+			assert.equal(accepted, 1);
+			assert.equal(channel.pending.size, 0);
+		} finally { channel.dispose(); }
+	});
+
 	it("registers both asks even when every user-turn notification throws", () => {
 		const sessionId = `session-${randomUUID()}`;
 		const runId = `run-${randomUUID()}`;

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -1,0 +1,381 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, it } from "node:test";
+import {
+	NATIVE_SUPERVISOR_TOOL_NAME,
+	createNativeSupervisorChannel,
+	ensureSupervisorChannelDir,
+	registerNativeSupervisorClient,
+	resolveSupervisorChannelDir,
+} from "../../src/intercom/native-supervisor-channel.ts";
+import { steerWorkflowForegroundTarget } from "../../src/runs/foreground/workflow-foreground-steering.ts";
+import type { ForegroundSteerInput, SubagentState } from "../../src/shared/types.ts";
+
+const createdChannels: string[] = [];
+
+interface SupervisorTool {
+	execute: (id: string, params: { action: string; replyTo?: string; message?: string }) => Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }>;
+}
+
+function makeState(sessionId: string | null, ctx: unknown): SubagentState {
+	return {
+		baseCwd: process.cwd(),
+		currentSessionId: sessionId,
+		asyncJobs: new Map(),
+		foregroundControls: new Map(),
+		lastForegroundControlId: null,
+		cleanupTimers: new Map(),
+		lastUiContext: ctx as SubagentState["lastUiContext"],
+		poller: null,
+		completionSeen: new Map(),
+		watcher: null,
+		watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear: () => {} },
+	};
+}
+
+function makeCtx(sessionId: string): { cwd: string; hasUI: boolean; sessionManager: { getSessionId: () => string; getSessionFile: () => null; getEntries: () => [] } } {
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => null,
+			getEntries: () => [],
+		},
+	};
+}
+
+/**
+ * Write an ask directly to the channel the way a child's `contact_supervisor` call does, without
+ * going through a live poller. This is the state the wave-11 incident was in: the request file was
+ * on disk and no scan had happened yet.
+ */
+function writeRequest(input: { sessionId: string; runId: string; agent?: string; index?: number; message?: string; reason?: "need_decision" | "progress_update" }): string {
+	const agent = input.agent ?? "worker";
+	const index = input.index ?? 0;
+	const channelDir = resolveSupervisorChannelDir(input.runId, agent, index);
+	createdChannels.push(channelDir);
+	ensureSupervisorChannelDir(channelDir);
+	const requestId = randomUUID();
+	const reason = input.reason ?? "need_decision";
+	fs.writeFileSync(path.join(channelDir, "requests", `${requestId}.json`), JSON.stringify({
+		type: "subagent.supervisor.request",
+		id: requestId,
+		createdAt: Date.now(),
+		reason,
+		message: input.message ?? "Need a decision",
+		expectsReply: reason !== "progress_update",
+		orchestratorSessionId: input.sessionId,
+		orchestratorTarget: "shared-name",
+		runId: input.runId,
+		agent,
+		childIndex: index,
+	}, null, "\t"));
+	return requestId;
+}
+
+function makePi(options: { tools: Map<string, SupervisorTool>; onSend?: () => void }): Record<string, unknown> {
+	return {
+		getAllTools: () => [...options.tools.keys()].map((name) => ({ name })),
+		registerTool: (tool: { name: string } & SupervisorTool) => { options.tools.set(tool.name, tool); },
+		sendMessage: () => { options.onSend?.(); },
+		getSessionName: () => "shared-name",
+	};
+}
+
+function registerWorkflowChild(state: SubagentState, workflowRunId: string, childRunId: string, steer: (input: ForegroundSteerInput) => Promise<{ state: "delivered" | "queued" | "failed"; reason?: string }>): void {
+	state.workflowControllers ??= new Map();
+	state.workflowControllers.set(workflowRunId, new AbortController());
+	state.foregroundControls.set(childRunId, {
+		runId: childRunId,
+		parentWorkflowRunId: workflowRunId,
+		workflowKey: childRunId,
+		sessionId: "session",
+		mode: "single",
+		startedAt: 100,
+		updatedAt: 100,
+		activeChildren: new Map([[0, { index: 0, agent: "worker", startedAt: 100, updatedAt: 100, steer }]]),
+		schedulingOwners: 1,
+	} as never);
+}
+
+function text(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content[0]?.type === "text" ? result.content[0].text ?? "" : "";
+}
+
+afterEach(() => {
+	delete process.env.PI_INTERCOM_ASK_TIMEOUT_MS;
+	for (const channel of createdChannels.splice(0)) fs.rmSync(channel, { recursive: true, force: true });
+});
+
+describe("supervisor ask registration", () => {
+	// D1: `refreshPendingRequests` only re-evaluates asks already in `pending`; it never reads the
+	// filesystem. With no watcher installed and the demand-gated poller stopped, an ask written by
+	// a child was unfindable by ANY number of `action:"pending"` calls.
+	it("discovers an ask written while nothing was polling", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, {
+			platform: "darwin",
+			watch: (() => { throw new Error("darwin must not install a supervisor fs watcher"); }) as never,
+			timers: {
+				setInterval: (() => ({ unref() {} }) as NodeJS.Timeout) as typeof setInterval,
+				clearInterval: (() => {}) as typeof clearInterval,
+				setImmediate,
+				clearImmediate,
+			},
+		});
+
+		try {
+			channel.start();
+			// The ask lands AFTER start(), so the start-time poll cannot have seen it.
+			const requestId = writeRequest({ sessionId, runId });
+			assert.equal(channel.pending.has(requestId), false, "precondition: nothing has scanned the ask yet");
+
+			const result = await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+
+			assert.equal(channel.pending.has(requestId), true, "an explicit supervisor query must be authoritative against disk");
+			assert.match(text(result), new RegExp(requestId), "the ask must be listed with its reply id");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("accepts a reply to an ask that was never seen by a poller", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, makeCtx(sessionId)), { platform: "darwin" });
+
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId, runId });
+
+			const result = await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", {
+				action: "reply",
+				replyTo: requestId,
+				message: "Approved",
+			});
+
+			assert.notEqual(result.isError, true, text(result));
+			const reply = path.join(resolveSupervisorChannelDir(runId, "worker", 0), "replies", `${requestId}.json`);
+			assert.equal(fs.existsSync(reply), true, "the child's reply file must be written");
+			assert.equal(JSON.parse(fs.readFileSync(reply, "utf-8")).message, "Approved");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	// D3: `poll()` returned early whenever `state.lastUiContext` was null, which blinded the QUEUE
+	// and not just the display. Session ownership is carried by `state.currentSessionId`.
+	it("registers an ask with a null UI context", () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId, runId });
+		const tools = new Map<string, SupervisorTool>();
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, null), { platform: "darwin" });
+
+		try {
+			channel.start();
+			assert.equal(channel.pending.has(requestId), true, "a null lastUiContext must not drop the ask");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("still refuses an ask that belongs to another session when the UI context is null", () => {
+		const sessionId = `session-${randomUUID()}`;
+		const foreignSessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const foreignId = writeRequest({ sessionId: foreignSessionId, runId });
+		const tools = new Map<string, SupervisorTool>();
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, makeState(sessionId, null), { platform: "darwin" });
+
+		try {
+			channel.start();
+			assert.equal(channel.pending.has(foreignId), false, "session-ownership filtering must survive the null-context path");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("keeps a queued ask when the user-turn notification throws", () => {
+		const sessionId = `session-${randomUUID()}`;
+		const runId = `run-${randomUUID()}`;
+		const requestId = writeRequest({ sessionId, runId });
+		const tools = new Map<string, SupervisorTool>();
+		const pi = makePi({ tools, onSend: () => { throw new Error("no UI attached"); } });
+		const channel = createNativeSupervisorChannel(pi as never, makeState(sessionId, makeCtx(sessionId)), { platform: "darwin" });
+
+		try {
+			channel.start();
+			assert.equal(channel.pending.has(requestId), true, "a display failure must not lose an already-queued ask");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	// D4: a child inside `contact_supervisor` has no turn boundary, so `child.steer` can only
+	// return "queued" into a queue that never drains. The steer must instead answer the open ask.
+	it("answers a blocked child's open ask when a steer targets it", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const queued: string[] = [];
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
+			queued.push(input.message);
+			return { state: "queued" as const };
+		});
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			const requestId = writeRequest({ sessionId, runId: workflowRunId });
+			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+			assert.equal(channel.pending.has(requestId), true, "precondition: the child is blocked on a registered ask");
+
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const result = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "RULING VIA STEER: proceed with option A.",
+			});
+
+			assert.equal(result.details.steering?.state, "delivered", "the steer must report a real delivery, not a queue");
+			assert.match(text(result), new RegExp(`open supervisor request ${requestId}`));
+			assert.match(text(result), /the child is unblocked/);
+			assert.deepEqual(queued, [], "the message must be delivered exactly once, not also queued in the dead queue");
+
+			const reply = path.join(resolveSupervisorChannelDir(workflowRunId, "worker", 0), "replies", `${requestId}.json`);
+			assert.equal(JSON.parse(fs.readFileSync(reply, "utf-8")).message, "RULING VIA STEER: proceed with option A.");
+			assert.equal(channel.pending.has(requestId), false, "the answered ask must leave the pending queue");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("falls back to the normal steer route and reports its real state when no ask is pending", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const queued: string[] = [];
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
+			queued.push(input.message);
+			return { state: "queued" as const };
+		});
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const result = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "No ask is open here.",
+			});
+
+			// A queued in-memory steer reports `state: "pending"` with a queued target: the honest
+			// receipt for a message that has not reached the child yet.
+			assert.equal(result.details.steering?.state, "pending", "without a pending ask the receipt must stay honest");
+			assert.equal(result.details.steering?.targets[0]?.state, "queued");
+			assert.deepEqual(queued, ["No ask is open here."]);
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	it("does not answer an ask that belongs to a different child index", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const tools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		const queued: string[] = [];
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async (input) => {
+			queued.push(input.message);
+			return { state: "queued" as const };
+		});
+		const channel = createNativeSupervisorChannel(makePi({ tools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			const otherIndexAsk = writeRequest({ sessionId, runId: workflowRunId, index: 3 });
+			await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+			assert.equal(channel.pending.has(otherIndexAsk), true, "precondition: index 3 has the open ask");
+
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const result = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "Meant for index 0.",
+			});
+
+			assert.equal(result.details.steering?.state, "pending", "index 0 has no ask, so the normal route must be used");
+			assert.equal(result.details.steering?.targets[0]?.state, "queued");
+			assert.deepEqual(queued, ["Meant for index 0."]);
+			assert.equal(channel.pending.has(otherIndexAsk), true, "index 3's ask must be left untouched");
+		} finally {
+			channel.dispose();
+		}
+	});
+
+	// The end-to-end seam: drive the real child-side `contact_supervisor` tool and prove the
+	// blocked child actually receives the steer text as its tool result.
+	it("unblocks the real contact_supervisor tool call through a steer", async () => {
+		const sessionId = `session-${randomUUID()}`;
+		const workflowRunId = `workflow-${randomUUID()}`;
+		const channelDir = resolveSupervisorChannelDir(workflowRunId, "worker", 0);
+		createdChannels.push(channelDir);
+		const supervisorTools = new Map<string, SupervisorTool>();
+		const childTools = new Map<string, SupervisorTool>();
+		const state = makeState(sessionId, makeCtx(sessionId));
+		registerWorkflowChild(state, workflowRunId, workflowRunId, async () => ({ state: "queued" as const }));
+		const channel = createNativeSupervisorChannel(makePi({ tools: supervisorTools }) as never, state, { platform: "darwin" });
+
+		try {
+			channel.start();
+			registerNativeSupervisorClient(makePi({ tools: childTools }) as never, {
+				channelDir,
+				runId: workflowRunId,
+				agent: "worker",
+				childIndex: 0,
+				orchestratorSessionId: sessionId,
+			});
+
+			// The child blocks here exactly as it does in production: inside an open tool call,
+			// polling its reply file.
+			const blocked = childTools.get("contact_supervisor")!.execute("ask", {
+				action: "ask",
+				reason: "need_decision",
+				message: "Which option should I take?",
+			} as never);
+
+			await waitForCondition(() => fs.readdirSync(path.join(channelDir, "requests")).length > 0, "the child's ask to reach disk");
+			await supervisorTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+
+			const control = state.foregroundControls.get(workflowRunId)!;
+			const steerResult = await steerWorkflowForegroundTarget({
+				target: { control, workflowRunId, sourceRunId: workflowRunId },
+				message: "RULING VIA STEER: take option A.",
+			});
+			assert.equal(steerResult.details.steering?.state, "delivered");
+
+			const childResult = await blocked;
+			assert.notEqual(childResult.isError, true, text(childResult));
+			assert.match(text(childResult), /RULING VIA STEER: take option A\./, "the blocked child must receive the steer as its answer");
+		} finally {
+			channel.dispose();
+		}
+	});
+});
+
+async function waitForCondition(condition: () => boolean, description: string): Promise<void> {
+	const deadline = Date.now() + 2000;
+	while (!condition()) {
+		if (Date.now() > deadline) assert.fail(`Timed out waiting for ${description}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+}


### PR DESCRIPTION
Closes #1975. Supersedes #1982 after landing. Related #1977 and #1980 remain separate follow-ups.

Thanks to @brandonmwest for the discovery diagnosis, reproduction and original implementation. Contributor authorship and changelog credit are preserved.

Retains on-demand disk discovery and notification-error isolation. Supervisor ownership now uses the exact cached runtime session ID independently of stale UI context or persisted session-file identity. Explicit mistargeted replies fail closed.

Drops automatic steer-as-reply: a queued follow-up or unrelated steer must not silently answer a pending approval question. Only explicit supervisor reply writes answers. The later upstream bookkeeping correction affects that removed resolver; its intent is covered by removing the second delivery path entirely.

Darwin idle polling policy remains unchanged. This does not promise proactive notification-floor or single-run steer unblocking.

Validation: focused ownership/lifecycle/explicit-reply and replay tests, typecheck, retained deletion challenge, fresh read-only review and diff hygiene. Additive changelog-only conflict resolved during promotion; reviewed production delta retained.
