### PR TITLE
fix(workflows): consume steers with exact targeting and terminal receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 - Keep unconfigured prompt-runtime loads inert. Thanks to [@lertian](https://github.com/lertian) for #1973.
 - Discover supervisor asks on demand even without a UI context, isolate notification failures, and keep answers explicit (#1975, #1982). Thanks to [@brandonmwest](https://github.com/brandonmwest).
+- Consume async workflow steering with exact child targeting, terminal shutdown receipts, and handler-selective inbox watching (#1976, #1983). Thanks to [@brandonmwest](https://github.com/brandonmwest) for the diagnosis, Herdr reproduction, initial consumer, and tests.
 - Return `invalid_state` instead of queuing unreachable workflow stop requests when live workflow controllers are unavailable (#1965).
 - Forward bounded live tool activity, timing, model/effort, and counters for synchronous workflow children without forwarding transcripts (#1964).
 - Allow `action: "status", view: "transcript"` to inspect bounded live foreground child artifacts on demand (#1963).

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -275,28 +275,36 @@ function parseSteerRequest(raw: unknown): SteerRequest | undefined {
 	};
 }
 
-export function consumeSteerRequestsFromDir(dir: string, fsImpl: Pick<typeof fs, "existsSync" | "rmSync" | "readdirSync" | "readFileSync"> = fs): SteerRequest[] {
-	if (!fsImpl.existsSync(dir)) return [];
+export function consumeSteerRequestsFromDir(dir: string, fsImpl: Pick<typeof fs, "existsSync" | "rmSync" | "readdirSync" | "readFileSync"> = fs, onError: (error: unknown) => void = () => {}): SteerRequest[] {
 	let entries: string[];
 	try {
 		entries = fsImpl.readdirSync(dir).filter((name) => name.endsWith(".json")).sort();
-	} catch {
+	} catch (error) {
 		// Leave requests in place so the periodic poll can retry the scan.
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") onError(error);
 		return [];
 	}
 	const requests: SteerRequest[] = [];
 	for (const entry of entries) {
 		const requestPath = path.join(dir, entry);
 		let parsed: SteerRequest | undefined;
+		let text: string;
 		try {
-			parsed = parseSteerRequest(JSON.parse(fsImpl.readFileSync(requestPath, "utf-8")));
+			text = fsImpl.readFileSync(requestPath, "utf-8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") onError(error);
+			continue;
+		}
+		try {
+			parsed = parseSteerRequest(JSON.parse(text));
 		} catch {
 			parsed = undefined;
 		}
 		try {
 			fsImpl.rmSync(requestPath, { recursive: true });
-		} catch {
+		} catch (error) {
 			// Already removed by a concurrent check — do not execute it twice.
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") onError(error);
 			continue;
 		}
 		if (parsed) requests.push(parsed);
@@ -304,8 +312,8 @@ export function consumeSteerRequestsFromDir(dir: string, fsImpl: Pick<typeof fs,
 	return requests.sort((left, right) => left.ts - right.ts || left.id.localeCompare(right.id));
 }
 
-export function consumeSteerRequests(asyncDir: string, fsImpl: Pick<typeof fs, "existsSync" | "rmSync" | "readdirSync" | "readFileSync"> = fs): SteerRequest[] {
-	return consumeSteerRequestsFromDir(steerRequestsDir(asyncDir), fsImpl);
+export function consumeSteerRequests(asyncDir: string, fsImpl: Pick<typeof fs, "existsSync" | "rmSync" | "readdirSync" | "readFileSync"> = fs, onError?: (error: unknown) => void): SteerRequest[] {
+	return consumeSteerRequestsFromDir(steerRequestsDir(asyncDir), fsImpl, onError);
 }
 
 export function queueRevivalBrief(asyncDir: string, request: SteerRequest): string {
@@ -470,99 +478,21 @@ export function deliverStopRequest(input: {
 	requestAsyncStop(input.asyncDir, { ...(input.source ? { source: input.source } : {}), ...(input.targetIndex !== undefined ? { targetIndex: input.targetIndex } : {}), ...(input.childId ? { childId: input.childId } : {}) }, { now: input.now });
 }
 
-/**
- * Workflow side: watch ONLY `steer-requests/` and route each request into
- * `onSteer`. Deliberately narrower than `watchAsyncControlInbox`: workflow-mode
- * runs handle interrupt, stop, and timeout through their in-memory controller,
- * and nothing else consumes those inbox files for a workflow run, so consuming
- * them here would silently discard a stop request. Uses the same watch strategy
- * as the runner inbox (native `fs.watch` plus a safety poll, interval polling as
- * the fallback) and the same up-front `check()` for a request that landed before
- * the watcher was installed. Returns a disposer.
- */
-export function watchAsyncSteerInbox(
-	asyncDir: string,
-	opts: {
-		onSteer: (request: SteerRequest) => void;
-		pollIntervalMs?: number;
-		safetyPollIntervalMs?: number;
-		platform?: NodeJS.Platform;
-		fs?: ControlChannelFs;
-		timers?: ControlChannelTimers;
-	},
-): () => void {
-	const fsImpl = opts.fs ?? fs;
-	const timers = opts.timers ?? { setInterval, clearInterval };
-	const dir = steerRequestsDir(asyncDir);
-	try {
-		fsImpl.mkdirSync(dir, { recursive: true });
-	} catch {
-		// Best effort, because the poll and watch paths below tolerate a missing dir.
-	}
-
-	let disposed = false;
-	const check = (): void => {
-		if (disposed) return;
-		try {
-			for (const request of consumeSteerRequests(asyncDir, fsImpl)) opts.onSteer(request);
-		} catch {
-			// Never let inbox errors crash the workflow.
-		}
-	};
-
-	// Handle a request that may have arrived before the watcher started.
-	check();
-
-	const watchers: fs.FSWatcher[] = [];
-	let interval: ReturnType<typeof setInterval> | undefined;
-	let safetyInterval: ReturnType<typeof setInterval> | undefined;
-	const startPolling = (): void => {
-		if (interval || disposed) return;
-		interval = timers.setInterval(check, opts.pollIntervalMs ?? POLL_INTERVAL_MS);
-		interval.unref?.();
-	};
-	try {
-		if (shouldUseNativeFsWatch("runner-control-inbox", opts.platform)) {
-			const watcher = fsImpl.watch(resolveWatchPath(dir, fsImpl.realpathSync.native), () => check());
-			watcher.on?.("error", startPolling);
-			watchers.push(watcher);
-			safetyInterval = timers.setInterval(check, opts.safetyPollIntervalMs ?? CONTROL_SAFETY_POLL_INTERVAL_MS);
-			safetyInterval.unref?.();
-		} else {
-			startPolling();
-		}
-	} catch {
-		startPolling();
-	}
-
-	return () => {
-		if (disposed) return;
-		disposed = true;
-		for (const watcher of watchers) {
-			try {
-				watcher.close();
-			} catch {
-				// ignore
-			}
-		}
-		if (interval) timers.clearInterval(interval);
-		if (safetyInterval) timers.clearInterval(safetyInterval);
-	};
-}
 
 /**
- * Runner side: watch the control inbox and route interrupt requests into
- * `onInterrupt`. Uses `fs.watch` when available and starts interval polling
+ * Active owner: watch and consume only kinds with installed handlers.
+ * Uses `fs.watch` when available and starts interval polling
  * only when native watching is unavailable or fails. Fires once per distinct
  * request. Returns a disposer.
  */
 export function watchAsyncControlInbox(
 	asyncDir: string,
 	opts: {
-		onInterrupt: () => void;
+		onInterrupt?: () => void;
 		onTimeout?: () => void;
 		onStop?: (request: StopRequest) => void;
 		onSteer?: (request: SteerRequest) => void;
+		onError?: (error: unknown, phase: "install" | "scan" | "callback", request?: SteerRequest) => void;
 		pollIntervalMs?: number;
 		safetyPollIntervalMs?: number;
 		platform?: NodeJS.Platform;
@@ -573,22 +503,44 @@ export function watchAsyncControlInbox(
 	const fsImpl = opts.fs ?? fs;
 	const timers = opts.timers ?? { setInterval, clearInterval };
 	const dir = controlInboxDir(asyncDir);
+	const report = (error: unknown, phase: "install" | "scan" | "callback", request?: SteerRequest): void => {
+		try {
+			if (opts.onError) opts.onError(error, phase, request);
+			else console.error(`Control inbox ${phase} failed:`, error);
+		} catch (reportError) {
+			console.error("Control inbox error reporter failed:", reportError);
+		}
+	};
+	const dirs = [
+		...(opts.onInterrupt || opts.onTimeout || opts.onStop ? [dir] : []),
+		...(opts.onStop ? [stopRequestsDir(asyncDir)] : []),
+		...(opts.onSteer ? [steerRequestsDir(asyncDir)] : []),
+	];
+	if (dirs.length === 0) return () => {};
 	try {
-		fsImpl.mkdirSync(dir, { recursive: true });
-	} catch {
-		// Best effort — the poll/watch below tolerates a missing dir.
+		for (const target of dirs) fsImpl.mkdirSync(target, { recursive: true });
+	} catch (error) {
+		report(error, "install");
 	}
 
 	let disposed = false;
 	const check = (): void => {
 		if (disposed) return;
 		try {
-			for (const stopRequest of consumeStopRequestPayloads(asyncDir, fsImpl)) opts.onStop?.(stopRequest);
-			if (consumeTimeoutRequest(asyncDir, fsImpl)) opts.onTimeout?.();
-			if (consumeInterruptRequest(asyncDir, fsImpl)) opts.onInterrupt();
-			for (const request of consumeSteerRequests(asyncDir, fsImpl)) opts.onSteer?.(request);
-		} catch {
-			// Never let inbox errors crash the runner.
+			if (opts.onStop) for (const request of consumeStopRequestPayloads(asyncDir, fsImpl)) {
+				try { opts.onStop(request); } catch (error) { report(error, "callback"); }
+			}
+			if (opts.onTimeout && consumeTimeoutRequest(asyncDir, fsImpl)) {
+				try { opts.onTimeout(); } catch (error) { report(error, "callback"); }
+			}
+			if (opts.onInterrupt && consumeInterruptRequest(asyncDir, fsImpl)) {
+				try { opts.onInterrupt(); } catch (error) { report(error, "callback"); }
+			}
+			if (opts.onSteer) for (const request of consumeSteerRequestsFromDir(steerRequestsDir(asyncDir), fsImpl, (error) => report(error, "scan"))) {
+				try { opts.onSteer(request); } catch (error) { report(error, "callback", request); }
+			}
+		} catch (error) {
+			report(error, "scan");
 		}
 	};
 
@@ -596,40 +548,31 @@ export function watchAsyncControlInbox(
 	check();
 
 	const watchers: fs.FSWatcher[] = [];
-	const watchedDirs = new Set<string>();
 	let interval: ReturnType<typeof setInterval> | undefined;
 	let safetyInterval: ReturnType<typeof setInterval> | undefined;
 	const startPolling = (): void => {
 		if (interval || disposed) return;
+		if (safetyInterval) { timers.clearInterval(safetyInterval); safetyInterval = undefined; }
 		interval = timers.setInterval(check, opts.pollIntervalMs ?? POLL_INTERVAL_MS);
 		interval.unref?.();
 	};
-	const startSafetyPolling = (): void => {
-		if (safetyInterval || disposed) return;
-		safetyInterval = timers.setInterval(check, opts.safetyPollIntervalMs ?? CONTROL_SAFETY_POLL_INTERVAL_MS);
-		safetyInterval.unref?.();
-	};
-	const watchDir = (target: string, create = false): void => {
-		if (disposed || watchedDirs.has(target)) return;
-		if (create) fsImpl.mkdirSync(target, { recursive: true });
-		const watcher = fsImpl.watch(resolveWatchPath(target, fsImpl.realpathSync.native), () => check());
-		watcher.on?.("error", startPolling);
-		watchers.push(watcher);
-		watchedDirs.add(target);
-	};
 	try {
 		if (shouldUseNativeFsWatch("runner-control-inbox", opts.platform)) {
-			watchDir(dir);
-			watchDir(stopRequestsDir(asyncDir), true);
-			watchDir(steerRequestsDir(asyncDir), true);
-			startSafetyPolling();
+			for (const target of dirs) {
+				const watcher = fsImpl.watch(resolveWatchPath(target, fsImpl.realpathSync.native), check);
+				watcher.on?.("error", startPolling);
+				watchers.push(watcher);
+			}
+			if (!interval) {
+				safetyInterval = timers.setInterval(check, opts.safetyPollIntervalMs ?? CONTROL_SAFETY_POLL_INTERVAL_MS);
+				safetyInterval.unref?.();
+			}
 		} else {
 			startPolling();
 		}
 	} catch {
 		startPolling();
 	}
-
 	return () => {
 		if (disposed) return;
 		disposed = true;

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -471,6 +471,86 @@ export function deliverStopRequest(input: {
 }
 
 /**
+ * Workflow side: watch ONLY `steer-requests/` and route each request into
+ * `onSteer`. Deliberately narrower than `watchAsyncControlInbox`: workflow-mode
+ * runs handle interrupt, stop, and timeout through their in-memory controller,
+ * and nothing else consumes those inbox files for a workflow run, so consuming
+ * them here would silently discard a stop request. Uses the same watch strategy
+ * as the runner inbox (native `fs.watch` plus a safety poll, interval polling as
+ * the fallback) and the same up-front `check()` for a request that landed before
+ * the watcher was installed. Returns a disposer.
+ */
+export function watchAsyncSteerInbox(
+	asyncDir: string,
+	opts: {
+		onSteer: (request: SteerRequest) => void;
+		pollIntervalMs?: number;
+		safetyPollIntervalMs?: number;
+		platform?: NodeJS.Platform;
+		fs?: ControlChannelFs;
+		timers?: ControlChannelTimers;
+	},
+): () => void {
+	const fsImpl = opts.fs ?? fs;
+	const timers = opts.timers ?? { setInterval, clearInterval };
+	const dir = steerRequestsDir(asyncDir);
+	try {
+		fsImpl.mkdirSync(dir, { recursive: true });
+	} catch {
+		// Best effort, because the poll and watch paths below tolerate a missing dir.
+	}
+
+	let disposed = false;
+	const check = (): void => {
+		if (disposed) return;
+		try {
+			for (const request of consumeSteerRequests(asyncDir, fsImpl)) opts.onSteer(request);
+		} catch {
+			// Never let inbox errors crash the workflow.
+		}
+	};
+
+	// Handle a request that may have arrived before the watcher started.
+	check();
+
+	const watchers: fs.FSWatcher[] = [];
+	let interval: ReturnType<typeof setInterval> | undefined;
+	let safetyInterval: ReturnType<typeof setInterval> | undefined;
+	const startPolling = (): void => {
+		if (interval || disposed) return;
+		interval = timers.setInterval(check, opts.pollIntervalMs ?? POLL_INTERVAL_MS);
+		interval.unref?.();
+	};
+	try {
+		if (shouldUseNativeFsWatch("runner-control-inbox", opts.platform)) {
+			const watcher = fsImpl.watch(resolveWatchPath(dir, fsImpl.realpathSync.native), () => check());
+			watcher.on?.("error", startPolling);
+			watchers.push(watcher);
+			safetyInterval = timers.setInterval(check, opts.safetyPollIntervalMs ?? CONTROL_SAFETY_POLL_INTERVAL_MS);
+			safetyInterval.unref?.();
+		} else {
+			startPolling();
+		}
+	} catch {
+		startPolling();
+	}
+
+	return () => {
+		if (disposed) return;
+		disposed = true;
+		for (const watcher of watchers) {
+			try {
+				watcher.close();
+			} catch {
+				// ignore
+			}
+		}
+		if (interval) timers.clearInterval(interval);
+		if (safetyInterval) timers.clearInterval(safetyInterval);
+	};
+}
+
+/**
  * Runner side: watch the control inbox and route interrupt requests into
  * `onInterrupt`. Uses `fs.watch` when available and starts interval polling
  * only when native watching is unavailable or fails. Fires once per distinct

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -82,7 +82,7 @@ import {
 	stripDetailsOutputsForIntercomReceipt,
 } from "../../intercom/result-intercom.ts";
 import { applySteeringRecoveryAgentConfig, asyncReviveRequiresRecoveryDescriptor, buildRevivedAsyncTask, readAsyncRecoveryDescriptor, resolveAsyncResumeTarget, resolveAsyncRunLocation } from "../background/async-resume.ts";
-import { closeSteerInbox, consumeSteerRequests, deliverInterruptRequest, readRevivalBriefs, requestAsyncSteer, watchAsyncSteerInbox, type SteerDeliveryMode, type SteerRequest } from "../background/control-channel.ts";
+import { closeSteerInbox, consumeSteerRequests, deliverInterruptRequest, readRevivalBriefs, requestAsyncSteer, watchAsyncControlInbox, type SteerDeliveryMode, type SteerRequest } from "../background/control-channel.ts";
 import { createSteeringStatus, recordSteeringRequest, steeringStatus, updateSteeringTarget, waitForSteeringAction } from "../background/steering.ts";
 import { canQueueRetainedAsyncFollowUp, steerAsyncRun } from "./async-steering-action.ts";
 import {
@@ -5225,13 +5225,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					return { content: [{ type: "text", text: `Failed to create async workflow storage: ${error instanceof Error ? error.message : String(error)}` }], isError: true, details: { mode: "workflow", results: [] } };
 				}
 				appendWorkflowEvent({ type: "subagent.workflow.started" });
-				// Consume the durable steer inbox for async workflow runs. `watchAsyncControlInbox` is
-				// installed only by subagent-runner.ts, and the runner never executes workflow scripts
-				// (`runWorkflowScript` is called only from this file), so no process was watching
-				// `control/steer-requests/` for a workflow run and a queued request file sat on disk until
-				// the run ended. A workflow's children are in-process foreground children of THIS process,
-				// so deliver through their in-memory controls and write the same status.steering and
-				// subagent.steer.* receipts that the requesting side already reads.
+				// The runner does not execute workflow scripts: this active owner must consume its own
+				// durable steer inbox, deliver through in-process child controls, and persist receipts.
 				const emitWorkflowSteerEvent = (type: string, requestId: string, index?: number, extra: Record<string, unknown> = {}): void => {
 					appendWorkflowEvent({ type, requestId, ...(index !== undefined ? { index } : {}), ...extra });
 				};
@@ -5245,72 +5240,127 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						targets,
 					});
 				};
-				const failWorkflowSteer = (request: SteerRequest, index: number, reason: string): void => {
-					recordWorkflowSteerTargets(request, [{ index, state: "failed", reason }]);
-					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets: [{ index, state: "failed", reason }] });
-					emitWorkflowSteerEvent("subagent.steer.failed", request.id, index, { reason });
+				const explicitWorkflowSteerIndexes = (request: SteerRequest): number[] | undefined => request.targetIndex !== undefined ? [request.targetIndex] : request.targetIndexes;
+				const failWorkflowSteer = (request: SteerRequest, indexes: number[], reason: string): void => {
+					const targets = indexes.map((index) => ({ index, state: "failed" as const, reason }));
+					recordWorkflowSteerTargets(request, targets);
+					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets });
+					for (const index of indexes) emitWorkflowSteerEvent("subagent.steer.failed", request.id, index, { reason });
 					persist({ tolerateStatusWriteFailure: true });
 				};
+				const pendingWorkflowSteers = new Set<(state: "delivered" | "queued" | "failed", reason?: string) => void>();
 				const deliverWorkflowSteerRequest = (request: SteerRequest): void => {
-					const index = request.targetIndex ?? request.targetIndexes?.[0] ?? 0;
+					let indexes = explicitWorkflowSteerIndexes(request);
 					if (status.state !== "running") {
-						failWorkflowSteer(request, index, `run became ${status.state} before steering request was consumed`);
-						return;
-					}
-					// Resolve the workflow step the requester addressed, then that step's live in-process control.
-					const step = status.steps?.[index];
-					// An addressed index beyond the projected steps is a caller error, not a race: fail it
-					// explicitly rather than falling back and steering an unrelated child.
-					if (step === undefined && (status.steps?.length ?? 0) > 0) {
-						failWorkflowSteer(request, index, "child index out of range");
+						failWorkflowSteer(request, indexes ?? [0], `run became ${status.state} before steering request was consumed`);
 						return;
 					}
 					const liveControls = [...deps.state.foregroundControls.values()].filter((candidate) => candidate.parentWorkflowRunId === workflowRunId && (candidate.activeChildren?.size ?? 0) > 0);
-					// Prefer the keyed control, then fall back to the sole live child, which covers a step whose
-					// control registered before its workflowKey was projected into status.steps.
-					const control = (step?.workflowKey ? liveControls.find((candidate) => candidate.workflowKey === step.workflowKey) : undefined)
-						?? (liveControls.length === 1 ? liveControls[0] : undefined);
-					if (!control) {
-						failWorkflowSteer(request, index, liveControls.length > 1
-							? `workflow has ${liveControls.length} live children; steer a child run id instead`
-							: "workflow child is not live in this process");
-						return;
-					}
-					recordWorkflowSteerTargets(request, [{ index, state: "routed" }]);
-					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets: [{ index, state: "routed" }] });
-					emitWorkflowSteerEvent("subagent.steer.routed", request.id, index);
-					persist({ tolerateStatusWriteFailure: true });
-					const applyWorkflowSteerDelivery = (state: "delivered" | "queued" | "failed", reason?: string): void => {
-						const now = Date.now();
-						updateSteeringTarget(steeringStatus(status), request.id, index, state === "delivered" ? "delivered" : state === "queued" ? "queued" : "failed", now, reason ? { reason } : {});
-						if (state === "failed") {
-							const failedStep = status.steps?.[index];
-							if (failedStep) failedStep.activityState = "needs_attention";
-							status.activityState = "needs_attention";
+					if (indexes === undefined) {
+						if (liveControls.length !== 1) {
+							failWorkflowSteer(request, [0], liveControls.length > 1
+								? `workflow has ${liveControls.length} live children; steer a child run id instead`
+								: "workflow child is not live in this process");
+							return;
 						}
-						emitWorkflowSteerEvent(`subagent.steer.${state}`, request.id, index, state === "failed" ? { reason } : { deliveryStatus: state, message: request.message });
-						persist({ tolerateStatusWriteFailure: true });
-					};
-					void steerWorkflowForegroundTarget({
-						target: { control, workflowRunId, sourceRunId: workflowRunId },
-						message: request.message,
-						...(request.mode ? { mode: request.mode } : {}),
-					}).then(
-						(result) => {
-							const target = result.details.steering?.targets[0];
-							applyWorkflowSteerDelivery(target?.state === "delivered" ? "delivered" : target?.state === "queued" ? "queued" : "failed", target?.reason ?? (target ? undefined : "steering produced no target receipt"));
-						},
-						(error) => applyWorkflowSteerDelivery("failed", error instanceof Error ? error.message : String(error)),
-					);
+						const index = status.steps?.findIndex((step) => !!step.workflowKey && step.workflowKey === liveControls[0]!.workflowKey) ?? -1;
+						if (index < 0) {
+							failWorkflowSteer(request, [0], "live workflow child has no projected step");
+							return;
+						}
+						indexes = [index];
+					}
+					// Normalize and record the whole set once: recordSteeringRequest is idempotent by id.
+					// Explicit indexes resolve only by their projected key, never by a live sibling.
+					const resolved = indexes.map((index) => {
+						const step = status.steps?.[index];
+						const control = step?.workflowKey ? liveControls.find((candidate) => candidate.workflowKey === step.workflowKey) : undefined;
+						return { index, control, reason: !step ? "child index out of range" : !control ? "workflow child is not live in this process" : undefined };
+					});
+					const targets = resolved.map(({ index, reason }) => ({ index, state: reason ? "failed" as const : "routed" as const, ...(reason ? { reason } : {}) }));
+					recordWorkflowSteerTargets(request, targets);
+					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets });
+					persist({ tolerateStatusWriteFailure: true });
+					for (const { index, control, reason } of resolved) {
+						if (!control) {
+							emitWorkflowSteerEvent("subagent.steer.failed", request.id, index, { reason });
+							continue;
+						}
+						emitWorkflowSteerEvent("subagent.steer.routed", request.id, index);
+						const applyWorkflowSteerDelivery = (state: "delivered" | "queued" | "failed", reason?: string): void => {
+							// Shutdown settles unresolved receipts synchronously; late SDK callbacks cannot rewrite them.
+							if (!pendingWorkflowSteers.delete(applyWorkflowSteerDelivery)) return;
+							const now = Date.now();
+							const steering = steeringStatus(status);
+							// This once-only callback owns a routed target, even after bounded display history
+							// evicts its request. Account independently; queued still represents one pending target.
+							if (state !== "queued") steering.pending = Math.max(0, steering.pending - 1);
+							if (state === "delivered") {
+								steering.delivered++;
+								steering.lastDeliveredAt = now;
+							} else if (state === "failed") steering.failed++;
+							const receipt = steering.recent.find((candidate) => candidate.id === request.id)?.targets.find((target) => target.index === index);
+							if (receipt) {
+								receipt.state = state;
+								if (state === "delivered") receipt.deliveredAt = now;
+								if (state === "failed") receipt.failedAt = now;
+								if (reason) receipt.reason = reason;
+							}
+							if (state === "failed") {
+								const failedStep = status.steps?.[index];
+								if (failedStep) failedStep.activityState = "needs_attention";
+								status.activityState = "needs_attention";
+							}
+							emitWorkflowSteerEvent(`subagent.steer.${state}`, request.id, index, state === "failed" ? { reason } : { deliveryStatus: state, message: request.message });
+							persist({ tolerateStatusWriteFailure: true });
+						};
+						pendingWorkflowSteers.add(applyWorkflowSteerDelivery);
+						void steerWorkflowForegroundTarget({
+							target: { control, workflowRunId, sourceRunId: workflowRunId },
+							message: request.message,
+							...(request.mode ? { mode: request.mode } : {}),
+						}).then(
+							(result) => {
+								const target = result.details.steering?.targets[0];
+								applyWorkflowSteerDelivery(target?.state === "delivered" ? "delivered" : target?.state === "queued" ? "queued" : "failed", target?.reason ?? (target ? undefined : "steering produced no target receipt"));
+							},
+							(error) => applyWorkflowSteerDelivery("failed", error instanceof Error ? error.message : String(error)),
+						);
+					}
 				};
 				let disposeWorkflowSteerInbox: (() => void) | undefined;
 				try {
-					disposeWorkflowSteerInbox = watchAsyncSteerInbox(asyncDir, { onSteer: deliverWorkflowSteerRequest });
+					disposeWorkflowSteerInbox = watchAsyncControlInbox(asyncDir, {
+						onSteer: deliverWorkflowSteerRequest,
+						onError: (error, phase, request) => {
+							const reason = error instanceof Error ? error.message : String(error);
+							appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", phase, error: reason });
+							if (request) failWorkflowSteer(request, explicitWorkflowSteerIndexes(request) ?? [0], `steer consumer failed: ${reason}`);
+						},
+					});
 				} catch (error) {
 					// Steering is an optional control surface, so a watcher that cannot install must not fail the run.
 					appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", error: error instanceof Error ? error.message : String(error) });
 				}
 				const { workflowScript, async: _workflowAsync, chatProgress: _chatProgress, ...workflowRequest } = requestParams;
+				let workflowSteerInboxClosed = false;
+				const settleWorkflowSteerInbox = (): void => {
+					if (workflowSteerInboxClosed) return;
+					workflowSteerInboxClosed = true;
+					disposeWorkflowSteerInbox?.();
+					// Consumed deliveries are not files anymore. Fail unresolved SDK operations without awaiting them.
+					for (const settle of pendingWorkflowSteers) settle("failed", `run became ${status.state} before steering delivery settled`);
+					try {
+						closeSteerInbox(asyncDir, status.state);
+						// Separately drain requests that never reached the consumer.
+						const undelivered = consumeSteerRequests(asyncDir, undefined, (error) => {
+							appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", phase: "drain", error: error instanceof Error ? error.message : String(error) });
+						});
+						for (const request of undelivered) failWorkflowSteer(request, explicitWorkflowSteerIndexes(request) ?? [0], `run became ${status.state} before steering request was consumed`);
+					} catch (error) {
+						appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", phase: "close", error: error instanceof Error ? error.message : String(error) });
+					}
+				};
 				void Promise.resolve().then(async () => {
 					const workflowDeadlineAt = timeout === undefined ? undefined : Date.now() + timeout;
 					const workflowResults: SingleResult[] = [];
@@ -5596,6 +5646,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, workflowChildren, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						settleWorkflowSteerInbox();
 						persist();
 						deps.refreshResultDelivery?.();
 						persistClosed = true;
@@ -5644,23 +5695,16 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, workflowChildren, ...(terminalOutcome ? { terminalOutcome } : {}), results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						settleWorkflowSteerInbox();
 						persist();
 						deps.refreshResultDelivery?.();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(terminalOutcome ? { terminalOutcome } : {}), ...(status.error ? { error: status.error } : {}), ...(status.activityState ? { activityState: status.activityState } : {}) });
 					} finally {
-						// Stop watching, close the inbox so the requesting side cannot queue into a dead run, then
-						// drain in-flight requests to a terminal receipt (mirroring the runner teardown) so a late
-						// steer fails visibly instead of vanishing.
+						// Also settle early result-write exits, while persistence is still open.
 						try {
-							disposeWorkflowSteerInbox?.();
-							closeSteerInbox(asyncDir, status.state);
-							const undelivered = consumeSteerRequests(asyncDir);
-							if (undelivered.length > 0) {
-								persistClosed = false;
-								const reason = `run became ${status.state} before steering request was consumed`;
-								for (const request of undelivered) failWorkflowSteer(request, request.targetIndex ?? request.targetIndexes?.[0] ?? 0, reason);
-							}
+							settleWorkflowSteerInbox();
+							if (!persistClosed) persist();
 						} catch (error) {
 							console.error(`Failed to close async workflow steer inbox '${asyncDir}':`, error);
 						}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5289,10 +5289,12 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						emitWorkflowSteerEvent("subagent.steer.routed", request.id, index);
 						const applyWorkflowSteerDelivery = (state: "delivered" | "queued" | "failed", reason?: string): void => {
 							// Shutdown settles unresolved receipts synchronously; late SDK callbacks cannot rewrite them.
-							if (!pendingWorkflowSteers.delete(applyWorkflowSteerDelivery)) return;
+							if (!pendingWorkflowSteers.has(applyWorkflowSteerDelivery)) return;
+							// Queuing is not confirmation of delivery: retain ownership until terminal settlement.
+							if (state !== "queued") pendingWorkflowSteers.delete(applyWorkflowSteerDelivery);
 							const now = Date.now();
 							const steering = steeringStatus(status);
-							// This once-only callback owns a routed target, even after bounded display history
+							// This callback owns a pending target, even after bounded display history
 							// evicts its request. Account independently; queued still represents one pending target.
 							if (state !== "queued") steering.pending = Math.max(0, steering.pending - 1);
 							if (state === "delivered") {
@@ -5349,7 +5351,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					workflowSteerInboxClosed = true;
 					disposeWorkflowSteerInbox?.();
 					// Consumed deliveries are not files anymore. Fail unresolved SDK operations without awaiting them.
-					for (const settle of pendingWorkflowSteers) settle("failed", `run became ${status.state} before steering delivery settled`);
+					for (const settle of pendingWorkflowSteers) settle("failed", `run became ${status.state} before steering delivery settled; delivery unconfirmed`);
 					try {
 						closeSteerInbox(asyncDir, status.state);
 						// Separately drain requests that never reached the consumer.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -82,8 +82,8 @@ import {
 	stripDetailsOutputsForIntercomReceipt,
 } from "../../intercom/result-intercom.ts";
 import { applySteeringRecoveryAgentConfig, asyncReviveRequiresRecoveryDescriptor, buildRevivedAsyncTask, readAsyncRecoveryDescriptor, resolveAsyncResumeTarget, resolveAsyncRunLocation } from "../background/async-resume.ts";
-import { deliverInterruptRequest, readRevivalBriefs, requestAsyncSteer, type SteerDeliveryMode } from "../background/control-channel.ts";
-import { updateSteeringTarget, waitForSteeringAction } from "../background/steering.ts";
+import { closeSteerInbox, consumeSteerRequests, deliverInterruptRequest, readRevivalBriefs, requestAsyncSteer, watchAsyncSteerInbox, type SteerDeliveryMode, type SteerRequest } from "../background/control-channel.ts";
+import { createSteeringStatus, recordSteeringRequest, steeringStatus, updateSteeringTarget, waitForSteeringAction } from "../background/steering.ts";
 import { canQueueRetainedAsyncFollowUp, steerAsyncRun } from "./async-steering-action.ts";
 import {
 	resolveWorkflowForegroundSteeringTarget,
@@ -196,6 +196,7 @@ import {
 	resolveMaxSubagentSpawnsPerRun,
 	wrapForkTask,
 	type ScheduleOrigin,
+	type SteeringTargetState,
 } from "../../shared/types.ts";
 import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 
@@ -5224,6 +5225,91 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					return { content: [{ type: "text", text: `Failed to create async workflow storage: ${error instanceof Error ? error.message : String(error)}` }], isError: true, details: { mode: "workflow", results: [] } };
 				}
 				appendWorkflowEvent({ type: "subagent.workflow.started" });
+				// Consume the durable steer inbox for async workflow runs. `watchAsyncControlInbox` is
+				// installed only by subagent-runner.ts, and the runner never executes workflow scripts
+				// (`runWorkflowScript` is called only from this file), so no process was watching
+				// `control/steer-requests/` for a workflow run and a queued request file sat on disk until
+				// the run ended. A workflow's children are in-process foreground children of THIS process,
+				// so deliver through their in-memory controls and write the same status.steering and
+				// subagent.steer.* receipts that the requesting side already reads.
+				const emitWorkflowSteerEvent = (type: string, requestId: string, index?: number, extra: Record<string, unknown> = {}): void => {
+					appendWorkflowEvent({ type, requestId, ...(index !== undefined ? { index } : {}), ...extra });
+				};
+				const recordWorkflowSteerTargets = (request: SteerRequest, targets: Array<{ index: number; state: SteeringTargetState; reason?: string }>): void => {
+					status.steering ??= createSteeringStatus();
+					recordSteeringRequest(steeringStatus(status), {
+						id: request.id,
+						requestedAt: request.ts,
+						...(request.source ? { source: request.source } : {}),
+						message: request.message,
+						targets,
+					});
+				};
+				const failWorkflowSteer = (request: SteerRequest, index: number, reason: string): void => {
+					recordWorkflowSteerTargets(request, [{ index, state: "failed", reason }]);
+					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets: [{ index, state: "failed", reason }] });
+					emitWorkflowSteerEvent("subagent.steer.failed", request.id, index, { reason });
+					persist({ tolerateStatusWriteFailure: true });
+				};
+				const deliverWorkflowSteerRequest = (request: SteerRequest): void => {
+					const index = request.targetIndex ?? request.targetIndexes?.[0] ?? 0;
+					if (status.state !== "running") {
+						failWorkflowSteer(request, index, `run became ${status.state} before steering request was consumed`);
+						return;
+					}
+					// Resolve the workflow step the requester addressed, then that step's live in-process control.
+					const step = status.steps?.[index];
+					// An addressed index beyond the projected steps is a caller error, not a race: fail it
+					// explicitly rather than falling back and steering an unrelated child.
+					if (step === undefined && (status.steps?.length ?? 0) > 0) {
+						failWorkflowSteer(request, index, "child index out of range");
+						return;
+					}
+					const liveControls = [...deps.state.foregroundControls.values()].filter((candidate) => candidate.parentWorkflowRunId === workflowRunId && (candidate.activeChildren?.size ?? 0) > 0);
+					// Prefer the keyed control, then fall back to the sole live child, which covers a step whose
+					// control registered before its workflowKey was projected into status.steps.
+					const control = (step?.workflowKey ? liveControls.find((candidate) => candidate.workflowKey === step.workflowKey) : undefined)
+						?? (liveControls.length === 1 ? liveControls[0] : undefined);
+					if (!control) {
+						failWorkflowSteer(request, index, liveControls.length > 1
+							? `workflow has ${liveControls.length} live children; steer a child run id instead`
+							: "workflow child is not live in this process");
+						return;
+					}
+					recordWorkflowSteerTargets(request, [{ index, state: "routed" }]);
+					emitWorkflowSteerEvent("subagent.steer.requested", request.id, undefined, { targets: [{ index, state: "routed" }] });
+					emitWorkflowSteerEvent("subagent.steer.routed", request.id, index);
+					persist({ tolerateStatusWriteFailure: true });
+					const applyWorkflowSteerDelivery = (state: "delivered" | "queued" | "failed", reason?: string): void => {
+						const now = Date.now();
+						updateSteeringTarget(steeringStatus(status), request.id, index, state === "delivered" ? "delivered" : state === "queued" ? "queued" : "failed", now, reason ? { reason } : {});
+						if (state === "failed") {
+							const failedStep = status.steps?.[index];
+							if (failedStep) failedStep.activityState = "needs_attention";
+							status.activityState = "needs_attention";
+						}
+						emitWorkflowSteerEvent(`subagent.steer.${state}`, request.id, index, state === "failed" ? { reason } : { deliveryStatus: state, message: request.message });
+						persist({ tolerateStatusWriteFailure: true });
+					};
+					void steerWorkflowForegroundTarget({
+						target: { control, workflowRunId, sourceRunId: workflowRunId },
+						message: request.message,
+						...(request.mode ? { mode: request.mode } : {}),
+					}).then(
+						(result) => {
+							const target = result.details.steering?.targets[0];
+							applyWorkflowSteerDelivery(target?.state === "delivered" ? "delivered" : target?.state === "queued" ? "queued" : "failed", target?.reason ?? (target ? undefined : "steering produced no target receipt"));
+						},
+						(error) => applyWorkflowSteerDelivery("failed", error instanceof Error ? error.message : String(error)),
+					);
+				};
+				let disposeWorkflowSteerInbox: (() => void) | undefined;
+				try {
+					disposeWorkflowSteerInbox = watchAsyncSteerInbox(asyncDir, { onSteer: deliverWorkflowSteerRequest });
+				} catch (error) {
+					// Steering is an optional control surface, so a watcher that cannot install must not fail the run.
+					appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", error: error instanceof Error ? error.message : String(error) });
+				}
 				const { workflowScript, async: _workflowAsync, chatProgress: _chatProgress, ...workflowRequest } = requestParams;
 				void Promise.resolve().then(async () => {
 					const workflowDeadlineAt = timeout === undefined ? undefined : Date.now() + timeout;
@@ -5563,6 +5649,21 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(terminalOutcome ? { terminalOutcome } : {}), ...(status.error ? { error: status.error } : {}), ...(status.activityState ? { activityState: status.activityState } : {}) });
 					} finally {
+						// Stop watching, close the inbox so the requesting side cannot queue into a dead run, then
+						// drain in-flight requests to a terminal receipt (mirroring the runner teardown) so a late
+						// steer fails visibly instead of vanishing.
+						try {
+							disposeWorkflowSteerInbox?.();
+							closeSteerInbox(asyncDir, status.state);
+							const undelivered = consumeSteerRequests(asyncDir);
+							if (undelivered.length > 0) {
+								persistClosed = false;
+								const reason = `run became ${status.state} before steering request was consumed`;
+								for (const request of undelivered) failWorkflowSteer(request, request.targetIndex ?? request.targetIndexes?.[0] ?? 0, reason);
+							}
+						} catch (error) {
+							console.error(`Failed to close async workflow steer inbox '${asyncDir}':`, error);
+						}
 						persistClosed = true;
 						deps.state.workflowControllers?.delete(workflowRunId);
 						deps.state.workflowChildStops?.delete(workflowRunId);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5346,22 +5346,25 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 				const { workflowScript, async: _workflowAsync, chatProgress: _chatProgress, ...workflowRequest } = requestParams;
 				let workflowSteerInboxClosed = false;
-				const settleWorkflowSteerInbox = (): void => {
+				const settleWorkflowSteerInbox = (outcome = status.state): void => {
 					if (workflowSteerInboxClosed) return;
 					workflowSteerInboxClosed = true;
 					disposeWorkflowSteerInbox?.();
 					// Consumed deliveries are not files anymore. Fail unresolved SDK operations without awaiting them.
-					for (const settle of pendingWorkflowSteers) settle("failed", `run became ${status.state} before steering delivery settled; delivery unconfirmed`);
+					for (const settle of pendingWorkflowSteers) settle("failed", `run became ${outcome} before steering delivery settled; delivery unconfirmed`);
 					try {
-						closeSteerInbox(asyncDir, status.state);
+						closeSteerInbox(asyncDir, outcome);
 						// Separately drain requests that never reached the consumer.
 						const undelivered = consumeSteerRequests(asyncDir, undefined, (error) => {
 							appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", phase: "drain", error: error instanceof Error ? error.message : String(error) });
 						});
-						for (const request of undelivered) failWorkflowSteer(request, explicitWorkflowSteerIndexes(request) ?? [0], `run became ${status.state} before steering request was consumed`);
+						for (const request of undelivered) failWorkflowSteer(request, explicitWorkflowSteerIndexes(request) ?? [0], `run became ${outcome} before steering request was consumed`);
 					} catch (error) {
 						appendWorkflowEvent({ type: "subagent.workflow.steer_inbox_unavailable", phase: "close", error: error instanceof Error ? error.message : String(error) });
 					}
+					// Commit receipts while run status is still nonterminal. Result/index publication
+					// can fail next; teardown must not publish the subsequently computed terminal status.
+					persist();
 				};
 				void Promise.resolve().then(async () => {
 					const workflowDeadlineAt = timeout === undefined ? undefined : Date.now() + timeout;
@@ -5636,6 +5639,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						const outputWarning = writeWorkflowAggregateOutput(workflowAggregateOutputPath, summary, producedChildOutputPaths);
 						const resultSummary = appendWorkflowOutputWarning(summary, outputWarning);
 						const workflowUsage = sumResultsUsage(workflowResults);
+						settleWorkflowSteerInbox("complete");
 						const workflowChildren = workflowChildSummary({ parentToolCallId: toolCallId, workflowRunId, workflowState: "completed", inventoryComplete: true, trace: workflow.trace, children: workflow.children, steps: status.steps });
 						status = { ...status, state: "complete", endedAt: Date.now(), workflow: { value: workflow.value, trace: finalPreflightTrace, emits: workflow.emits, console: workflow.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}) }, workflowChildren, totalTokens: { input: workflowUsage.input, output: workflowUsage.output, total: workflowUsage.input + workflowUsage.output }, totalCost: sumResultsCost(workflowResults) };
 						const receipt = terminalWorkflowReceipt(workflowRunId, "complete", workflow.children, workflowChildren, undefined, validHostStepNodes(status.workflowGraph), workflowResource?.provenance);
@@ -5648,7 +5652,6 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, workflowChildren, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
-						settleWorkflowSteerInbox();
 						persist();
 						deps.refreshResultDelivery?.();
 						persistClosed = true;
@@ -5672,10 +5675,11 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							}
 						}
 						const workflowState = state === "paused" ? "paused" : state === "stopped" ? "stopped" : "failed";
+						settleWorkflowSteerInbox(state);
 						const workflowChildren = workflowChildSummary({ parentToolCallId: toolCallId, workflowRunId, workflowState, inventoryComplete: true, trace: partial.trace, children: partial.children, steps: status.steps });
 						const finalPreflightWarnings = workflowPreflightWarnings(workflowPreflight, partial.trace, { settled: true });
 						const finalPreflightTrace = annotateWorkflowPreflightTrace(partial.trace, workflowPreflight);
-						status = compactOptional<AsyncStatus>({ ...status, state, stopped: stopped || undefined, activityState: pauseForDetached ? "needs_attention" : undefined, error: workflowFailureMessage(error, workflowRunId, partial.children), endedAt: Date.now(), workflow: { trace: finalPreflightTrace, emits: partial.emits, console: partial.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}) }, workflowChildren });
+						status = compactOptional<AsyncStatus>({ ...status, state, stopped: stopped || undefined, activityState: pauseForDetached || status.activityState === "needs_attention" ? "needs_attention" : undefined, error: workflowFailureMessage(error, workflowRunId, partial.children), endedAt: Date.now(), workflow: { trace: finalPreflightTrace, emits: partial.emits, console: partial.console, ...(workflowResource ? { resource: workflowResource.provenance } : {}), ...(finalPreflightWarnings.length ? { preflightWarnings: finalPreflightWarnings } : {}) }, workflowChildren });
 						if (pauseForDetached) {
 							const promoted = promotePausedWorkflowIfSettled(status);
 							if (promoted) status = promoted;
@@ -5697,16 +5701,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, workflowChildren, ...(terminalOutcome ? { terminalOutcome } : {}), results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
-						settleWorkflowSteerInbox();
 						persist();
 						deps.refreshResultDelivery?.();
 						persistClosed = true;
 						appendWorkflowEvent({ type: "subagent.workflow.completed", state: status.state, ...(terminalOutcome ? { terminalOutcome } : {}), ...(status.error ? { error: status.error } : {}), ...(status.activityState ? { activityState: status.activityState } : {}) });
 					} finally {
-						// Also settle early result-write exits, while persistence is still open.
+						// Idempotent cleanup only: a failed result/index write must not authorize terminal status.
 						try {
 							settleWorkflowSteerInbox();
-							if (!persistClosed) persist();
 						} catch (error) {
 							console.error(`Failed to close async workflow steer inbox '${asyncDir}':`, error);
 						}

--- a/test/integration/workflow-steer-inbox.test.ts
+++ b/test/integration/workflow-steer-inbox.test.ts
@@ -43,9 +43,15 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 		await waitForMockPiCall(mockPi, 0, 10_000);
 		const session = mockPi.sessions[0]!.session!;
 		const originalSteer = session.steer.bind(session);
+		const originalFollowUp = session.followUp.bind(session);
 		let releaseSteers!: () => void;
 		const blocked = new Promise<void>((resolve) => { releaseSteers = resolve; });
 		let calls = 0;
+		session.followUp = async (text) => {
+			calls++;
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), []);
+			await originalFollowUp(text);
+		};
 		session.steer = async (text) => {
 			calls++;
 			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), [], "entire batch consumed before first delivery callback");
@@ -54,9 +60,14 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 		};
 		const accounting = (candidate: AsyncStatusPayload) => (candidate as { steering?: SteeringStatus }).steering;
 		try {
-			for (let index = 0; index < 21; index++) requestAsyncSteer(asyncDir, { id: `batch-${index}`, message: `batch-${index}`, targetIndex: 0, ts: index + 1 });
-			const active = await waitForAsyncState(runId, (candidate) => calls === 21 && accounting(candidate)?.recent.every((request) => request.targets[0]?.state === (shutdown ? "routed" : "delivered")) === true, 15_000);
+			for (let index = 0; index < 21; index++) requestAsyncSteer(asyncDir, { id: `batch-${index}`, message: `batch-${index}`, targetIndex: 0, ts: index + 1, ...(shutdown && (index === 0 || index === 20) ? { mode: "follow_up" as const } : {}) });
+			const active = await waitForAsyncState(runId, (candidate) => calls === 21 && accounting(candidate)?.recent.every((request) => request.targets[0]?.state === (shutdown ? request.id === "batch-20" ? "queued" : "routed" : "delivered")) === true, 15_000);
 			assert.equal(accounting(active)!.requested, 21);
+			assert.equal(accounting(active)!.pending, shutdown ? 21 : 0, "queued acknowledgments still count once as pending");
+			if (shutdown) {
+				const queuedEvents = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.type === "subagent.steer.queued");
+				assert.deepEqual(queuedEvents.map((event) => event.requestId), ["batch-0", "batch-20"], "both evicted and retained queued receipts remain pending");
+			}
 			assert.equal(accounting(active)!.recent.length, 20);
 			assert.equal(accounting(active)!.recent.some((request) => request.id === "batch-0"), false, "first unresolved receipt was evicted");
 			fs.writeFileSync(release, "go");
@@ -66,6 +77,7 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 			assert.equal(counters.delivered, shutdown ? 0 : 21);
 			assert.equal(counters.failed, shutdown ? 21 : 0);
 			assert.equal(counters.recent.length, 20, "history cap must not grow");
+			if (shutdown) assert.ok(counters.recent.every((request) => request.targets[0]?.state === "failed" && request.targets[0].reason?.includes("delivery unconfirmed")));
 			const before = fs.readFileSync(path.join(asyncDir, "status.json"), "utf8");
 			const journal = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8");
 			const terminalEvents = journal.trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.requestId?.startsWith("batch-") && event.type === `subagent.steer.${shutdown ? "failed" : "delivered"}`);
@@ -77,6 +89,7 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 			assert.equal(fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8"), journal);
 		} finally {
 			session.steer = originalSteer;
+			session.followUp = originalFollowUp;
 			releaseSteers();
 			fs.writeFileSync(release, "go");
 		}
@@ -182,6 +195,13 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 
 		const payload = await readAsyncPayload(runId);
 		assert.equal(payload.success, true);
+		const terminal = await waitForAsyncState(runId, (candidate) => candidate.state === "complete", 15_000);
+		const counters = (terminal as { steering: SteeringStatus }).steering;
+		assert.equal(counters.pending, 0);
+		assert.equal(counters.delivered, 1);
+		assert.equal(counters.failed, 1);
+		assert.equal(recentSteering(terminal, "workflow-follow-up")?.state, "failed");
+		assert.match(recentSteering(terminal, "workflow-follow-up")!.reason!, /delivery unconfirmed/);
 	});
 
 	for (const parallel of [false, true]) it(`routes every explicit target without sibling fallback (${parallel ? "parallel" : "sequential"})`, { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {

--- a/test/integration/workflow-steer-inbox.test.ts
+++ b/test/integration/workflow-steer-inbox.test.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 import { events, makeAgent, makeMinimalCtx } from "../support/helpers.ts";
 import { requestAsyncSteer, steerInboxClosedPath, steerRequestsDir } from "../../src/runs/background/control-channel.ts";
 import type { AsyncStatusPayload } from "../support/async-execution-fixture.ts";
+import type { SteeringStatus } from "../../src/shared/types.ts";
 import {
 	installAsyncExecutionHooks, available, isAsyncAvailable, ASYNC_DIR,
 	createSubagentExecutor, waitForMockPiCall, waitForAsyncState, tempDir, mockPi,
@@ -28,6 +29,109 @@ function recentSteering(status: AsyncStatusPayload, requestId: string): { index:
 
 describe("async workflow steer inbox", { skip: !available ? "pi packages not available" : undefined }, () => {
 	installAsyncExecutionHooks();
+
+	for (const shutdown of [false, true]) it(`accounts for 21 same-scan requests beyond display history (${shutdown ? "shutdown" : "delivered"})`, { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const release = path.join(tempDir, "batch-accounting-release");
+		mockPi.onCall({ steps: [{ waitForPath: release, jsonl: [events.assistantMessage("done")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-batch-accounting";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+		const launch = await executor.execute("batch-accounting", { workflowScript: `return await runs.run("A", { agent: "worker", task: "Wait" });`, async: true }, new AbortController().signal, undefined, ctx);
+		assert.equal(launch.isError, undefined);
+		const runId = launch.details!.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		await waitForMockPiCall(mockPi, 0, 10_000);
+		const session = mockPi.sessions[0]!.session!;
+		const originalSteer = session.steer.bind(session);
+		let releaseSteers!: () => void;
+		const blocked = new Promise<void>((resolve) => { releaseSteers = resolve; });
+		let calls = 0;
+		session.steer = async (text) => {
+			calls++;
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), [], "entire batch consumed before first delivery callback");
+			if (shutdown) await blocked;
+			else await originalSteer(text);
+		};
+		const accounting = (candidate: AsyncStatusPayload) => (candidate as { steering?: SteeringStatus }).steering;
+		try {
+			for (let index = 0; index < 21; index++) requestAsyncSteer(asyncDir, { id: `batch-${index}`, message: `batch-${index}`, targetIndex: 0, ts: index + 1 });
+			const active = await waitForAsyncState(runId, (candidate) => calls === 21 && accounting(candidate)?.recent.every((request) => request.targets[0]?.state === (shutdown ? "routed" : "delivered")) === true, 15_000);
+			assert.equal(accounting(active)!.requested, 21);
+			assert.equal(accounting(active)!.recent.length, 20);
+			assert.equal(accounting(active)!.recent.some((request) => request.id === "batch-0"), false, "first unresolved receipt was evicted");
+			fs.writeFileSync(release, "go");
+			const terminal = await waitForAsyncState(runId, (candidate) => candidate.state === "complete", 15_000);
+			const counters = accounting(terminal)!;
+			assert.equal(counters.pending, 0);
+			assert.equal(counters.delivered, shutdown ? 0 : 21);
+			assert.equal(counters.failed, shutdown ? 21 : 0);
+			assert.equal(counters.recent.length, 20, "history cap must not grow");
+			const before = fs.readFileSync(path.join(asyncDir, "status.json"), "utf8");
+			const journal = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8");
+			const terminalEvents = journal.trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.requestId?.startsWith("batch-") && event.type === `subagent.steer.${shutdown ? "failed" : "delivered"}`);
+			assert.equal(terminalEvents.length, counters.delivered + counters.failed);
+			assert.equal(new Set(terminalEvents.map((event) => event.requestId)).size, 21, "every request has exactly one terminal event");
+			releaseSteers();
+			await new Promise((resolve) => setTimeout(resolve, 350));
+			assert.equal(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8"), before);
+			assert.equal(fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8"), journal);
+		} finally {
+			session.steer = originalSteer;
+			releaseSteers();
+			fs.writeFileSync(release, "go");
+		}
+	});
+
+	for (const stop of [false, true]) it(`settles consumed pending deliveries before ${stop ? "stop" : "completion"} and ignores late callbacks`, { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const release = path.join(tempDir, "pending-steer-release");
+		mockPi.onCall({ steps: [{ waitForPath: release, jsonl: [events.assistantMessage("done")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-pending-steer";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+		const launch = await executor.execute("pending-steer", { workflowScript: `return await runs.run("A", { agent: "worker", task: "Wait" });`, async: true }, new AbortController().signal, undefined, ctx);
+		assert.equal(launch.isError, undefined);
+		const runId = launch.details!.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		await waitForMockPiCall(mockPi, 0, 10_000);
+		const session = mockPi.sessions[0]!.session!;
+		const originalSteer = session.steer;
+		let settle!: () => void;
+		let entered = false;
+		session.steer = async () => {
+			entered = true;
+			await new Promise<void>((resolve, reject) => { settle = stop ? () => reject(new Error("late rejection")) : resolve; });
+		};
+		try {
+			requestAsyncSteer(asyncDir, { id: "pending", message: "pending", targetIndex: 0 });
+			await waitForAsyncState(runId, (candidate) => entered && recentSteering(candidate, "pending")?.state === "routed", 15_000);
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), [], "pending request is consumed, not available to file drain");
+			if (stop) {
+				requestAsyncSteer(asyncDir, { id: "file-resident", message: "not consumed", targetIndexes: [0, 99] });
+				const stopped = await executor.execute("stop-pending", { action: "stop", id: runId }, new AbortController().signal, undefined, ctx);
+				assert.notEqual(stopped.isError, true, stopped.content[0]?.text);
+			} else fs.writeFileSync(release, "go");
+			const terminal = await waitForAsyncState(runId, (candidate) => candidate.state === (stop ? "stopped" : "complete"), 15_000);
+			assert.equal(recentSteering(terminal, "pending")?.state, "failed");
+			assert.match(recentSteering(terminal, "pending")!.reason!, /before steering delivery settled/);
+			assert.equal(fs.existsSync(steerInboxClosedPath(asyncDir)), true);
+			if (stop) {
+				const targets = (terminal as SteeringTargets).steering!.recent.find((request) => request.id === "file-resident")!.targets;
+				assert.deepEqual(targets.map(({ index, state }) => [index, state]), [[0, "failed"], [99, "failed"]]);
+				assert.ok(targets.every(({ reason }) => reason?.includes("before steering request was consumed")));
+			}
+			const before = fs.readFileSync(path.join(asyncDir, "status.json"), "utf8");
+			const journalBefore = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8");
+			assert.equal(journalBefore.split("\n").filter((line) => line.includes('"type":"subagent.steer.failed"') && line.includes('"requestId":"pending"')).length, 1);
+			settle();
+			await new Promise((resolve) => setTimeout(resolve, 350));
+			assert.equal(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8"), before, "late callback must not rewrite durable terminal state");
+			assert.equal(fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8"), journalBefore, "late callback must not append contradictory evidence");
+		} finally {
+			session.steer = originalSteer;
+			settle?.();
+			fs.writeFileSync(release, "go");
+		}
+	});
 
 	it("delivers an inbox steer request to a live async workflow child", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		const release = path.join(tempDir, "workflow-steer-release");
@@ -66,12 +170,88 @@ describe("async workflow steer inbox", { skip: !available ? "pi packages not ava
 			const eventsText = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
 			assert.match(eventsText, /"type":"subagent\.steer\.routed"[^\n]*"requestId":"workflow-steer-1"/);
 			assert.match(eventsText, /"type":"subagent\.steer\.delivered"[^\n]*"requestId":"workflow-steer-1"/);
+			requestAsyncSteer(asyncDir, { message: "Follow up later", id: "workflow-follow-up", mode: "follow_up" });
+			const queued = await waitForAsyncState(runId, (candidate) => recentSteering(candidate, "workflow-follow-up")?.state === "queued", 15_000);
+			const counters = (queued as { steering: SteeringStatus }).steering;
+			assert.equal(counters.requested, 2);
+			assert.equal(counters.delivered, 1);
+			assert.equal(counters.pending, 1, "routed to queued must not double-count the pending target");
 		} finally {
 			fs.writeFileSync(release, "go");
 		}
 
 		const payload = await readAsyncPayload(runId);
 		assert.equal(payload.success, true);
+	});
+
+	for (const parallel of [false, true]) it(`routes every explicit target without sibling fallback (${parallel ? "parallel" : "sequential"})`, { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const releaseA = path.join(tempDir, "target-release-a");
+		const releaseB = path.join(tempDir, "target-release-b");
+		mockPi.onCall({ steps: [{ waitForPath: releaseA, jsonl: [events.assistantMessage("A done")] }] });
+		mockPi.onCall({ steps: [{ waitForPath: releaseB, jsonl: [events.assistantMessage("B done")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-workflow-targets";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+		const launch = await executor.execute("workflow-targets", {
+			workflowScript: parallel
+				? `return await Promise.all([runs.run("A", { agent: "worker", task: "A" }), runs.run("B", { agent: "worker", task: "B" })]);`
+				: `await runs.run("A", { agent: "worker", task: "A" }); return await runs.run("B", { agent: "worker", task: "B" });`,
+			async: true,
+		}, new AbortController().signal, undefined, ctx);
+		assert.equal(launch.isError, undefined, launch.content[0]?.text);
+		const runId = launch.details?.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		const deliveredTexts = (): string[] => {
+			const file = path.join(mockPi.dir, "steers.jsonl");
+			return fs.existsSync(file) ? fs.readFileSync(file, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line).text) : [];
+		};
+		const check = async (id: string, address: { targetIndex?: number; targetIndexes?: number[] }, expected: Array<[number, string]>, deliveries: number, alreadyWritten = false) => {
+			if (!alreadyWritten) requestAsyncSteer(asyncDir, { id, message: id, ...address });
+			const status = await waitForAsyncState(runId, (candidate) => {
+				const targets = (candidate as SteeringTargets).steering?.recent.find((request) => request.id === id)?.targets;
+				return targets !== undefined && targets.every((target) => target.state === "delivered" || target.state === "failed");
+			}, 15_000);
+			const targets = (status as SteeringTargets).steering!.recent.find((request) => request.id === id)!.targets;
+			assert.deepEqual(targets.map(({ index, state }) => [index, state]), expected);
+			assert.equal(deliveredTexts().filter((text) => text.includes(id)).length, deliveries);
+			const journal = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.requestId === id);
+			assert.equal(journal.filter((event) => event.type === "subagent.steer.requested").length, 1);
+			for (const [index, state] of expected) assert.equal(journal.filter((event) => event.index === index && event.type === `subagent.steer.${state}`).length, 1);
+			return targets;
+		};
+		try {
+			await waitForMockPiCall(mockPi, 0, 10_000);
+			// Hold a transport-written request outside the watched inbox until A disappears.
+			// This controls queue-to-consumption delay without changing the watcher or child lifecycle.
+			const heldDir = path.join(tempDir, "held-steer");
+			if (!parallel) {
+				requestAsyncSteer(heldDir, { id: "disappeared-A", message: "disappeared-A", targetIndex: 0 });
+				fs.writeFileSync(releaseA, "go");
+			}
+			await waitForMockPiCall(mockPi, 1, 10_000);
+			await waitForAsyncState(runId, (candidate) => (candidate.steps?.length ?? 0) === 2, 15_000);
+			if (parallel) {
+				const targets = await check("ambiguous", {}, [[0, "failed"]], 0);
+				assert.match(targets[0]!.reason!, /2 live children/);
+			} else {
+				for (const file of fs.readdirSync(steerRequestsDir(heldDir))) fs.renameSync(path.join(steerRequestsDir(heldDir), file), path.join(steerRequestsDir(asyncDir), file));
+				await check("disappeared-A", {}, [[0, "failed"]], 0, true);
+				const targets = await check("dead-A", { targetIndex: 0 }, [[0, "failed"]], 0);
+				assert.match(targets[0]!.reason!, /not live/);
+				await check("unique-B", {}, [[1, "delivered"]], 1);
+			}
+			await check("aggregate", { targetIndexes: [0, 1] }, [[0, parallel ? "delivered" : "failed"], [1, "delivered"]], parallel ? 2 : 1);
+			if (parallel) {
+				const deliveries = fs.readFileSync(path.join(mockPi.dir, "steers.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line) as { text: string; sessionId: string });
+				assert.equal(new Set(deliveries.filter(({ text }) => text.includes("aggregate")).map(({ sessionId }) => sessionId)).size, 2, "aggregate must reach two distinct children");
+			}
+			await check("out-of-range", { targetIndex: 99 }, [[99, "failed"]], 0);
+			await check("mixed-range", { targetIndexes: [1, 99] }, [[1, "delivered"], [99, "failed"]], 1);
+		} finally {
+			fs.writeFileSync(releaseA, "go");
+			fs.writeFileSync(releaseB, "go");
+		}
+		assert.equal((await readAsyncPayload(runId)).success, true);
 	});
 
 	it("closes the inbox and fails a late steer request when the workflow ends", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {

--- a/test/integration/workflow-steer-inbox.test.ts
+++ b/test/integration/workflow-steer-inbox.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration tests for the durable steer inbox of async WORKFLOW runs.
+ *
+ * `watchAsyncControlInbox` is installed only by subagent-runner.ts, and the runner never executes
+ * workflow scripts, so before this fix no process consumed `control/steer-requests/` for a
+ * workflow run: a queued request file sat on disk until the run ended and the requester's
+ * "delivered" receipt was never backed by a delivery.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { events, makeAgent, makeMinimalCtx } from "../support/helpers.ts";
+import { requestAsyncSteer, steerInboxClosedPath, steerRequestsDir } from "../../src/runs/background/control-channel.ts";
+import type { AsyncStatusPayload } from "../support/async-execution-fixture.ts";
+import {
+	installAsyncExecutionHooks, available, isAsyncAvailable, ASYNC_DIR,
+	createSubagentExecutor, waitForMockPiCall, waitForAsyncState, tempDir, mockPi,
+	makeAsyncExecutor, readAsyncPayload,
+} from "../support/async-execution-fixture.ts";
+
+type SteeringTargets = { steering?: { recent: Array<{ id: string; targets: Array<{ index: number; state: string; reason?: string }> }> } };
+
+function recentSteering(status: AsyncStatusPayload, requestId: string): { index: number; state: string; reason?: string } | undefined {
+	return (status as SteeringTargets).steering?.recent?.find((request) => request.id === requestId)?.targets[0];
+}
+
+describe("async workflow steer inbox", { skip: !available ? "pi packages not available" : undefined }, () => {
+	installAsyncExecutionHooks();
+
+	it("delivers an inbox steer request to a live async workflow child", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const release = path.join(tempDir, "workflow-steer-release");
+		mockPi.onCall({ steps: [{ waitForPath: release, jsonl: [events.assistantMessage("steered workflow child")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-workflow-steer";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+
+		const launch = await executor.execute(
+			`workflow-steer-inbox-${Date.now().toString(36)}`,
+			{ workflowScript: `return await runs.run("waits", { agent: "worker", task: "Wait for guidance" });`, async: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(launch.isError, undefined, launch.content[0]?.text);
+		const runId = launch.details?.asyncId as string;
+		assert.ok(runId, "expected an async workflow run id");
+		const asyncDir = path.join(ASYNC_DIR, runId);
+
+		try {
+			// The child is now live and parked on the release path, so the workflow run is genuinely
+			// steerable: the only question is whether anything consumes its inbox.
+			await waitForMockPiCall(mockPi, 0, 10_000);
+			requestAsyncSteer(asyncDir, { message: "Focus on the failing test.", id: "workflow-steer-1", ts: Date.now() });
+
+			const status = await waitForAsyncState(runId, (candidate) => recentSteering(candidate, "workflow-steer-1") !== undefined, 15_000);
+			const target = recentSteering(status, "workflow-steer-1");
+			assert.equal(target?.state, "delivered", `expected a real delivery, got ${JSON.stringify(target)}`);
+			// The request file must be consumed, not left on disk for the life of the run.
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), []);
+
+			const steers = fs.readFileSync(path.join(mockPi.dir, "steers.jsonl"), "utf-8").trim().split("\n").map((line) => JSON.parse(line) as { text: string });
+			assert.match(steers[0]?.text ?? "", /Focus on the failing test\./, "the live child must receive the steer text");
+
+			const eventsText = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf-8");
+			assert.match(eventsText, /"type":"subagent\.steer\.routed"[^\n]*"requestId":"workflow-steer-1"/);
+			assert.match(eventsText, /"type":"subagent\.steer\.delivered"[^\n]*"requestId":"workflow-steer-1"/);
+		} finally {
+			fs.writeFileSync(release, "go");
+		}
+
+		const payload = await readAsyncPayload(runId);
+		assert.equal(payload.success, true);
+	});
+
+	it("closes the inbox and fails a late steer request when the workflow ends", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-workflow-steer-closed";
+		const executor = makeAsyncExecutor([]);
+
+		const launch = await executor.execute(
+			`workflow-steer-closed-${Date.now().toString(36)}`,
+			{ workflowScript: "return 'done'", async: true },
+			new AbortController().signal,
+			undefined,
+			ctx,
+		);
+		assert.equal(launch.isError, undefined, launch.content[0]?.text);
+		const runId = launch.details?.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+
+		await waitForAsyncState(runId, (candidate) => candidate.state === "complete", 15_000);
+		// A terminal run must refuse new steering rather than accept a request nothing will read.
+		assert.equal(fs.existsSync(steerInboxClosedPath(asyncDir)), true, "the steer inbox must be closed at teardown");
+		assert.throws(
+			() => requestAsyncSteer(asyncDir, { message: "Too late.", id: "workflow-steer-late", ts: Date.now() }),
+			/no longer accepts steering requests/,
+		);
+	});
+});

--- a/test/integration/workflow-steer-inbox.test.ts
+++ b/test/integration/workflow-steer-inbox.test.ts
@@ -18,7 +18,7 @@ import type { SteeringStatus } from "../../src/shared/types.ts";
 import {
 	installAsyncExecutionHooks, available, isAsyncAvailable, ASYNC_DIR,
 	createSubagentExecutor, waitForMockPiCall, waitForAsyncState, tempDir, mockPi,
-	makeAsyncExecutor, readAsyncPayload,
+	makeAsyncExecutor, readAsyncPayload, RESULTS_DIR, waitForAsyncEvent,
 } from "../support/async-execution-fixture.ts";
 
 type SteeringTargets = { steering?: { recent: Array<{ id: string; targets: Array<{ index: number; state: string; reason?: string }> }> } };
@@ -29,6 +29,70 @@ function recentSteering(status: AsyncStatusPayload, requestId: string): { index:
 
 describe("async workflow steer inbox", { skip: !available ? "pi packages not available" : undefined }, () => {
 	installAsyncExecutionHooks();
+
+	for (const outcome of ["complete", "failed", "stopped"]) it(`settles steering without terminal status when result index publication fails (${outcome})`, { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const release = path.join(tempDir, "index-failure-release");
+		const indexPath = path.join(RESULTS_DIR, "result-index");
+		mockPi.onCall({ steps: [{ waitForPath: release, jsonl: [events.assistantMessage("done")] }] });
+		const ctx = makeMinimalCtx(tempDir);
+		ctx.sessionManager.getSessionId = () => "session-index-steering";
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+		const launch = await executor.execute("index-steering", {
+			workflowScript: `await runs.run("A", { agent: "worker", task: "Wait" }); ${outcome === "failed" ? 'throw new Error("script failed")' : 'return "done"'}`,
+			async: true,
+		}, new AbortController().signal, undefined, ctx);
+		assert.equal(launch.isError, undefined);
+		const runId = launch.details!.asyncId as string;
+		const asyncDir = path.join(ASYNC_DIR, runId);
+		await waitForMockPiCall(mockPi, 0, 10_000);
+		const session = mockPi.sessions[0]!.session!;
+		const originalSteer = session.steer;
+		let entered = false;
+		let releaseSteer!: () => void;
+		const blocked = new Promise<void>((resolve) => { releaseSteer = resolve; });
+		session.steer = async () => { entered = true; await blocked; };
+		try {
+			requestAsyncSteer(asyncDir, { id: "queued", message: "later", mode: "follow_up" });
+			requestAsyncSteer(asyncDir, { id: "unresolved", message: "pending" });
+			await waitForAsyncState(runId, (candidate) => entered && recentSteering(candidate, "queued")?.state === "queued" && recentSteering(candidate, "unresolved")?.state === "routed", 15_000);
+			fs.rmSync(indexPath, { recursive: true, force: true });
+			fs.mkdirSync(RESULTS_DIR, { recursive: true });
+			fs.writeFileSync(indexPath, "not a directory");
+			if (outcome === "stopped") {
+				const stop = await executor.execute("stop-index-steering", { action: "stop", id: runId }, new AbortController().signal, undefined, ctx);
+				assert.notEqual(stop.isError, true);
+			} else fs.writeFileSync(release, "go");
+			await waitForAsyncEvent(runId, "subagent.workflow.result_write_failed");
+			const before = fs.readFileSync(path.join(asyncDir, "status.json"), "utf8");
+			const status = JSON.parse(before) as { state: string; endedAt?: number; activityState?: string; steering: SteeringStatus };
+			assert.equal(status.state, "running", "failed index publication cannot authorize terminal status");
+			assert.equal(status.endedAt, undefined);
+			assert.equal(status.activityState, "needs_attention");
+			assert.equal(status.steering.pending, 0);
+			assert.equal(status.steering.failed, 2);
+			assert.equal(status.steering.delivered, 0);
+			assert.ok(status.steering.recent.every((request) => request.targets[0]?.state === "failed" && request.targets[0].reason === `run became ${outcome} before steering delivery settled; delivery unconfirmed`));
+			assert.equal(fs.existsSync(path.join(ASYNC_DIR, ".active-runs", runId)), true);
+			assert.equal(fs.existsSync(path.join(RESULTS_DIR, `${runId}.json`)), false);
+			assert.equal(fs.existsSync(path.join(RESULTS_DIR, "result-pending", "session-index-steering", `${runId}.json`)), true);
+			const unpublished = JSON.parse(fs.readFileSync(path.join(RESULTS_DIR, "result-pending", "session-index-steering", `${runId}.json`), "utf8"));
+			assert.equal(unpublished.state, outcome, "computed outcome is retained only in unpublished result");
+			if (outcome !== "complete") assert.equal(unpublished.activityState, "needs_attention", "failure finalization preserves steering attention");
+			assert.equal(fs.existsSync(steerInboxClosedPath(asyncDir)), true);
+			const journal = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8");
+			assert.equal(journal.split("\n").filter((line) => line.includes('"type":"subagent.steer.failed"')).length, 2);
+			assert.doesNotMatch(journal, /"type":"subagent.workflow.completed"/);
+			releaseSteer();
+			await new Promise((resolve) => setTimeout(resolve, 350));
+			assert.equal(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8"), before);
+			assert.equal(fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8"), journal);
+		} finally {
+			session.steer = originalSteer;
+			releaseSteer();
+			fs.writeFileSync(release, "go");
+			fs.rmSync(indexPath, { recursive: true, force: true });
+		}
+	});
 
 	for (const shutdown of [false, true]) it(`accounts for 21 same-scan requests beyond display history (${shutdown ? "shutdown" : "delivered"})`, { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		const release = path.join(tempDir, "batch-accounting-release");

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -23,6 +23,7 @@ import {
 	stopRequestPath,
 	steerRequestsDir,
 	watchAsyncControlInbox,
+	watchAsyncSteerInbox,
 } from "../../src/runs/background/control-channel.ts";
 
 function tmpAsyncDir(label: string): string {
@@ -559,6 +560,176 @@ describe("control channel: watchAsyncControlInbox", () => {
 
 			assert.deepEqual(steers, ["first", "second"]);
 			assert.deepEqual(h.intervalDelays(), [5000]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+});
+
+describe("control channel: watchAsyncSteerInbox", () => {
+	type SteerWatchHarness = {
+		fsImpl: import("../../src/runs/background/control-channel.ts").ControlChannelFs;
+		timers: import("../../src/runs/background/control-channel.ts").ControlChannelTimers;
+		trigger: () => void;
+		triggerError: () => void;
+		closed: () => boolean;
+		intervalDelays: () => number[];
+		watchedDir: () => string | undefined;
+	};
+
+	function steerHarness(): SteerWatchHarness {
+		const listeners = new Map<string, () => void>();
+		const errorListeners = new Map<string, () => void>();
+		let closed = false;
+		const intervalDelays: number[] = [];
+		let watchedDir: string | undefined;
+		const realpathSync = ((target: fs.PathLike, options?: unknown) => fs.realpathSync(target, options as BufferEncoding)) as typeof fs.realpathSync;
+		realpathSync.native = ((target: fs.PathLike) => fs.realpathSync.native(target)) as typeof fs.realpathSync.native;
+		const fsImpl = {
+			mkdirSync: fs.mkdirSync,
+			existsSync: fs.existsSync,
+			rmSync: fs.rmSync,
+			readdirSync: fs.readdirSync,
+			readFileSync: fs.readFileSync,
+			realpathSync,
+			watch: ((dir: string, cb: () => void) => {
+				watchedDir = dir;
+				listeners.set(dir, cb);
+				return {
+					close: () => { closed = true; },
+					on: (event: string, handler: () => void) => {
+						if (event === "error") errorListeners.set(dir, handler);
+					},
+				};
+			}),
+		} as unknown as SteerWatchHarness["fsImpl"];
+		const timers = {
+			setInterval: ((_handler: Parameters<typeof setInterval>[0], delay?: number) => {
+				intervalDelays.push(delay ?? 0);
+				return { unref() {} };
+			}) as unknown as typeof setInterval,
+			clearInterval: (() => {}) as unknown as typeof clearInterval,
+		};
+		return {
+			fsImpl,
+			timers,
+			trigger: () => { for (const listener of listeners.values()) listener(); },
+			triggerError: () => { for (const listener of errorListeners.values()) listener(); },
+			closed: () => closed,
+			intervalDelays: () => [...intervalDelays],
+			watchedDir: () => watchedDir,
+		};
+	}
+
+	it("consumes a steer request that arrived before the watcher started", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-early-");
+		try {
+			requestAsyncSteer(asyncDir, { message: "queued before install", id: "s1", ts: 1 });
+			const steers: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			assert.deepEqual(steers, ["queued before install"]);
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), []);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("consumes later requests via the watch event and stops after dispose", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-event-");
+		try {
+			const steers: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			assert.deepEqual(steers, []);
+
+			requestAsyncSteer(asyncDir, { message: "first", id: "s1", ts: 1 });
+			h.trigger();
+			assert.deepEqual(steers, ["first"]);
+
+			// A spurious event with nothing queued is a no-op.
+			h.trigger();
+			assert.deepEqual(steers, ["first"]);
+
+			dispose();
+			assert.equal(h.closed(), true);
+
+			requestAsyncSteer(asyncDir, { message: "after dispose", id: "s2", ts: 2 });
+			h.trigger();
+			assert.deepEqual(steers, ["first"], "a disposed watcher must not consume further requests");
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("watches only the steer directory, so a stop request stays for its own consumer", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-scope-");
+		try {
+			requestAsyncStop(asyncDir, { source: "test" });
+			const steers: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			h.trigger();
+			assert.deepEqual(steers, []);
+			assert.equal(h.watchedDir(), fs.realpathSync.native(steerRequestsDir(asyncDir)));
+			assert.equal(fs.readdirSync(stopRequestsDir(asyncDir)).length, 1, "a stop request must not be consumed by the steer watcher");
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("uses portable polling without native watchers on Darwin", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-darwin-");
+		try {
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer() {}, fs: h.fsImpl, timers: h.timers, platform: "darwin" });
+			assert.equal(h.watchedDir(), undefined);
+			assert.deepEqual(h.intervalDelays(), [250]);
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("starts portable polling once when the native watcher fails", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-fallback-");
+		try {
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer() {}, fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			assert.deepEqual(h.intervalDelays(), [5000], "the native path installs only the safety poll");
+			h.triggerError();
+			h.triggerError();
+			assert.deepEqual(h.intervalDelays(), [5000, 250], "polling starts once, not per error");
+			dispose();
+		} finally {
+			cleanup(asyncDir);
+		}
+	});
+
+	it("keeps watching when a consumer throws", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-watch-throws-");
+		try {
+			const seen: string[] = [];
+			const h = steerHarness();
+			const dispose = watchAsyncSteerInbox(asyncDir, {
+				onSteer: (request) => {
+					seen.push(request.message);
+					if (request.message === "boom") throw new Error("consumer failed");
+				},
+				fs: h.fsImpl,
+				timers: h.timers,
+				platform: "linux",
+			});
+
+			requestAsyncSteer(asyncDir, { message: "boom", id: "s1", ts: 1 });
+			h.trigger();
+			requestAsyncSteer(asyncDir, { message: "still delivered", id: "s2", ts: 2 });
+			h.trigger();
+
+			assert.deepEqual(seen, ["boom", "still delivered"], "a throwing consumer must not kill the watcher");
 			dispose();
 		} finally {
 			cleanup(asyncDir);

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -18,12 +18,13 @@ import {
 	requestAsyncInterrupt,
 	requestAsyncSteer,
 	requestAsyncStop,
+	requestAsyncTimeout,
+	timeoutRequestPath,
 	steerInboxClosedPath,
 	stopRequestsDir,
 	stopRequestPath,
 	steerRequestsDir,
 	watchAsyncControlInbox,
-	watchAsyncSteerInbox,
 } from "../../src/runs/background/control-channel.ts";
 
 function tmpAsyncDir(label: string): string {
@@ -476,17 +477,23 @@ describe("control channel: watchAsyncControlInbox", () => {
 		try {
 			requestAsyncStop(asyncDir);
 			requestAsyncInterrupt(asyncDir);
+			requestAsyncTimeout(asyncDir);
+			requestAsyncSteer(asyncDir, { id: "all-handlers", message: "guide" });
 			const events: string[] = [];
 			const h = harness();
 			const dispose = watchAsyncControlInbox(asyncDir, {
 				onInterrupt: () => events.push("interrupt"),
 				onStop: () => events.push("stop"),
+				onTimeout: () => events.push("timeout"),
+				onSteer: () => events.push("steer"),
 				fs: h.fsImpl,
 				timers: h.timers,
 				platform: "linux",
 			});
 
-			assert.deepEqual(events, ["stop", "interrupt"]);
+			assert.deepEqual(events, ["stop", "timeout", "interrupt", "steer"]);
+			h.trigger();
+			assert.deepEqual(events, ["stop", "timeout", "interrupt", "steer"], "all-handler runner consumes each request once");
 			dispose();
 		} finally {
 			cleanup(asyncDir);
@@ -565,70 +572,14 @@ describe("control channel: watchAsyncControlInbox", () => {
 			cleanup(asyncDir);
 		}
 	});
-});
-
-describe("control channel: watchAsyncSteerInbox", () => {
-	type SteerWatchHarness = {
-		fsImpl: import("../../src/runs/background/control-channel.ts").ControlChannelFs;
-		timers: import("../../src/runs/background/control-channel.ts").ControlChannelTimers;
-		trigger: () => void;
-		triggerError: () => void;
-		closed: () => boolean;
-		intervalDelays: () => number[];
-		watchedDir: () => string | undefined;
-	};
-
-	function steerHarness(): SteerWatchHarness {
-		const listeners = new Map<string, () => void>();
-		const errorListeners = new Map<string, () => void>();
-		let closed = false;
-		const intervalDelays: number[] = [];
-		let watchedDir: string | undefined;
-		const realpathSync = ((target: fs.PathLike, options?: unknown) => fs.realpathSync(target, options as BufferEncoding)) as typeof fs.realpathSync;
-		realpathSync.native = ((target: fs.PathLike) => fs.realpathSync.native(target)) as typeof fs.realpathSync.native;
-		const fsImpl = {
-			mkdirSync: fs.mkdirSync,
-			existsSync: fs.existsSync,
-			rmSync: fs.rmSync,
-			readdirSync: fs.readdirSync,
-			readFileSync: fs.readFileSync,
-			realpathSync,
-			watch: ((dir: string, cb: () => void) => {
-				watchedDir = dir;
-				listeners.set(dir, cb);
-				return {
-					close: () => { closed = true; },
-					on: (event: string, handler: () => void) => {
-						if (event === "error") errorListeners.set(dir, handler);
-					},
-				};
-			}),
-		} as unknown as SteerWatchHarness["fsImpl"];
-		const timers = {
-			setInterval: ((_handler: Parameters<typeof setInterval>[0], delay?: number) => {
-				intervalDelays.push(delay ?? 0);
-				return { unref() {} };
-			}) as unknown as typeof setInterval,
-			clearInterval: (() => {}) as unknown as typeof clearInterval,
-		};
-		return {
-			fsImpl,
-			timers,
-			trigger: () => { for (const listener of listeners.values()) listener(); },
-			triggerError: () => { for (const listener of errorListeners.values()) listener(); },
-			closed: () => closed,
-			intervalDelays: () => [...intervalDelays],
-			watchedDir: () => watchedDir,
-		};
-	}
 
 	it("consumes a steer request that arrived before the watcher started", () => {
 		const asyncDir = tmpAsyncDir("pi-steer-watch-early-");
 		try {
 			requestAsyncSteer(asyncDir, { message: "queued before install", id: "s1", ts: 1 });
 			const steers: string[] = [];
-			const h = steerHarness();
-			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			assert.deepEqual(steers, ["queued before install"]);
 			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), []);
 			dispose();
@@ -641,8 +592,8 @@ describe("control channel: watchAsyncSteerInbox", () => {
 		const asyncDir = tmpAsyncDir("pi-steer-watch-event-");
 		try {
 			const steers: string[] = [];
-			const h = steerHarness();
-			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			assert.deepEqual(steers, []);
 
 			requestAsyncSteer(asyncDir, { message: "first", id: "s1", ts: 1 });
@@ -668,41 +619,17 @@ describe("control channel: watchAsyncSteerInbox", () => {
 		const asyncDir = tmpAsyncDir("pi-steer-watch-scope-");
 		try {
 			requestAsyncStop(asyncDir, { source: "test" });
+			requestAsyncInterrupt(asyncDir);
+			requestAsyncTimeout(asyncDir);
 			const steers: string[] = [];
-			const h = steerHarness();
-			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, { onSteer: (request) => steers.push(request.message), fs: h.fsImpl, timers: h.timers, platform: "linux" });
 			h.trigger();
 			assert.deepEqual(steers, []);
 			assert.equal(h.watchedDir(), fs.realpathSync.native(steerRequestsDir(asyncDir)));
 			assert.equal(fs.readdirSync(stopRequestsDir(asyncDir)).length, 1, "a stop request must not be consumed by the steer watcher");
-			dispose();
-		} finally {
-			cleanup(asyncDir);
-		}
-	});
-
-	it("uses portable polling without native watchers on Darwin", () => {
-		const asyncDir = tmpAsyncDir("pi-steer-watch-darwin-");
-		try {
-			const h = steerHarness();
-			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer() {}, fs: h.fsImpl, timers: h.timers, platform: "darwin" });
-			assert.equal(h.watchedDir(), undefined);
-			assert.deepEqual(h.intervalDelays(), [250]);
-			dispose();
-		} finally {
-			cleanup(asyncDir);
-		}
-	});
-
-	it("starts portable polling once when the native watcher fails", () => {
-		const asyncDir = tmpAsyncDir("pi-steer-watch-fallback-");
-		try {
-			const h = steerHarness();
-			const dispose = watchAsyncSteerInbox(asyncDir, { onSteer() {}, fs: h.fsImpl, timers: h.timers, platform: "linux" });
-			assert.deepEqual(h.intervalDelays(), [5000], "the native path installs only the safety poll");
-			h.triggerError();
-			h.triggerError();
-			assert.deepEqual(h.intervalDelays(), [5000, 250], "polling starts once, not per error");
+			assert.equal(fs.existsSync(interruptRequestPath(asyncDir)), true);
+			assert.equal(fs.existsSync(timeoutRequestPath(asyncDir)), true);
 			dispose();
 		} finally {
 			cleanup(asyncDir);
@@ -713,8 +640,10 @@ describe("control channel: watchAsyncSteerInbox", () => {
 		const asyncDir = tmpAsyncDir("pi-steer-watch-throws-");
 		try {
 			const seen: string[] = [];
-			const h = steerHarness();
-			const dispose = watchAsyncSteerInbox(asyncDir, {
+			const failures: string[] = [];
+			const h = harness();
+			const dispose = watchAsyncControlInbox(asyncDir, {
+				onError: (_error, phase, request) => failures.push(`${phase}:${request?.id}`),
 				onSteer: (request) => {
 					seen.push(request.message);
 					if (request.message === "boom") throw new Error("consumer failed");
@@ -725,14 +654,104 @@ describe("control channel: watchAsyncSteerInbox", () => {
 			});
 
 			requestAsyncSteer(asyncDir, { message: "boom", id: "s1", ts: 1 });
-			h.trigger();
 			requestAsyncSteer(asyncDir, { message: "still delivered", id: "s2", ts: 2 });
 			h.trigger();
 
 			assert.deepEqual(seen, ["boom", "still delivered"], "a throwing consumer must not kill the watcher");
+			assert.deepEqual(failures, ["callback:s1"]);
 			dispose();
 		} finally {
 			cleanup(asyncDir);
 		}
+	});
+});
+
+describe("control inbox diagnostics and active-owner cost", () => {
+	it("reports scan/read/install failures, retains retryable files, and distinguishes healthy watch fallback", () => {
+		const asyncDir = tmpAsyncDir("pi-steer-diagnostics-");
+		const failures: string[] = [];
+		const seen: string[] = [];
+		let tick: () => void = () => {};
+		let fault: "scan" | "read" | "none" = "scan";
+		const denied = Object.assign(new Error("denied"), { code: "EACCES" });
+		const dispose = watchAsyncControlInbox(asyncDir, {
+			onSteer: (request) => seen.push(request.id),
+			onError: (_error, phase) => failures.push(phase),
+			platform: "linux",
+			fs: {
+				...fs,
+				mkdirSync: (() => { throw denied; }) as typeof fs.mkdirSync,
+				readdirSync: ((...args: Parameters<typeof fs.readdirSync>) => { if (fault === "scan") throw denied; return fs.readdirSync(...args); }) as typeof fs.readdirSync,
+				readFileSync: ((...args: Parameters<typeof fs.readFileSync>) => { if (fault === "read") throw denied; return fs.readFileSync(...args); }) as typeof fs.readFileSync,
+				watch: (() => { throw new Error("native watch unavailable"); }) as typeof fs.watch,
+			},
+			timers: {
+				setInterval: ((handler: () => void) => { tick = handler; return { unref() {} }; }) as unknown as typeof setInterval,
+				clearInterval: (() => {}) as typeof clearInterval,
+			},
+		});
+		try {
+			requestAsyncSteer(asyncDir, { id: "retry", message: "retry" });
+			tick();
+			assert.deepEqual(failures, ["install", "scan", "scan"]);
+			assert.equal(fs.readdirSync(steerRequestsDir(asyncDir)).length, 1);
+			fault = "read";
+			tick();
+			assert.equal(failures.at(-1), "scan");
+			assert.equal(fs.readdirSync(steerRequestsDir(asyncDir)).length, 1);
+			fault = "none";
+			tick();
+			assert.deepEqual(seen, ["retry"]);
+			assert.deepEqual(fs.readdirSync(steerRequestsDir(asyncDir)), []);
+			assert.equal(failures.length, 4, "healthy fallback does not report consumption failure");
+		} finally { dispose(); cleanup(asyncDir); }
+	});
+
+	for (const mode of ["native", "fallback", "portable"]) for (const owners of [1, 8]) it(`measures bounded empty-inbox ${mode} and cleanup for ${owners} active owners`, async (t) => {
+		const asyncDir = tmpAsyncDir("pi-steer-cost-");
+		const handles = new Set<ReturnType<typeof setInterval>>();
+		const watchers = new Set<fs.FSWatcher>();
+		const watchedDirs: string[] = [];
+		const disposers: Array<() => void> = [];
+		let scans = 0;
+		let scanMs = 0;
+		const cpuStart = process.cpuUsage();
+		const start = performance.now();
+		try {
+			for (let index = 0; index < owners; index++) disposers.push(watchAsyncControlInbox(path.join(asyncDir, String(index)), {
+				onSteer() {}, platform: mode === "portable" ? "darwin" : "linux",
+				fs: { ...fs, readdirSync: ((...args: Parameters<typeof fs.readdirSync>) => {
+					const before = performance.now();
+					try { return fs.readdirSync(...args); } finally { scans++; scanMs += performance.now() - before; }
+				}) as typeof fs.readdirSync, watch: ((target: string, listener: fs.WatchListener<string>) => {
+					watchedDirs.push(target);
+					const watcher = fs.watch(target, listener);
+					watchers.add(watcher);
+					const close = watcher.close.bind(watcher);
+					watcher.close = () => { watchers.delete(watcher); close(); };
+					if (mode === "fallback") queueMicrotask(() => watcher.emit("error", new Error("watch unavailable")));
+					return watcher;
+				}) as typeof fs.watch },
+				timers: {
+					setInterval: ((handler: () => void, delay: number) => { const handle = setInterval(handler, delay); handles.add(handle); return handle; }) as typeof setInterval,
+					clearInterval: ((handle: ReturnType<typeof setInterval>) => { handles.delete(handle); clearInterval(handle); }) as typeof clearInterval,
+				},
+			}));
+			await new Promise((resolve) => setTimeout(resolve, 1_100));
+			const elapsed = performance.now() - start;
+			const cpu = process.cpuUsage(cpuStart);
+			assert.ok(scans >= owners && scans <= owners * 6, `bounded scans: ${scans}`);
+			assert.equal(handles.size, owners);
+			assert.equal(watchers.size, mode === "portable" ? 0 : owners);
+			assert.equal(watchedDirs.length, mode === "portable" ? 0 : owners, "only one directory watched per steer owner");
+			assert.ok(watchedDirs.every((dir) => dir.endsWith("steer-requests")));
+			for (const dispose of disposers) { dispose(); dispose(); }
+			assert.equal(handles.size, 0, "all real polling intervals cleared");
+			assert.equal(watchers.size, 0, "all native watchers closed");
+			const finalScans = scans;
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			assert.equal(scans, finalScans, "no scans after owner cleanup");
+			t.diagnostic(JSON.stringify({ mode, owners, elapsedMs: +elapsed.toFixed(2), scans, scanMs: +scanMs.toFixed(3), processCpuMs: (cpu.user + cpu.system) / 1000, remainingTimers: handles.size, remainingWatchers: watchers.size }));
+		} finally { for (const dispose of disposers) dispose(); cleanup(asyncDir); }
 	});
 });

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -109,12 +109,12 @@ describe("supervisor ask registration", () => {
 			import { resolveSupervisorChannelDir, ensureSupervisorChannelDir } from "./src/intercom/native-supervisor-channel.ts";
 			const root = fs.mkdtempSync(path.join(os.tmpdir(), "supervisor-owner-"));
 			const channels = [];
-			function start(owner) {
+			async function start(owner) {
 				const handlers = new Map();
 				const tools = new Map();
 				const pi = new Proxy({
 					events: { on() { return () => {}; }, emit() {} },
-					on(name, handler) { handlers.set(name, handler); },
+					on(name, handler) { handlers.set(name, [...(handlers.get(name) ?? []), handler]); },
 					getAllTools() { return [...tools.keys()].map(name => ({ name })); },
 					registerTool(tool) { tools.set(tool.name, tool); },
 					registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {}, sendMessage() {}, getSessionName() {},
@@ -133,11 +133,11 @@ describe("supervisor ask registration", () => {
 					modelRegistry: { getAvailable() { return []; } },
 				};
 				registerExtension(pi);
-				handlers.get("session_start")({ reason: "startup" }, ctx);
+				for (const handler of handlers.get("session_start") ?? []) await handler({ reason: "startup" }, ctx);
 				stale = true;
 				// Exercise the production stale-context clearing path, not direct state assignment.
-				handlers.get("session_before_compact")({ reason: "threshold", signal: new AbortController().signal });
-				return { tool: tools.get("subagent_supervisor"), shutdown: () => handlers.get("session_shutdown")() };
+				for (const handler of handlers.get("session_before_compact") ?? []) await handler({ reason: "threshold", signal: new AbortController().signal });
+				return { tool: tools.get("subagent_supervisor"), shutdown: async () => { for (const handler of handlers.get("session_shutdown") ?? []) await handler(); } };
 			}
 			function ask(owner) {
 				const id = randomUUID();
@@ -151,7 +151,7 @@ describe("supervisor ask registration", () => {
 			let runtime;
 			try {
 				const owner = randomUUID();
-				runtime = start(owner);
+				runtime = await start(owner);
 				const first = ask(owner);
 				assert.match(JSON.stringify(await runtime.tool.execute("pending", { action: "pending" })), new RegExp(first));
 				await runtime.shutdown();
@@ -159,7 +159,7 @@ describe("supervisor ask registration", () => {
 				await assert.rejects(runtime.tool.execute("reply", { action: "reply", replyTo: afterShutdown, message: "No authority" }), /No pending supervisor request found/);
 				runtime = undefined;
 				const replacement = randomUUID();
-				runtime = start(replacement);
+				runtime = await start(replacement);
 				await assert.rejects(runtime.tool.execute("reply", { action: "reply", replyTo: first, message: "Foreign" }), /No pending supervisor request found/);
 				const next = ask(replacement);
 				assert.match(JSON.stringify(await runtime.tool.execute("reply", { action: "reply", replyTo: next, message: "Approved" })), new RegExp(next));


### PR DESCRIPTION
Closes #1976. Supersedes #1983 after landing. #1978 remains a separate live-owner proof task; no restart recovery is added.

Preserves @brandonmwest's diagnosis, original implementation commit and changelog credit. Incorporates the intended lifecycle/error corrections without the later unbounded teardown await.

Workflow owners consume their durable steer inbox through the existing handler-selective watcher. Explicit dead targets never redirect; aggregate targets retain all outcomes; unaddressed parallel requests fail ambiguity. Pending acknowledgements receive terminal shutdown receipts without waiting indefinitely, and late callbacks cannot overwrite them. Accounting remains correct beyond the 20-entry display history. Unhandled stop/interrupt/timeout files remain untouched.

Validation: targeted routing/teardown tests, >20-request delivered/failed accounting regressions, watcher/error tests, retained deletion challenge, fresh full review and focused accounting re-review, typecheck and diff hygiene. Bounded local active-owner measurements and cleanup evidence are in the handoff: polling remains active-owner-only, not zero-cost or a cross-platform performance guarantee. No idle/status-loop scanning added.
