### PR TITLE
fix(runner): publish indexed results before terminal status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Keep unconfigured prompt-runtime loads inert. Thanks to [@lertian](https://github.com/lertian) for #1973.
 - Discover supervisor asks on demand even without a UI context, isolate notification failures, and keep answers explicit (#1975, #1982). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Consume async workflow steering with exact child targeting, terminal shutdown receipts, and handler-selective inbox watching (#1976, #1983). Thanks to [@brandonmwest](https://github.com/brandonmwest) for the diagnosis, Herdr reproduction, initial consumer, and tests.
+- Publish indexed background runner results before successful terminal status after storage-capacity recovery, preserving macOS completion delivery demand (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest) for reporting completion-delivery observations.
 - Return `invalid_state` instead of queuing unreachable workflow stop requests when live workflow controllers are unavailable (#1965).
 - Forward bounded live tool activity, timing, model/effort, and counters for synchronous workflow children without forwarding transcripts (#1964).
 - Allow `action: "status", view: "transcript"` to inspect bounded live foreground child artifacts on demand (#1963).

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -2092,20 +2092,29 @@ async function runSubagent(
 		},
 		onError: (error, filePath) => console.error(`Failed to update async run index '${filePath}':`, error),
 	});
-	const queueActiveRunIndex = (): void => {
-		const state = statusPayload.state;
+	const queueActiveRunIndex = (status: AsyncStatus): void => {
+		const state = status.state;
 		if (state === lastIndexedStatusState && indexPersistence.pendingCount() === 0) return;
-		indexPersistence.write(asyncDir, { state, toolCallId: statusPayload.toolCallId }, (_filePath, payload) => {
+		indexPersistence.write(asyncDir, { state, toolCallId: status.toolCallId }, (_filePath, payload) => {
 			const indexPayload = payload as { state: AsyncStatus["state"]; toolCallId?: string };
 			updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId, { retryCapacityErrors: true });
 		});
 	};
+	let finalResultCommitted = false;
+	let finalResultPublication: { resolve(): void; reject(error: unknown): void } | undefined;
 	const runPersistence = createCapacityResilientJsonWriter({
 		keepAlive: true,
-		onSuccess: (filePath) => {
-			if (filePath === statusPath) queueActiveRunIndex();
+		onSuccess: (filePath, payload) => {
+			if (filePath === statusPath) queueActiveRunIndex(payload as AsyncStatus);
+			if (filePath === resultPath && finalResultPublication) {
+				finalResultCommitted = true;
+				finalResultPublication.resolve();
+			}
 		},
-		onError: (error, filePath) => console.error(`Failed to persist async run state '${filePath}':`, error),
+		onError: (error, filePath) => {
+			console.error(`Failed to persist async run state '${filePath}':`, error);
+			if (filePath === resultPath) finalResultPublication?.reject(error);
+		},
 	});
 	try {
 		fs.mkdirSync(asyncDir, { recursive: true });
@@ -2113,7 +2122,7 @@ async function runSubagent(
 		if (!isStorageCapacityError(error)) throw error;
 		console.error(`Failed to prepare async run storage '${asyncDir}' while storage is full:`, error);
 	}
-	runPersistence.write(statusPath, statusPayload);
+	runPersistence.write(statusPath, { ...statusPayload });
 
 	let pendingParallelUsageCost: CostSummary = { inputTokens: 0, outputTokens: 0, costUsd: 0 };
 	const currentUsageTotals = (): CostSummary => {
@@ -2186,7 +2195,6 @@ async function runSubagent(
 		for (const node of graph.nodes) updateNode(node);
 		statusPayload.workflowGraph = graph;
 	};
-	let finalResultCommitted = false;
 	const statusResultState = (): AsyncStatus["state"] | undefined => {
 		if (statusPayload.state === "running" || statusPayload.state === "queued") return undefined;
 		return statusPayload.state;
@@ -2248,9 +2256,10 @@ async function runSubagent(
 		}), (filePath, payload) => writePendingAsyncResultFile(filePath, payload as Record<string, unknown>));
 	};
 	const writeStatusPayloadNow = (): void => {
+		if (finalResultPublication) return;
 		refreshWorkflowGraph();
 		writeRecoverableStatusResult();
-		runPersistence.write(statusPath, statusPayload);
+		runPersistence.write(statusPath, { ...statusPayload });
 		emitNestedSelfEvent(statusPayload.state === "running" || statusPayload.state === "queued" ? "subagent.nested.updated" : "subagent.nested.completed");
 	};
 	const statusWriteCoalescer = createFileCoalescer(writeStatusPayloadNow, 100);
@@ -4756,6 +4765,11 @@ async function runSubagent(
 		stopped: result.stopped,
 	})));
 	const partialWithEvidence = !stopped && !signalTerminated && !timedOut && !usageBudgetExceeded && !interrupted && results.some(partialEvidenceResult) && !results.some(concreteFailureResult);
+	// Flush while still nonterminal; deferred status retries retain that state snapshot.
+	statusWriteCoalescer.flush(statusPath);
+	const publication = new Promise<void>((resolve, reject) => {
+		finalResultPublication = { resolve, reject };
+	});
 	statusPayload.state = stopped || signalTerminated ? "stopped" : timedOut || usageBudgetExceeded ? "failed" : interrupted ? "paused" : results.every((r) => r.success) ? "complete" : partialWithEvidence ? "partial" : "failed";
 	closeSteerInbox(asyncDir, statusPayload.state, (filePath, payload) => runPersistence.write(filePath, payload));
 	disposeControlInbox();
@@ -4814,6 +4828,9 @@ async function runSubagent(
 			statusPayload.error = `Step failed: ${failedStep.agent}`;
 		}
 	}
+	let childSessionDisposal: Promise<void> | undefined;
+	const disposeChildSessions = (): Promise<void> => childSessionDisposal ??= childSessions.dispose()
+		.catch((error: unknown) => console.error("Failed to dispose runner child sessions:", error));
 	try {
 		runPersistence.write(resultPath, {
 			lifecycleArtifactVersion: SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -4909,13 +4926,16 @@ async function runSubagent(
 			...(taskIndex !== undefined && { taskIndex }),
 			...(totalTasks !== undefined && { totalTasks }),
 		}, (filePath, payload) => { writeAsyncResultFile(filePath, payload as Record<string, unknown>); });
-		finalResultCommitted = true;
+		// Only capacity deferral releases settled sessions before terminal publication.
+		if (!finalResultCommitted) await Promise.all([publication, disposeChildSessions()]);
 	} catch (err) {
 		const message = `Failed to write result file ${resultPath}: ${err instanceof Error ? err.message : String(err)}`;
 		console.error(message, err);
 		statusPayload.state = "failed";
 		statusPayload.error = message;
 		statusPayload.lastUpdate = Date.now();
+	} finally {
+		finalResultPublication = undefined;
 	}
 	writeStatusPayload();
 	await orcaProgressTab?.finish(statusPayload.state === "complete" ? "completed" : statusPayload.state === "stopped" ? "stopped" : "failed", effectiveSessionFile);
@@ -4953,9 +4973,8 @@ async function runSubagent(
 	}), (filePath, content) => runPersistence.write(filePath, { content }, (_path, payload) => {
 		fs.writeFileSync(_path, (payload as { content: string }).content, "utf-8");
 	}));
-	// The run is committed: release the child sessions first, then wait for the
-	// storage-capacity retries that may still hold the final status or result.
-	await childSessions.dispose().catch((error: unknown) => console.error("Failed to dispose runner child sessions:", error));
+	// Preserve normal-success disposal ordering, then drain remaining persistence retries.
+	await disposeChildSessions();
 	while (runPersistence.pendingCount() + indexPersistence.pendingCount() > 0) {
 		await new Promise((resolve) => setTimeout(resolve, 200));
 	}

--- a/test/integration/async-execution.part-4.test.ts
+++ b/test/integration/async-execution.part-4.test.ts
@@ -160,7 +160,7 @@ export default function() {
 	});
 
 	for (const mode of ["success", "stop", "pause", "deadline", "failure-before-JSON"] as const) {
-		it(`background setup lifecycle: ${mode}`, { skip: !isAsyncAvailable() || process.platform === "win32" ? "requires real POSIX setup executable" : undefined, timeout: 25_000 }, async () => {
+		it(`background setup lifecycle: ${mode}`, { skip: !isAsyncAvailable() || process.platform === "win32" ? "requires real POSIX setup executable" : undefined, timeout: 25_000 }, async (t) => {
 			const repo = createRepo("pi-background-setup-");
 			const baseDir = createTempDir();
 			const id = `async-setup-${mode}-${Date.now().toString(36)}`;
@@ -217,6 +217,42 @@ setTimeout(() => process.exit(90), 15000).unref();
 				const proof = await terminal;
 				const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8"));
 				const expected = mode === "success" ? "complete" : mode === "stop" ? "stopped" : mode === "pause" ? "paused" : "failed";
+				if (payload.state !== expected || status.state !== expected || status.steps?.[0]?.status !== expected) {
+					// Failure-only, bounded projections: never print prompts, output, paths or raw stderr.
+					const record = (value: unknown): Record<string, unknown> => value !== null && typeof value === "object" ? value as Record<string, unknown> : {};
+					const token = (value: unknown) => typeof value === "string" && /^[a-z_-]{1,64}$/i.test(value) ? value : undefined;
+					const errors = (value: unknown) => {
+						const text = typeof value === "string" ? value.slice(0, 8192) : "";
+						return { present: Boolean(text), kinds: [
+							"EPIPE", "ENOENT", "EACCES", "ENOSPC", "ETIMEDOUT", "ABORT_ERR", "ENOBUFS",
+							"setup aborted", "setup deadline", "setup settlement unknown", "process tree settlement",
+							"empty stdout", "invalid JSON", "hook failed", "manual reconciliation required",
+							"not a git repository", "index.lock", "already exists", "Failed to write result",
+							"No model", "model not found", "completion", "acceptance",
+						].filter((kind) => text.toLowerCase().includes(kind.toLowerCase())), exitCode: text.match(/exit (?:code |status )?(-?\d+)/i)?.[1] };
+					};
+					const project = (value: unknown) => {
+						const item = record(value);
+						return { state: token(item.state), status: token(item.status), reason: token(item.reason),
+							exitCode: typeof item.exitCode === "number" ? item.exitCode : undefined,
+							success: typeof item.success === "boolean" ? item.success : undefined,
+							timedOut: item.timedOut === true, stopped: item.stopped === true, error: errors(item.error) };
+					};
+					let cleanup: unknown;
+					try {
+						const handoffPath = held.parallelHandoff?.path;
+						if (handoffPath && fs.statSync(handoffPath).size <= 65_536) {
+							const handoff = JSON.parse(fs.readFileSync(handoffPath, "utf8"));
+							cleanup = (handoff.groups ?? []).slice(0, 2).map((group: { cleanup?: { state?: string; pruned?: boolean; tasks?: unknown[]; errors?: string[] } }) => ({
+								state: token(group.cleanup?.state), pruned: group.cleanup?.pruned,
+								taskCount: group.cleanup?.tasks?.length, errors: group.cleanup?.errors?.slice(0, 4).map(errors),
+							}));
+						}
+					} catch (error) { cleanup = { readError: token(record(error).code) }; }
+					t.diagnostic(JSON.stringify({ mode, expected, mockCalls: mockPi.callCount(), markerPresent: fs.existsSync(marker),
+						result: project(payload), status: project(status), steps: (status.steps ?? []).slice(0, 2).map(project),
+						children: (payload.results ?? []).slice(0, 2).map(project), cleanup, processTerminal: project(proof) }));
+				}
 				assert.equal(payload.state, expected);
 				assert.equal(status.state, expected);
 				assert.equal(status.steps[0].status, expected);

--- a/test/integration/result-publication.test.ts
+++ b/test/integration/result-publication.test.ts
@@ -13,7 +13,8 @@ import {
 
 function fileBarrier(file: string): Promise<void> {
 	return new Promise((resolve, reject) => {
-		const watcher = fs.watch(path.dirname(file), check);
+		// libuv on Windows compares long event paths against this watch path; expand TEMP's 8.3 aliases.
+		const watcher = fs.watch(fs.realpathSync.native(path.dirname(file)), check);
 		const deadline = setTimeout(() => { watcher.close(); reject(new Error(`Missing barrier: ${file}`)); }, 15_000);
 		function check() {
 			if (!fs.existsSync(file)) return;
@@ -27,6 +28,21 @@ function fileBarrier(file: string): Promise<void> {
 
 describe("native runner result publication", { skip: !available ? "pi packages unavailable" : undefined }, () => {
 	installAsyncExecutionHooks();
+	it("watches the canonical barrier directory through a path alias", async (t) => {
+		const directory = path.join(tempDir, "barrier-directory");
+		const alias = path.join(tempDir, "barrier-alias");
+		fs.mkdirSync(directory);
+		fs.symlinkSync(directory, alias, "junction");
+		const watch = fs.watch;
+		t.mock.method(fs, "watch", ((watched, ...args) => {
+			assert.equal(watched, fs.realpathSync.native(directory));
+			return Reflect.apply(watch, fs, [watched, ...args]);
+		}) as typeof fs.watch);
+		const file = path.join(alias, "ready");
+		const ready = fileBarrier(file);
+		fs.writeFileSync(file, "");
+		await ready;
+	});
 	for (const outcome of ["recovered", "retry-error"] as const) {
 		it(`keeps Darwin delivery demand until deferred indexed final result publication settles (${outcome})`, { skip: !isAsyncAvailable() ? "jiti unavailable" : undefined }, async () => {
 			const root = path.join(tempDir, "publication-barriers");

--- a/test/integration/result-publication.test.ts
+++ b/test/integration/result-publication.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "../../src/shared/types.ts";
+import registerSubagentNotify from "../../src/runs/background/notify.ts";
+import { makeAgent } from "../support/helpers.ts";
+import {
+	installAsyncExecutionHooks, available, isAsyncAvailable, executeAsyncSingle,
+	ASYNC_DIR, RESULTS_DIR, tempDir, mockPi,
+} from "../support/async-execution-fixture.ts";
+
+function fileBarrier(file: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const watcher = fs.watch(path.dirname(file), check);
+		const deadline = setTimeout(() => { watcher.close(); reject(new Error(`Missing barrier: ${file}`)); }, 15_000);
+		function check() {
+			if (!fs.existsSync(file)) return;
+			clearTimeout(deadline);
+			watcher.close();
+			resolve();
+		}
+		check();
+	});
+}
+
+describe("native runner result publication", { skip: !available ? "pi packages unavailable" : undefined }, () => {
+	installAsyncExecutionHooks();
+	for (const outcome of ["recovered", "retry-error"] as const) {
+		it(`keeps Darwin delivery demand until deferred indexed final result publication settles (${outcome})`, { skip: !isAsyncAvailable() ? "jiti unavailable" : undefined }, async () => {
+			const root = path.join(tempDir, "publication-barriers");
+			fs.mkdirSync(root);
+			if (outcome === "retry-error") fs.writeFileSync(path.join(root, "fail-on-recovery"), "");
+			const id = "publication-capacity";
+			const sessionId = "publication-session";
+			const owner = "publication-owner";
+			const asyncDir = path.join(ASYNC_DIR, id);
+			const resultPath = path.join(RESULTS_DIR, `${id}.json`);
+			const state: SubagentState = {
+				baseCwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner,
+				asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null,
+				cleanupTimers: new Map(), lastUiContext: null, poller: null, completionSeen: new Map(),
+				watcher: null, watcherRestartTimer: null,
+				resultFileCoalescer: { schedule: () => false, clear() {} },
+			};
+			let poll: ReturnType<typeof setInterval> | undefined;
+			let delivered = 0;
+			let complete!: () => void;
+			let deliveryDeadline: ReturnType<typeof setTimeout> | undefined;
+			const completion = new Promise<void>((resolve) => { complete = resolve; });
+			const pi = {
+				events: { on: () => () => {}, emit(event: string, data: unknown) {
+					if (event !== SUBAGENT_ASYNC_COMPLETE_EVENT) return;
+					assert.equal((data as { completionOwnerId?: string }).completionOwnerId, owner);
+					complete();
+				} },
+				sendMessage() { delivered++; },
+			};
+			const notifier = registerSubagentNotify(pi, state, { batchConfig: { enabled: false } });
+			const watcher = createResultWatcher(pi, state, RESULTS_DIR, 60_000, {
+				platform: "darwin", coalesceDelayMs: 0,
+				hasDeliveryDemand: () => {
+					const statusPath = path.join(asyncDir, "status.json");
+					if (!fs.existsSync(statusPath)) return true;
+					const status = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+					return status.state === "running" || status.state === "queued";
+				},
+				notifier,
+				timers: {
+					setTimeout, clearTimeout,
+					setInterval: ((handler: () => void, delay: number) => {
+						assert.equal(delay, 3000);
+						poll = setInterval(() => {
+							handler();
+							if (fs.existsSync(path.join(root, "blocked.json"))) fs.writeFileSync(path.join(root, "polled"), "");
+						}, delay);
+						return poll;
+					}) as typeof setInterval,
+					clearInterval: ((handle: ReturnType<typeof setInterval>) => { clearInterval(handle); poll = undefined; }) as typeof clearInterval,
+				},
+			});
+			const oldOptions = process.env.NODE_OPTIONS;
+			const oldRoot = process.env.RESULT_PUBLICATION_TEST_ROOT;
+			try {
+				process.env.NODE_OPTIONS = `${oldOptions ?? ""} --import=${new URL("../support/result-publication-capacity-preload.mjs", import.meta.url).href}`;
+				process.env.RESULT_PUBLICATION_TEST_ROOT = root;
+				mockPi.onCall({ output: "Indexed completion after capacity recovery" });
+				const receipt = executeAsyncSingle(id, {
+					agent: "worker", task: "Complete without a provider", agentConfig: makeAgent("worker", { completionGuard: false }),
+					ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner },
+					artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+					shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2, acceptance: false,
+				});
+				assert.notEqual(receipt.isError, true);
+				watcher.startResultWatcher();
+				await fileBarrier(path.join(root, "blocked.json"));
+				const blocked = JSON.parse(fs.readFileSync(path.join(root, "blocked.json"), "utf8"));
+				assert.equal(blocked.statusDeferred, true, "exercise an older deferred status write too");
+				await fileBarrier(path.join(root, "polled")); // A real demand-interval tick while capacity is held.
+				assert.equal(blocked.state, "running", "terminal status must not precede indexed final result publication");
+				assert.equal(blocked.active, true, "older status retry must not remove the active index");
+				const events = fs.readFileSync(path.join(asyncDir, "events.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+				assert.ok(events.some((event) => event.type === "subagent.steer.failed" && event.requestId === "publication-steer"), "exercise incidental status writing during finalization");
+				assert.ok(poll, "the demand interval must remain installed before recovery");
+				assert.equal(fs.existsSync(resultPath), false);
+				assert.equal(delivered, 0);
+				fs.writeFileSync(path.join(root, "release"), "");
+				await fileBarrier(path.join(root, "terminal.json"));
+				const terminal = JSON.parse(fs.readFileSync(path.join(root, "terminal.json"), "utf8"));
+				assert.equal(terminal.state, outcome === "recovered" ? "complete" : "failed");
+				if (outcome === "retry-error") assert.match(terminal.error, /injected non-capacity publication failure/);
+				const publishedPath = outcome === "recovered" ? resultPath : path.join(RESULTS_DIR, "result-pending", sessionId, `${id}.json`);
+				// An automatic tick may already have accepted and cleaned the indexed result.
+				assert.ok(fs.existsSync(publishedPath) || delivered === 1, "terminal result must be published or already delivered");
+				if (fs.existsSync(publishedPath)) assert.equal(JSON.parse(fs.readFileSync(publishedPath, "utf8")).completionOwnerId, owner);
+				await Promise.race([completion, new Promise((_, reject) => {
+					deliveryDeadline = setTimeout(() => reject(new Error("completion not delivered")), 5000);
+				})]);
+				clearTimeout(deliveryDeadline);
+				assert.equal(delivered, 1);
+				assert.equal(fs.existsSync(resultPath), false);
+				assert.equal(poll, undefined);
+				assert.equal(state.watcherRestartTimer, null);
+				await fileBarrier(path.join(asyncDir, "process-terminal-candidate.json"));
+			} finally {
+				clearTimeout(deliveryDeadline);
+				fs.writeFileSync(path.join(root, "release"), "");
+				watcher.stopResultWatcher();
+				notifier.dispose();
+				if (oldOptions === undefined) delete process.env.NODE_OPTIONS; else process.env.NODE_OPTIONS = oldOptions;
+				if (oldRoot === undefined) delete process.env.RESULT_PUBLICATION_TEST_ROOT; else process.env.RESULT_PUBLICATION_TEST_ROOT = oldRoot;
+			}
+		});
+	}
+});

--- a/test/support/result-publication-capacity-preload.mjs
+++ b/test/support/result-publication-capacity-preload.mjs
@@ -1,0 +1,65 @@
+// Child-runner-only fault injection. Barriers are filesystem events, not elapsed waits.
+import fs from "node:fs";
+import path from "node:path";
+import { syncBuiltinESMExports } from "node:module";
+
+const root = process.env.RESULT_PUBLICATION_TEST_ROOT;
+if (root) {
+	const write = fs.writeFileSync;
+	const rename = fs.renameSync;
+	let resultAttempts = 0;
+	let runningWritten = false;
+	let statusDeferred = false;
+	let asyncDir;
+	let failedRecovery = false;
+	const barrier = (name, data) => {
+		write(path.join(root, `${name}.tmp`), JSON.stringify(data));
+		rename(path.join(root, `${name}.tmp`), path.join(root, name));
+	};
+	const full = () => Object.assign(new Error("injected result publication capacity failure"), { code: "ENOSPC" });
+	fs.writeFileSync = function (file, data, ...args) {
+		const target = String(file);
+		if (path.basename(target).startsWith(".status.json.") && typeof data === "string") {
+			const status = JSON.parse(data);
+			asyncDir = path.dirname(target);
+			if (runningWritten && resultAttempts === 0) {
+				statusDeferred = true;
+				throw full();
+			}
+			if (status.state === "running") runningWritten = true;
+		}
+		if (target.includes(`${path.sep}result-pending${path.sep}`) && target.endsWith(".tmp")) {
+			resultAttempts++;
+			if (!fs.existsSync(path.join(root, "release"))) {
+				if (resultAttempts >= 2) {
+					const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8"));
+					barrier("blocked.json", {
+						state: status.state, statusDeferred,
+						active: fs.existsSync(path.join(path.dirname(asyncDir), ".active-runs", path.basename(asyncDir))),
+					});
+				}
+				throw full();
+			}
+			if (!failedRecovery && fs.existsSync(path.join(root, "fail-on-recovery"))) {
+				failedRecovery = true;
+				throw Object.assign(new Error("injected non-capacity publication failure"), { code: "EIO" });
+			}
+		}
+		return write.call(this, file, data, ...args);
+	};
+	fs.renameSync = function (source, target) {
+		const result = rename.call(this, source, target);
+		if (path.basename(String(target)) === "steer-inbox-closed.json") {
+			// A request queued just before inbox closure is consumed during finalization.
+			const dir = path.join(path.dirname(String(target)), "steer-requests");
+			fs.mkdirSync(dir, { recursive: true });
+			write(path.join(dir, "publication-steer.json"), JSON.stringify({ type: "steer", id: "publication-steer", ts: 1, message: "Late queued request", targetIndex: 0 }));
+		}
+		if (path.basename(String(target)) === "status.json") {
+			const status = JSON.parse(fs.readFileSync(target, "utf8"));
+			if (status.state === "complete" || status.state === "failed") barrier("terminal.json", status);
+		}
+		return result;
+	};
+	syncBuiltinESMExports();
+}


### PR DESCRIPTION
Refs #1981. Thanks to @brandonmwest for reporting completion-delivery observations.

Fixes a reproduced native-runner path: storage-capacity deferral could publish terminal status before the indexed result, ending the last Darwin delivery demand before a later result appeared. Final commitment now follows the indexed writer's success callback; deferred status/index snapshots cannot publish later terminal state early. Ordinary success ordering remains unchanged.

Validation uses the actual native runner with bounded filesystem fault barriers. Recovery and ENOSPC-to-EIO cases prove automatic notification via the existing demand interval without manual post-release refresh. Focused surrounding lifecycle/ownership tests, typecheck, retained deletion challenge, fresh source review, and the review's test-only proof correction passed.

No new watcher, idle polling, ownership or cache policy. This is not a diagnosis of the reporter's historical sessions or a claim that every producer is fixed. The analogous async-workflow producer and earlier-terminal paths remain explicitly separate follow-ups, so this PR does not close #1981.
