### PR TITLE
fix(workflow): await indexed publication before terminal persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Publish indexed async workflow results before terminal persistence after storage-capacity recovery (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest) for reporting completion-delivery observations.
 - Keep unconfigured prompt-runtime loads inert. Thanks to [@lertian](https://github.com/lertian) for #1973.
 - Discover supervisor asks on demand even without a UI context, isolate notification failures, and keep answers explicit (#1975, #1982). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Consume async workflow steering with exact child targeting, terminal shutdown receipts, and handler-selective inbox watching (#1976, #1983). Thanks to [@brandonmwest](https://github.com/brandonmwest) for the diagnosis, Herdr reproduction, initial consumer, and tests.

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -5098,18 +5098,31 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					onSuccess: (_filePath, payload) => { indexedState = (payload as { state: AsyncStatus["state"] }).state; },
 					onError: (error, filePath) => console.error(`Failed to update async workflow index '${filePath}':`, error),
 				});
-				const queueActiveRunIndex = (): void => {
-					const state = status.state;
+				const queueActiveRunIndex = (snapshot: AsyncStatus = status): void => {
+					const state = snapshot.state;
 					if (indexedState === state && indexPersistence.pendingCount() === 0) return;
-					indexPersistence.write(asyncDir, { state, toolCallId: status.toolCallId }, (_filePath, payload) => {
+					indexPersistence.write(asyncDir, { state, toolCallId: snapshot.toolCallId }, (_filePath, payload) => {
 						const indexPayload = payload as { state: AsyncStatus["state"]; toolCallId?: string };
 						updateActiveRunIndex(asyncDir, indexPayload.state, indexPayload.toolCallId, { retryCapacityErrors: true });
 					});
 				};
+				let pendingResultPublication: Promise<boolean> | undefined;
+				let settleResultPublication: ((published: boolean) => void) | undefined;
+				const reportResultWriteFailure = (error: unknown): void => {
+					const message = `Failed to write async workflow result ${resultPath}: ${error instanceof Error ? error.message : String(error)}`;
+					console.error(message, error);
+					appendWorkflowEvent({ type: "subagent.workflow.result_write_failed", error: message });
+				};
 				const runPersistence = createCapacityResilientJsonWriter({
 					keepAlive: true,
-					onSuccess: (filePath) => { if (filePath === statusPath) queueActiveRunIndex(); },
-					onError: (error, filePath) => console.error(`Failed to persist async workflow state '${filePath}':`, error),
+					onSuccess: (filePath, payload) => {
+						if (filePath === statusPath) queueActiveRunIndex(payload as AsyncStatus);
+						if (filePath === resultPath) settleResultPublication?.(true);
+					},
+					onError: (error, filePath) => {
+						if (filePath === resultPath) { reportResultWriteFailure(error); settleResultPublication?.(false); }
+						else console.error(`Failed to persist async workflow state '${filePath}':`, error);
+					},
 					write: (filePath, payload) => filePath === resultPath
 						? writeAsyncResultFile(filePath, payload as Record<string, unknown>)
 						: writeAtomicJson(filePath, payload),
@@ -5137,7 +5150,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						queueActiveRunIndex();
 					} else if (options.tolerateStatusWriteFailure) {
 						try {
-							runPersistence.write(statusPath, status);
+							runPersistence.write(statusPath, { ...status });
 							statusPersistenceDegraded = false;
 						} catch (error) {
 							const message = `Failed to persist async workflow state ${statusPath}: ${error instanceof Error ? error.message : String(error)}`;
@@ -5152,7 +5165,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							}
 						}
 					} else {
-						runPersistence.write(statusPath, status);
+						runPersistence.write(statusPath, { ...status });
 					}
 					if (liveJob) {
 						liveJob.status = status.state;
@@ -5180,12 +5193,15 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				};
 				const writeWorkflowResult = (payload: Record<string, unknown>): boolean => {
 					try {
+						let resultPublished = false;
+						settleResultPublication = (published) => { resultPublished = published; };
+						pendingResultPublication = undefined;
 						runPersistence.write(resultPath, payload);
+						// Only capacity deferral yields; ordinary publication remains synchronous.
+						if (!resultPublished) pendingResultPublication = new Promise<boolean>((resolve) => { settleResultPublication = resolve; });
 						return true;
 					} catch (error) {
-						const message = `Failed to write async workflow result ${resultPath}: ${error instanceof Error ? error.message : String(error)}`;
-						console.error(message, error);
-						appendWorkflowEvent({ type: "subagent.workflow.result_write_failed", error: message });
+						reportResultWriteFailure(error);
 						return false;
 					}
 				};
@@ -5652,6 +5668,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: true, state: "complete", summary: resultSummary, output: resultSummary, workflowChildren, results: workflow.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (pendingResultPublication && !await pendingResultPublication) return;
 						persist();
 						deps.refreshResultDelivery?.();
 						persistClosed = true;
@@ -5701,6 +5718,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							appendWorkflowEvent({ type: "subagent.workflow.receipt_write_failed", error: `Failed to persist async workflow receipt: ${receiptError instanceof Error ? receiptError.message : String(receiptError)}` });
 						}
 						if (!writeWorkflowResult({ id: workflowRunId, runId: workflowRunId, toolCallId, agent: "workflow", mode: "workflow", success: status.state === "complete", state: status.state, summary: resultSummary, error: status.state === "complete" ? undefined : status.error, stopped: status.stopped, activityState: status.activityState, workflowChildren, ...(terminalOutcome ? { terminalOutcome } : {}), results: partial.children.map((child) => ({ workflowKey: child.key, ...(child.agent ? { agent: child.agent } : {}), ...(child.runId ? { runId: child.runId } : {}), ...(status.steps?.find((step) => step.workflowKey === child.key)?.sessionName ? { sessionName: status.steps?.find((step) => step.workflowKey === child.key)?.sessionName } : {}), ...workflowChildAccountingFields(child), output: child.output, outputState: child.output.trim() || child.structuredOutput !== undefined ? "present" : "absent", structuredOutput: child.structuredOutput, success: child.ok, ...(child.outputReference ? { outputReference: child.outputReference } : {}), ...(child.terminalOutcome ? { terminalOutcome: child.terminalOutcome } : {}), ...(child.outputPathMapping ? { outputPathMapping: child.outputPathMapping } : {}), ...(child.stopped ? { stopped: true } : {}), ...(child.interrupted ? { interrupted: true } : {}), ...(child.detached && status.state !== "complete" ? { detached: true } : {}), ...(child.artifactPaths[0] ? { artifactPaths: { outputPath: child.artifactPaths[0] } } : {}) })), workflow: status.workflow, ...(workflowReceipt ? { workflowReceipt } : {}), asyncDir, cwd: workflowCwd, sessionId: currentSessionId, completionOwnerId, ...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}), timestamp: Date.now(), durationMs: Date.now() - startedAt })) return;
+						if (pendingResultPublication && !await pendingResultPublication) return;
 						persist();
 						deps.refreshResultDelivery?.();
 						persistClosed = true;

--- a/test/integration/workflow-result-publication.test.ts
+++ b/test/integration/workflow-result-publication.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { syncBuiltinESMExports } from "node:module";
+import { describe, it } from "node:test";
+import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
+import registerSubagentNotify from "../../src/runs/background/notify.ts";
+import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "../../src/shared/types.ts";
+import { makeMinimalCtx } from "../support/helpers.ts";
+import { installAsyncExecutionHooks, available, createSubagentExecutor, ASYNC_DIR, RESULTS_DIR, tempDir } from "../support/async-execution-fixture.ts";
+
+function barrier() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => { resolve = done; });
+	return { promise, resolve };
+}
+async function bounded(promise: Promise<unknown>) {
+	let timer: ReturnType<typeof setTimeout>;
+	try { await Promise.race([promise, new Promise((_, reject) => { timer = setTimeout(() => reject(new Error("publication barrier timed out")), 12000); })]); }
+	finally { clearTimeout(timer!); }
+}
+
+describe("host workflow result publication", { skip: !available }, () => {
+	installAsyncExecutionHooks();
+	for (const outcome of ["complete", "failed", "stopped", "retry-error"] as const) {
+	it(`retains real Darwin demand until deferred indexed workflow publication settles (${outcome})`, async () => {
+		const polled = barrier(), published = barrier(), delivered = barrier(), retired = barrier(), failed = barrier(), emitted = barrier();
+		let held = true, attempted = false, notifications = 0, refreshes = 0;
+		let statusWrites = 0, statusDeferred = false, statusRecovered = false;
+		let poll: ReturnType<typeof setInterval> | undefined;
+		const sessionId = "workflow-publication-session", owner = "workflow-publication-owner";
+		const state = { baseCwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner,
+			asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null,
+			cleanupTimers: new Map(), lastUiContext: null, poller: null, completionSeen: new Map(),
+			watcher: null, watcherRestartTimer: null, resultFileCoalescer: { schedule: () => false, clear() {} },
+		} as SubagentState;
+		const pi = { getSessionName: () => undefined, events: { on: () => () => {}, emit(event: string, data: unknown) {
+			if (event === SUBAGENT_ASYNC_COMPLETE_EVENT) { assert.equal((data as { completionOwnerId: string }).completionOwnerId, owner); delivered.resolve(); }
+		} }, sendMessage() { notifications++; } };
+		const notifier = registerSubagentNotify(pi, state, { batchConfig: { enabled: false } });
+		const watcher = createResultWatcher(pi, state, RESULTS_DIR, 60000, { platform: "darwin", coalesceDelayMs: 0, notifier,
+			hasDeliveryDemand: () => [...state.asyncJobs.values()].some((job) => job.status === "running" || job.status === "queued"),
+			timers: { setTimeout, clearTimeout, setInterval: ((handler: () => void, delay: number) => {
+				assert.equal(delay, 3000);
+				poll = setInterval(() => { handler(); if (attempted) polled.resolve(); }, delay); return poll;
+			}) as typeof setInterval, clearInterval: ((handle: ReturnType<typeof setInterval>) => { clearInterval(handle); poll = undefined; retired.resolve(); }) as typeof clearInterval },
+		});
+		const originalWrite = fs.writeFileSync, originalRename = fs.renameSync, originalAppend = fs.appendFileSync;
+		fs.writeFileSync = ((file, ...args) => {
+			if (String(file).includes(`${path.sep}result-pending${path.sep}`)) {
+				attempted = true;
+				if (held) throw Object.assign(new Error("injected workflow capacity failure"), { code: "ENOSPC" });
+				if (outcome === "retry-error") throw Object.assign(new Error("injected workflow retry EIO"), { code: "EIO" });
+			}
+			return originalWrite(file, ...args);
+		}) as typeof fs.writeFileSync;
+		fs.renameSync = ((from, to) => {
+			if (path.basename(String(to)) === "status.json") {
+				if (++statusWrites > 1 && !attempted) { statusDeferred = true; throw Object.assign(new Error("injected running status capacity failure"), { code: "ENOSPC" }); }
+				if (statusDeferred && held && attempted) statusRecovered = true;
+			}
+			originalRename(from, to); if (path.dirname(String(to)) === RESULTS_DIR) published.resolve();
+		}) as typeof fs.renameSync;
+		fs.appendFileSync = ((file, data, ...args) => {
+			originalAppend(file, data, ...args);
+			if (String(data).includes('"type":"subagent.workflow.result_write_failed"')) failed.resolve();
+			if (String(data).includes('"type":"subagent.workflow.emit"')) emitted.resolve();
+		}) as typeof fs.appendFileSync;
+		syncBuiltinESMExports();
+		try {
+			const executor = createSubagentExecutor!({ pi, state, config: {}, asyncByDefault: false, tempArtifactsDir: tempDir,
+				getSubagentSessionRoot: () => tempDir, expandTilde: (p: string) => p, discoverAgents: () => ({ agents: [] }),
+				refreshResultDelivery: () => { refreshes++; watcher.refreshResultDelivery(); },
+			});
+			const ctx = makeMinimalCtx(tempDir); ctx.sessionManager.getSessionId = () => sessionId;
+			const script = outcome === "stopped" ? "await new Promise(() => {})" : outcome === "failed" ? "throw new Error('workflow script failed')" : "return 'done'";
+			const launch = await executor.execute("workflow-publication", { workflowScript: `emit('progress'); ${script}`, async: true }, new AbortController().signal, undefined, ctx);
+			assert.notEqual(launch.isError, true);
+			const id = launch.details.asyncId!;
+			watcher.startResultWatcher();
+			if (outcome === "stopped") {
+				await bounded(emitted.promise);
+				const stop = await executor.execute("workflow-stop", { action: "stop", id }, new AbortController().signal, undefined, ctx);
+				assert.notEqual(stop.isError, true);
+				assert.match(stop.content[0]?.text ?? "", /Stop requested/);
+				assert.equal(state.workflowControllers?.get(id)?.signal.aborted, true);
+			}
+			await bounded(polled.promise);
+			const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf8"));
+			assert.equal(status.state, "running", "terminal status must not precede indexed workflow result publication");
+			assert.equal(state.asyncJobs.get(id)?.status, "running");
+			assert.equal(statusDeferred, true); assert.equal(statusRecovered, true);
+			assert.equal(fs.existsSync(path.join(ASYNC_DIR, ".active-runs", id)), true);
+			assert.ok(poll); assert.equal(notifications, 0); assert.equal(refreshes, 0);
+			held = false;
+			if (outcome === "retry-error") {
+				await bounded(failed.promise);
+				// Allow the awaited failure callback to finish its existing cleanup.
+				await new Promise<void>((resolve) => setImmediate(resolve));
+				assert.equal(state.workflowControllers?.has(id), false);
+				assert.equal(state.asyncJobs.get(id)?.status, "running");
+				assert.equal(notifications, 0); assert.equal(refreshes, 0);
+				assert.match(fs.readFileSync(path.join(ASYNC_DIR, id, "events.jsonl"), "utf8"), /injected workflow retry EIO/);
+				assert.equal(fs.existsSync(path.join(RESULTS_DIR, `${id}.json`)), false);
+				return;
+			}
+			await bounded(Promise.all([published.promise, delivered.promise]));
+			assert.equal(state.asyncJobs.get(id)?.status, outcome);
+			const terminalStatus = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, id, "status.json"), "utf8"));
+			assert.equal(terminalStatus.state, outcome);
+			if (outcome === "stopped") assert.equal(terminalStatus.stopped, true);
+			assert.equal(notifications, 1); assert.equal(refreshes, 1);
+			assert.equal(fs.existsSync(path.join(RESULTS_DIR, `${id}.json`)), false);
+			// The existing demand timer retires itself after terminal publication.
+			await bounded(retired.promise);
+			assert.equal(poll, undefined);
+		} finally {
+			held = false;
+			try { await bounded(outcome === "retry-error" ? failed.promise : published.promise); }
+			finally {
+				watcher.stopResultWatcher(); notifier.dispose();
+				fs.writeFileSync = originalWrite; fs.renameSync = originalRename; fs.appendFileSync = originalAppend; syncBuiltinESMExports();
+			}
+		}
+	});
+	}
+});


### PR DESCRIPTION
Completes the workflow-host publication correction accompanying #1988 for #1981.

Settle steering receipts while durable status remains running, then await successful indexed result publication before terminal persistence and delivery refresh. Deferred retries index their persisted snapshot, not mutable live terminal state. Failed publication does not permit finally or late callbacks to publish terminal success.

Validation: retained implementation challenge and fresh producer review, followed by targeted composition review against the native publication and inbox prerequisites. Sixteen combined focused tests and typecheck passed. Mechanical promotion onto merged prerequisites preserved source/test blobs; diff hygiene clean. No new polling cadence or native runner changes.

Thanks to @brandonmwest for completion-delivery observations; linked changelog credit retained. This fixes proven publication failures, not every unreported macOS notification symptom.