### PR TITLE
feat(observability): trace completion suppression on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove generation suffixes from developer-facing contract types and helpers; request shapes, format versions, and behavior are unchanged (#1913).
 
 ### Added
+- Add opt-in bounded completion delivery/suppression reason traces via `NODE_DEBUG=pi-subagents-notify` ([#1981](https://github.com/nicobailon/pi-subagents/issues/1981)). Thanks to [@brandonmwest](https://github.com/brandonmwest) for identifying the observability gap and offering instrumented sessions.
 - Let agents opt into parent-prompt discovery with `advertise: true`. Thanks to [@nwalke](https://github.com/nwalke) for #1972.
 - Add selective researcher source checks and explicit evidence, confidence, and uncertainty reporting (#1932). Thanks to [@Muskos](https://github.com/Muskos).
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -213,6 +213,26 @@ The `subagent:process-terminal` event and RPC `ping.capabilities.processTerminal
 
 Both launch paths subscribe to the child session's event stream directly; there is no stdout protocol. The `events.jsonl` artifact mirrors those events with `message_update` dropped, and the transcript records them with `message_update` projected the same way pi's JSON mode prints it. `agent_end.willRetry` defers completion until the child settles, and `agent_settled` is the terminal watermark; a child whose run does not settle shortly after its terminal event is aborted and finished without it.
 
+### Completion notification diagnostics
+
+For an instrumented parent session, enable Node's opt-in debug sink **before starting Pi**:
+
+```sh
+NODE_DEBUG=pi-subagents-notify pi 2>notification-debug.log
+```
+
+This writes bounded JSON records prefixed `PI-SUBAGENTS-NOTIFY <pid>:` to stderr, not run artifacts or chat. The capture also contains other stderr output; review it before sharing. Records contain only `reason`, sanitized `id`/`runId` (up to 128 characters each), and `source`; task/output text, paths, credentials, and exception bodies are not included.
+
+- `disposed`, `missing_session`, `foreground_session_mismatch`, `not_owned`: delivery rejected by an existing guard.
+- `emit_foreground_session_mismatch`, `emit_not_owned`: ownership/session recheck rejected emission.
+- `intercom_delivered`, `deduped_ttl`: already acknowledged; no new message needed.
+- `deduped_pending`: shares an in-flight delivery promise.
+- `batch_deferred`: held for batching, **not lost**; look for a later emission or disposal record for the same run.
+- `send_accepted`, `send_failed`: `sendMessage` returned or threw, respectively. Acceptance is not proof the model read the message; failures remain retryable.
+- `dispose_pending`: notifier shutdown left held results unacknowledged for later delivery.
+
+Without `NODE_DEBUG`, tracing only checks the debug-enabled flag: no identity sanitization/serialization, diagnostic buffering, or log I/O. Existing delivery guards, TTL, timers and batching are unchanged. Traces cover notifier decisions only, not discovery gaps; absence of a trace does not diagnose the original missing-notification symptom.
+
 ## Workflow and debug artifacts
 
 Each scripted workflow stores runtime artifacts under a workflow artifact directory. The on-disk directory is still named `chain-runs` for compatibility. With the default `artifactDir: "session"` or with `"temp"`, it is user-scoped temp storage. With `artifactDir: "project"`, the root is `<cwd>/.pi/subagents/chain-runs/`:

--- a/src/runs/background/notify.ts
+++ b/src/runs/background/notify.ts
@@ -6,6 +6,7 @@
  * observation channel, not a delivery acknowledgement.
  */
 
+import { debuglog } from "node:util";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { buildCompletionKey, markSeenWithTtl } from "./completion-dedupe.ts";
 import {
@@ -401,7 +402,31 @@ export function formatGroupedCompletion(details: SubagentNotifyDetails[]): strin
 	return blocks.join("\n").trimEnd();
 }
 
+const notificationDebug = debuglog("pi-subagents-notify");
+type TraceIdentity = Pick<CompletionNotification, "id" | "runId" | "source">;
+type NotificationReason = "disposed" | "missing_session" | "foreground_session_mismatch" | "not_owned"
+	| "intercom_delivered" | "deduped_ttl" | "deduped_pending" | "batch_deferred"
+	| "emit_foreground_session_mismatch" | "emit_not_owned" | "send_accepted" | "send_failed" | "dispose_pending";
+
+// Slice before sanitizing: diagnostic work and each identity are bounded even for
+// malformed result metadata. Never include task/output, paths, or error bodies.
+function traceIdentity(result: TraceIdentity): TraceIdentity {
+	const identity = (value: unknown) => typeof value === "string"
+		? value.slice(0, 128).replace(/[^a-zA-Z0-9_.:-]/g, "_") : undefined;
+	return { id: identity(result.id), runId: identity(result.runId), source: result.source === "foreground" ? "foreground" : "async" };
+}
+
+function traceNotification(reason: NotificationReason, result?: TraceIdentity): void {
+	if (!notificationDebug.enabled) return;
+	try {
+		notificationDebug("%s", JSON.stringify({ reason, ...(result ? traceIdentity(result) : {}) }));
+	} catch {
+		// Diagnostics must never change delivery acknowledgement.
+	}
+}
+
 interface PendingCompletion {
+	trace?: TraceIdentity;
 	key: string;
 	details: SubagentNotifyDetails;
 	sessionId: string;
@@ -574,8 +599,9 @@ export default function registerSubagentNotify(
 			&& typeof completionOwnerId === "string"
 			&& completionOwnerId === state.completionOwnerId);
 
-	const settle = (items: PendingCompletion[], accepted: boolean) => {
+	const settle = (items: PendingCompletion[], accepted: boolean, reason?: NotificationReason) => {
 		for (const item of items) {
+			if (reason) traceNotification(reason, item.trace);
 			pending.delete(item.key);
 			if (accepted) markSeenWithTtl(seen, item.key, now(), ttlMs);
 			item.resolve(accepted);
@@ -588,10 +614,12 @@ export default function registerSubagentNotify(
 			const owned = item.details.source === "foreground"
 				? item.sessionId === state.currentSessionId
 				: ownsResult(item.sessionId, item.completionOwnerId);
+			if (!owned) traceNotification(item.details.source === "foreground" ? "emit_foreground_session_mismatch" : "emit_not_owned", item.trace);
 			(owned ? accepted : rejected).push(item);
 		}
 		settle(rejected, false);
-		settle(accepted, sendCompletion(pi, accepted));
+		const sent = sendCompletion(pi, accepted);
+		settle(accepted, sent, sent ? "send_accepted" : "send_failed");
 	};
 	const getBatcher = (result: CompletionNotification) => {
 		const key = completionBatchKey(result);
@@ -609,17 +637,35 @@ export default function registerSubagentNotify(
 	};
 
 	const deliver = (result: CompletionNotification): Promise<boolean> => {
-		if (disposed || typeof result.sessionId !== "string") return Promise.resolve(false);
+		if (disposed || typeof result.sessionId !== "string") {
+			traceNotification(disposed ? "disposed" : "missing_session", result);
+			return Promise.resolve(false);
+		}
 		if (result.source === "foreground") {
-			if (result.sessionId !== state.currentSessionId) return Promise.resolve(false);
-		} else if (!ownsResult(result.sessionId, result.completionOwnerId)) return Promise.resolve(false);
-		if (result.intercomDelivered === true) return Promise.resolve(true);
+			if (result.sessionId !== state.currentSessionId) {
+				traceNotification("foreground_session_mismatch", result);
+				return Promise.resolve(false);
+			}
+		} else if (!ownsResult(result.sessionId, result.completionOwnerId)) {
+			traceNotification("not_owned", result);
+			return Promise.resolve(false);
+		}
+		if (result.intercomDelivered === true) {
+			traceNotification("intercom_delivered", result);
+			return Promise.resolve(true);
+		}
 		const key = buildCompletionKey(result, "notify");
 		const seenAt = seen.get(key);
-		if (seenAt !== undefined && now() - seenAt <= ttlMs) return Promise.resolve(true);
+		if (seenAt !== undefined && now() - seenAt <= ttlMs) {
+			traceNotification("deduped_ttl", result);
+			return Promise.resolve(true);
+		}
 		if (seenAt !== undefined) seen.delete(key);
 		const inFlight = pending.get(key);
-		if (inFlight) return inFlight;
+		if (inFlight) {
+			traceNotification("deduped_pending", result);
+			return inFlight;
+		}
 		const details = buildCompletionDetails(result);
 		let resolve!: (accepted: boolean) => void;
 		const completion = new Promise<boolean>((settleCompletion) => { resolve = settleCompletion; });
@@ -632,6 +678,7 @@ export default function registerSubagentNotify(
 			triggerTurn: result.triggerTurn !== false,
 			resolve,
 		};
+		if (notificationDebug.enabled) item.trace = traceIdentity(result);
 		if (details.source === "foreground") {
 			emit([item]);
 			return completion;
@@ -642,6 +689,7 @@ export default function registerSubagentNotify(
 			emit([item]);
 			return completion;
 		}
+		if (batchConfig.enabled) traceNotification("batch_deferred", item.trace);
 		batcher.push(item);
 		return completion;
 	};
@@ -659,7 +707,7 @@ export default function registerSubagentNotify(
 		dispose() {
 			if (disposed) return;
 			disposed = true;
-			for (const batcher of batchers.values()) settle(batcher.dispose(), false);
+			for (const batcher of batchers.values()) settle(batcher.dispose(), false, "dispose_pending");
 			batchers.clear();
 			for (const unsubscribe of [unsubscribeAsync, unsubscribeForeground]) {
 				try {

--- a/test/support/notify-diagnostics-fixture.ts
+++ b/test/support/notify-diagnostics-fixture.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import registerSubagentNotify, { type CompletionNotification } from "../../src/runs/background/notify.ts";
+
+const callbacks = new Map<number, () => void>();
+let timerId = 0;
+let now = 0;
+let failSend = false;
+const state = { currentSessionId: "session-a", completionOwnerId: "owner-a" };
+const sent: unknown[] = [];
+const pi = {
+	events: { on: () => () => {} },
+	sendMessage(message: unknown, options: unknown) {
+		if (failSend) throw new Error("PRIVATE_ERROR_CREDENTIAL");
+		sent.push({ message, options });
+	},
+};
+const notifier = registerSubagentNotify(pi as never, state, {
+	now: () => now,
+	timers: {
+		setTimeout(callback) { callbacks.set(++timerId, callback); return timerId; },
+		clearTimeout(handle) { callbacks.delete(handle as number); },
+	},
+});
+const result = (id: string, extra: Partial<CompletionNotification> = {}): CompletionNotification => ({
+	id, runId: id, sessionId: "session-a", completionOwnerId: "owner-a", success: true,
+	summary: "PRIVATE_OUTPUT", task: "PRIVATE_TASK", credential: "PRIVATE_CREDENTIAL",
+	sessionFile: "/PRIVATE_SESSION_PATH", ...extra,
+});
+const flush = () => { for (const callback of [...callbacks.values()]) callback(); };
+assert.equal(await notifier.deliver(result("missing", { sessionId: undefined })), false);
+assert.equal(await notifier.deliver(result("foreground-other", { source: "foreground", sessionId: "other" })), false);
+assert.equal(await notifier.deliver(result("foreign", { completionOwnerId: "other" })), false);
+assert.equal(await notifier.deliver(result("relayed", { intercomDelivered: true })), true);
+assert.equal(sent.length, 0);
+const first = result("first");
+const firstDelivery = notifier.deliver(first);
+assert.equal(notifier.deliver(first), firstDelivery);
+const secondDelivery = notifier.deliver(result("second"));
+assert.equal(sent.length, 0);
+assert.equal(notifier.hasPendingDelivery(), true);
+flush();
+assert.equal(await firstDelivery, true);
+assert.equal(await secondDelivery, true);
+assert.equal(sent.length, 1); // grouped, not dropped
+now = 600_000;
+assert.equal(await notifier.deliver(first), true); // inclusive TTL boundary
+assert.equal(sent.length, 1);
+now++;
+const expired = notifier.deliver(first);
+flush();
+assert.equal(await expired, true);
+assert.equal(sent.length, 2);
+const lostOwnership = notifier.deliver(result("owner-changed"));
+state.completionOwnerId = "other";
+flush();
+assert.equal(await lostOwnership, false);
+state.completionOwnerId = "owner-a";
+failSend = true;
+assert.equal(await notifier.deliver(result("retry", { success: false })), false);
+failSend = false;
+assert.equal(await notifier.deliver(result("retry", { success: false })), true);
+assert.equal(await notifier.deliver(result("foreground", { source: "foreground" })), true);
+// Attention still flushes held successes before its own immediate send.
+const held = notifier.deliver(result("held"));
+assert.equal(await notifier.deliver(result("attention", { success: false })), true);
+assert.equal(await held, true);
+const abandoned = notifier.deliver(result("abandoned"));
+notifier.dispose();
+assert.equal(await abandoned, false);
+assert.equal(notifier.hasPendingDelivery(), false);
+assert.equal(callbacks.size, 0);
+assert.equal(await notifier.deliver(result("after-dispose")), false);
+// Malformed/large identity cannot create multiline or unbounded trace records.
+await notifier.deliver(result("unsafe\n\u001b[31m" + "x".repeat(10_000)));
+// Disabled diagnostics must not even read diagnostic identity fields at a guard.
+if (!process.env.NODE_DEBUG) {
+	const unread = result("unread");
+	Object.defineProperty(unread, "runId", { get() { throw new Error("diagnostic metadata read while disabled"); } });
+	assert.equal(await notifier.deliver(unread), false);
+}
+const immediate = registerSubagentNotify(pi as never, state, { batchConfig: { enabled: false } });
+assert.equal(await immediate.deliver(result("unbatched", { triggerTurn: false })), true);
+immediate.dispose();
+console.log(JSON.stringify(sent));

--- a/test/unit/notify-diagnostics.test.ts
+++ b/test/unit/notify-diagnostics.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { it } from "node:test";
+
+it("traces bounded completion reasons through NODE_DEBUG without changing delivery", () => {
+	const run = (debug: string) => {
+		const child = spawnSync(process.execPath, [
+			"--experimental-strip-types",
+			"--import", new URL("../support/isolated-temp-root.mjs", import.meta.url).href,
+			fileURLToPath(new URL("../support/notify-diagnostics-fixture.ts", import.meta.url)),
+		], { env: { ...process.env, NODE_DEBUG: debug, NODE_NO_WARNINGS: "1" }, encoding: "utf8" });
+		assert.equal(child.status, 0, child.stderr);
+		return child;
+	};
+	const disabled = run("");
+	const enabled = run("pi-subagents-notify");
+	assert.equal(disabled.stderr, "");
+	assert.equal(enabled.stdout, disabled.stdout);
+	assert.equal(JSON.parse(enabled.stdout).length, 7);
+	assert.deepEqual(JSON.parse(enabled.stdout).at(-1).options, { triggerTurn: false });
+	const records = enabled.stderr.trim().split("\n").map((line) => {
+		assert.ok(line.length < 512, line);
+		assert.match(line, /^PI-SUBAGENTS-NOTIFY \d+: /);
+		return JSON.parse(line.slice(line.indexOf("{")));
+	});
+	assert.deepEqual([...new Set(records.map((row) => row.reason))].sort(), [
+		"missing_session", "foreground_session_mismatch", "not_owned", "intercom_delivered",
+		"batch_deferred", "deduped_pending", "send_accepted", "deduped_ttl", "emit_not_owned",
+		"send_failed", "dispose_pending", "disposed",
+	].sort());
+	assert.deepEqual(records.filter((row) => row.id === "first").map((row) => row.reason), [
+		"batch_deferred", "deduped_pending", "send_accepted", "deduped_ttl", "batch_deferred", "send_accepted",
+	]);
+	assert.deepEqual(records.filter((row) => row.id === "unbatched").map((row) => row.reason), ["send_accepted"]);
+	for (const row of records) {
+		assert.deepEqual(Object.keys(row).sort(), ["id", "reason", "runId", "source"]);
+		assert.ok(row.id.length <= 128);
+		assert.ok(row.runId.length <= 128);
+	}
+	assert.doesNotMatch(enabled.stderr, /PRIVATE_|owner-a|session-a|\u001b/);
+});


### PR DESCRIPTION
Addresses the remaining diagnostics request in #1981 after #1988/#1992.

Enable NODE_DEBUG=pi-subagents-notify before parent startup to capture bounded delivery/suppression/defer reasons on stderr. No new configuration system, file sink, watcher, timer, ownership rule or TTL change. Disabled tracing avoids identity reads, formatting and log I/O. Output excludes task/result/error bodies and session paths. Batching is described as deferred, not lost.

Thanks to @brandonmwest for identifying the gap and offering instrumented fleet sessions; linked Unreleased credit and capture instructions included.

Retained simplification and fresh review passed. Sixty focused notifier/batcher/dedupe tests plus an independently isolated subprocess test passed; enabled and disabled processes produce identical delivered messages. Typecheck and diff hygiene passed. Windows URL/temp handling inspected; exact CI pending. This adds diagnostic evidence, not a claim to have reproduced every historical missing-notification symptom.