### PR TITLE
fix(runtime): renew delivery after early terminal publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Renew native async result delivery after visible early failure and deferred publication, without idle polling (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Publish indexed async workflow results before terminal persistence after storage-capacity recovery (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest) for reporting completion-delivery observations.
 - Refuse single async steering and follow-up when an exact live supervisor ask is known; report explicit request IDs without answering, queueing, or recovering the blocked child (#1980). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Activate demand-gated supervisor polling when an async workflow registers, including scheduled workflows owned by the current runtime session and rearming after prior work finishes, without restoring idle Darwin timers or native watchers (#1977). Thanks to [@brandonmwest](https://github.com/brandonmwest); preserves [@youlikemodernart](https://github.com/youlikemodernart)'s #1220/#1228 idle-Darwin constraints.

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -26,6 +26,7 @@ import { EXTERNAL_JOB_BRIDGE_REQUEST_DIR, serviceExternalJobBridgeRequests } fro
 import { shouldUseNativeFsWatch } from "../../shared/watch-strategy.ts";
 import { parseWorkflowChildSummary } from "../../workflows/workflow-child-summary.ts";
 import { validHostStepNodes } from "../shared/host-step-status.ts";
+import { readProcessTerminal } from "./process-terminal.ts";
 import { withCachedUiContext } from "../../shared/extension-context.ts";
 
 interface AsyncJobTrackerOptions {
@@ -78,6 +79,9 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	let widgetRerenderTimer: ReturnType<typeof setTimeout> | undefined;
 	const runningJobIds = new Set<string>();
 	const externalJobBridgeRuns = new Set<string>();
+	// Early native failure is visible before its publisher finishes. Retain only
+	// that scoped observation, using the existing liveness sweep to renew delivery.
+	const terminalPublications = new Map<string, { instanceId: string; pending: true } | { pending: false }>();
 	const externalJobBridgeEligibility = (steps: AsyncJobState["steps"]): "required" | "not-required" | "unknown" => {
 		if (!Array.isArray(steps)) return "unknown";
 		for (const step of steps) {
@@ -380,6 +384,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		refreshTimers.delete(asyncId);
 		runningJobIds.delete(asyncId);
 		externalJobBridgeRuns.delete(asyncId);
+		terminalPublications.delete(asyncId);
 	};
 
 	const refreshJob = (job: AsyncJobState): boolean => {
@@ -440,6 +445,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			if (status) {
 				const previousStatus = job.status;
 				job.status = status.state;
+				if (!terminalStatus(job.status)) terminalPublications.delete(job.asyncId);
 				if (job.status === "running") runningJobIds.add(job.asyncId);
 				else runningJobIds.delete(job.asyncId);
 				if (job.status !== "complete" && job.status !== "failed" && job.status !== "paused" && job.status !== "stopped") cancelCleanup(job.asyncId);
@@ -497,9 +503,30 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				job.wrapUpRequested = status.wrapUpRequested ?? job.wrapUpRequested;
 				job.sessionFile = status.sessionFile ?? job.sessionFile;
 				if (terminalStatus(job.status)) {
-					if (!terminalStatus(previousStatus)) options.onJobTerminal?.();
+					let publication = terminalPublications.get(job.asyncId);
+					if (!publication && status.mode !== "workflow" && status.processTerminal?.state === "pending"
+						&& status.runId === job.asyncId && status.sessionId === state.currentSessionId
+						&& status.completionOwnerId && status.completionOwnerId === state.completionOwnerId) {
+						publication = { instanceId: status.processTerminal.runnerProcessInstanceId, pending: true };
+						terminalPublications.set(job.asyncId, publication);
+					}
+					const wasPending = publication?.pending;
+					if (publication?.pending) {
+						// Reconciliation resolves pending as well as public payloads. The
+						// watcher already discovers exact tracked run IDs without promotion.
+						const published = reconciliation.resultPath && fs.existsSync(reconciliation.resultPath);
+						const closed = !published && readProcessTerminal(job.asyncDir, {
+							runId: job.asyncId, runnerProcessInstanceId: publication.instanceId,
+						})?.state === "observed";
+						if (published || closed) {
+							publication = { pending: false };
+							terminalPublications.set(job.asyncId, publication);
+						} else cancelCleanup(job.asyncId);
+					}
+					// Scan on close too: publication may have raced the payload check.
+					if (!terminalStatus(previousStatus) || (wasPending && !publication?.pending)) options.onJobTerminal?.();
 					rememberFleetJob(state, job);
-					if (!nestedRefreshFailed && !hasLiveNestedDescendants(job.nestedChildren) && (previousStatus !== job.status || !state.cleanupTimers.has(job.asyncId))) {
+					if (!publication?.pending && !nestedRefreshFailed && !hasLiveNestedDescendants(job.nestedChildren) && (previousStatus !== job.status || !state.cleanupTimers.has(job.asyncId))) {
 						scheduleCleanup(job.asyncId);
 					}
 				}
@@ -526,7 +553,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			}
 			runningJobIds.delete(job.asyncId);
 			rememberFleetJob(state, job);
-			if (!hasLiveNestedDescendants(job.nestedChildren) && !state.cleanupTimers.has(job.asyncId)) scheduleCleanup(job.asyncId);
+			if (!terminalPublications.get(job.asyncId)?.pending && !hasLiveNestedDescendants(job.nestedChildren) && !state.cleanupTimers.has(job.asyncId)) scheduleCleanup(job.asyncId);
 		}
 		return widgetRenderKey(job, widgetExpanded) !== widgetStateBefore;
 	};
@@ -668,6 +695,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		const sessionRoot = state.liveAsyncSessionRoots?.get(info.id);
 		state.liveAsyncSessionRoots?.delete(info.id);
 		externalJobBridgeRuns.delete(info.id);
+		terminalPublications.delete(info.id);
 		state.asyncJobs.set(info.id, {
 			asyncId: info.id,
 			asyncDir,
@@ -721,6 +749,9 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				job.asyncDir = result.asyncDir;
 				watchJob(job);
 			}
+			// Delivery can precede the first terminal status refresh. Remember its
+			// settlement even when no pending publication has been observed yet.
+			terminalPublications.set(asyncId, { pending: false });
 			try {
 				updateAsyncJobNestedProjection(job);
 			} catch (error) {
@@ -745,6 +776,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 		widgetRerenderTimer = undefined;
 		runningJobIds.clear();
 		externalJobBridgeRuns.clear();
+		terminalPublications.clear();
 	};
 
 	const resetJobs = (ctx?: ExtensionContext) => {

--- a/test/integration/result-publication.test.ts
+++ b/test/integration/result-publication.test.ts
@@ -3,11 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, it } from "node:test";
 import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
+import { createAsyncJobTracker } from "../../src/runs/background/async-job-tracker.ts";
 import { SUBAGENT_ASYNC_COMPLETE_EVENT, type SubagentState } from "../../src/shared/types.ts";
 import registerSubagentNotify from "../../src/runs/background/notify.ts";
 import { makeAgent } from "../support/helpers.ts";
 import {
-	installAsyncExecutionHooks, available, isAsyncAvailable, executeAsyncSingle,
+	installAsyncExecutionHooks, available, isAsyncAvailable, executeAsyncSingle, executeAsyncChain,
 	ASYNC_DIR, RESULTS_DIR, tempDir, mockPi,
 } from "../support/async-execution-fixture.ts";
 
@@ -26,8 +27,215 @@ function fileBarrier(file: string): Promise<void> {
 	});
 }
 
+function publicationState(sessionId: string, owner: string): SubagentState {
+	return {
+		baseCwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner,
+		asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null,
+		cleanupTimers: new Map(), lastUiContext: null, poller: null, completionSeen: new Map(),
+		watcher: null, watcherRestartTimer: null,
+		resultFileCoalescer: { schedule: () => false, clear() {} },
+	};
+}
+
 describe("native runner result publication", { skip: !available ? "pi packages unavailable" : undefined }, () => {
 	installAsyncExecutionHooks();
+	it("renews Darwin delivery after early native failure and deferred indexed publication", { timeout: 15_000, skip: !isAsyncAvailable() ? "jiti unavailable" : undefined }, async (t) => {
+		const root = path.join(tempDir, "early-terminal-barriers");
+		fs.mkdirSync(root);
+		fs.writeFileSync(path.join(root, "early-terminal"), "");
+		const id = "early-terminal-publication";
+		const sessionId = "publication-session";
+		const owner = "publication-owner";
+		const asyncDir = path.join(ASYNC_DIR, id);
+		const state = publicationState(sessionId, owner);
+		let delivered = 0;
+		let terminalRefreshes = 0;
+		let demandTick: (() => void) | undefined;
+		let trackerTick!: () => void;
+		let complete!: () => void;
+		const completion = new Promise<void>((resolve) => { complete = resolve; });
+		const pi = { events: { on: () => () => {}, emit(event: string) {
+			if (event === SUBAGENT_ASYNC_COMPLETE_EVENT) complete();
+		} }, sendMessage() { delivered++; } };
+		const notifier = registerSubagentNotify(pi, state, { batchConfig: { enabled: false } });
+		const watcher = createResultWatcher(pi, state, RESULTS_DIR, 60_000, {
+			platform: "darwin", coalesceDelayMs: 0, notifier,
+			// index.ts wiring: no foreground controls, scheduled observations or missions in this fixture.
+			hasDeliveryDemand: () => [...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running") || state.foregroundControls.size > 0,
+			timers: {
+				setTimeout, clearTimeout,
+				setInterval: ((handler: () => void, delay: number) => {
+					assert.equal(delay, 3000);
+					demandTick = handler;
+					return { unref() {} } as ReturnType<typeof setInterval>;
+				}) as typeof setInterval,
+				clearInterval: (() => { demandTick = undefined; }) as typeof clearInterval,
+			},
+		});
+		const tracker = createAsyncJobTracker(pi, state, ASYNC_DIR, {
+			platform: "darwin", resultsDir: RESULTS_DIR, widgetEnabled: false,
+			pollIntervalMs: 0, completionRetentionMs: 60_000,
+			onJobTerminal: () => { terminalRefreshes++; watcher.refreshResultDelivery(); },
+		});
+		const oldOptions = process.env.NODE_OPTIONS;
+		const oldRoot = process.env.RESULT_PUBLICATION_TEST_ROOT;
+		try {
+			process.env.NODE_OPTIONS = `${oldOptions ?? ""} --import=${new URL("../support/result-publication-capacity-preload.mjs", import.meta.url).href}`;
+			process.env.RESULT_PUBLICATION_TEST_ROOT = root;
+			mockPi.onCall({ output: "targets", structuredOutput: { items: [{ path: "a.ts" }, { path: "b.ts" }] } });
+			const receipt = executeAsyncChain(id, {
+				chain: [
+					{ agent: "producer", task: "Produce targets", as: "targets", outputSchema: { type: "object" } },
+					{
+						expand: { from: { output: "targets", path: "/items" }, item: "target", maxItems: 2 },
+						parallel: { agent: "reviewer", task: "Review {target.path}", output: "shared.md" },
+						collect: { as: "reviews" }, concurrency: 2,
+					},
+				],
+				agents: [makeAgent("producer", { completionGuard: false }), makeAgent("reviewer", { completionGuard: false })],
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false, maxSubagentDepth: 2, acceptance: false,
+			});
+			assert.notEqual(receipt.isError, true);
+			// Capture only the real tracker's liveness callback; execute it at explicit filesystem boundaries.
+			const intervalMock = t.mock.method(globalThis, "setInterval", ((handler: () => void) => {
+				trackerTick = handler;
+				return { unref() {} } as ReturnType<typeof setInterval>;
+			}) as typeof setInterval);
+			tracker.handleStarted({ id, asyncDir, sessionId, completionOwnerId: owner, mode: "chain" });
+			intervalMock.mock.restore();
+			watcher.startResultWatcher();
+			await fileBarrier(path.join(root, "blocked.json"));
+			await fileBarrier(path.join(root, "terminal.json"));
+			const early = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf8"));
+			assert.equal(early.state, "failed", "early failure remains visible while publication is blocked");
+			assert.match(early.error, /materialized 2 items that resolve output to the same path/);
+			trackerTick();
+			assert.equal(state.asyncJobs.get(id)?.status, "failed");
+			assert.equal(terminalRefreshes, 1);
+			assert.equal(state.cleanupTimers.has(id), false, "retain the early terminal publisher beyond display retention");
+			assert.ok(demandTick);
+			demandTick(); // Real Darwin scan-before-stop callback, not elapsed silence.
+			assert.equal(demandTick, undefined);
+			assert.equal(delivered, 0);
+			assert.equal(fs.existsSync(path.join(RESULTS_DIR, "result-index", "sessions", sessionId, `${id}.json`)), false);
+			fs.writeFileSync(path.join(root, "release"), "");
+			await fileBarrier(path.join(root, "drained.json"));
+			const index = JSON.parse(fs.readFileSync(path.join(RESULTS_DIR, "result-index", "sessions", sessionId, `${id}.json`), "utf8"));
+			assert.equal(index.runId, id, "deferred publication committed its session index");
+			const publicPath = path.join(RESULTS_DIR, `${id}.json`);
+			const publishedPath = fs.existsSync(publicPath) ? publicPath : path.join(RESULTS_DIR, "result-pending", sessionId, `${id}.json`);
+			const published = JSON.parse(fs.readFileSync(publishedPath, "utf8"));
+			assert.equal(published.completionOwnerId, owner);
+			assert.equal(published.success, false);
+			assert.equal(mockPi.callCount(), 1, "dynamic failure occurs before reviewer children start");
+			trackerTick(); // Final failed-to-failed refresh through the actual tracker.
+			assert.equal(state.asyncJobs.get(id)?.status, "failed");
+			assert.equal(terminalRefreshes, 2, "settled publication renews delivery exactly once");
+			await completion;
+			assert.equal(delivered, 1, "actual notifier send, without an injected result refresh");
+			trackerTick();
+			assert.equal(terminalRefreshes, 2);
+			assert.equal(state.cleanupTimers.has(id), true, "settlement retires the publication obligation");
+			assert.equal(state.watcher, null, "Darwin has no native result watcher");
+			assert.equal(demandTick, undefined);
+			assert.equal(state.watcherRestartTimer, null);
+		} finally {
+			fs.writeFileSync(path.join(root, "release"), "");
+			tracker.resetJobs();
+			watcher.stopResultWatcher();
+			notifier.dispose();
+			if (oldOptions === undefined) delete process.env.NODE_OPTIONS; else process.env.NODE_OPTIONS = oldOptions;
+			if (oldRoot === undefined) delete process.env.RESULT_PUBLICATION_TEST_ROOT; else process.env.RESULT_PUBLICATION_TEST_ROOT = oldRoot;
+		}
+	});
+	for (const terminal of ["failed", "stopped"] as const) {
+		it(`keeps consumed ${terminal} publication settled before the first terminal refresh`, (t) => {
+			const id = `consumed-${terminal}`;
+			const asyncDir = path.join(ASYNC_DIR, id);
+			fs.mkdirSync(asyncDir, { recursive: true });
+			const state = publicationState("session", "owner");
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: id, sessionId: "session", completionOwnerId: "owner", mode: "single",
+				state: terminal, startedAt: Date.now(), steps: [],
+				processTerminal: { version: 1, state: "pending", runId: id, runnerProcessInstanceId: "instance" },
+			}));
+			let tick!: () => void;
+			let refreshes = 0;
+			const tracker = createAsyncJobTracker({ events: { emit() {} } }, state, ASYNC_DIR, {
+				platform: "darwin", widgetEnabled: false, resultsDir: RESULTS_DIR, pollIntervalMs: 0,
+				onJobTerminal: () => { refreshes++; },
+			});
+			const interval = t.mock.method(globalThis, "setInterval", ((handler: () => void) => {
+				tick = handler;
+				return { unref() {} } as ReturnType<typeof setInterval>;
+			}) as typeof setInterval);
+			try {
+				tracker.handleStarted({ id, asyncDir, sessionId: "session", completionOwnerId: "owner" });
+				interval.mock.restore();
+				// The result watcher has consumed the payload before status polling.
+				tracker.handleComplete({ id, sessionId: "session", state: terminal, success: false });
+				const cleanup = state.cleanupTimers.get(id);
+				assert.ok(cleanup);
+				tick();
+				tick();
+				assert.equal(state.asyncJobs.get(id)?.status, terminal);
+				assert.equal(state.cleanupTimers.get(id), cleanup, "consumed publication must not reopen or replace cleanup");
+				assert.equal(refreshes, 0, "consumed publication needs no delivery renewal");
+			} finally {
+				tracker.resetJobs();
+			}
+		});
+		it(`retires an early ${terminal} publisher on identity-proven close or reset`, (t) => {
+			const id = `closed-${terminal}`;
+			const asyncDir = path.join(ASYNC_DIR, id);
+			fs.mkdirSync(asyncDir);
+			const state = publicationState("session", "owner");
+			const proof = { version: 1, state: "pending", runId: id, runnerProcessInstanceId: "instance" };
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: id, sessionId: "session", completionOwnerId: "owner", mode: "single",
+				state: terminal, startedAt: Date.now(), steps: [], processTerminal: proof,
+			}));
+			let tick!: () => void;
+			let refreshes = 0;
+			const tracker = createAsyncJobTracker({ events: { emit() {} } }, state, ASYNC_DIR, {
+				platform: "darwin", widgetEnabled: false, resultsDir: RESULTS_DIR, pollIntervalMs: 0,
+				onJobTerminal: () => { refreshes++; },
+			});
+			const interval = t.mock.method(globalThis, "setInterval", ((handler: () => void) => {
+				tick = handler;
+				return { unref() {} } as ReturnType<typeof setInterval>;
+			}) as typeof setInterval);
+			try {
+				tracker.handleStarted({ id, asyncDir, sessionId: "session", completionOwnerId: "owner" });
+				interval.mock.restore();
+				tick();
+				assert.equal(state.asyncJobs.get(id)?.status, terminal);
+				assert.equal(state.cleanupTimers.has(id), false);
+				const closed = { ...proof, state: "observed", observedAt: Date.now(), instances: [{
+					kind: "runner", processInstanceId: "instance", closeObservedAt: Date.now(), exitCode: 1, signal: null,
+				}] };
+				fs.writeFileSync(path.join(asyncDir, "process-terminal.json"), JSON.stringify({ ...closed, runnerProcessInstanceId: "other" }));
+				tick();
+				assert.equal(state.cleanupTimers.has(id), false, "foreign/unknown process proof cannot discharge publication");
+				assert.equal(refreshes, 1);
+				if (terminal === "failed") {
+					fs.writeFileSync(path.join(asyncDir, "process-terminal.json"), JSON.stringify(closed));
+					tick();
+					assert.equal(state.cleanupTimers.has(id), true, "definitive publisher failure needs no further observation");
+					assert.equal(refreshes, 2, "close supplies a final scan for publication racing the proof read");
+					tick();
+					assert.equal(refreshes, 2);
+				}
+			} finally {
+				tracker.resetJobs();
+			}
+			assert.equal(state.poller, null);
+			assert.equal(state.asyncJobs.size, 0);
+			assert.equal(state.cleanupTimers.size, 0);
+		});
+	}
 	it("watches the canonical barrier directory through a path alias", async (t) => {
 		const directory = path.join(tempDir, "barrier-directory");
 		const alias = path.join(tempDir, "barrier-alias");

--- a/test/support/result-publication-capacity-preload.mjs
+++ b/test/support/result-publication-capacity-preload.mjs
@@ -12,6 +12,7 @@ if (root) {
 	let statusDeferred = false;
 	let asyncDir;
 	let failedRecovery = false;
+	const earlyTerminal = fs.existsSync(path.join(root, "early-terminal"));
 	const barrier = (name, data) => {
 		write(path.join(root, `${name}.tmp`), JSON.stringify(data));
 		rename(path.join(root, `${name}.tmp`), path.join(root, name));
@@ -22,7 +23,7 @@ if (root) {
 		if (path.basename(target).startsWith(".status.json.") && typeof data === "string") {
 			const status = JSON.parse(data);
 			asyncDir = path.dirname(target);
-			if (runningWritten && resultAttempts === 0) {
+			if (!earlyTerminal && runningWritten && resultAttempts === 0) {
 				statusDeferred = true;
 				throw full();
 			}
@@ -49,7 +50,7 @@ if (root) {
 	};
 	fs.renameSync = function (source, target) {
 		const result = rename.call(this, source, target);
-		if (path.basename(String(target)) === "steer-inbox-closed.json") {
+		if (!earlyTerminal && path.basename(String(target)) === "steer-inbox-closed.json") {
 			// A request queued just before inbox closure is consumed during finalization.
 			const dir = path.join(path.dirname(String(target)), "steer-requests");
 			fs.mkdirSync(dir, { recursive: true });
@@ -58,6 +59,10 @@ if (root) {
 		if (path.basename(String(target)) === "status.json") {
 			const status = JSON.parse(fs.readFileSync(target, "utf8"));
 			if (status.state === "complete" || status.state === "failed") barrier("terminal.json", status);
+		}
+		if (earlyTerminal && path.basename(String(target)) === "process-terminal-candidate.json") {
+			const candidate = JSON.parse(fs.readFileSync(target, "utf8"));
+			if (candidate.expectedWriters) barrier("drained.json", candidate);
 		}
 		return result;
 	};


### PR DESCRIPTION
## Summary
Follow-up for #1981: retain an owned native publication obligation after early failed/stopped status, then renew delivery when the result becomes discoverable or the matching publisher settles. Uses the existing tracker sweep; no new timer, global scan, public status field, or ownership change. Early terminal visibility remains intact.

Completion before the first terminal refresh is also remembered so an already-consumed result cannot recreate the obligation. Unknown publisher evidence retains only the scoped outstanding observation until settlement or reset.

## Evidence
- Actual native early-failure + deferred-capacity publication regression: red before correction, real notifier delivery green afterward.
- Fresh reviewer found the completion-first ordering case; focused failed/stopped red/green correction accepted by parent.
- Final 57 publication/tracker tests, typecheck and diff hygiene passed. Earlier implementation validation covered watcher and process-proof seams.
- Retained-writer simplification completed. Exact-head cross-platform CI and Greptile remain required before merge.

Thanks to [@brandonmwest](https://github.com/brandonmwest) for the report. This proves a specific discovery failure, not the cause of every historical fleet notification symptom; #1981 remains open for that residual evidence. No release.