### PR TITLE
fix(runtime): preserve acceptance protocol across compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Renew native async result delivery after visible early failure and deferred publication, without idle polling (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest).
+- Keep native child acceptance instructions verbatim in session system resources across compaction (#1996). Thanks to reporter [@Zsbyqx20](https://github.com/Zsbyqx20).
 - Publish indexed async workflow results before terminal persistence after storage-capacity recovery (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest) for reporting completion-delivery observations.
 - Refuse single async steering and follow-up when an exact live supervisor ask is known; report explicit request IDs without answering, queueing, or recovering the blocked child (#1980). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Activate demand-gated supervisor polling when an async workflow registers, including scheduled workflows owned by the current runtime session and rearming after prior work finishes, without restoring idle Darwin timers or native watchers (#1977). Thanks to [@brandonmwest](https://github.com/brandonmwest); preserves [@youlikemodernart](https://github.com/youlikemodernart)'s #1220/#1228 idle-Darwin constraints.

--- a/src/runs/background/runner-child-launch.ts
+++ b/src/runs/background/runner-child-launch.ts
@@ -4,6 +4,8 @@ import { buildInProcessChildLaunch, type BuildInProcessChildLaunchInput, type In
 import { deriveForkPromptCacheKey } from "../shared/child-tool-plan.ts";
 import { normalizeExtensionBindings } from "../shared/extension-bindings.ts";
 import type { RunnerSubagentStep } from "../shared/parallel-utils.ts";
+import { formatAcceptancePrompt } from "../shared/acceptance.ts";
+import { isAgentContract } from "../shared/agent-contract.ts";
 
 export interface RunnerChildLaunchContext {
 	cwd: string;
@@ -27,6 +29,10 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 	childWatchdog?: BuildInProcessChildLaunchInput["childWatchdog"];
 	watchdogStatus: NonNullable<BuildInProcessChildLaunchInput["watchdogStatus"]>;
 }) {
+	// Resource-backed system instructions survive SDK split-turn compaction verbatim.
+	const acceptancePrompt = step.effectiveAcceptance
+		? formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContract(step.agentContract), structuredOutput: Boolean(step.structuredOutput?.acceptanceReportPath) })
+		: "";
 	return buildInProcessChildLaunch({
 		parentSessionId: step.parentSessionId,
 		forkCacheKey: step.context === "fork" ? deriveForkPromptCacheKey(step.parentSessionId) : undefined,
@@ -45,7 +51,7 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 		subagentOnlyExtensions: step.subagentOnlyExtensions,
 		fast: step.fast,
 		modelCandidates: step.modelCandidates,
-		systemPrompt: step.systemPrompt ?? "",
+		systemPrompt: acceptancePrompt ? `${step.systemPrompt ?? ""}\n${acceptancePrompt}` : step.systemPrompt ?? "",
 		systemPromptMode: step.systemPromptMode,
 		mcpDirectTools: step.mcpDirectTools,
 		extensionBindings: normalizeExtensionBindings(step.extensionBindings)?.value,

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -838,7 +838,7 @@ export async function runSingleStepInner(
 	// Derive from the pre-acceptance task so internal acceptance/recovery
 	// instructions never leak into the display name.
 	const childSessionName = step.sessionName ?? deriveChildSessionName({ agent: step.agent, task, label: step.label });
-	if (step.effectiveAcceptance) {
+	if (step.effectiveAcceptance && (step.runner?.type === "external-cli" || step.runner?.type === "external-job")) {
 		const acceptancePrompt = formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContract(step.agentContract), structuredOutput: Boolean(step.structuredOutput?.acceptanceReportPath) });
 		if (acceptancePrompt) task = `${task}\n${acceptancePrompt}`;
 	}

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -357,6 +357,7 @@ async function runSingleAttempt(
 	shared: {
 		sessionEnabled: boolean;
 		systemPrompt: string;
+		acceptancePrompt: string;
 		resolvedSkillNames?: string[];
 		modelCandidates?: string[];
 		skillsWarning?: string;
@@ -412,7 +413,8 @@ async function runSingleAttempt(
 		allowNestedSubagents: agent.allowNestedSubagents,
 		extensions: agent.extensions,
 		subagentOnlyExtensions: agent.subagentOnlyExtensions,
-		systemPrompt: shared.systemPrompt,
+		// Exact terminal protocol belongs to session resources, not compactable history.
+		systemPrompt: shared.acceptancePrompt ? `${shared.systemPrompt}\n${shared.acceptancePrompt}` : shared.systemPrompt,
 		mcpDirectTools: agent.mcpDirectTools,
 		cwd: options.cwd ?? runtimeCwd,
 		intercomSessionName: options.intercomSessionName,
@@ -1914,7 +1916,7 @@ async function runSyncCompletionInner(
 		&& (continuationDeadline === undefined || Date.now() < continuationDeadline)
 		&& (!readonlySource || getReadonlySessionEvidence(readonlySource) === readonlyExpected)
 		&& !readonlySource?.detached && !readonlySource?.shutDown;
-	let nextAttemptTask = taskWithAcceptance;
+	let nextAttemptTask = task;
 	modelAttemptsLoop: for (let modelIndex = 0; modelIndex < modelsToTry.length; modelIndex++) {
 		const candidate = modelsToTry[modelIndex];
 		// The inner loop re-runs the same candidate at most once, for abort recovery.
@@ -1927,6 +1929,7 @@ async function runSyncCompletionInner(
 			const result = await runSingleAttempt(runtimeCwd, agent, attemptTask, candidate, attemptOptions, {
 				sessionEnabled,
 				systemPrompt,
+				acceptancePrompt,
 				resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
 				skillsWarning: missingSkills.length > 0 ? `Skills not found: ${missingSkills.join(", ")}` : undefined,
 				jsonlPath,

--- a/test/integration/fork-context-execution.test.ts
+++ b/test/integration/fork-context-execution.test.ts
@@ -305,7 +305,10 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		assert.equal(result.isError, undefined);
 		const args = readAllCallArgs()[0] ?? [];
 		const taskArg = args.at(-1) ?? "";
-		assert.ok(taskArg.startsWith("Task: \n\n## Acceptance Contract"));
+		assert.equal(taskArg, "Task: ");
+		const systemIndex = args.findIndex((arg) => arg === "--system-prompt" || arg === "--append-system-prompt");
+		assert.notEqual(systemIndex, -1);
+		assert.match(args[systemIndex + 1] ?? "", /## Acceptance Contract/);
 	});
 
 	it("fails pruned fork model auth before child spawn", async () => {
@@ -1307,7 +1310,10 @@ describe("fork context execution wiring", { skip: !available ? "subagent executo
 		assert.equal(result.isError, undefined);
 		const args = readAllCallArgs()[0] ?? [];
 		const taskArg = args.at(-1) ?? "";
-		assert.ok(taskArg.startsWith(`Task: ${task}\n\n## Acceptance Contract`));
+		assert.equal(taskArg, `Task: ${task}`);
+		const systemIndex = args.findIndex((arg) => arg === "--system-prompt" || arg === "--append-system-prompt");
+		assert.notEqual(systemIndex, -1);
+		assert.match(args[systemIndex + 1] ?? "", /## Acceptance Contract/);
 		const modelIndex = args.indexOf("--model");
 		assert.notEqual(modelIndex, -1);
 		assert.equal(args[modelIndex + 1], "anthropic/claude-haiku-4-5");

--- a/test/support/fake-child-session.ts
+++ b/test/support/fake-child-session.ts
@@ -166,8 +166,8 @@ function defaultAcceptanceReport(): string {
 	].join("\n");
 }
 
-function withAcceptanceReport(output: string, task: string): string {
-	if (!task.includes("## Acceptance Contract") || output.includes("```acceptance-report")) return output;
+function withAcceptanceReport(output: string, prompt: string): string {
+	if (!prompt.includes("## Acceptance Contract") || output.includes("```acceptance-report")) return output;
 	return `${output}\n${defaultAcceptanceReport()}`;
 }
 
@@ -244,7 +244,8 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 						const textPart = typed.message?.content?.find?.((part) => part?.type === "text");
 						const providerError = Boolean(typed.message?.errorMessage || typed.message?.stopReason === "error");
 						if (providerError) sawProviderError = true;
-						if (!providerError && textPart && typeof textPart.text === "string" && (!sawProviderError || textPart.text.trim())) textPart.text = withAcceptanceReport(textPart.text, task);
+						// Native acceptance lives in system resources, not the compactable task.
+						if (!providerError && textPart && typeof textPart.text === "string" && (!sawProviderError || textPart.text.trim())) textPart.text = withAcceptanceReport(textPart.text, [launch.systemPrompt, launch.appendSystemPrompt, task].join("\n"));
 					}
 					// A real child's watchdog hook reports through the host's sink, not the session stream.
 					if (isChildWatchdogStatusEvent(entry)) launch.runtime.watchdogStatus?.(entry);

--- a/test/unit/acceptance-compaction.test.ts
+++ b/test/unit/acceptance-compaction.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { it } from "node:test";
+import { createDefaultChildSessionFactory, type PiCodingAgentModule } from "../../src/runs/shared/child-session.ts";
+import { runSync } from "../../src/runs/foreground/execution.ts";
+import { runSingleStepInner } from "../../src/runs/background/subagent-runner.ts";
+import { formatAcceptancePrompt, resolveEffectiveAcceptance } from "../../src/runs/shared/acceptance.ts";
+import type { AgentConfig } from "../../src/agents/agents.ts";
+import { createStructuredOutputRuntime } from "../../src/runs/shared/structured-output.ts";
+
+// Uses the existing isolated SDK fixture; never install dependencies or call a provider.
+const sdkRoot = process.env.PI_SUBAGENTS_NATIVE_SDK;
+for (const host of ["foreground", "runner"] as const) {
+	for (const [systemPromptMode, structured] of [["append", false], ["replace", false], ["append", true], ["replace", true]] as const) {
+		it(`exact acceptance survives actual SDK split-turn compaction: ${host}/${systemPromptMode}/${structured ? "structured" : "fenced"}`, { skip: !sdkRoot && "Set PI_SUBAGENTS_NATIVE_SDK to the isolated 0.85.1 SDK root" }, async () => {
+			const entry = execFileSync(process.execPath, ["--input-type=module", "-e", "console.log(import.meta.resolve('@earendil-works/pi-coding-agent'))"], { cwd: sdkRoot, encoding: "utf8" }).trim();
+			const pi: PiCodingAgentModule = await import(entry);
+			assert.equal(pi.VERSION, "0.85.1");
+			const cwd = mkdtempSync(join(tmpdir(), "acceptance-compaction-"));
+			const agentDir = join(cwd, "agent"); mkdirSync(agentDir);
+			const oldDir = process.env.PI_CODING_AGENT_DIR;
+			const oldFetch = globalThis.fetch;
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ retry: { enabled: false, provider: { maxRetries: 0 } }, compaction: { enabled: true, reserveTokens: 2048, keepRecentTokens: 32 } }));
+			writeFileSync(join(agentDir, "models.json"), JSON.stringify({ providers: { baseten: { baseUrl: "https://synthetic.invalid/v1", apiKey: "fixture-key", models: [{ id: "acceptance", name: "acceptance", api: "openai-completions", reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 512, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } }] } } }));
+			writeFileSync(join(cwd, "marker.txt"), "WORK_EVIDENCE");
+			const task = "UNIQUE_TASK read marker.txt once and report evidence.";
+			const explicit = { level: "checked" as const, criteria: [{ id: "read-marker", must: "Read the marker exactly once" }], evidence: ["commands-run" as const, "no-staged-files" as const] };
+			const acceptance = resolveEffectiveAcceptance({ explicit, task, agentName: "reader", mode: "single" });
+			const structuredOutput = structured ? createStructuredOutputRuntime({ type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] }, cwd, { acceptanceReport: "optional" }) : undefined;
+			const protocol = formatAcceptancePrompt(acceptance, { structuredOutput: structured });
+			const report = { criteriaSatisfied: [{ id: "read-marker", status: "satisfied", evidence: "WORK_EVIDENCE" }], changedFiles: [], testsAddedOrUpdated: [], residualRisks: ["none"], commandsRun: [{ command: "read marker.txt", result: "passed", summary: "WORK_EVIDENCE" }], noStagedFiles: true };
+			const requests: any[] = [];
+			const preparations: any[] = [];
+			const events: any[] = [];
+			let prompts = 0;
+			let creates = 0;
+			let reads = 0;
+			let summaries = 0;
+			globalThis.fetch = async (input, init) => {
+				assert.equal(input instanceof Request ? input.url : String(input), "https://synthetic.invalid/v1/chat/completions");
+				const body = JSON.parse(String(init?.body)); requests.push(body);
+				assert.ok(requests.length <= 3, "no extra request or correction turn");
+				const summary = !body.tools?.length;
+				let delta: unknown;
+				let finish = "stop";
+				let tokens = 10;
+				if (summary) {
+					summaries++;
+					// Deliberately lossy model output: real SDK summary generation/rebuild remains intact.
+					delta = { content: "The marker was read. Finish the work." };
+				} else if (reads++ === 0) {
+					delta = { content: "Inspecting the marker for evidence. ".repeat(12), tool_calls: [{ index: 0, id: "read-once", type: "function", function: { name: "read", arguments: JSON.stringify({ path: "marker.txt" }) } }] };
+					finish = "tool_calls"; tokens = 127000;
+				} else {
+					const system = body.messages.filter((m: any) => m.role === "system" || m.role === "developer").map((m: any) => m.content).join("\n");
+					delta = { content: system.includes(protocol) ? `Completed.\n\`\`\`acceptance-report\n${JSON.stringify(report)}\n\`\`\`` : "Completed the read. Validation passed; no staged files." };
+					if (structured) {
+						delta = { tool_calls: [{ index: 0, id: "final-output", type: "function", function: { name: "structured_output", arguments: JSON.stringify({ value: { ok: true }, ...(system.includes(protocol) ? { acceptanceReport: report } : {}) }) } }] };
+						finish = "tool_calls";
+					}
+				}
+				const chunk = { id: "synthetic", object: "chat.completion.chunk", created: 1, model: "acceptance", choices: [{ index: 0, delta, finish_reason: finish }], usage: { prompt_tokens: tokens, completion_tokens: 1, total_tokens: tokens + 1 } };
+				return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, { headers: { "content-type": "text/event-stream" } });
+			};
+			const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => ({ ...pi, createAgentSession: async (options) => {
+				const result = await pi.createAgentSession(options);
+				assert.deepEqual(result.session.settingsManager.getCompactionSettings(), { enabled: true, reserveTokens: 2048, keepRecentTokens: 32 });
+				result.session.subscribe((event) => events.push(event));
+				return result;
+			} }) });
+			const observedFactory = { ...factory, async create(launch: Parameters<typeof factory.create>[0]) {
+				creates++;
+				const child = await factory.create({ ...launch, hooks: [...launch.hooks, (api) => {
+					api.on("session_before_compact", (event) => { preparations.push(event.preparation); });
+				}] });
+				const prompt = child.prompt.bind(child);
+				child.prompt = (text) => { prompts++; return prompt(text); };
+				return child;
+			} };
+			const agent: AgentConfig = { name: "reader", description: "Read marker", source: "project", filePath: join(cwd, "reader.md"), model: "baseten/acceptance", systemPrompt: "Read only.", systemPromptMode, inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false, tools: ["read"], extensions: [], allowNestedSubagents: false };
+			try {
+				const result = host === "foreground"
+					? await runSync(cwd, [agent], agent.name, task, { acceptance: explicit, structuredOutput, waitToolEnabled: false, childSessionFactory: observedFactory })
+					: await runSingleStepInner({ ...agent, agent: agent.name, task, context: "fresh", effectiveAcceptance: acceptance, structuredOutput, modelCandidates: [agent.model!], waitToolEnabled: false }, { cwd, id: "compact-runner", flatIndex: 0, flatStepCount: 1, previousOutput: "", placeholder: "{previous}", outputFile: join(cwd, "output.log"), sessionEnabled: false, childSessions: observedFactory });
+				assert.equal(result.exitCode, 0, `${result.error}; ${JSON.stringify(events.filter((e) => e.type.includes("compact") || (e.type === "message_end" && e.message?.stopReason === "error")))}`);
+				assert.equal(result.acceptance?.status, "checked");
+				if (structured) assert.deepEqual(result.structuredOutput, { ok: true });
+				assert.equal(creates, 1); assert.equal(prompts, 1, "no replay or correction prompt");
+				assert.equal(summaries, 1);
+				assert.equal(preparations.length, 1);
+				assert.equal(preparations[0].isSplitTurn, true);
+				assert.ok(JSON.stringify(preparations[0].turnPrefixMessages).includes("UNIQUE_TASK"));
+				assert.equal(events.filter((e) => e.type === "tool_execution_end" && e.toolName === "read").length, 1);
+				assert.equal(events.filter((e) => e.type === "compaction_end" && e.result).length, 1);
+				assert.ok(events.some((e) => e.type === "compaction_end" && e.reason === "threshold" && e.willRetry === false));
+				const normal = requests.filter((r) => r.tools?.length);
+				assert.equal(normal.length, 2, "one tool request and one terminal request");
+				assert.ok(!JSON.stringify(normal[0].messages.filter((m: any) => m.role === "user")).includes("Acceptance Contract"), "protocol is moved, not duplicated into user history");
+				for (const request of normal) {
+					const system = request.messages.filter((m: any) => m.role === "system" || m.role === "developer").map((m: any) => m.content).join("\n");
+					assert.equal(system.split(protocol).length - 1, 1, "verbatim contract exactly once in durable resources");
+				}
+				const retained = JSON.stringify(normal[1].messages.filter((m: any) => m.role !== "system" && m.role !== "developer"));
+				assert.ok(!retained.includes("UNIQUE_TASK"), "actual SDK removed original user task");
+				assert.ok(!retained.includes("acceptance-report"), "lossy conversation no longer contains envelope");
+				assert.ok(retained.includes("WORK_EVIDENCE"), "tool evidence survives");
+			} finally {
+				await factory.dispose(); globalThis.fetch = oldFetch;
+				if (oldDir === undefined) delete process.env.PI_CODING_AGENT_DIR; else process.env.PI_CODING_AGENT_DIR = oldDir;
+				rmSync(cwd, { recursive: true, force: true });
+			}
+		});
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1996. Move unchanged native acceptance instructions from compactable task history into SDK session system resources. Both foreground and background native paths retain the exact protocol after compaction. External runners retain their existing prompt behavior; validation, recovery and retry policy are unchanged. No corrective turn is added.

## Validation
- Real SDK 0.85.1 automatic between-tool-turn split compaction: four original fenced cases red; eight corrected foreground/background, append/replace and structured-output cases green.
- One original task/read, discarded task history, retained tool evidence and exact protocol once before/after compaction.
- 110 focused tests, 26 contract tests, typecheck and diff hygiene passed.
- Retained implementer challenge and fresh independent review: no issues. Reviewer independently reran all eight actual-SDK cases using synthetic transport, no live provider.
- Exact-head CI and Greptile required before serial merge. SDK fixture remains opt-in; evidence establishes protocol availability, not universal model obedience.

Thanks to [@Zsbyqx20](https://github.com/Zsbyqx20) for the report. No release.