### PR TITLE
fix(models): explain native response-alias verification remedy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Identify native Pi model-verification failures and point to the existing exact `modelResponseAliases` configuration remedy (#1922). Thanks to [@sixtus](https://github.com/sixtus).
 - Document the startup fallback boundary and the narrow native foreground/background read-only HTTP 429 continuation, including host-specific budget and compatibility limits (#1936). Thanks to reporter [@peedrr](https://github.com/peedrr).
 - Document steer delivery modes and `scheduledRuns.storeRoot` in the bundled skill reference (`execution-controls.md`) (#1933). Thanks to [@G0-0000](https://github.com/G0-0000).
 - Remove generation suffixes from developer-facing contract types and helpers; request shapes, format versions, and behavior are unchanged (#1913).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,18 @@ Optionally accept exact response model IDs for an exact provider-qualified launc
 
 This is your explicit assertion that the declared response IDs identify the requested model, not proof from model output. It does not rewrite the outgoing model or provider route, authorize fallback models, or bypass verification for other routes. Foreground and background runs capture this declaration for launch and retain it on revival, including when no aliases were declared. Changing config affects new independent runs, not the retained declaration. Without a matching declaration, existing strict verification remains unchanged.
 
+For a native Pi `model_verification_failed` where your proxy accepts `claude-haiku-4-5` but reports `anthropic.claude-haiku-4-5-20251001-v1:0`, independently confirm your proxy's mapping, then configure:
+
+```json
+{
+  "modelResponseAliases": {
+    "YOUR_PROVIDER/claude-haiku-4-5": ["anthropic.claude-haiku-4-5-20251001-v1:0"]
+  }
+}
+```
+
+Replace `YOUR_PROVIDER` with the resolved Pi provider ID. Keep the outgoing model alias unchanged. This native remedy already exists in v0.65.1; it does not infer equivalence from provider prefixes or dates. The built-in external `claude-code` adapter does not invoke this verifier or use this setting. If an external run shows this diagnostic, identify the installed version, resolved runner kind/adapter, and error location before applying a native remedy. Thanks to [sixtus](https://github.com/sixtus) for the concrete request-ID/response-ID example in [#1922](https://github.com/nicobailon/pi-subagents/issues/1922).
+
 ## `modelExclusions`
 
 ```json

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -38,7 +38,7 @@ export function formatSubagentModelVerificationError(
 		const expectedFullIdLeaf = expectedEntry.fullId.slice(expectedEntry.fullId.lastIndexOf("/") + 1);
 		if (expectedIdLeaf === observedBase || expectedFullIdLeaf === observedBase) return undefined;
 	}
-	return `model_verification_failed: child reported a different model than the launch candidate. Expected '${expectedModel}' but observed '${observedModel}'.`;
+	return `model_verification_failed: native Pi child reported a different model than the launch candidate. Expected '${expectedModel}' but observed '${observedModel}'. If you have independently verified this response ID identifies the requested model, declare the exact mapping in modelResponseAliases in ~/.pi/agent/extensions/subagent/config.json (see docs/configuration.md#modelresponsealiases). Use the resolved provider/model ID without its thinking suffix as the key. This leaves the outgoing request unchanged and applies to new independent native runs, not resumed runs or external CLI adapters.`;
 }
 
 /** Sentinel model value requesting that a subagent inherit the parent session's model. */

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -38,7 +38,7 @@ export function formatSubagentModelVerificationError(
 		const expectedFullIdLeaf = expectedEntry.fullId.slice(expectedEntry.fullId.lastIndexOf("/") + 1);
 		if (expectedIdLeaf === observedBase || expectedFullIdLeaf === observedBase) return undefined;
 	}
-	return `model_verification_failed: native Pi child reported a different model than the launch candidate. Expected '${expectedModel}' but observed '${observedModel}'. If you have independently verified this response ID identifies the requested model, declare the exact mapping in modelResponseAliases in ~/.pi/agent/extensions/subagent/config.json (see docs/configuration.md#modelresponsealiases). Use the resolved provider/model ID without its thinking suffix as the key. This leaves the outgoing request unchanged and applies to new independent native runs, not resumed runs or external CLI adapters.`;
+	return `model_verification_failed: native Pi child reported a different model than the launch candidate. Expected '${expectedModel}' but observed '${observedModel}'. If you have independently verified this response ID identifies the requested model, declare the exact mapping in modelResponseAliases in ~/.pi/agent/extensions/subagent/config.json (see docs/configuration.md#modelresponsealiases). Use the resolved provider/model ID without its thinking suffix as the key. This leaves the outgoing request unchanged. Configuration changes affect new independent native runs; resumed native runs retain their launch-time declaration. External CLI adapters do not use this setting.`;
 }
 
 /** Sentinel model value requesting that a subagent inherit the parent session's model. */

--- a/test/integration/intercom-result-delivery.test.ts
+++ b/test/integration/intercom-result-delivery.test.ts
@@ -359,7 +359,8 @@ describe("intercom result delivery cutover", { skip: !available ? "executor not 
 			assert.notEqual(revivedIds[1], revivedIds[0], "expected the latest revived run id from pass two");
 			assert.equal(value?.firstOutput, "Completed retained follow-up one");
 			assert.equal(value?.output, "Completed retained follow-up two");
-			assert.equal(revivedIds.every((id) => !fs.existsSync(path.join(ASYNC_DIR, id, "workflow-result.json"))), true);
+			// Awaiting may consume a pending result before the runner promotes its public file.
+			assert.equal(mockPi.callCount(), 2, "each retained follow-up must execute once without replay or extra children");
 		} finally {
 			fs.rmSync(sourceAsyncDir, { recursive: true, force: true });
 			for (const id of revivedIds) fs.rmSync(path.join(ASYNC_DIR, id), { recursive: true, force: true });

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -30,10 +30,15 @@ describe("model fallback helpers", () => {
 	});
 
 	it("fails verification when the child reports an unregistered different model", () => {
-		assert.match(
-			formatSubagentModelVerificationError("openai/gpt-5-mini:high", "unknown-provider/wrong-model", availableModels) ?? "",
-			/model_verification_failed/,
-		);
+		const error = formatSubagentModelVerificationError("openai/gpt-5-mini:high", "unknown-provider/wrong-model", availableModels) ?? "";
+		assert.match(error, /model_verification_failed: native Pi child/);
+		assert.match(error, /Expected 'openai\/gpt-5-mini:high' but observed 'unknown-provider\/wrong-model'/);
+		assert.match(error, /independently verified/);
+		assert.match(error, /modelResponseAliases in ~\/\.pi\/agent\/extensions\/subagent\/config\.json/);
+		assert.match(error, /docs\/configuration\.md#modelresponsealiases/);
+		assert.match(error, /resolved provider\/model ID without its thinking suffix/);
+		assert.match(error, /outgoing request unchanged/);
+		assert.match(error, /new independent native runs, not resumed runs or external CLI adapters/);
 	});
 
 	it("accepts child-reported bare model ids for the expected registry entry", () => {
@@ -87,20 +92,21 @@ describe("model fallback helpers", () => {
 	});
 
 	it("accepts exact response aliases only for the resolved candidate route", () => {
-		const route = "databricks-bedrock/ias-claude-opus-5";
-		const registry = [{ provider: "databricks-bedrock", id: "ias-claude-opus-5", fullId: route }];
-		const aliases = { [route]: ["claude-opus-5"] };
-		const candidate = resolveModelCandidate("ias-claude-opus-5:high", registry)!;
+		const route = "litellm/claude-haiku-4-5";
+		const responseId = "anthropic.claude-haiku-4-5-20251001-v1:0";
+		const registry = [{ provider: "litellm", id: "claude-haiku-4-5", fullId: route }];
+		const aliases = { [route]: [responseId] };
+		const candidate = resolveModelCandidate("claude-haiku-4-5:high", registry)!;
 		assert.equal(candidate, `${route}:high`);
-		assert.equal(formatSubagentModelVerificationError(candidate, "claude-opus-5", registry, aliases), undefined);
-		for (const expected of ["other-provider/ias-claude-opus-5", "databricks-bedrock/other-route", "ias-claude-opus-5"]) {
-			assert.match(formatSubagentModelVerificationError(expected, "claude-opus-5", registry, aliases) ?? "", /model_verification_failed/);
+		assert.equal(formatSubagentModelVerificationError(candidate, responseId, registry, aliases), undefined);
+		for (const expected of ["other-provider/claude-haiku-4-5", "litellm/other-route", "claude-haiku-4-5"]) {
+			assert.match(formatSubagentModelVerificationError(expected, responseId, registry, aliases) ?? "", /model_verification_failed/);
 		}
-		for (const observed of ["wrong-provider/claude-opus-5", "claude-opus-4", "opus-5", "Claude-Opus-5", "claude-opus-5:high"]) {
+		for (const observed of [`wrong-provider/${responseId}`, "anthropic.claude-haiku-4-5-20251002-v1:0", "claude-sonnet-4", responseId.toUpperCase(), `${responseId}:high`]) {
 			assert.match(formatSubagentModelVerificationError(candidate, observed, registry, aliases) ?? "", /model_verification_failed/);
 		}
 		for (const map of [undefined, {}, { [route]: [] }]) {
-			assert.match(formatSubagentModelVerificationError(candidate, "claude-opus-5", registry, map) ?? "", /model_verification_failed/);
+			assert.match(formatSubagentModelVerificationError(candidate, responseId, registry, map) ?? "", /model_verification_failed/);
 		}
 		assert.equal(formatSubagentModelVerificationError(candidate, "response:high", registry, { [route]: ["response:high"] }), undefined);
 		assert.match(formatSubagentModelVerificationError(candidate, "response", registry, { [route]: ["response:high"] }) ?? "", /model_verification_failed/);

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -38,7 +38,7 @@ describe("model fallback helpers", () => {
 		assert.match(error, /docs\/configuration\.md#modelresponsealiases/);
 		assert.match(error, /resolved provider\/model ID without its thinking suffix/);
 		assert.match(error, /outgoing request unchanged/);
-		assert.match(error, /new independent native runs, not resumed runs or external CLI adapters/);
+		assert.match(error, /Configuration changes affect new independent native runs; resumed native runs retain their launch-time declaration\. External CLI adapters do not use this setting\./);
 	});
 
 	it("accepts child-reported bare model ids for the expected registry entry", () => {


### PR DESCRIPTION
Addresses #1922 with actionable native verification guidance and the exact Haiku/Bedrock configuration example. Existing modelResponseAliases support is unchanged: requests keep their alias; only explicitly declared exact response IDs are accepted. No fuzzy matching or external Claude Code verification is added. Real SDK synthetic transport preserved outgoing request IDs and proved acceptance/rejection against the production verifier; focused tests and fresh review passed. Thanks to [@sixtus](https://github.com/sixtus). Exact-head CI and Greptile required before merge; no release.