### PR TITLE
test(ci): preserve shared-cwd terminal failure evidence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,14 @@ jobs:
         timeout-minutes: 10
         env:
           NODE_DISABLE_COMPILE_CACHE: '1'
+          PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR: ${{ runner.temp }}/1906-terminal-evidence
         run: npm run test:integration
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: shared-cwd-terminal-${{ matrix.os }}
+          path: ${{ runner.temp }}/1906-terminal-evidence/shared-cwd-terminal.json
+          if-no-files-found: ignore
 
   bun-workflow-script:
     runs-on: ubuntu-latest

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -898,13 +898,7 @@ export default function() {
 		const observer = observeSharedCwdRunner(id);
 		const originalFactoryModule = childSessionFactoryModule();
 		const failures: unknown[] = [];
-		let reported = false;
-		const reportFailure = () => {
-			if (reported) return;
-			reported = true;
-			try { t.diagnostic(`#1906 ${JSON.stringify({ ...observer.summary(), snapshot: observer.snapshot() })}`); }
-			catch { t.diagnostic("#1906 failure snapshot unavailable (contents withheld)"); }
-		};
+		const reportFailure = () => observer.reportFailure((message) => t.diagnostic(message));
 		try {
 			assert.ok(originalFactoryModule, "expected the installed scripted runner factory");
 			const factoryPath = path.join(tempDir, "shared-cwd-exit-phases.mjs");

--- a/test/integration/shared-cwd-terminal-evidence.test.ts
+++ b/test/integration/shared-cwd-terminal-evidence.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { ChildProcess } from "node:child_process";
+import { channel } from "node:diagnostics_channel";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import { ASYNC_DIR, RESULTS_DIR, observeSharedCwdRunner } from "../support/async-execution-fixture.ts";
+
+// Synthetic lifecycle only: no runner, providers, polling, or Windows control.
+test("shared-cwd failure artifact preserves correlated allowlisted lifecycle once", () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "terminal-evidence-"));
+	const previous = process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+	process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR = path.join(root, "artifacts");
+	const id = `terminal-evidence-${process.pid}`;
+	const runDir = path.join(ASYNC_DIR, id);
+	const resultFile = path.join(RESULTS_DIR, `${id}.json`);
+	const observer = observeSharedCwdRunner(id);
+	const secret = "DO_NOT_PERSIST_TASK_RESULT_OR_SECRET";
+	try {
+		fs.mkdirSync(runDir, { recursive: true });
+		fs.mkdirSync(RESULTS_DIR, { recursive: true });
+		const proc = new ChildProcess();
+		proc.pid = process.pid;
+		observer.launch(() => {
+			channel("child_process").publish({ process: proc });
+			observer.emit("subagent:async-started", { id, pid: proc.pid, task: secret });
+			proc.emit("spawn");
+			proc.emit("exit", 0, null);
+			proc.emit("close", 0, null);
+			return { content: [], isError: false, details: { asyncId: id } };
+		});
+		const proof = { runId: id, runnerProcessInstanceId: "instance-1906", state: "pending", task: secret };
+		fs.writeFileSync(path.join(runDir, "process-terminal.json"), JSON.stringify(proof));
+		fs.writeFileSync(path.join(runDir, "process-terminal-candidate.json"), JSON.stringify({ ...proof, writers: { "0": [], "1": [] }, expectedWriters: { "0": 0, "1": 0 } }));
+		fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({ ...proof, state: "complete", result: secret }));
+		fs.writeFileSync(resultFile, JSON.stringify({ runId: id, output: secret }));
+		fs.writeFileSync(path.join(runDir, "events.jsonl"), JSON.stringify({ ...proof, type: "subagent.run.completed", output: secret }) + "\n");
+		fs.writeFileSync(path.join(runDir, "runner.stderr.log"), `${secret}\n#1906 phase=dispose-return invocation=2 ts=123 pid=${proc.pid}\n#1906 phase=exit invocation=0 ts=124 pid=${proc.pid}\n#1906 phase=exit invocation=0 ts=124 pid=${proc.pid + 1}\n`);
+		fs.writeFileSync(path.join(runDir, "runner.stdout.log"), secret);
+		observer.marks.waitStartedAt = Date.now();
+		const diagnostics: string[] = [];
+		observer.reportFailure((message) => diagnostics.push(message));
+		const artifact = path.join(root, "artifacts", "shared-cwd-terminal.json");
+		const text = fs.readFileSync(artifact, "utf8");
+		assert.ok(Buffer.byteLength(text) <= 65536);
+		assert.equal(text.includes(secret), false);
+		assert.equal(diagnostics[0], `#1906 ${text}`);
+		const evidence = JSON.parse(text);
+		assert.equal(evidence.pid, process.pid);
+		assert.equal(evidence.correlatedProcesses, 1);
+		assert.deepEqual(evidence.processEvents[0].map((event: { type: string }) => event.type), ["spawn", "exit", "close"]);
+		const files = evidence.snapshot.files;
+		assert.equal(files.find((file: { name: string }) => file.name === "status.json").state, "complete");
+		assert.equal(files.find((file: { name: string }) => file.name === "process-terminal.json").runnerProcessInstanceId, "instance-1906");
+		assert.deepEqual(files.find((file: { name: string }) => file.name === "process-terminal-candidate.json").writers, [{ index: "0", count: 0, expected: 0 }, { index: "1", count: 0, expected: 0 }]);
+		const journal = files.find((file: { name: string }) => file.name === "events.jsonl");
+		assert.equal(journal.terminalPresentInRead, false);
+		assert.equal(journal.parseErrors, 0);
+		assert.equal(journal.lifecycle[0].type, "subagent.run.completed");
+		assert.deepEqual(files.find((file: { name: string }) => file.name === "runner.stderr.log").phases, [
+			{ phase: "dispose-return", invocation: 2, ts: 123, pid: process.pid },
+			{ phase: "exit", invocation: 0, ts: 124, pid: process.pid },
+		]);
+		fs.rmSync(runDir, { recursive: true, force: true });
+		fs.rmSync(resultFile, { force: true });
+		observer.snapshot = () => { throw new Error("must not capture again"); };
+		observer.reportFailure((message) => diagnostics.push(message));
+		assert.equal(diagnostics.length, 1);
+		assert.equal(fs.readFileSync(artifact, "utf8"), text, "artifact survives fixture cleanup");
+		assert.deepEqual(fs.readdirSync(path.dirname(artifact)), ["shared-cwd-terminal.json"]);
+	} finally {
+		observer.dispose();
+		if (previous === undefined) delete process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+		else process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR = previous;
+		fs.rmSync(runDir, { recursive: true, force: true });
+		fs.rmSync(resultFile, { force: true });
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("shared-cwd evidence is failure-only and write errors retain safe log evidence", () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "terminal-evidence-"));
+	const previous = process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+	const destination = path.join(root, "artifacts");
+	process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR = destination;
+	const observer = observeSharedCwdRunner("terminal-evidence-no-run");
+	try {
+		observer.snapshot = () => { throw new Error("raw secret error"); };
+		observer.summary();
+		observer.dispose();
+		assert.equal(fs.existsSync(destination), false, "success does not create artifacts or snapshot");
+		const diagnostics: string[] = [];
+		observer.reportFailure((message) => diagnostics.push(message));
+		assert.deepEqual(diagnostics, ["#1906 failure snapshot unavailable (contents withheld)"]);
+		assert.equal(fs.existsSync(destination), false);
+
+		fs.writeFileSync(destination, "not a directory");
+		const failedWrite = observeSharedCwdRunner("terminal-evidence-no-run");
+		failedWrite.reportFailure((message) => diagnostics.push(message));
+		assert.match(diagnostics[1]!, /^#1906 \{"id":"terminal-evidence-no-run"/);
+		assert.equal(diagnostics[2], "#1906 failure artifact unavailable (contents withheld)");
+		assert.equal(diagnostics.join("\n").includes("raw secret error"), false);
+		failedWrite.dispose();
+
+		delete process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+		const logOnly = observeSharedCwdRunner("terminal-evidence-no-run");
+		logOnly.reportFailure((message) => diagnostics.push(message));
+		assert.equal(diagnostics.length, 4, "unconfigured local failures remain log-only");
+		logOnly.dispose();
+	} finally {
+		observer.dispose();
+		if (previous === undefined) delete process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+		else process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR = previous;
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/test/support/async-execution-fixture.ts
+++ b/test/support/async-execution-fixture.ts
@@ -403,6 +403,7 @@ export function observeSharedCwdRunner(id: string) {
 	const notifications: unknown[] = [];
 	const processes: Array<{ proc: ChildProcess; events: unknown[]; dispose: () => void }> = [];
 	let pid: number | undefined;
+	let reported = false;
 	let signalZero: { at: number; state: string } | undefined;
 	const diagnosticChannel = channel("child_process");
 	const onProcess = (message: unknown) => {
@@ -499,6 +500,23 @@ export function observeSharedCwdRunner(id: string) {
 				finally { if (fd !== undefined) fs.closeSync(fd); }
 			});
 			return { snapshotAt, finishedAt: Date.now(), waitElapsedMs: typeof marks.waitStartedAt === "number" ? snapshotAt - marks.waitStartedAt : undefined, processState, signalZero, files };
+		},
+		// Called only at the failing assertion boundary, before fixture cleanup.
+		reportFailure(diagnostic: (message: string) => void) {
+			if (reported) return;
+			reported = true;
+			let text: string;
+			try { text = JSON.stringify({ ...this.summary(), snapshot: this.snapshot() }); }
+			catch { diagnostic("#1906 failure snapshot unavailable (contents withheld)"); return; }
+			diagnostic(`#1906 ${text}`);
+			const directory = process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+			if (!directory) return;
+			try {
+				// Persist only the existing allowlisted projection, never copy run files.
+				if (Buffer.byteLength(text) > 65536) throw new Error("snapshot exceeds bound");
+				fs.mkdirSync(directory, { recursive: true });
+				fs.writeFileSync(path.join(directory, "shared-cwd-terminal.json"), text, { mode: 0o600 });
+			} catch { diagnostic("#1906 failure artifact unavailable (contents withheld)"); }
 		},
 		dispose() { for (const entry of processes) entry.dispose(); },
 	};


### PR DESCRIPTION
Advances #1906 by preserving the existing bounded, allowlisted lifecycle snapshot outside fixture cleanup and uploading that exact file only on test-job failure. No production changes, new jobs, retries, timeout increases or weakened cleanup assertions. Raw tasks/results/logs are not copied. Two focused synthetic capture tests, workflow wiring validation, retained-writer challenge and fresh review passed. This is instrumentation, not a proven Windows race fix; #1906 remains open for exact recurrence evidence. No release.