### PR TITLE
fix(supervisor): align native actions and routing hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Align native supervisor actions and reply/steer routing hints with supported routes. Thanks to [@rtbe](https://github.com/rtbe) for #2002.
 - Renew native async result delivery after visible early failure and deferred publication, without idle polling (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Keep native child acceptance instructions verbatim in session system resources across compaction (#1996). Thanks to reporter [@Zsbyqx20](https://github.com/Zsbyqx20).
 - Publish indexed async workflow results before terminal persistence after storage-capacity recovery (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest) for reporting completion-delivery observations.

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -74,7 +74,7 @@ interface ContactSupervisorParams {
 }
 
 interface IntercomParams {
-	action: "list" | "send" | "ask" | "reply" | "pending" | "status";
+	action: "list" | "pending" | "status" | "reply";
 	to?: string;
 	message?: string;
 	replyTo?: string;
@@ -97,7 +97,7 @@ const ContactSupervisorParamsSchema = Type.Object({
 }, { additionalProperties: false });
 
 const IntercomParamsSchema = Type.Object({
-	action: Type.String({ enum: ["list", "send", "ask", "reply", "pending", "status"] }),
+	action: Type.String({ enum: ["list", "pending", "status", "reply"] }),
 	to: Type.Optional(Type.String()),
 	message: Type.Optional(Type.String()),
 	replyTo: Type.Optional(Type.String()),
@@ -490,7 +490,6 @@ function requestVisibleText(request: PendingSupervisorRequest): string {
 		`Agent: ${request.agent}`,
 		`Child index: ${request.childIndex}`,
 	];
-	if (request.childTarget) lines.push(`Child intercom target: ${request.childTarget}`);
 	lines.push("");
 	if (request.message) lines.push(request.message);
 	if (request.reason === "interview_request") {
@@ -501,6 +500,7 @@ function requestVisibleText(request: PendingSupervisorRequest): string {
 		if (request.interview !== undefined) lines.push(JSON.stringify(request.interview, null, "\t"));
 	}
 	if (request.expectsReply) lines.push("", `Reply with: ${supervisorReplyHint(request.id)}`);
+	lines.push("", `Live guidance: subagent({ action: "steer", id: ${JSON.stringify(request.runId)}, index: ${request.childIndex}, message: "..." })${request.expectsReply ? " (Reply to the pending request first.)" : ""}`);
 	return lines.join("\n").trimEnd();
 }
 
@@ -604,9 +604,6 @@ function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, Pendin
 				pending.delete(request.id);
 				clearForegroundSupervisorAttention(request, pending, state);
 				return { content: [{ type: "text", text: `Replied to supervisor request ${request.id}.` }], details: { replyTo: request.id, runId: request.runId, agent: request.agent } };
-			}
-			if (input.action === "send" || input.action === "ask") {
-				throw new Error("The native subagent supervisor handles replies only. Child agents initiate asks with contact_supervisor.");
 			}
 			throw new Error(`Unsupported supervisor action: ${input.action}`);
 		},

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -105,7 +105,7 @@ describe("native supervisor channel", () => {
 			message: { content?: string; details?: { id?: string } };
 			options?: { triggerTurn?: boolean };
 		}> = [];
-		const registeredTools: string[] = [];
+		const registeredTools: Array<{ name: string; parameters: { properties: { action: unknown } } }> = [];
 		const ctx = {
 			cwd: process.cwd(),
 			hasUI: false,
@@ -117,7 +117,7 @@ describe("native supervisor channel", () => {
 		};
 		const pi = {
 			getAllTools: () => [],
-			registerTool: (tool: { name: string }) => { registeredTools.push(tool.name); },
+			registerTool: (tool: typeof registeredTools[number]) => { registeredTools.push(tool); },
 			sendMessage: (
 				message: { content?: string; details?: { id?: string } },
 				options?: { triggerTurn?: boolean },
@@ -130,7 +130,8 @@ describe("native supervisor channel", () => {
 		channel.start();
 		channel.dispose();
 
-		assert.deepEqual(registeredTools, [NATIVE_SUPERVISOR_TOOL_NAME]);
+		assert.deepEqual(registeredTools.map((tool) => tool.name), [NATIVE_SUPERVISOR_TOOL_NAME]);
+		assert.deepEqual(registeredTools[0]?.parameters.properties.action, { type: "string", enum: ["list", "pending", "status", "reply"] });
 		assert.deepEqual(sent.map(({ message }) => message.details?.id), [matchingId]);
 		assert.deepEqual(sent[0]?.options, { triggerTurn: true });
 		assert.equal(channel.pending.has(matchingId), false, "disposed channel clears pending requests");
@@ -698,7 +699,9 @@ describe("native supervisor channel", () => {
 			assert.equal(sent[0]?.customType, SUPERVISOR_REQUEST_MESSAGE_TYPE);
 			assert.match(sent[0]?.content ?? "", /Subagent requests a structured supervisor interview\./);
 			assert.match(sent[0]?.content ?? "", /Should this change be applied\?/);
-			assert.match(sent[0]?.content ?? "", /Reply with: subagent_supervisor/);
+			assert.ok(sent[0]?.content?.includes(`Reply with: subagent_supervisor({ action: "reply", replyTo: "${requestId}", message: "..." })`));
+			assert.ok(sent[0]?.content?.includes(`Live guidance: subagent({ action: "steer", id: "${runId}", index: 2, message: "..." }) (Reply to the pending request first.)`));
+			assert.doesNotMatch(sent[0]?.content ?? "", /Child intercom target:|child-worker/);
 			assert.deepEqual(sent[0]?.details, {
 				id: requestId,
 				requestId,

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -83,11 +83,11 @@ function writeRequest(input: { sessionId: string; runId: string; agent?: string;
 	return requestId;
 }
 
-function makePi(options: { tools: Map<string, SupervisorTool>; onSend?: () => void }): Record<string, unknown> {
+function makePi(options: { tools: Map<string, SupervisorTool>; onSend?: (message: { content: string }) => void }): Record<string, unknown> {
 	return {
 		getAllTools: () => [...options.tools.keys()].map((name) => ({ name })),
 		registerTool: (tool: { name: string } & SupervisorTool) => { options.tools.set(tool.name, tool); },
-		sendMessage: () => { options.onSend?.(); },
+		sendMessage: (message: { content: string }) => { options.onSend?.(message); },
 		getSessionName: () => "shared-name",
 	};
 }
@@ -545,7 +545,9 @@ describe("supervisor ask registration", () => {
 		let attempts = 0;
 		let accepted = 0;
 		let requestFile = "";
-		const pi = makePi({ tools, onSend: () => {
+		let visibleText = "";
+		const pi = makePi({ tools, onSend: (message) => {
+			visibleText = message.content;
 			attempts++;
 			assert.equal(fs.existsSync(requestFile), true, "retain the update until sendMessage returns");
 			if (attempts === 1) throw new Error("notification not accepted");
@@ -566,6 +568,8 @@ describe("supervisor ask registration", () => {
 			assert.equal(attempts, 2);
 			assert.equal(accepted, 1);
 			assert.equal(fs.existsSync(requestFile), false);
+			assert.ok(visibleText.includes(`Live guidance: subagent({ action: "steer", id: "${runId}", index: 0, message: "..." })`));
+			assert.doesNotMatch(visibleText, /Reply with:|replyTo:|Child intercom target:/);
 			await tool.execute("after-acceptance", { action: "pending" });
 			assert.equal(attempts, 2);
 			assert.equal(accepted, 1);


### PR DESCRIPTION
## Summary
- Expose only the implemented native supervisor actions: list, pending, status, and reply.
- Replace the misleading native intercom target with correlated reply and current-run/index steering guidance.
- Preserve external pi-intercom, internal targets, reply handling, and steering semantics.

Fixes #2002. Thanks to [@rtbe](https://github.com/rtbe) for the report; credit is also in CHANGELOG.md.

## Validation
- Red-before regression checks reproduced the exposed-schema and routing-hint failures.
- 82 focused tests passed; typecheck and diff hygiene passed.
- Retained-writer simplification folded assertions into existing tests.
- Fresh read-only review of 6d58f90de8a9aa5b11d9705f997c64745f4d212a: no issues found.
- Full cross-platform CI and Greptile gates remain required before merge.