### PR TITLE
refactor: simplify unreleased workflows and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Let trusted extensions register session-scoped named workflows with validated arguments and exact host-command grants (#1907).
 
 ### Fixed
+- Retain unreadable stop requests for retry, reject workflow argument validation failures with empty error messages, and preserve worktree setup timeout causes.
 - Align native supervisor actions and reply/steer routing hints with supported routes. Thanks to [@rtbe](https://github.com/rtbe) for #2002.
 - Renew native async result delivery after visible early failure and deferred publication, without idle polling (#1981). Thanks to [@brandonmwest](https://github.com/brandonmwest).
 - Keep native child acceptance instructions verbatim in session system resources across compaction (#1996). Thanks to reporter [@Zsbyqx20](https://github.com/Zsbyqx20).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -54,9 +54,9 @@ For compact chat results with FleetView as the only live editor surface, merge t
 }
 ```
 
-- `inlineToolDisplay: "summary"` keeps one static result row per call, alongside its call heading. It does not erase history or collapse different calls for one run. A completed status query is not proof that the queried child has finished.
+- `inlineToolDisplay: "summary"` keeps one static result row per call, alongside its call heading. A completed status query is not proof that the queried child has finished.
 - `fleetView: true` retains live progress. Open `/subagents-fleet` or press `Ctrl+Alt+F` for details instead of repeatedly requesting status just to watch progress. Pi's expand key does not expand summary results; keep `"rich"` if you want expandable inline output.
-- `asyncWidget: false` hides only the additional under-editor async widget, leaving FleetView available. Both surfaces are enabled by default. This configuration reduces visible surfaces; it does not guarantee ordering relative to other extensions.
+- `asyncWidget: false` hides only the additional under-editor async widget, leaving FleetView available. This configuration reduces visible surfaces; it does not guarantee ordering relative to other extensions.
 
 Thanks to [DraconDev](https://github.com/DraconDev) for reporting the display noise and suggesting summary mode in [#1931](https://github.com/nicobailon/pi-subagents/issues/1931).
 

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -580,12 +580,7 @@ function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, Pendin
 		description: "Native pi-subagents supervisor channel. Use reply/pending/status to answer child subagent requests without overriding pi-intercom.",
 		parameters: IntercomParamsSchema,
 		async execute(_id, params) {
-			// Scan the channel root before answering. `refreshPendingRequests` only re-evaluates asks
-			// ALREADY in `pending`; it never reads the filesystem. Because no fs watcher is installed on
-			// darwin and the 500ms poller is demand-gated and self-cancelling, an ask written while
-			// nothing was polling stayed invisible and every `action:"pending"` reported "No pending
-			// supervisor requests" while the child blocked in contact_supervisor. An explicit supervisor
-			// query must always be authoritative against disk.
+			// Discover new request files even when demand-gated polling is idle.
 			discover();
 			refreshPendingRequests(pending, state, onLifecycle, runState);
 			const input = params as IntercomParams;
@@ -716,10 +711,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 
 	const poll = (): void => {
 		cleanupStaleChannelsIfDue();
-		// Registration must not require a live UI context. Returning early whenever
-		// `state.lastUiContext` was null (never set yet, or nulled by a stale-context error) meant an
-		// ask written by a child was never read off disk, so `subagent_supervisor({action:"pending"})`
-		// reported nothing. The queue is authoritative; only the display notification needs the context.
+		// Only display notifications require a live UI context, not request registration.
 		refreshPendingRequests(pending, state, observeRequestLifecycle, runState);
 		const now = Date.now();
 		for (const { channelDir, file } of listRequestFiles()) {

--- a/src/runs/background/async-status-snapshot.ts
+++ b/src/runs/background/async-status-snapshot.ts
@@ -1,6 +1,6 @@
 import type { AsyncJobState, SubagentState } from "../../shared/types.ts";
 import {
-	projectAsyncStatusSnapshot,
+	projectAsyncStatusSnapshot as buildAsyncStatusSnapshot,
 	type AsyncStatusSnapshotOptions,
 	type AsyncStatusSnapshot,
 } from "../shared/async-status-projection.ts";
@@ -23,9 +23,7 @@ export type {
 
 export const ASYNC_STATUS_SNAPSHOT_WIDGET_PREFIX = "PI_SUBAGENT_ASYNC_JSON:";
 
-export function buildAsyncStatusSnapshot(jobs: Iterable<AsyncJobState>, options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshot {
-	return projectAsyncStatusSnapshot(jobs, options);
-}
+export { buildAsyncStatusSnapshot };
 
 export function asyncStatusSnapshotJobsForState(state: SubagentState | undefined, sessionId: string | null | undefined): AsyncJobState[] {
 	if (!state || !sessionId || state.currentSessionId !== sessionId) return [];

--- a/src/runs/background/control-channel.ts
+++ b/src/runs/background/control-channel.ts
@@ -395,17 +395,26 @@ function parseStopRequest(raw: unknown): StopRequest | undefined {
 function consumeStopRequestFile(
 	requestPath: string,
 	fsImpl: Pick<typeof fs, "rmSync" | "readFileSync">,
+	onError?: (error: unknown) => void,
 ): StopRequest | undefined {
+	let text: string;
+	try {
+		text = fsImpl.readFileSync(requestPath, "utf-8");
+	} catch (error) {
+		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) onError?.(error);
+		return undefined;
+	}
 	let request: StopRequest | undefined;
 	try {
-		request = parseStopRequest(JSON.parse(fsImpl.readFileSync(requestPath, "utf-8")));
+		request = parseStopRequest(JSON.parse(text));
 	} catch {
 		request = undefined;
 	}
 	try {
 		fsImpl.rmSync(requestPath, { force: true, recursive: true });
-	} catch {
-		// Already removed by a concurrent check — do not execute it twice.
+	} catch (error) {
+		// Execute only after successful removal.
+		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) onError?.(error);
 		return undefined;
 	}
 	return request;
@@ -414,6 +423,7 @@ function consumeStopRequestFile(
 export function consumeStopRequestPayloads(
 	asyncDir: string,
 	fsImpl: Pick<typeof fs, "existsSync" | "rmSync" | "readdirSync" | "readFileSync"> = fs,
+	onError?: (error: unknown) => void,
 ): StopRequest[] {
 	const dir = stopRequestsDir(asyncDir);
 	const requests: StopRequest[] = [];
@@ -421,18 +431,19 @@ export function consumeStopRequestPayloads(
 		let entries: string[];
 		try {
 			entries = fsImpl.readdirSync(dir).filter((name) => name.endsWith(".json")).sort();
-		} catch {
+		} catch (error) {
+			if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) onError?.(error);
 			entries = [];
 		}
 		for (const entry of entries) {
-			const request = consumeStopRequestFile(path.join(dir, entry), fsImpl);
+			const request = consumeStopRequestFile(path.join(dir, entry), fsImpl, onError);
 			if (request) requests.push(request);
 		}
 	}
 
 	const legacyPath = stopRequestPath(asyncDir);
 	if (fsImpl.existsSync(legacyPath)) {
-		const request = consumeStopRequestFile(legacyPath, fsImpl);
+		const request = consumeStopRequestFile(legacyPath, fsImpl, onError);
 		if (request) requests.push(request);
 	}
 	return requests.sort((left, right) => (left.ts ?? 0) - (right.ts ?? 0));
@@ -527,7 +538,7 @@ export function watchAsyncControlInbox(
 	const check = (): void => {
 		if (disposed) return;
 		try {
-			if (opts.onStop) for (const request of consumeStopRequestPayloads(asyncDir, fsImpl)) {
+			if (opts.onStop) for (const request of consumeStopRequestPayloads(asyncDir, fsImpl, (error) => report(error, "scan"))) {
 				try { opts.onStop(request); } catch (error) { report(error, "callback"); }
 			}
 			if (opts.onTimeout && consumeTimeoutRequest(asyncDir, fsImpl)) {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3408,15 +3408,6 @@ function resolveSingleRunOutputBaseDir(deps: ExecutorDeps, artifactsDir: string,
 	return resolveConfiguredSingleRunOutputBaseDir(deps) ?? path.join(artifactsDir, "outputs", sanitizeRunPathSegment(runId));
 }
 
-function resolveWorkflowAggregateOutputPath(
-	output: string | boolean | undefined,
-	ctxCwd: string,
-	workflowCwd: string,
-	outputBaseDir: string,
-): string | undefined {
-	return resolveSingleOutputPath(output, ctxCwd, workflowCwd, outputBaseDir);
-}
-
 function workflowChildDefaultOutput(aggregateOutputPath: string | undefined, artifactsDir: string, workflowRunId: string, workflowKey: string): string {
 	if (aggregateOutputPath) {
 		const parsed = path.parse(aggregateOutputPath);
@@ -5399,7 +5390,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					const { action: _action, agent: _agent, task: _task, resume: _resume, tasks: _tasks, chain: _chain, concurrency: _concurrency, foregroundOnly: _foregroundOnly, clarify: _clarify, timeoutMs: _timeoutMs, maxRuntimeMs: _maxRuntimeMs, usageBudget: _usageBudget, missionId: _missionId, mission: _mission, preflight: _preflight, globalConcurrencyLimit: _globalConcurrencyLimit, maxSubagentSpawnsPerRun: _maxSubagentSpawnsPerRun, ...workflowChildDefaults } = workflowRequest;
 					const workflowOutput = typeof workflowChildDefaults.output === "string" || typeof workflowChildDefaults.output === "boolean" ? workflowChildDefaults.output : undefined;
 					const configuredOutputBaseDir = resolveConfiguredSingleRunOutputBaseDir(deps);
-					const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, parentCwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, workflowRunId));
+					const workflowAggregateOutputPath = resolveSingleOutputPath(workflowOutput, parentCwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, workflowRunId));
 					const claimedOutputPaths = new Map<string, string>();
 					const childOutputOverrides = new Map<string, string>();
 					const childOutputClaimPaths = new Map<string, string>();
@@ -5756,7 +5747,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const { workflowScript: _workflowScript, action: _action, agent: _agent, task: _task, resume: _resume, tasks: _tasks, chain: _chain, concurrency: _concurrency, async: _async, foregroundOnly: _foregroundOnly, clarify: _clarify, timeoutMs: _timeoutMs, maxRuntimeMs: _maxRuntimeMs, usageBudget: _usageBudget, chatProgress: _chatProgress, missionId: _missionId, mission: _mission, preflight: _preflight, globalConcurrencyLimit: _globalConcurrencyLimit, maxSubagentSpawnsPerRun: _maxSubagentSpawnsPerRun, ...workflowChildDefaults } = requestParams;
 			const workflowOutput = typeof workflowChildDefaults.output === "string" || typeof workflowChildDefaults.output === "boolean" ? workflowChildDefaults.output : undefined;
 			const configuredOutputBaseDir = resolveConfiguredSingleRunOutputBaseDir(deps);
-			const workflowAggregateOutputPath = resolveWorkflowAggregateOutputPath(workflowOutput, ctx.cwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, foregroundWorkflowRunId));
+			const workflowAggregateOutputPath = resolveSingleOutputPath(workflowOutput, ctx.cwd, workflowCwd, resolveSingleRunOutputBaseDir(deps, workflowArtifactsDir, foregroundWorkflowRunId));
 			const claimedOutputPaths = new Map<string, string>();
 			const childOutputOverrides = new Map<string, string>();
 			const childOutputClaimPaths = new Map<string, string>();

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -1,4 +1,4 @@
-import { splitKnownThinkingSuffix, type ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
+import { splitKnownThinkingSuffix as splitThinkingSuffix, type ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
 import type { Usage } from "../../shared/types.ts";
 import { filterFallbackCandidates, findModelExclusion, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
 import { checkModelScope, type ModelScopeCheckRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
@@ -14,9 +14,7 @@ interface ModelAttemptSummary {
 	usage?: Usage;
 }
 
-export function splitThinkingSuffix(model: string): { baseModel: string; thinkingSuffix: string } {
-	return splitKnownThinkingSuffix(model);
-}
+export { splitThinkingSuffix };
 
 /** Aliases apply only to the resolved launch candidate (without its thinking suffix) and the exact raw response ID. */
 export function formatSubagentModelVerificationError(

--- a/src/runs/shared/readonly-drain-observation.ts
+++ b/src/runs/shared/readonly-drain-observation.ts
@@ -22,7 +22,7 @@ export class ReadonlyDrainObservation {
 		this.check();
 	}
 	/** Called at the existing initial read, before reconciliation or filtering. */
-	readonly status = (status: { sessionId?: unknown; state?: unknown } | null): void => {
+	readonly status: RawDrainStatusObserver = (status) => {
 		if (!status || typeof status.sessionId !== "string" || !status.sessionId
 			|| !knownStates.has(status.state as string)) this.deny();
 		else if (status.sessionId === this.file && (status.state === "queued" || status.state === "running")) this.deny();

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -255,7 +255,6 @@ class SetupTransaction {
 	}
 	async gitChecked(cwd: string, args: string[]): Promise<string> {
 		const result = await this.git(cwd, args);
-		if (result.status !== 0) throw new Error(result.stderr.trim() || result.stdout.trim() || `git ${args.join(" ")} failed`);
 		return result.stdout;
 	}
 	attempt(index: number, branch: string, worktreePath?: string): void {
@@ -815,18 +814,9 @@ async function runWorktreeSetupHook(
 			hookTimeoutMs: hook.timeoutMs,
 		});
 	} catch (error) {
-		const code = error instanceof Error && "code" in error ? error.code : undefined;
-		if (code === "ETIMEDOUT") {
-			throw new Error(`worktree setup hook timed out after ${hook.timeoutMs}ms`);
-		}
 		throw new Error(`worktree setup hook failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
 	}
 	tx.progress.phase = "hook-validation";
-
-	if (result.status !== 0) {
-		const details = result.stderr.trim() || result.stdout.trim() || "no output";
-		throw new Error(`worktree setup hook failed with exit code ${result.status}: ${details}`);
-	}
 
 	try {
 		const output = parseWorktreeSetupHookOutput(result.stdout);
@@ -900,11 +890,7 @@ async function createNativeWorktree(
 	if (branch.status !== 1 || pathExists) throw new Error(`worktree path or branch already exists: ${worktreePath}, ${naming.requestedBranch}`);
 	tx.attempt(index, naming.requestedBranch, worktreePath);
 	ensureProjectWorktreeDir(dedicatedRoot, toplevel);
-	const add = await tx.git(toplevel, ["worktree", "add", worktreePath, "-b", naming.requestedBranch, baseCommit]);
-	if (add.status !== 0) {
-		const message = add.stderr.trim() || add.stdout.trim() || `failed to create worktree ${worktreePath}`;
-		throw new Error(message);
-	}
+	await tx.git(toplevel, ["worktree", "add", worktreePath, "-b", naming.requestedBranch, baseCommit]);
 	const worktree: WorktreeInfo = {
 		path: worktreePath,
 		agentCwd: worktreePath,
@@ -958,10 +944,6 @@ async function createWorktrunkWorktree(
 	tx.attempt(index, naming.requestedBranch);
 	const result = await tx.command("wt", args, { cwd: toplevel, maxBuffer: WORKTREE_COMMAND_OUTPUT_MAX_BYTES });
 	tx.progress.phase = "validation";
-	if (result.status !== 0) {
-		const message = result.error?.message || result.stderr.trim() || result.stdout.trim() || "Worktrunk provisioning failed";
-		throw new Error(`Worktrunk provisioning failed: ${message}`);
-	}
 	try {
 		const output = parseWorktrunkSwitchOutput(result.stdout);
 		if (output.action !== "created" || output.created_branch !== true || output.branch !== naming.requestedBranch || output.base_branch !== baseCommit) {

--- a/src/workflows/workflow-checklist.ts
+++ b/src/workflows/workflow-checklist.ts
@@ -1,6 +1,6 @@
 import type { AsyncJobStep, HostStepNode, WorkflowGraphNode, WorkflowGraphSnapshot, WorkflowPreflightLane, WorkflowPreflight } from "../shared/types.ts";
 import { sanitizeDisplayText } from "../shared/display-text.ts";
-import { workflowPreflightLaneForRuntimeKey } from "./workflow-preflight.ts";
+import { workflowPreflightLaneForRuntimeKey as laneFor } from "./workflow-preflight.ts";
 
 export type WorkflowChecklistState = "complete" | "running" | "queued" | "blocked" | "failed" | "paused" | "stopped";
 
@@ -188,10 +188,6 @@ function duration(step: Pick<WorkflowChecklistStep, "durationMs" | "startedAt" |
 	if (startedAt === undefined) return undefined;
 	const end = state === "running" ? now : finite(step.endedAt) ?? now;
 	return end === undefined ? undefined : Math.max(0, end - startedAt);
-}
-
-function laneFor(preflight: WorkflowPreflight | undefined, key: string, preferredKeys: readonly (string | undefined)[] = []): WorkflowPreflightLane | undefined {
-	return workflowPreflightLaneForRuntimeKey(preflight, key, preferredKeys);
 }
 
 function stepKey(step: WorkflowChecklistStep): string | undefined {

--- a/src/workflows/workflow-resources.ts
+++ b/src/workflows/workflow-resources.ts
@@ -125,7 +125,7 @@ function validatePlainJson(value: unknown, path: string, depth = 0): void {
 	}
 }
 
-function normalizeArgs(value: unknown): { args?: Record<string, unknown>; error?: string } {
+function normalizeArgs(value: unknown): { args: Record<string, unknown> } | { error: string } {
 	if (value === undefined) return { args: {} };
 	if (!isPlainRecord(value)) return { error: "workflow args must be a plain JSON object." };
 	try {
@@ -192,8 +192,8 @@ function resolveResource(nameValue: unknown, argsValue?: unknown, sessionId?: st
 	const resource = findWorkflowResource(name) ?? (sessionId ? registry().bySession.get(sessionId)?.get(name) : undefined);
 	if (!resource) return { ok: false, error: `Unknown workflow resource '${name}'. Available resources: ${listWorkflowResourceNames().join(", ")}.` };
 	const normalizedArgs = normalizeArgs(argsValue);
-	if (normalizedArgs.error) return { ok: false, error: normalizedArgs.error };
-	const resolved = resource.resolve(normalizedArgs.args!);
+	if ("error" in normalizedArgs) return { ok: false, error: normalizedArgs.error };
+	const resolved = resource.resolve(normalizedArgs.args);
 	if (resolved && typeof (resolved as unknown as { then?: unknown }).then === "function") {
 		void Promise.resolve(resolved).catch(() => {});
 		throw new Error("Workflow resource resolve must be synchronous.");

--- a/test/integration/result-publication.test.ts
+++ b/test/integration/result-publication.test.ts
@@ -261,13 +261,7 @@ describe("native runner result publication", { skip: !available ? "pi packages u
 			const owner = "publication-owner";
 			const asyncDir = path.join(ASYNC_DIR, id);
 			const resultPath = path.join(RESULTS_DIR, `${id}.json`);
-			const state: SubagentState = {
-				baseCwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner,
-				asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null,
-				cleanupTimers: new Map(), lastUiContext: null, poller: null, completionSeen: new Map(),
-				watcher: null, watcherRestartTimer: null,
-				resultFileCoalescer: { schedule: () => false, clear() {} },
-			};
+			const state = publicationState(sessionId, owner);
 			let poll: ReturnType<typeof setInterval> | undefined;
 			let delivered = 0;
 			let complete!: () => void;

--- a/test/integration/workflow-result-publication.test.ts
+++ b/test/integration/workflow-result-publication.test.ts
@@ -29,11 +29,11 @@ describe("host workflow result publication", { skip: !available }, () => {
 		let statusWrites = 0, statusDeferred = false, statusRecovered = false;
 		let poll: ReturnType<typeof setInterval> | undefined;
 		const sessionId = "workflow-publication-session", owner = "workflow-publication-owner";
-		const state = { baseCwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner,
+		const state: SubagentState = { baseCwd: tempDir, currentSessionId: sessionId, completionOwnerId: owner,
 			asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null,
 			cleanupTimers: new Map(), lastUiContext: null, poller: null, completionSeen: new Map(),
 			watcher: null, watcherRestartTimer: null, resultFileCoalescer: { schedule: () => false, clear() {} },
-		} as SubagentState;
+		};
 		const pi = { getSessionName: () => undefined, events: { on: () => () => {}, emit(event: string, data: unknown) {
 			if (event === SUBAGENT_ASYNC_COMPLETE_EVENT) { assert.equal((data as { completionOwnerId: string }).completionOwnerId, owner); delivered.resolve(); }
 		} }, sendMessage() { notifications++; } };

--- a/test/unit/acceptance-compaction.test.ts
+++ b/test/unit/acceptance-compaction.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { it } from "node:test";
+import type { AgentSessionEvent, SessionBeforeCompactEvent } from "@earendil-works/pi-coding-agent";
 import { createDefaultChildSessionFactory, type PiCodingAgentModule } from "../../src/runs/shared/child-session.ts";
 import { runSync } from "../../src/runs/foreground/execution.ts";
 import { runSingleStepInner } from "../../src/runs/background/subagent-runner.ts";
@@ -34,8 +35,8 @@ for (const host of ["foreground", "runner"] as const) {
 			const protocol = formatAcceptancePrompt(acceptance, { structuredOutput: structured });
 			const report = { criteriaSatisfied: [{ id: "read-marker", status: "satisfied", evidence: "WORK_EVIDENCE" }], changedFiles: [], testsAddedOrUpdated: [], residualRisks: ["none"], commandsRun: [{ command: "read marker.txt", result: "passed", summary: "WORK_EVIDENCE" }], noStagedFiles: true };
 			const requests: any[] = [];
-			const preparations: any[] = [];
-			const events: any[] = [];
+			const preparations: SessionBeforeCompactEvent["preparation"][] = [];
+			const events: AgentSessionEvent[] = [];
 			let prompts = 0;
 			let creates = 0;
 			let reads = 0;
@@ -86,12 +87,13 @@ for (const host of ["foreground", "runner"] as const) {
 				const result = host === "foreground"
 					? await runSync(cwd, [agent], agent.name, task, { acceptance: explicit, structuredOutput, waitToolEnabled: false, childSessionFactory: observedFactory })
 					: await runSingleStepInner({ ...agent, agent: agent.name, task, context: "fresh", effectiveAcceptance: acceptance, structuredOutput, modelCandidates: [agent.model!], waitToolEnabled: false }, { cwd, id: "compact-runner", flatIndex: 0, flatStepCount: 1, previousOutput: "", placeholder: "{previous}", outputFile: join(cwd, "output.log"), sessionEnabled: false, childSessions: observedFactory });
-				assert.equal(result.exitCode, 0, `${result.error}; ${JSON.stringify(events.filter((e) => e.type.includes("compact") || (e.type === "message_end" && e.message?.stopReason === "error")))}`);
+				assert.equal(result.exitCode, 0, `${result.error}; ${JSON.stringify(events.filter((e) => e.type.includes("compact") || (e.type === "message_end" && e.message.role === "assistant" && e.message.stopReason === "error")))}`);
 				assert.equal(result.acceptance?.status, "checked");
 				if (structured) assert.deepEqual(result.structuredOutput, { ok: true });
 				assert.equal(creates, 1); assert.equal(prompts, 1, "no replay or correction prompt");
 				assert.equal(summaries, 1);
 				assert.equal(preparations.length, 1);
+				assert.ok(preparations[0]);
 				assert.equal(preparations[0].isSplitTurn, true);
 				assert.ok(JSON.stringify(preparations[0].turnPrefixMessages).includes("UNIQUE_TASK"));
 				assert.equal(events.filter((e) => e.type === "tool_execution_end" && e.toolName === "read").length, 1);

--- a/test/unit/control-channel.test.ts
+++ b/test/unit/control-channel.test.ts
@@ -667,6 +667,39 @@ describe("control channel: watchAsyncControlInbox", () => {
 });
 
 describe("control inbox diagnostics and active-owner cost", () => {
+	for (const operation of ["read", "remove"] as const) it(`retries stop request ${operation} failures without losing readable siblings`, () => {
+		const asyncDir = tmpAsyncDir("pi-stop-retry-");
+		const denied = Object.assign(new Error("denied"), { code: "EACCES" });
+		const pending = requestAsyncStop(asyncDir, { childId: "retry" });
+		requestAsyncStop(asyncDir, { childId: "ready" });
+		const seen: string[] = [], failures: unknown[] = [];
+		let failing = true, tick = () => {};
+		const dispose = watchAsyncControlInbox(asyncDir, {
+			onStop: (request) => seen.push(request.childId!),
+			onError: (error, phase) => { assert.equal(phase, "scan"); failures.push(error); },
+			platform: "darwin",
+			fs: { ...fs, readFileSync: ((...args: Parameters<typeof fs.readFileSync>) => {
+				if (failing && operation === "read" && args[0] === pending) throw denied;
+				return fs.readFileSync(...args);
+			}) as typeof fs.readFileSync, rmSync: (target, options) => {
+				if (failing && operation === "remove" && target === pending) throw denied;
+				fs.rmSync(target, options);
+			} },
+			timers: { setInterval: ((handler: () => void) => { tick = handler; return { unref() {} }; }) as unknown as typeof setInterval, clearInterval() {} },
+		});
+		try {
+			assert.deepEqual(seen, ["ready"]);
+			assert.deepEqual(failures, [denied]);
+			assert.equal(fs.existsSync(pending), true);
+			failing = false;
+			tick();
+			assert.deepEqual(seen, ["ready", "retry"]);
+			assert.equal(fs.existsSync(pending), false);
+			tick();
+			assert.deepEqual(seen, ["ready", "retry"]);
+		} finally { dispose(); cleanup(asyncDir); }
+	});
+
 	it("reports scan/read/install failures, retains retryable files, and distinguishes healthy watch fallback", () => {
 		const asyncDir = tmpAsyncDir("pi-steer-diagnostics-");
 		const failures: string[] = [];

--- a/test/unit/readonly-session-evidence.test.ts
+++ b/test/unit/readonly-session-evidence.test.ts
@@ -27,7 +27,7 @@ import { resolveChildWatchdogConfig } from "../../src/watchdog/child-status.ts";
 import { DEFAULT_WATCHDOG_CONFIG } from "../../src/watchdog/settings.ts";
 import { DEFAULT_CONTROL_CONFIG } from "../../src/runs/shared/subagent-control.ts";
 
-function launch(cwd: string): ChildSessionLaunch {
+function launch(cwd: string): ChildSessionLaunch & { storage: Extract<ChildSessionLaunch["storage"], { kind: "file" }> } {
 	return { cwd, storage: { kind: "file", sessionFile: join(cwd, "session.jsonl") }, model: "baseten/model-a", tools: ["read"], extensionPaths: [],
 		ambientExtensions: false, hooks: [], noSkills: true, noContextFiles: true,
 		runtime: { fanoutChild: false, fast: false, depth: 1, waitTool: { enabled: false } } };
@@ -131,7 +131,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	}
 	type NativeSession = Awaited<ReturnType<PiCodingAgentModule["createAgentSession"]>>["session"];
 	type Captured = { session: NativeSession; original: NativeSession["agent"]["streamFunction"]; runtime: NonNullable<Parameters<PiCodingAgentModule["createAgentSession"]>[0]>["modelRuntime"] };
-	async function fixture(run: (f: { pi: PiCodingAgentModule; cwd: string; agentDir: string; l: ChildSessionLaunch; factory: ReturnType<typeof createDefaultChildSessionFactory>; captured: Captured[]; acknowledge: (id: string) => void; requests: { body: Record<string, unknown> }[]; setResponses: (responses: (() => Response | Promise<Response>)[]) => void }) => Promise<void>, settings: Record<string, unknown> = {}, fresh = false) {
+	async function fixture(run: (f: { pi: PiCodingAgentModule; cwd: string; agentDir: string; l: ReturnType<typeof launch>; factory: ReturnType<typeof createDefaultChildSessionFactory>; captured: Captured[]; acknowledge: (id: string) => void; requests: { body: Record<string, unknown> }[]; setResponses: (responses: (() => Response | Promise<Response>)[]) => void }) => Promise<void>, settings: Record<string, unknown> = {}, fresh = false) {
 		const realPi = await sdk();
 		const cwd = mkdtempSync(join(tmpdir(), "readonly-factory-"));
 		const agentDir = join(cwd, "agent"); mkdirSync(agentDir);
@@ -144,7 +144,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 		const l = launch(cwd);
 		l.hooks = createChildHooks(l.runtime);
 		if (!fresh) {
-			const manager = realPi.SessionManager.open((l.storage as { sessionFile: string }).sessionFile, undefined, cwd);
+			const manager = realPi.SessionManager.open(l.storage.sessionFile, undefined, cwd);
 			manager.appendMessage({ role: "user", content: "Earlier context", timestamp: 1 });
 			manager.appendMessage({ role: "assistant", content: [{ type: "text", text: "Earlier answer" }], api: "openai-completions", provider: "baseten", model: "model-a", stopReason: "stop", timestamp: 2, usage: { ...usage, input: 101, output: 103, totalTokens: 204, cost: { ...usage.cost, total: 2 } } });
 		}
@@ -185,10 +185,9 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 		}
 	}
 
-	function resolvedLaunch(l: ChildSessionLaunch, model = "baseten/model-a") {
-		assert.equal(l.storage.kind, "file");
+	function resolvedLaunch(l: ReturnType<typeof launch>, model = "baseten/model-a") {
 		return buildInProcessChildLaunch({
-			cwd: l.cwd, host: "parent", sessionEnabled: true, sessionFile: (l.storage as { sessionFile: string }).sessionFile,
+			cwd: l.cwd, host: "parent", sessionEnabled: true, sessionFile: l.storage.sessionFile,
 			model, tools: ["read"], requireReadTool: true, allowNestedSubagents: false, waitToolEnabled: false,
 			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
 			parentSessionId: "resolved-parent", runId: "resolved-run", childAgentName: "reader", childIndex: 0,
@@ -198,7 +197,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 
 	for (const scenario of ["success", "retained", "cross-provider-skip", "no-sibling", "second429", "sibling-startup", "sibling-abort", "unverified-sibling", "wrong-model", "changed-file", "missing-file", "cancel-at-create", "deadline-at-create", "usage-budget", "tool-budget", "wait-profile", "directory", "text429", "stop-at-settlement", "steer-at-settlement", "smaller-model"] as const) {
 		it(`actual foreground owned continuation loop: ${scenario}`, async (test) => fixture(async ({ pi, l, factory, requests, setResponses, captured, cwd, agentDir }) => {
-			const file = (l.storage as { sessionFile: string }).sessionFile;
+			const file = l.storage.sessionFile;
 			if (scenario === "retained") {
 				const manager = pi.SessionManager.open(file, undefined, cwd);
 				manager.appendMessage({ role: "assistant", content: [{ type: "text", text: "Earlier billed answer" }], api: "openai-completions", provider: "baseten", model: "model-a", stopReason: "stop", timestamp: 3, usage: { ...usage, input: 100, output: 100, totalTokens: 200 } });
@@ -326,7 +325,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	}
 
 	it("certifies explicitly test-opted-in actual foreground and sibling with no admission/dispatch/settlement native scans", async () => countAsyncIO(async (io) => fixture(async ({ l, factory, captured, requests, setResponses, cwd }) => {
-		const file = (l.storage as { sessionFile: string }).sessionFile;
+		const file = l.storage.sessionFile;
 		assert.equal(existsSync(file), false, "fixture never preinitializes the assigned file");
 		const agent: AgentConfig = {
 			name: "reader", description: "Read only", systemPrompt: "Retain the completed read.", systemPromptMode: "append",
@@ -387,10 +386,10 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 		assert.deepEqual(inputs.map((input) => input.storage), [{ kind: "file", sessionFile: file }, { kind: "file", sessionFile: file }]);
 	}, {}, true)));
 
-	function runnerLaunch(l: ChildSessionLaunch, model = "baseten/model-a", overrides: Partial<RunnerSubagentStep> = {}, context = {}) {
+	function runnerLaunch(l: ReturnType<typeof launch>, model = "baseten/model-a", overrides: Partial<RunnerSubagentStep> = {}, context = {}) {
 		const step: RunnerSubagentStep = {
 			agent: "reader", task: "Runner original task: read marker.txt once", context: "fresh",
-			sessionFile: (l.storage as { sessionFile: string }).sessionFile, parentSessionId: "runner-parent",
+			sessionFile: l.storage.sessionFile, parentSessionId: "runner-parent",
 			tools: ["read"], extensions: [], allowNestedSubagents: false, waitToolEnabled: false,
 			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
 			systemPrompt: "Retain the completed read.", ...overrides,
@@ -428,7 +427,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 			const exclusionsPath = getExclusionsFilePath();
 			const exclusionsBefore = existsSync(exclusionsPath) ? readFileSync(exclusionsPath, "utf8") : undefined;
 			if (kind !== "equal window") enlargeRunnerSibling(agentDir);
-			const file = (l.storage as { sessionFile: string }).sessionFile;
+			const file = l.storage.sessionFile;
 			const step = ownedRunnerStep(cwd, file);
 			if (kind === "retained image" || kind === "retained context too large") {
 				pi.SessionManager.open(file, undefined, cwd).appendMessage({ role: "user", timestamp: 3,
@@ -513,7 +512,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 
 	it("owned run deadline without step timeout vetoes creation before timer delivery", async () => fixture(async ({ cwd, agentDir, l, factory, requests, setResponses }) => {
 		enlargeRunnerSibling(agentDir);
-		const file = (l.storage as { sessionFile: string }).sessionFile;
+		const file = l.storage.sessionFile;
 		const step = ownedRunnerStep(cwd, file);
 		assert.equal(step.timeoutMs, undefined);
 		const asyncDir = join(cwd, "deadline-async");
@@ -559,7 +558,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	for (const kind of ["unconfigured", "available tokens", "exhausted tokens", "concurrent exhausted tokens", "concurrent unknown tokens", "cost unknown"] as const) {
 		it(`owned run ledger and final publication: ${kind}`, async () => fixture(async ({ cwd, agentDir, l, factory, requests, setResponses }) => {
 			enlargeRunnerSibling(agentDir);
-			const step = ownedRunnerStep(cwd, (l.storage as { sessionFile: string }).sessionFile);
+			const step = ownedRunnerStep(cwd, l.storage.sessionFile);
 			const concurrent = kind.startsWith("concurrent");
 			const unknown = kind === "concurrent unknown tokens";
 			const asyncDir = join(cwd, "owned-async");
@@ -617,7 +616,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	}
 
 	for (const optedIn of [false, true]) it(`actual native runner construction and mandatory captures, evidence opt-in=${optedIn}`, async () => countAsyncIO(async (io) => fixture(async ({ l, factory, captured, acknowledge, requests, setResponses, cwd }) => {
-		const file = (l.storage as { sessionFile: string }).sessionFile;
+		const file = l.storage.sessionFile;
 		assert.equal(existsSync(file), false);
 		const children: ChildSession[] = [];
 		let expected: SettledReadonlyEvidence | undefined;
@@ -717,7 +716,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 		const childWatchdog = resolveChildWatchdogConfig({ config: { ...DEFAULT_WATCHDOG_CONFIG, enabled: true, children: { ...DEFAULT_WATCHDOG_CONFIG.children, enabled: true } } });
 		assert.ok(childWatchdog);
 		const sink = () => {};
-		const built = buildRunnerChildLaunch({ agent: "reader", task: "read", sessionFile: (l.storage as { sessionFile: string }).sessionFile,
+		const built = buildRunnerChildLaunch({ agent: "reader", task: "read", sessionFile: l.storage.sessionFile,
 			tools: ["read"], extensions: [], allowNestedSubagents: false, waitToolEnabled: false,
 			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false },
 			{ cwd: l.cwd, id: "runner-watchdog", flatIndex: 0 }, { sessionEnabled: true, childWatchdog, watchdogStatus: sink });
@@ -744,7 +743,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 
 	for (const kind of ["empty preexisting", "corrupt preexisting", "appeared during open", "memory", "directory", "default"] as const) {
 		it(`does not certify fresh storage: ${kind}`, async () => fixture(async ({ l, factory, captured, setResponses }) => {
-			const file = (l.storage as { sessionFile: string }).sessionFile;
+			const file = l.storage.sessionFile;
 			if (kind === "empty preexisting") writeFileSync(file, "");
 			if (kind === "corrupt preexisting") writeFileSync(file, "corrupt\n");
 			const built = resolvedLaunch(l);
@@ -1002,7 +1001,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	for (const kind of ["dead-owned", "result-owned", "unrelated-dead", "unknown-owner", "completed-before-drain"] as const) {
 		it(`actual SDK receipt uses same-pass pre-repair evidence: ${kind}`, async () => fixture(async ({ l, factory, setResponses }) => {
 			const runId = `sdk-drain-${kind}`; const dir = join(DIRS.async, runId);
-			const file = (l.storage as { sessionFile: string }).sessionFile;
+			const file = l.storage.sessionFile;
 			mkdirSync(dir, { recursive: true });
 			const status = { runId, mode: "single", state: "running", startedAt: Date.now(), steps: [{ agent: "reader", status: "running" }],
 				sessionId: kind === "unrelated-dead" ? "/another/session" : kind === "unknown-owner" ? undefined : file,
@@ -1031,7 +1030,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 		l.hooks = createChildHooks(l.runtime);
 		const runId = "hook-existing-work";
 		const dir = join(DIRS.async, runId); mkdirSync(dir, { recursive: true });
-		writeFileSync(join(dir, "status.json"), JSON.stringify({ runId, state: "queued", mode: "single", startedAt: Date.now(), sessionId: (l.storage as { sessionFile: string }).sessionFile, steps: [{ agent: "worker", status: "pending" }] }));
+		writeFileSync(join(dir, "status.json"), JSON.stringify({ runId, state: "queued", mode: "single", startedAt: Date.now(), sessionId: l.storage.sessionFile, steps: [{ agent: "worker", status: "pending" }] }));
 		updateActiveRunIndex(dir, "queued");
 		try {
 			requestReadonlySessionEvidence(l); const child = await factory.create(l);
@@ -1061,15 +1060,6 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	it("cannot issue a receipt without the actual installed drain even after real read/429 and shutdown", async () => fixture(async ({ l, factory, setResponses }) => {
 		l.hooks = [];
 		requestReadonlySessionEvidence(l); const child = await factory.create(l);
-		setResponses([() => sse(true), () => http(429)]);
-		await child.prompt("Read marker.txt"); await child.dispose();
-		assert.equal(getReadonlySessionEvidence(child), undefined);
-	}));
-
-	it("leaves ordinary known-hook launches uninstrumented", async () => fixture(async ({ l, factory, captured, setResponses }) => {
-		l.hooks = createChildHooks(l.runtime);
-		const child = await factory.create(l);
-		assert.equal(captured[0].session.agent.streamFunction, captured[0].original);
 		setResponses([() => sse(true), () => http(429)]);
 		await child.prompt("Read marker.txt"); await child.dispose();
 		assert.equal(getReadonlySessionEvidence(child), undefined);
@@ -1288,7 +1278,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	}));
 
 	it("rejects an unresolved old call before SDK provider-context synthesis", async () => fixture(async ({ pi, l, factory, captured }) => {
-		const manager = pi.SessionManager.open((l.storage as { sessionFile: string }).sessionFile, undefined, l.cwd);
+		const manager = pi.SessionManager.open(l.storage.sessionFile, undefined, l.cwd);
 		manager.appendMessage({ role: "assistant", content: [{ type: "toolCall", id: "unresolved", name: "read", arguments: { path: "marker.txt" } }], api: "openai-completions", provider: "baseten", model: "model-a", stopReason: "toolUse", timestamp: 3, usage });
 		requestReadonlySessionEvidence(l); const child = await factory.create(l);
 		assert.equal(captured[0].session.agent.streamFunction, captured[0].original);
@@ -1297,7 +1287,7 @@ describe("native 0.85.1 factory evidence (synthetic transport, real configured M
 	}));
 
 	it("checks the settled active branch rather than flattening retired branches", async () => fixture(async ({ pi, l, factory, setResponses }) => {
-		const manager = pi.SessionManager.open((l.storage as { sessionFile: string }).sessionFile, undefined, l.cwd);
+		const manager = pi.SessionManager.open(l.storage.sessionFile, undefined, l.cwd);
 		const leaf = manager.getLeafId()!;
 		manager.appendMessage({ role: "assistant", content: [{ type: "toolCall", id: "retired-unresolved", name: "write", arguments: {} }], api: "openai-completions", provider: "baseten", model: "model-a", stopReason: "toolUse", timestamp: 3, usage });
 		manager.branch(leaf); manager.appendThinkingLevelChange("off");

--- a/test/unit/scheduled-supervisor-demand.test.ts
+++ b/test/unit/scheduled-supervisor-demand.test.ts
@@ -17,12 +17,12 @@ function fixture() {
 		cwd: root, hasUI: false,
 		sessionManager: { getSessionId: () => owner, getSessionFile: () => file, getEntries: () => [] },
 	});
-	const state = {
+	const state: SubagentState = {
 		baseCwd: root, currentSessionId: context().sessionManager.getSessionFile(), supervisorOwnerSessionId: initialOwner,
-		asyncJobs: new Map(), foregroundControls: new Map(), cleanupTimers: new Map(), lastUiContext: null,
+		asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null, cleanupTimers: new Map(), lastUiContext: null,
 		poller: null, completionSeen: new Map(), watcher: null, watcherRestartTimer: null,
 		resultFileCoalescer: { schedule: () => false, clear() {} },
-	} as SubagentState;
+	};
 	const intervals = new Map<object, () => void>();
 	const sent: string[] = [], cleanupDirs: string[] = [];
 	let starts = 0, activations = 0, terminal = () => {};

--- a/test/unit/workflow-resources.test.ts
+++ b/test/unit/workflow-resources.test.ts
@@ -208,6 +208,15 @@ describe("named workflow resources", () => {
 		}
 	});
 
+	it("rejects argument validation failures even when the error message is empty", () => {
+		const registration = registerWorkflowResource({ sessionId: "invalid-args", definition: {
+			name: "check-args", version: 1, resolve: () => assert.fail("invalid args reached the resolver"),
+		} });
+		try {
+			assert.deepEqual(resolveWorkflowResource("check-args", { get task() { throw new Error(""); } }, "invalid-args"), { ok: false, error: "" });
+		} finally { registration.dispose(); }
+	});
+
 	it("reports unauthorized raw host execution through the workflow primitive when no host is supplied", async () => {
 		await assert.rejects(
 			runWorkflowScript({

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -1219,7 +1219,12 @@ setTimeout(() => {
 				() => createWorktrees(repoDir, runId, 1, {
 					setupHook: { hookPath: path.relative(repoDir, hookPath), timeoutMs: 50 },
 				}),
-				/timed out/i,
+				(error: unknown) => {
+					assert.ok(error instanceof WorktreeSetupError);
+					assert.ok(error.cause instanceof Error && error.cause.cause instanceof Error);
+					assert.match(error.cause.cause.message, /timed out/i);
+					return true;
+				},
 			);
 		} finally {
 			cleanupRepo(repoDir);


### PR DESCRIPTION
## Summary
- Remove redundant wrappers, unreachable worktree error branches, stale comments, repeated prose and duplicate test setup.
- Preserve canonical SDK and file-storage types instead of assertions; keep one owner for ordinary-session dormancy coverage.
- Reject failed workflow argument validation even with an empty error message, retain/report stop-request I/O failures, and preserve worktree timeout causes.

Reviewed the unreleased changes since v0.65.1. Production code is 32 lines smaller. Focused regression coverage brings the overall diff to +2 lines; no public request shapes, recovery policies, dependencies or polling intervals changed.

## Validation
- Typecheck and diff hygiene pass.
- 134 focused unit tests; final stop-channel suite 40/40.
- 145 real Pi 0.85.1 SDK tests pass, including split-turn compaction and read-only continuation; none skipped.
- Integration: 986 passed, 6 skipped.
- Full local unit run: 2,948 passed, 12 skipped, one unchanged workflow validation case exceeded its existing 2-second timeout under parallel load. Its isolated rerun passed in 305ms. No timeout or assertion was relaxed.
- Fresh initial reviews, edited-candidate TypeScript reviews and final conciseness reviews completed. New regressions fail with the corresponding production fixes reverted.

CI and Greptile must pass on the final head before merge. Existing contributor credits are unchanged. No release or tag.
