### PR TITLE
fix: await offline model refresh before admin selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Await a bounded, offline model registry refresh before opening `/subagents` model and thinking pickers, and warn on refresh failures. Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for #2008.
+
 ## [0.66.0] - 2026-09-06
 
 ### Highlights

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -71,9 +71,16 @@ function modelFullId(model: ModelInfo): string {
 	return `${model.provider}/${model.id}`;
 }
 
-function liveAvailableModels(ctx: ExtensionContext) {
+async function liveAvailableModels(ctx: ExtensionContext) {
 	try {
-		ctx.modelRegistry.refresh?.();
+		// Reload local configuration and cached catalogs without network discovery on picker open.
+		const result = await ctx.modelRegistry.refresh?.({ allowNetwork: false, signal: AbortSignal.timeout(5_000) });
+		const firstError = result?.errors.entries().next().value;
+		if (firstError) {
+			ctx.ui.notify(`Could not refresh ${firstError[0]}; using the currently loaded choices. ${firstError[1].message}`, "warning");
+		} else if (result?.aborted) {
+			ctx.ui.notify("Model registry refresh timed out; using the currently loaded choices.", "warning");
+		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		ctx.ui.notify(`Could not refresh the model registry; using the last loaded choices. ${message}`, "warning");
@@ -217,7 +224,7 @@ async function selectFromList(ctx: ExtensionContext, title: string, subtitle: st
 }
 
 async function chooseModel(ctx: ExtensionContext, agent: AgentConfig): Promise<string | undefined | null> {
-	const models = liveAvailableModels(ctx);
+	const models = await liveAvailableModels(ctx);
 	const current = agent.model ?? INHERIT_MODEL_CHOICE;
 	const items: SelectorItem[] = [{ value: INHERIT_MODEL_CHOICE, label: INHERIT_MODEL_CHOICE, current: !agent.model }];
 	if (agent.model && !models.some((model) => modelFullId(model) === agent.model)) {
@@ -233,7 +240,7 @@ async function chooseModel(ctx: ExtensionContext, agent: AgentConfig): Promise<s
 }
 
 async function chooseThinking(ctx: ExtensionContext, agent: AgentConfig): Promise<string | undefined | null> {
-	const availableModels = liveAvailableModels(ctx).map(toModelInfo);
+	const availableModels = (await liveAvailableModels(ctx)).map(toModelInfo);
 	const effectiveModel = agent.model ?? (ctx.model ? modelFullId(ctx.model) : undefined);
 	const modelInfo = findModelInfo(effectiveModel, availableModels, ctx.model?.provider);
 	const levels = getSupportedThinkingLevels(modelInfo);

--- a/test/fixtures/pi-coding-agent-shim/dist/core/model-registry.d.ts
+++ b/test/fixtures/pi-coding-agent-shim/dist/core/model-registry.d.ts
@@ -1,4 +1,4 @@
-import type { Api, AuthResult, Model, Provider } from "@earendil-works/pi-ai";
+import type { Api, AuthResult, Model, ModelsRefreshOptions, ModelsRefreshResult, Provider } from "@earendil-works/pi-ai";
 import type { ModelRuntime } from "./model-runtime.ts";
 import type { AuthStatus, ProviderConfigInput } from "./provider-composer.ts";
 export type { ProviderConfigInput } from "./provider-composer.ts";
@@ -20,7 +20,7 @@ export declare class ModelRegistry {
     private readonly runtime;
     constructor(runtime: ModelRuntime);
     /** Reload models.json asynchronously. Await before making synchronous registry reads. */
-    refresh(): Promise<void>;
+    refresh(options?: ModelsRefreshOptions): Promise<ModelsRefreshResult>;
     getError(): string | undefined;
     getAll(): Model<Api>[];
     getAvailable(): Model<Api>[];

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -1052,6 +1052,68 @@ Drive the failing test first.
 		assert.doesNotMatch(content, /^thinking:/m);
 	});
 
+	for (const action of ["model", "thinking"]) {
+		it(`awaits an offline registry refresh before opening the ${action} picker`, async () => {
+			const agentPath = path.join(tempDir, ".pi", "agents", "refresh-worker.md");
+			fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+			fs.writeFileSync(agentPath, "---\nname: refresh-worker\ndescription: Refresh test\nmodel: custom/fresh\n---\nPrompt.\n");
+			let refreshed = false;
+			let choices: string[] = [];
+			const warnings: string[] = [];
+			await openSubagentsAdmin({ sendMessage: () => assert.fail("cancel must not save") } as never, {
+				cwd: tempDir, hasUI: true,
+				modelRegistry: {
+					refresh: async (options: { allowNetwork: boolean; signal: AbortSignal }) => {
+						assert.equal(options.allowNetwork, false);
+						assert.ok(options.signal instanceof AbortSignal);
+						await new Promise((resolve) => setImmediate(resolve));
+						refreshed = true;
+						return { aborted: false, errors: new Map() };
+					},
+					getAvailable: () => refreshed
+						? [{ provider: "custom", id: "fresh", reasoning: true, thinkingLevelMap: { minimal: null, low: null, medium: null, high: "high", max: "max" } }, { provider: "custom", id: "added" }]
+						: [],
+				},
+				ui: {
+					select: async (_title: string, items: string[]) => { choices = items; return undefined; },
+					notify: (message: string) => warnings.push(message),
+				},
+			} as never, `refresh-worker ${action}`);
+			assert.deepEqual(choices, action === "model"
+				? ["Default / inherit session model", "custom/fresh", "custom/added"]
+				: ["Default / inherit session thinking", "off", "high", "max"]);
+			assert.deepEqual(warnings, []);
+		});
+	}
+
+	for (const outcome of ["returned error", "aborted", "rejected"]) {
+		it(`warns and keeps registry choices when refresh ${outcome}`, async () => {
+			const agentPath = path.join(tempDir, ".pi", "agents", "refresh-worker.md");
+			fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+			fs.writeFileSync(agentPath, "---\nname: refresh-worker\ndescription: Refresh test\n---\nPrompt.\n");
+			const notices: Array<[string, string]> = [];
+			let choices: string[] = [];
+			await openSubagentsAdmin({ sendMessage: () => assert.fail("cancel must not save") } as never, {
+				cwd: tempDir, hasUI: true,
+				modelRegistry: {
+					refresh: async () => {
+						if (outcome === "rejected") throw new Error("refresh failed");
+						return { aborted: outcome === "aborted", errors: new Map(outcome === "returned error" ? [["custom", new Error("catalog failed")]] : []) };
+					},
+					getAvailable: () => [{ provider: "custom", id: "cached" }],
+				},
+				ui: {
+					select: async (_title: string, items: string[]) => { choices = items; return undefined; },
+					notify: (message: string, level: string) => notices.push([message, level]),
+				},
+			} as never, "refresh-worker model");
+			assert.deepEqual(choices, ["Default / inherit session model", "custom/cached"]);
+			assert.equal(notices.length, 1);
+			assert.equal(notices[0]?.[1], "warning");
+			assert.match(notices[0]![0], outcome === "returned error" ? /custom.*catalog failed/ : outcome === "aborted" ? /timed out/ : /refresh failed/);
+		});
+	}
+
 	it("keeps same-value custom override ownership for interactive admin edits", async () => {
 		const settingsPath = path.join(tempDir, ".pi", "settings.json");
 		const agentPath = path.join(tempDir, ".pi", "agents", "implementer.md");


### PR DESCRIPTION
## Summary
- Await local configuration and cached model catalog refresh before showing model or thinking choices.
- Keep picker refresh offline, supply a five-second cancellation signal, and report returned refresh failures.
- Align the test registry declaration with the host API and cover refreshed choices and warning behavior.

Closes #2008.

Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for the report and detailed reproduction.

## Validation
- 56 agent-management tests passed, including five regression cases; baseline failed the new cases.
- Typecheck and diff hygiene passed.
- Retained-writer simplification and fresh read-only review completed with no findings.

Refresh deliberately does not discover uncached remote catalogs. The timeout uses host cancellation; it does not forcibly interrupt initial configuration loading or noncooperative underlying work.