### PR TITLE
feat(context): fork from seed session files with fork:<path> context values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- `fork:<seed-session-path>` context values: `context` (tool input), agent frontmatter `defaultContext`, and config `defaultSubagentContext` may now name a seed session file that the child branches from instead of the parent session. Seed forks are strict (a missing seed file fails the launch) and support `~` expansion. Parent-seeded `fork` behavior is unchanged.
+
 ## [0.66.0] - 2026-09-06
 
 ### Highlights

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -251,6 +251,7 @@ Use these fields when an agent should see more:
 | `inheritGlobalContext: true` | Also keep the operator's global context file from the Pi config agent directory (such as `~/.pi/agent/AGENTS.md`). Defaults to `false`. |
 | `inheritSkills: true` | Let the child see Pi's discovered skills catalog. |
 | `defaultContext: fork` | Prefer forked session context when a launch omits `context`; if the parent has no persisted session file or current leaf yet, the implicit default falls back to `fresh` without a failed first attempt. Explicit `context: "fork"` remains strict, and explicit `context: "fresh"` still wins. |
+| `defaultContext: fork:<seed-session-path>` | Always fork from the named seed session file instead of the parent session. The path may be absolute or `~`-expanded. Seed forks are strict: a missing seed file fails the launch with a clear error instead of silently falling back to `fresh`. Useful for role expert-context seeds — maintain a curated conversation and have every child of that role start from it. |
 
 Builtin agents opt into repository instruction inheritance by default so they follow repo-specific rules out of the box, but global context remains excluded unless `inheritGlobalContext: true` is set. This changes the behavior of existing agents that previously received global context as part of `inheritProjectContext: true`. `delegate` also uses append mode because its job is orchestration inside the parent workflow.
 
@@ -326,7 +327,7 @@ Field notes:
 | `inheritProjectContext` | Keeps or strips inherited repository instruction blocks. |
 | `inheritGlobalContext` | Keeps or strips the operator's global context file from the Pi config agent directory (e.g. `~/.pi/agent/AGENTS.md`). It has an effect only when `inheritProjectContext` is `true`; otherwise all context files are already disabled. Defaults to `false`. |
 | `inheritSkills` | Keeps or strips Pi's discovered skills catalog. |
-| `defaultContext` | Optional `fresh` or `fork` launch-context preference. An implicit `fork` falls back to `fresh` when the parent has no persisted session file or current leaf; an explicit launch `context: "fork"` remains strict. |
+| `defaultContext` | Optional `fresh`, `fork`, or `fork:<seed-session-path>` launch-context preference. An implicit `fork` falls back to `fresh` when the parent has no persisted session file or current leaf; an explicit launch `context: "fork"` remains strict. `fork:<path>` is strict and branches from the seed session file. |
 | `skills` | Selects specific skills for the child, regardless of `inheritSkills`. |
 | `skillPath` | Invocation-private skill files or discovery directories. Relative paths resolve from the agent definition file. Local matches take precedence, while unresolved or unreadable matches fall back to normal skill discovery. This field discovers candidates only; `skills` still selects what the child receives. |
 | `output` | Default single-agent output file. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,7 +161,7 @@ WorkflowScript calls use background execution when the request omits `async`. Se
 { "defaultSubagentContext": "fresh" }
 ```
 
-Sets `fresh` or `fork` for every subagent launch that omits `context`. This global preference replaces each agent-level `defaultContext`. Explicit `context: "fresh"` or `context: "fork"` still wins.
+Sets `fresh`, `fork`, or `fork:<seed-session-path>` for every subagent launch that omits `context`. This global preference replaces each agent-level `defaultContext`. Explicit `context: "fresh"`, `context: "fork"`, or `context: "fork:<seed-session-path>"` still wins.
 
 With `"fork"`, the setting uses the existing implicit-fork behavior. A launch starts fresh when the parent session file or current leaf is not available. `"fresh"` starts fresh even when the selected agent defaults to fork. Scheduled runs continue to set fresh context explicitly. A runner or provider that does not support fork context keeps its existing rejection behavior.
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -24,12 +24,13 @@ import { parseMemoryFrontmatter } from "./agent-memory.ts";
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
 import { parseThinkingLevel, type ThinkingLevel } from "../shared/thinking-ceiling.ts";
+import { isForkMode, type ForkSeedContextValue } from "../runs/shared/context-mode.ts";
 
 export type AgentScope = "user" | "project" | "both";
 
 export type AgentSource = "builtin" | "package" | "user" | "project" | "runtime";
 type SystemPromptMode = "append" | "replace";
-export type AgentDefaultContext = "fresh" | "fork";
+export type AgentDefaultContext = "fresh" | "fork" | ForkSeedContextValue;
 
 export type AgentMemoryScope = "project" | "user";
 
@@ -1032,10 +1033,10 @@ function parseBuiltinOverrideEntry(
 	}
 
 	if ("defaultContext" in input) {
-		if (input.defaultContext === "fresh" || input.defaultContext === "fork" || input.defaultContext === false) {
+		if (input.defaultContext === "fresh" || isForkMode(input.defaultContext) || input.defaultContext === false) {
 			override.defaultContext = input.defaultContext;
 		} else {
-			throw new Error(`Builtin override '${name}' in '${filePath}' has invalid 'defaultContext'; expected 'fresh', 'fork', or false.`);
+			throw new Error(`Builtin override '${name}' in '${filePath}' has invalid 'defaultContext'; expected 'fresh', 'fork', 'fork:<seed-session-path>', or false.`);
 		}
 	}
 

--- a/src/agents/runtime-agent-registry.ts
+++ b/src/agents/runtime-agent-registry.ts
@@ -4,6 +4,7 @@ import { CODE_OWNED_EXTERNAL_CLI_ADAPTER_LABEL, isCodeOwnedExternalCliAdapterId,
 import { validateAcceptanceInput } from "../runs/shared/acceptance.ts";
 import { validatePermissionRules, type PermissionRules } from "../runs/shared/permissions.ts";
 import { validateToolBudgetConfig } from "../runs/shared/tool-budget.ts";
+import { isForkMode } from "../runs/shared/context-mode.ts";
 import { BUILTIN_AGENT_NAMES } from "./builtin-names.ts";
 import type { AgentConfig, AgentDefaultContext, AgentDiscoveryDiagnostic } from "./agents.ts";
 
@@ -210,7 +211,7 @@ function validateDefinition(value: unknown): RuntimeAgentDefinition {
 	const systemPromptMode = definition.systemPromptMode;
 	if (systemPromptMode !== undefined && systemPromptMode !== "append" && systemPromptMode !== "replace") throw new Error("Runtime agent definition systemPromptMode must be 'append' or 'replace'.");
 	const defaultContext = definition.defaultContext;
-	if (defaultContext !== undefined && defaultContext !== "fresh" && defaultContext !== "fork") throw new Error("Runtime agent definition defaultContext must be 'fresh' or 'fork'.");
+	if (defaultContext !== undefined && defaultContext !== "fresh" && !isForkMode(defaultContext)) throw new Error("Runtime agent definition defaultContext must be 'fresh', 'fork', or 'fork:<seed-session-path>'.");
 	const thinking = definition.thinking;
 	if (thinking !== undefined && thinking !== false && typeof thinking !== "string") throw new Error("Runtime agent definition thinking must be a string or false when provided.");
 	const acceptanceRole = definition.acceptanceRole;

--- a/src/api/delegation.ts
+++ b/src/api/delegation.ts
@@ -1,6 +1,8 @@
 // This is the established extension-to-extension transport. The structured
 // delegation API intentionally reuses it instead of adding a second event
 // protocol. Unstructured legacy direct payloads are rejected.
+import type { ForkSeedContextValue } from "../runs/shared/context-mode.ts";
+
 export const SUBAGENT_DELEGATION_REQUEST_EVENT = "prompt-template:subagent:request";
 export const SUBAGENT_DELEGATION_STARTED_EVENT = "prompt-template:subagent:started";
 export const SUBAGENT_DELEGATION_UPDATE_EVENT = "prompt-template:subagent:update";
@@ -27,7 +29,7 @@ export interface SubagentDelegationRequest {
 	nodeId: string;
 	agent: string;
 	task: string;
-	context: "fresh" | "fork";
+	context: "fresh" | "fork" | ForkSeedContextValue;
 	cwd: string;
 	model?: string;
 	thinking?: SubagentDelegationThinking;

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { isForkContextValue, type ForkSeedContextValue } from "../runs/shared/context-mode.ts";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { discoverAgentSnapshot, findBlockingAgentDiagnostic, formatUnknownAgentError, resolveAgentName, unknownAgentDiagnosticContext, type AgentConfig, type AgentDiscoveryAllResult, type AgentScope, type AgentSource } from "../agents/agents.ts";
@@ -53,7 +54,7 @@ export interface SubagentLaunchContractInput {
 	cwd: string;
 	task?: string;
 	agentScope?: AgentScope;
-	context?: "fresh" | "fork";
+	context?: "fresh" | "fork" | ForkSeedContextValue;
 	model?: string;
 	fast?: boolean;
 	thinking?: string | false;
@@ -251,8 +252,8 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 		const detail = error instanceof Error ? ` ${error.message}` : "";
 		return { ok: false, code: "invalid_cwd", message: `cwd '${effectiveCwd}' is not a directory.${detail}`, diagnostics };
 	}
-	if (input.context !== undefined && input.context !== "fresh" && input.context !== "fork") {
-		return { ok: false, code: "unsupported_mode", message: `Unsupported context '${String(input.context)}'; expected 'fresh' or 'fork'.`, diagnostics };
+	if (input.context !== undefined && !isForkContextValue(input.context)) {
+		return { ok: false, code: "unsupported_mode", message: `Unsupported context '${String(input.context)}'; expected 'fresh', 'fork', or 'fork:<seed-session-path>'.`, diagnostics };
 	}
 	if (input.artifactDir !== undefined && input.artifactDir !== "project" && input.artifactDir !== "session" && input.artifactDir !== "temp") {
 		return { ok: false, code: "invalid_artifact_dir", message: `Unsupported artifactDir '${String(input.artifactDir)}'; expected 'project', 'session', or 'temp'.`, diagnostics };

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { isForkMode } from "../runs/shared/context-mode.ts";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Key } from "@earendil-works/pi-tui";
@@ -150,8 +151,8 @@ function validateConfig(config: Record<string, unknown>): void {
 		if (typeof config.worktreeBranchPrefix !== "string") throw new Error("config.worktreeBranchPrefix must be a string");
 		normalizeWorktreeBranchPrefix(config.worktreeBranchPrefix);
 	}
-	if (config.defaultSubagentContext !== undefined && config.defaultSubagentContext !== "fresh" && config.defaultSubagentContext !== "fork") {
-		throw new Error('config.defaultSubagentContext must be "fresh" or "fork"');
+	if (config.defaultSubagentContext !== undefined && config.defaultSubagentContext !== "fresh" && !isForkMode(config.defaultSubagentContext)) {
+		throw new Error('config.defaultSubagentContext must be "fresh", "fork", or "fork:<seed-session-path>"');
 	}
 	validateForkContextConfig(config.forkContext);
 	if (config.foregroundDetachShortcut !== undefined

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -53,7 +53,7 @@ import { encodeIndexSegment } from "../background/index-segment.ts";
 import { enqueueChainAppendRequest, readPendingChainAppendRequests, runnerStepOutputNames } from "../background/chain-append.ts";
 import { ChainOutputValidationError, validateChainOutputBindingsWithContext } from "../shared/chain-outputs.ts";
 import { normalizeGateAcceptance, resolveAcceptanceReportMode, validateAcceptanceInput, validateExecutionAcceptance } from "../shared/acceptance.ts";
-import { canPreferFork, createForkContextResolver, forkedChildRequiresThinkingOff, resolveSubagentLaunchContext } from "../../shared/fork-context.ts";
+import { canPreferFork, createForkContextResolver, forkSourceFromContext, forkedChildRequiresThinkingOff, resolveSubagentLaunchContext } from "../../shared/fork-context.ts";
 import { createPrunedForkSessionWriter } from "../../shared/pruned-fork.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { currentCompletionOwnerId } from "../../shared/completion-owner.ts";
@@ -72,7 +72,7 @@ import { assertJsonSchemaObject, cleanupStructuredOutputRuntime, createStructure
 import { compactForegroundDetails, getSingleResultOutput, readStatus, resolveChildCwd, sumResultsCost, sumResultsUsage, toAgentToolUsage } from "../../shared/utils.ts";
 import { createTaskMutationArbiter } from "../shared/llm-intent-arbiter.ts";
 import { discardPreservedWorktrees, formatParallelHandoffError, formatParallelHandoffReference, formatStoredParallelHandoffCleanup, parallelHandoffPath, readParallelHandoffManifest, recordParallelHandoffMerge, recordParallelHandoffSupersession, writeParallelHandoffGroup, writeWorktreeSetupHandoff } from "../shared/parallel-handoff.ts";
-import { summarizeContextModes, type ContextMode, type ContextSummary } from "../shared/context-mode.ts";
+import { isForkMode, summarizeContextModes, type ContextMode, type ContextSummary, type ForkSeedContextValue } from "../shared/context-mode.ts";
 import {
 	attachNestedChildrenToResultChildren,
 	buildSubagentResultIntercomPayload,
@@ -360,7 +360,7 @@ export interface SubagentParamsLike {
 	worktree?: boolean;
 	/** Git ref used as the managed worktree base. */
 	baseRef?: string;
-	context?: "fresh" | "fork" | "profile";
+	context?: "fresh" | "fork" | "profile" | ForkSeedContextValue;
 	/** Per-run intercom bridge config. It replaces the global config for this launch only. */
 	intercomBridge?: IntercomBridgeConfig;
 	async?: boolean;
@@ -1850,7 +1850,8 @@ async function resumeAsyncRun(input: {
 	const modelScope = discovered.modelScope;
 	const sessionName = resolveIntercomSessionTarget(input.deps.pi.getSessionName(), input.ctx.sessionManager.getSessionId());
 	const recoveryDescriptor = "recoveryDescriptor" in target ? target.recoveryDescriptor : undefined;
-	const recoveryContext = recoveryDescriptor?.context ?? (input.params.context === "profile" ? undefined : input.params.context);
+	const rawRecoveryContext = recoveryDescriptor?.context ?? (input.params.context === "profile" ? undefined : input.params.context);
+	const recoveryContext = rawRecoveryContext === undefined ? undefined : isForkMode(rawRecoveryContext) ? "fork" : "fresh";
 	const intercomBridge = resolveIntercomBridge({
 		config: input.deps.config.intercomBridge,
 		override: input.params.intercomBridge ?? recoveryDescriptor?.intercomBridge,
@@ -2603,6 +2604,8 @@ function formatStatusTargetLabel(params: Pick<SubagentParamsLike, "dir" | "index
 interface AgentDefaultContextPolicy {
 	params: SubagentParamsLike;
 	contextForAgent(agentName: string): ContextMode;
+	/** Seed session file for `fork:<path>` contexts, when the resolved context for the agent seeds from a file. */
+	forkSourceForAgent?(agentName: string): string | undefined;
 	contextSummary?: ContextSummary;
 	usesFork: boolean;
 }
@@ -2626,17 +2629,21 @@ function resolveAgentDefaultContextPolicy(
 		const contextForAgent = (agentName: string): ContextMode => {
 			const context = byName.get(agentName)?.defaultContext;
 			if (context === undefined) throw new Error(`context: "profile" requires agent '${agentName}' to declare defaultContext.`);
-			return context;
+			return isForkMode(context) ? "fork" : "fresh";
 		};
-		const contextSummary = summarizeContextModes(collectRequestedAgentNames(params).map(contextForAgent));
+		const forkSourceForAgent = (agentName: string): string | undefined =>
+			forkSourceFromContext(byName.get(agentName)?.defaultContext);
+		const contextSummary = summarizeContextModes(collectRequestedAgentNames(params)
+			.map((name) => byName.get(name)?.defaultContext));
 		return {
 			params,
 			contextForAgent,
+			forkSourceForAgent,
 			contextSummary,
 			usesFork: contextSummary === "fork" || contextSummary === "mixed",
 		};
 	}
-	if (params.context === "fresh" || params.context === "fork") return resolveExplicitContextPolicy(params);
+	if (params.context === "fresh" || isForkMode(params.context)) return resolveExplicitContextPolicy(params);
 	const byName = new Map(agents.map((agent) => [agent.name, agent]));
 	const contextForAgent = (agentName: string): ContextMode =>
 		resolveSubagentLaunchContext({
@@ -2645,27 +2652,35 @@ function resolveAgentDefaultContextPolicy(
 			defaultSubagentContext,
 			canUseImplicitFork: canUseDefaultFork,
 		});
+	const forkSourceForAgent = (agentName: string): string | undefined => {
+		const agentDefault = byName.get(agentName)?.defaultContext;
+		if (agentDefault !== undefined) return forkSourceFromContext(agentDefault);
+		return forkSourceFromContext(defaultSubagentContext);
+	};
 	const requestedAgentNames = collectRequestedAgentNames(params);
-	const contextSummary = summarizeContextModes(requestedAgentNames.map((name) => contextForAgent(name)));
+	const contextSummary = summarizeContextModes(requestedAgentNames.map((name) => byName.get(name)?.defaultContext));
 	const usesFork = contextSummary === "fork" || contextSummary === "mixed";
 	return omitUndefinedProperties({
 		params,
 		contextForAgent,
+		forkSourceForAgent,
 		contextSummary,
 		usesFork,
 	});
 }
 
 function resolveExplicitContextPolicy(params: SubagentParamsLike): AgentDefaultContextPolicy {
-	const context = resolveSubagentLaunchContext({
+	const mode = resolveSubagentLaunchContext({
 		explicitContext: params.context === "profile" ? undefined : params.context,
 		canUseImplicitFork: false,
 	});
+	const forkSource = forkSourceFromContext(params.context);
 	return {
 		params,
-		contextForAgent: () => context,
-		contextSummary: context,
-		usesFork: context === "fork",
+		contextForAgent: () => mode,
+		...(forkSource !== undefined ? { forkSourceForAgent: () => forkSource } : {}),
+		contextSummary: mode,
+		usesFork: mode === "fork",
 	};
 }
 
@@ -2717,7 +2732,7 @@ function buildRequestedModeError(params: SubagentParamsLike, message: string): A
 			isError: true,
 			details: { mode: getRequestedModeLabel(params), results: [] },
 		},
-		params.context === "profile" ? undefined : params.context,
+		params.context === "profile" || params.context === undefined ? undefined : isForkMode(params.context) ? "fork" : "fresh",
 	);
 }
 
@@ -4259,7 +4274,7 @@ function workflowChildResult(
 			resumability = { state: "not-resumable", reason: error instanceof Error ? error.message : String(error) };
 		}
 	}
-	const requestedContext = childParams.context === "fresh" || childParams.context === "fork" ? childParams.context : undefined;
+	const requestedContext = childParams.context === "fresh" || isForkMode(childParams.context) ? childParams.context : undefined;
 	const resolvedContext = result.details.context ?? (resolvedContexts.length === 1 ? resolvedContexts[0] : resolvedContexts.length > 1 ? "mixed" : undefined);
 	const outputReference = result.details.results.find((child) => child.savedOutputPath)?.savedOutputPath
 		?? result.details.results.find((child) => child.outputReference?.path)?.outputReference?.path;
@@ -6257,7 +6272,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 							cwd: requestCwd,
 							config: deps.config,
 							state: deps.state,
-							context: paramsWithResolvedCwd.context === "profile" ? undefined : paramsWithResolvedCwd.context,
+							context: ((): "fresh" | "fork" | undefined => {
+								const c = paramsWithResolvedCwd.context;
+								return c === undefined || c === "profile" ? undefined : isForkMode(c) ? "fork" : "fresh";
+							})(),
 							requestedSessionDir: paramsWithResolvedCwd.sessionDir,
 							currentSessionFile,
 							currentSessionId,
@@ -6706,6 +6724,17 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		let prepareForkThinking = (_agentName: string, _index: number, _modelOverride?: string, _modelOverrideFromParent?: boolean, _modelOrigin?: ModelOrigin): void => {};
 		const forkThinkingRequirements = new Map<number, boolean>();
 		const forkThinkingDowngrades = new Map<number, string>();
+		const selectedAgentNames = hasSingle
+			? [effectiveParams.agent!]
+			: hasTasks
+				? (effectiveParams.tasks ?? []).map((task) => task.agent)
+				: (effectiveParams.chain ?? []).flatMap((step) => getStepAgents(step as ChainStep));
+		// Track which seed session file each child index branches from.
+		const forkSourceByIndex = new Map<number, string>();
+		const noteForkSource = (agentName: string, index: number): void => {
+			const source = contextPolicy.forkSourceForAgent?.(agentName);
+			if (source !== undefined) forkSourceByIndex.set(index, source);
+		};
 		try {
 			const forkAvailableModels = contextPolicy.usesFork ? ctx.modelRegistry.getAvailable().map(toModelInfo) : [];
 			const parentModel = requestParentModel;
@@ -6754,8 +6783,18 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			const pruneSession = contextPolicy.usesFork && deps.config.forkContext?.mode === "pruned"
 				? await createPrunedForkSessionWriter(ctx, deps.config.forkContext, signal)
 				: undefined;
+			// Seed session files for fork:<path> contexts. Sources are recorded when a
+			// task calls in with its agent name; the selectedAgentNames fallback covers
+			// resolver calls that race ahead of that bookkeeping.
+			const forkSourceForIndex = (index: number): string | undefined => {
+				const mapped = forkSourceByIndex.get(index);
+				if (mapped !== undefined) return mapped;
+				const fallbackName = selectedAgentNames.length > 0 ? selectedAgentNames[Math.min(index, selectedAgentNames.length - 1)] : undefined;
+				return fallbackName !== undefined ? contextPolicy.forkSourceForAgent?.(fallbackName) : undefined;
+			};
 			const forkContextResolver = createForkContextResolver(ctx.sessionManager, contextPolicy.usesFork ? "fork" : undefined, {
 				forceThinkingOffForIndex: (index) => forkThinkingRequirements.get(index) ?? true,
+				forkSourceForIndex,
 				...(pruneSession ? { pruneSession } : {}),
 			});
 			prepareForkSessionForIndex = forkContextResolver.prepareSessionForIndex;
@@ -6764,11 +6803,6 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		} catch (error) {
 			return toExecutionErrorResult(effectiveParams, error, contextPolicy.contextSummary);
 		}
-		const selectedAgentNames = hasSingle
-			? [effectiveParams.agent!]
-			: hasTasks
-				? (effectiveParams.tasks ?? []).map((task) => task.agent)
-				: (effectiveParams.chain ?? []).flatMap((step) => getStepAgents(step as ChainStep));
 		const externalAgent = selectedAgentNames
 			.map((name) => agents.find((agent) => agent.name === name))
 			.find((agent) => agent?.runner?.type === "external-cli" || agent?.runner?.type === "external-job");
@@ -6865,16 +6899,19 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			path.join(sessionRoot, `run-${idx ?? 0}`);
 		const forkSessionFileForTask: ForkSessionFileForTask = (agentName, idx = 0, modelOverride, modelOverrideFromParent, modelOrigin) => {
 			if (!shouldForkAgent(contextPolicy, agentName)) return undefined;
+			noteForkSource(agentName, idx);
 			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin);
 			return forkSessionFileForIndex(idx);
 		};
 		const prepareForkSessionForTask: PrepareForkSessionForTask = async (agentName, idx = 0, modelOverride, modelOverrideFromParent, modelOrigin) => {
 			if (!shouldForkAgent(contextPolicy, agentName)) return;
+			noteForkSource(agentName, idx);
 			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin);
 			await prepareForkSessionForIndex(idx);
 		};
 		const forkThinkingOverrideForTask: ForkThinkingOverrideForTask = (agentName, idx = 0, modelOverride, modelOverrideFromParent, modelOrigin) => {
 			if (!shouldForkAgent(contextPolicy, agentName)) return delegatedThinkingOverride;
+			noteForkSource(agentName, idx);
 			prepareForkThinking(agentName, idx, modelOverride, modelOverrideFromParent, modelOrigin);
 			const override = forkThinkingOverrideForIndex(idx);
 			if (override === "off") forkThinkingDowngrades.set(idx, agentName);

--- a/src/runs/shared/context-mode.ts
+++ b/src/runs/shared/context-mode.ts
@@ -1,6 +1,18 @@
 export type ContextMode = "fresh" | "fork";
 export type ContextSummary = ContextMode | "mixed";
 
+/** A fork context that branches from a named seed session file instead of the parent session. */
+export type ForkSeedContextValue = `fork:${string}`;
+
+export function isForkContextValue(value: unknown): value is ContextMode | ForkSeedContextValue {
+	return value === "fresh" || value === "fork" || (typeof value === "string" && value.startsWith("fork:"));
+}
+
+/** True when the value selects fork context, whether parent-seeded ("fork") or seed-file-seeded ("fork:<path>"). */
+export function isForkMode(value: unknown): value is ContextMode | ForkSeedContextValue {
+	return value === "fork" || (typeof value === "string" && value.startsWith("fork:") && value.length > "fork:".length);
+}
+
 export function isContextMode(value: unknown): value is ContextMode {
 	return value === "fresh" || value === "fork";
 }
@@ -9,8 +21,13 @@ export function isContextSummary(value: unknown): value is ContextSummary {
 	return isContextMode(value) || value === "mixed";
 }
 
-export function summarizeContextModes(modes: Array<ContextMode | undefined>): ContextSummary | undefined {
-	const resolved = modes.filter(isContextMode);
+/** Reduce a mode value (including "fork:<seed>" forms) to its plain mode. */
+export function contextModeOf(value: ContextMode | ForkSeedContextValue): ContextMode {
+	return isForkMode(value) ? "fork" : "fresh";
+}
+
+export function summarizeContextModes(modes: Array<ContextMode | ForkSeedContextValue | undefined>): ContextSummary | undefined {
+	const resolved = modes.filter((mode) => mode !== undefined).map(contextModeOf);
 	if (resolved.length === 0) return undefined;
 	const first = resolved[0]!;
 	return resolved.every((mode) => mode === first) ? first : "mixed";

--- a/src/shared/fork-context.ts
+++ b/src/shared/fork-context.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { isForkMode, type ForkSeedContextValue } from "../runs/shared/context-mode.ts";
 import { findModelInfo, type ModelInfo } from "./model-info.ts";
 
 type SubagentExecutionContext = "fresh" | "fork";
-
 interface BranchSessionEntry {
 	type: string;
 	id?: string;
@@ -26,6 +27,8 @@ interface BranchSessionManager {
 	createBranchedSession(leafId: string): string | undefined;
 	getHeader?: () => BranchSessionEntry | null;
 	getEntries?: () => BranchSessionEntry[];
+	/** Present on real SessionManager instances; absent on test doubles that only expose entries. */
+	getLeafId?: () => string | null;
 }
 
 interface ForkableSessionManager {
@@ -42,6 +45,10 @@ interface ForkContextResolverOptions {
 	/** Decide per child index whether a sanitized transcript must also disable the child's
 	 * thinking. Defaults to true (the pre-existing conservative behavior) when omitted. */
 	forceThinkingOffForIndex?: (index: number) => boolean;
+	/** Per child index: seed session file to branch from instead of the parent session.
+	 * Returned paths may use a leading `~`. When undefined for an index, the fork branches
+	 * from the parent session's current leaf. */
+	forkSourceForIndex?: (index: number) => string | undefined;
 }
 
 interface ForkContextResolution {
@@ -56,7 +63,17 @@ interface ForkContextResolver {
 }
 
 export function resolveSubagentContext(value: unknown): SubagentExecutionContext {
-	return value === "fork" ? "fork" : "fresh";
+	return isForkMode(value) ? "fork" : "fresh";
+}
+
+/** Extract the seed session file from a `fork:<path>` context value, expanding a leading `~`. */
+export function forkSourceFromContext(value: unknown): string | undefined {
+	if (typeof value !== "string" || !value.startsWith("fork:")) return undefined;
+	const raw = value.slice("fork:".length).trim();
+	if (raw.length === 0) return undefined;
+	if (raw === "~") return os.homedir();
+	if (raw.startsWith("~/") || raw.startsWith("~\\")) return path.join(os.homedir(), raw.slice(2));
+	return raw;
 }
 
 export interface PreferredForkAvailability {
@@ -70,16 +87,20 @@ export interface PreferredForkSnapshot {
 }
 
 export interface SubagentLaunchContextInput {
-	explicitContext?: SubagentExecutionContext;
-	agentDefaultContext?: SubagentExecutionContext;
-	defaultSubagentContext?: SubagentExecutionContext;
+	explicitContext?: SubagentExecutionContext | ForkSeedContextValue;
+	agentDefaultContext?: SubagentExecutionContext | ForkSeedContextValue;
+	defaultSubagentContext?: SubagentExecutionContext | ForkSeedContextValue;
 	canUseImplicitFork: boolean;
 }
 
-/** Resolve the actual launch context from explicit, global, and agent preferences. */
+/** Resolve the actual launch context from explicit, global, and agent preferences.
+ * `fork:<path>` values resolve to fork mode; seed forks are strict (they do not fall back to
+ * fresh when the parent session is unavailable — only the seed file's existence matters, and
+ * that is validated at execution time with a clear error). */
 export function resolveSubagentLaunchContext(input: SubagentLaunchContextInput): SubagentExecutionContext {
-	if (input.explicitContext !== undefined) return input.explicitContext;
+	if (input.explicitContext !== undefined) return resolveSubagentContext(input.explicitContext);
 	const preferredContext = input.defaultSubagentContext ?? input.agentDefaultContext ?? "fresh";
+	if (typeof preferredContext === "string" && preferredContext.startsWith("fork:")) return "fork";
 	return preferredContext === "fork" && input.canUseImplicitFork ? "fork" : "fresh";
 }
 
@@ -187,48 +208,91 @@ export function createForkContextResolver(
 		};
 	}
 
-	const parentSessionFile = sessionManager.getSessionFile();
-	if (!parentSessionFile) {
-		throw new Error("Forked subagent context requires a persisted parent session.");
-	}
-
-	const leafId = sessionManager.getLeafId();
-	if (!leafId) {
-		throw new Error("Forked subagent context requires a current leaf to fork from.");
+	// Fail fast for parent-seeded forks when no per-index seed sources are configured;
+	// seed-backed forks defer validation to resolution so a missing parent session
+	// does not block a launch that only uses seed files.
+	if (!options.forkSourceForIndex) {
+		const parentSessionFile = sessionManager.getSessionFile();
+		if (!parentSessionFile) {
+			throw new Error("Forked subagent context requires a persisted parent session.");
+		}
+		if (!sessionManager.getLeafId()) {
+			throw new Error("Forked subagent context requires a current leaf to fork from.");
+		}
 	}
 
 	const openSession = options.openSession
 		?? sessionManager.openSession
 		?? ((file: string, dir?: string) => SessionManager.open(file, dir));
-	// Fork files must not land in the parent's top-level session directory.
-	// Pi's recent-session discovery (`pi -c` → findMostRecentSession) is
+	// Fork files must not land in the top-level session directory of the session they
+	// branch from. Pi's recent-session discovery (`pi -c` → findMostRecentSession) is
 	// non-recursive and picks the largest-mtime *.jsonl in that directory, so
 	// a still-running forked subagent — which keeps appending after the parent
 	// went idle — would hijack the next `pi -c` away from the conversation the
-	// user actually left. Nesting fork sessions in a per-parent directory keeps
+	// user actually left. Nesting fork sessions in a per-source directory keeps
 	// them invisible to that discovery; the `parentSession` header still
 	// records the tree relationship. The directory mirrors
 	// getSubagentSessionRoot() plus a "forks" level so fork files never sit
 	// loose next to run-N/ result directories. Derived from the file path
 	// rather than getSessionDir() so it also works when the manager cannot
 	// report its directory.
-	const sessionDir = path.join(
-		path.dirname(parentSessionFile),
-		path.basename(parentSessionFile, ".jsonl"),
-		"forks",
-	);
+	const forkSessionDirFor = (sourceFile: string): string =>
+		path.join(
+			path.dirname(sourceFile),
+			path.basename(sourceFile, ".jsonl"),
+			"forks",
+		);
 	const cachedResolutions = new Map<number, ForkContextResolution>();
 	const preparedIndexes = new Set<number>();
 	const preparationPromises = new Map<number, Promise<void>>();
+
+	const resolveSeed = (sourceFile: string): { manager: BranchSessionManager; leafId: string; sessionDir: string } => {
+		if (!fs.existsSync(sourceFile)) {
+			throw new Error(`Fork source session file does not exist: ${sourceFile}.`);
+		}
+		const sessionDir = forkSessionDirFor(sourceFile);
+		const manager = openSession(sourceFile, sessionDir) as unknown as BranchSessionManager;
+		let leafId = manager.getLeafId?.() ?? null;
+		if (!leafId) {
+			const entries = readSessionEntries(sourceFile);
+			const lastId = [...entries].reverse().find((entry) => typeof entry.id === "string")?.id;
+			if (typeof lastId !== "string") {
+				throw new Error(`Fork source session has no branchable entries: ${sourceFile}.`);
+			}
+			leafId = lastId;
+		}
+		return { manager, leafId, sessionDir };
+	};
 
 	const resolveFork = (index = 0): ForkContextResolution => {
 		const cached = cachedResolutions.get(index);
 		if (cached) return cached;
 		try {
-			if (!fs.existsSync(parentSessionFile)) {
-				throw new Error(`Parent session file does not exist: ${parentSessionFile}. Pi has not persisted enough history to fork yet.`);
+			const seedSource = options.forkSourceForIndex?.(index);
+			let sourceManager: BranchSessionManager;
+			let leafId: string;
+			let sessionDir: string;
+			if (seedSource !== undefined) {
+				const seed = resolveSeed(seedSource);
+				sourceManager = seed.manager;
+				leafId = seed.leafId;
+				sessionDir = seed.sessionDir;
+			} else {
+				const parentSessionFile = sessionManager.getSessionFile();
+				if (!parentSessionFile) {
+					throw new Error("Forked subagent context requires a persisted parent session.");
+				}
+				const parentLeafId = sessionManager.getLeafId();
+				if (!parentLeafId) {
+					throw new Error("Forked subagent context requires a current leaf to fork from.");
+				}
+				if (!fs.existsSync(parentSessionFile)) {
+					throw new Error(`Parent session file does not exist: ${parentSessionFile}. Pi has not persisted enough history to fork yet.`);
+				}
+				sessionDir = forkSessionDirFor(parentSessionFile);
+				sourceManager = openSession(parentSessionFile, sessionDir);
+				leafId = parentLeafId;
 			}
-			const sourceManager = openSession(parentSessionFile, sessionDir);
 			const sessionFile = sourceManager.createBranchedSession(leafId);
 			if (!sessionFile) {
 				throw new Error("Session manager did not return a forked session file.");

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,7 @@
  */
 
 import * as os from "node:os";
+import type { ForkSeedContextValue } from "../runs/shared/context-mode.ts";
 import * as path from "node:path";
 import type { Message } from "@earendil-works/pi-ai";
 import type { AgentConfig } from "../agents/agents.ts";
@@ -216,7 +217,7 @@ export type WorkflowReceiptEntry = WorkflowReceiptEntryResumability & {
 	lane?: WorkflowLaneMetadata;
 	terminalOutcome?: WorkflowTerminalOutcome;
 	agent?: string;
-	requestedContext?: "fresh" | "fork";
+	requestedContext?: "fresh" | "fork" | ForkSeedContextValue;
 	resolvedContext?: "fresh" | "fork" | "mixed";
 	outputReference?: string;
 	acceptanceRecovery?: AcceptanceRecoveryMetadata;
@@ -2556,7 +2557,7 @@ export interface ActiveAsyncCapacityConfig {
 export interface ExtensionConfig {
 	asyncByDefault?: boolean;
 	/** Set the context for launches that omit an explicit context. */
-	defaultSubagentContext?: "fresh" | "fork";
+	defaultSubagentContext?: "fresh" | "fork" | ForkSeedContextValue;
 	/** Configure how every resolved fork session is prepared before child spawn. */
 	forkContext?: ForkContextConfig;
 	/** Optional shortcut that detaches the active foreground single-subagent run. */

--- a/src/slash/delegation-adapters.ts
+++ b/src/slash/delegation-adapters.ts
@@ -8,12 +8,13 @@ import {
 } from "../api/delegation.ts";
 import type { AcceptanceInput, AgentContract, EffectsProjection, ExecutionProjection, JsonSchemaObject, ReviewProjection, ToolBudgetConfig, Usage } from "../shared/types.ts";
 import { cloneJsonWithinByteLimit } from "./delegation-json.ts";
+import { isForkContextValue, type ForkSeedContextValue } from "../runs/shared/context-mode.ts";
 
 export interface PromptTemplateDelegationRequest {
 	requestId: string;
 	agent: string;
 	task: string;
-	context: "fresh" | "fork";
+	context: "fresh" | "fork" | ForkSeedContextValue;
 	model: string;
 	cwd: string;
 }
@@ -115,7 +116,7 @@ export interface PromptTemplateBridgeResult {
 export interface DelegatedSubagentExecutionParams {
 	agent?: string;
 	task?: string;
-	context: "fresh" | "fork";
+	context: "fresh" | "fork" | ForkSeedContextValue;
 	model?: string;
 	cwd: string;
 	timeoutMs?: number;
@@ -145,7 +146,7 @@ export function parsePromptTemplateRequest(data: unknown): PromptTemplateDelegat
 	if (typeof value.task !== "string" || !value.task) return undefined;
 	if (typeof value.model !== "string" || !value.model) return undefined;
 	if (typeof value.cwd !== "string" || !value.cwd) return undefined;
-	if (value.context !== "fresh" && value.context !== "fork") return undefined;
+	if (!isForkContextValue(value.context)) return undefined;
 	return {
 		requestId: value.requestId,
 		agent: value.agent,

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import type { ForkSeedContextValue } from "../runs/shared/context-mode.ts";
 import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
 import { Worker } from "node:worker_threads";
@@ -1008,7 +1009,7 @@ export interface WorkflowScriptChildResult {
 	detached?: boolean;
 	interrupted?: boolean;
 	structuredOutput?: unknown;
-	requestedContext?: "fresh" | "fork";
+	requestedContext?: "fresh" | "fork" | ForkSeedContextValue;
 	resolvedContext?: "fresh" | "fork" | "mixed";
 	outputReference?: string;
 	recovery?: AcceptanceRecoveryMetadata;

--- a/test/unit/fork-context.test.ts
+++ b/test/unit/fork-context.test.ts
@@ -586,3 +586,145 @@ describe("createForkContextResolver", () => {
 		}
 	});
 });
+
+describe("fork seed session sources", () => {
+	it("resolveSubagentContext maps fork:<path> values to fork", () => {
+		assert.equal(resolveSubagentContext("fork:/tmp/seed.jsonl"), "fork");
+		assert.equal(resolveSubagentContext("fork:seed.jsonl"), "fork");
+		assert.equal(resolveSubagentContext("fresh"), "fresh");
+		assert.equal(resolveSubagentContext("fork:"), "fresh");
+	});
+
+	it("branches from the seed session file instead of the parent session", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-seed-"));
+		try {
+			const seedSessionFile = path.join(tempDir, "seed.jsonl");
+			writeMinimalSessionFile(seedSessionFile, "seed");
+			const openedPaths: string[] = [];
+			const seenLeafIds: string[] = [];
+			const resolver = createForkContextResolver({
+				getSessionFile: () => undefined,
+				getLeafId: () => null,
+			}, "fork", {
+				forkSourceForIndex: () => seedSessionFile,
+				openSession: (sessionFile: string) => {
+					openedPaths.push(sessionFile);
+					return {
+						createBranchedSession: (leafId: string) => {
+							seenLeafIds.push(leafId);
+							const childSessionFile = path.join(tempDir, `child-${seenLeafIds.length}.jsonl`);
+							writeMinimalSessionFile(childSessionFile, `child-${seenLeafIds.length}`);
+							return childSessionFile;
+						},
+					};
+				},
+			});
+
+			assert.equal(resolver.sessionFileForIndex(0), path.join(tempDir, "child-1.jsonl"));
+			assert.deepEqual(openedPaths, [seedSessionFile]);
+			assert.deepEqual(seenLeafIds, ["seed"]);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to the seed file's last entry id when the manager exposes no leaf", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-seed-fallback-"));
+		try {
+			const seedSessionFile = path.join(tempDir, "seed.jsonl");
+			writeSessionJsonl(seedSessionFile, [
+				{ type: "session", id: "seed-header", timestamp: "2026-04-16T00:00:00.000Z", cwd: "/tmp" },
+				{ type: "message", id: "entry-1", parentId: "seed-header", message: { role: "user", content: "hello" } },
+				{ type: "message", id: "entry-2", parentId: "entry-1", message: { role: "assistant", content: "hi" } },
+			]);
+			const seenLeafIds: string[] = [];
+			const resolver = createForkContextResolver({
+				getSessionFile: () => undefined,
+				getLeafId: () => null,
+			}, "fork", {
+				forkSourceForIndex: () => seedSessionFile,
+				openSession: () => ({
+					createBranchedSession: (leafId: string) => {
+						seenLeafIds.push(leafId);
+						const childSessionFile = path.join(tempDir, "child.jsonl");
+						writeMinimalSessionFile(childSessionFile, "child");
+						return childSessionFile;
+					},
+				}),
+			});
+
+			resolver.sessionFileForIndex(0);
+			assert.deepEqual(seenLeafIds, ["entry-2"]);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails with a clear error when the seed session file does not exist", () => {
+		const resolver = createForkContextResolver({
+			getSessionFile: () => undefined,
+			getLeafId: () => null,
+		}, "fork", {
+			forkSourceForIndex: () => "/tmp/does-not-exist-seed.jsonl",
+			openSession: () => ({ createBranchedSession: () => "/tmp/child.jsonl" }),
+		});
+
+		assert.throws(
+			() => resolver.sessionFileForIndex(0),
+			/Fork source session file does not exist: \/tmp\/does-not-exist-seed\.jsonl\./,
+		);
+	});
+
+	it("does not require a persisted parent session when every index uses a seed", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-seed-no-parent-"));
+		try {
+			const seedSessionFile = path.join(tempDir, "seed.jsonl");
+			writeMinimalSessionFile(seedSessionFile, "seed");
+			const resolver = createForkContextResolver({
+				getSessionFile: () => undefined,
+				getLeafId: () => null,
+			}, "fork", {
+				forkSourceForIndex: () => seedSessionFile,
+				openSession: () => ({
+					createBranchedSession: () => {
+						const childSessionFile = path.join(tempDir, "child.jsonl");
+						writeMinimalSessionFile(childSessionFile, "child");
+						return childSessionFile;
+					},
+				}),
+			});
+
+			assert.doesNotThrow(() => resolver.sessionFileForIndex(0));
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("still fails fast for parent-seeded forks when a seed resolver returns undefined for an index", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-fork-seed-mixed-"));
+		try {
+			const seedSessionFile = path.join(tempDir, "seed.jsonl");
+			writeMinimalSessionFile(seedSessionFile, "seed");
+			const resolver = createForkContextResolver({
+				getSessionFile: () => undefined,
+				getLeafId: () => null,
+			}, "fork", {
+				forkSourceForIndex: (index: number) => index === 0 ? seedSessionFile : undefined,
+				openSession: () => ({
+					createBranchedSession: () => {
+						const childSessionFile = path.join(tempDir, "child.jsonl");
+						writeMinimalSessionFile(childSessionFile, "child");
+						return childSessionFile;
+					},
+				}),
+			});
+
+			assert.throws(
+				() => resolver.sessionFileForIndex(1),
+				/Forked subagent context requires a persisted parent session\./,
+			);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -289,7 +289,10 @@ Package skill content.
 		assert.equal(loadConfig().defaultSubagentContext, "fresh");
 
 		writeFile(configPath, JSON.stringify({ defaultSubagentContext: "other" }));
-		assert.throws(() => updateConfig((config) => config), /config\.defaultSubagentContext must be "fresh" or "fork"/);
+		assert.throws(() => updateConfig((config) => config), /config\.defaultSubagentContext must be "fresh", "fork", or "fork:<seed-session-path>"/);
+
+		writeFile(configPath, JSON.stringify({ defaultSubagentContext: "fork:/tmp/seed-session.jsonl" }));
+		assert.equal(loadConfig().defaultSubagentContext, "fork:/tmp/seed-session.jsonl");
 	});
 
 	it("loads exact model response aliases and preserves them during config updates", () => {


### PR DESCRIPTION
## Summary

Extends subagent launch-context resolution so that `context` (tool input), agent frontmatter `defaultContext`, and config `defaultSubagentContext` accept a third form, `fork:<seed-session-path>`, in addition to `fresh` and `fork`.

A seed-backed fork branches from the named session file's current leaf (manager-reported leaf, or the last entry id as fallback) instead of the parent session. It reuses the existing branched-session creation, Anthropic thinking-block sanitization, and pruned-fork plumbing unchanged. Paths support `~` expansion.

## Motivation

Fork context currently always branches from the parent conversation. That makes it impossible to give an agent a durable, curated starting context: every launch either starts fresh (no context) or inherits whatever happens to be in the current parent session.

With seed sessions, a project can maintain one or more curated conversations (e.g. a role-specific expert briefing, a project post-mortem, an architecture primer) and have every child of that role start from that context — without re-injecting briefing content into every task prompt.

```md
---
name: trace-runner
defaultContext: fork:/path/to/expert-briefing-session.jsonl
---
```

## Semantics

- Parent-seeded `fork` behavior is unchanged, including implicit-fork fallback to `fresh` and fail-fast validation when no per-index seed sources are configured.
- Seed forks are **strict**: a missing seed file fails the launch with a clear error instead of silently falling back to `fresh` (silently starting fresh would be indistinguishable from success while losing the entire point of the seed).
- `fork:` with an empty path is not a fork value (rejects cleanly in config validation).
- Per-agent/per-index sources are supported: in a multi-child launch, each child resolves its seed from its own agent's `defaultContext`.

## Implementation notes

- `createForkContextResolver` gains an optional `forkSourceForIndex(index)`; the executor records each task's agent-resolved seed before forking, with a selected-agent fallback for calls that race ahead of bookkeeping.
- Parent-session existence/leaf checks become lazy only when per-index seed sources are configured; otherwise fail-fast behavior is preserved exactly.

## Testing

- New unit tests cover: `fork:<path>` parsing, branching from the seed file, last-entry-id leaf fallback, missing-seed error, no-parent-session-required when all indexes use seeds, and mixed seed/parent fail-fast.
- `npm run typecheck` clean; `npm run test:unit`: 2968 tests, 0 failures.
- Docs updated (`docs/agents.md`, `docs/configuration.md`) + CHANGELOG entry.