### PR TITLE
fix: show exact async child steering targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- Show exact recorded async child IDs in workflow status and actionable child steering guidance when an owned workflow has no foreground route, without treating queued messages as consumed (#2011).
 - Await a bounded, offline model registry refresh before opening `/subagents` model and thinking pickers, and warn on refresh failures. Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for #2008.
 
 ## [0.66.0] - 2026-09-06

--- a/src/runs/background/run-status.ts
+++ b/src/runs/background/run-status.ts
@@ -32,6 +32,7 @@ import { getExternalJobProvider } from "../../api/external-job-provider.ts";
 import { formatTimeoutRecoveryLines } from "../shared/mutation-evidence.ts";
 import { formatWorkflowChecklistText, projectWorkflowChecklist } from "../../workflows/workflow-checklist.ts";
 import { validHostStepNodes } from "../shared/host-step-status.ts";
+import { workflowAsyncChildSteeringGuidance } from "../shared/workflow-async-child-guidance.ts";
 
 interface RunStatusParams {
 	action?: string;
@@ -624,6 +625,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 				const display = runStatusStepDisplayName(step);
 				const phase = step.phase ? `[${step.phase}] ` : "";
 				lines.push(`${stepLineLabel(status, index)}: ${phase}${display} ${step.status}${modelText}${stepActivityText ? `, ${stepActivityText}` : ""}${steeringSuffix}${acceptanceText}${budgetText}${errorText}`);
+				if (status.mode === "workflow" && step.runId) lines.push(`  Child run: ${step.runId}`);
 				const structuredOutputPreview = step.structuredOutput === undefined ? undefined : formatWorkflowJsonPreview(step.structuredOutput, 4_000);
 				if (structuredOutputPreview !== undefined) lines.push(`  Structured output: ${structuredOutputPreview}`);
 				if (step.structuredOutputPath) lines.push(`  Structured output path: ${step.structuredOutputPath}`);
@@ -688,6 +690,7 @@ export function inspectSubagentStatus(params: RunStatusParams, deps: RunStatusDe
 						lines.push(`Steer live foreground child: subagent({ action: "steer", id: "${control.runId}", index: ${index}, message: "..." })`);
 					}
 				}
+				lines.push(...workflowAsyncChildSteeringGuidance(status, deps.state));
 			}
 			if (nestedWarning) lines.push(`Warning: ${nestedWarning}`);
 			if (status.workflowReceiptPath) lines.push(`Workflow receipt: ${status.workflowReceiptPath}`);

--- a/src/runs/foreground/workflow-foreground-steering.ts
+++ b/src/runs/foreground/workflow-foreground-steering.ts
@@ -6,6 +6,7 @@ import { readStatus } from "../../shared/utils.ts";
 import { steeringReceipt, waitForSteeringAction } from "../background/steering.ts";
 import { requestAsyncSteer, type SteerDeliveryMode } from "../background/control-channel.ts";
 import { currentCompletionOwnerId } from "../../shared/completion-owner.ts";
+import { workflowAsyncChildSteeringGuidance } from "../shared/workflow-async-child-guidance.ts";
 
 export interface WorkflowForegroundSteeringTarget {
 	control: ForegroundRunControl;
@@ -85,7 +86,7 @@ export async function steerWorkflowRun(input: {
 	}
 	if (state.workflowControllers?.has(runId)) {
 		const route = resolveWorkflowForegroundSteeringTarget({ state, workflowRunId: runId, asyncDirRoot: path.dirname(asyncDir) });
-		if (!route.ok) return managementError(route.message);
+		if (!route.ok) return managementError([route.message, ...workflowAsyncChildSteeringGuidance(status, state)].join("\n"));
 		return steerWorkflowForegroundTarget({ target: route.target, message: input.message, mode: input.mode, index: input.index });
 	}
 	if (!state.currentSessionId) return managementError("Workflow steering requires an active parent session.");

--- a/src/runs/shared/workflow-async-child-guidance.ts
+++ b/src/runs/shared/workflow-async-child-guidance.ts
@@ -1,0 +1,18 @@
+import type { AsyncStatus, SubagentState } from "../../shared/types.ts";
+
+/** Projection-only guidance, not a control route or proof of current child liveness. */
+export function workflowAsyncChildSteeringGuidance(status: AsyncStatus, state?: SubagentState): string[] {
+	if (status.mode !== "workflow" || (status.state !== "running" && status.state !== "queued")
+		|| !state?.currentSessionId || status.sessionId !== state.currentSessionId
+		|| !state.workflowControllers?.has(status.runId)) return [];
+	const ids = new Set((status.steps ?? []).flatMap((step) =>
+		step.async === true && step.status === "running"
+		&& step.runner?.type !== "external-cli" && step.runner?.type !== "external-job"
+		&& typeof step.runId === "string" && /^[A-Za-z0-9_-]+$/.test(step.runId) && step.runId !== status.runId
+			? [step.runId] : []));
+	if (ids.size === 0) return [];
+	return [
+		"Async children recorded as running; direct steering rechecks controls. Choose an exact child ID (queued does not mean consumed):",
+		...[...ids].map((id) => `  subagent({ action: "steer", id: "${id}", mode: "follow_up", message: "..." })`),
+	];
+}

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -447,6 +447,81 @@ describe("async interrupt action", () => {
 		}
 	});
 
+	it("exposes exact async child targets when owned workflow steering has no foreground route", async () => {
+		const state = createState();
+		const workflowRunId = `workflow-async-target-${Date.now().toString(36)}`;
+		const childRunId = `${workflowRunId}-child`;
+		const asyncDir = createRunningAsync(state, workflowRunId, { track: false, mode: "workflow" });
+		const childDir = createRunningAsync(state, childRunId);
+		state.currentSessionId = "session";
+		state.workflowControllers = new Map([[workflowRunId, new AbortController()]]);
+		const statusPath = path.join(asyncDir, "status.json");
+		const status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+		status.steps = [{ agent: "worker", workflowKey: "writer", status: "running", async: true, runId: childRunId }];
+		writeJson(statusPath, status);
+		try {
+			const executor = executorWithKill(state, () => true);
+			const result = await executor.execute("steer", { action: "steer", id: workflowRunId, mode: "follow_up", message: "Continue carefully." }, new AbortController().signal, undefined, ctx());
+			assert.equal(result.isError, true);
+			assert.match(text(result), /no live foreground child/);
+			assert.ok(text(result).includes(`id: "${childRunId}"`));
+			assert.match(text(result), /recorded as running; direct steering rechecks/);
+			assert.deepEqual(consumeSteerRequests(asyncDir), []);
+			assert.deepEqual(consumeSteerRequests(childDir), []);
+			const view = inspectSubagentStatus({ id: workflowRunId }, { state, kill: () => true });
+			assert.ok(text(view).includes(`Child run: ${childRunId}`));
+			assert.ok(text(view).includes(`action: "steer", id: "${childRunId}"`));
+			assert.doesNotMatch(text(view), new RegExp(`action: "steer", id: "${workflowRunId}"`));
+			const direct = await executor.execute("steer-child", { action: "steer", id: childRunId, mode: "follow_up", message: "Continue carefully." }, new AbortController().signal, undefined, ctx());
+			assert.equal(direct.isError, undefined);
+			assert.equal(direct.details.steering?.deliveryStatus, "queued");
+			assert.notEqual(direct.details.steering?.state, "delivered");
+			assert.equal(consumeSteerRequests(childDir)[0]?.mode, "follow_up");
+		} finally {
+			cleanup(workflowRunId, asyncDir);
+			cleanup(childRunId, childDir);
+		}
+	});
+
+	it("keeps async workflow hints projection-only, selective, and scoped to the active owner", () => {
+		const state = createState();
+		const workflowRunId = `workflow-async-hints-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, workflowRunId, { track: false, mode: "workflow" });
+		state.currentSessionId = "session";
+		state.workflowControllers = new Map([[workflowRunId, new AbortController()]]);
+		const statusPath = path.join(asyncDir, "status.json");
+		const status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+		const child = (runId: string, overrides = {}) => ({ agent: "worker", workflowKey: runId, status: "running", async: true, runId, ...overrides });
+		status.steps = [child("async-one"), child("async-two"), child("async-one"),
+			child("completed-child", { status: "complete" }), child("paused-child", { status: "paused" }),
+			child("pending-child", { status: "pending" }), child("foreground-child", { async: false }),
+			child("unknown-child", { async: undefined }), child("external-child", { runner: { type: "external-cli" } }),
+			child("job-child", { runner: { type: "external-job", provider: "test" } }), child("../unsafe"), child(workflowRunId)];
+		writeJson(statusPath, status);
+		try {
+			const read = () => text(inspectSubagentStatus({ id: workflowRunId }, { state, kill: () => true }));
+			const view = read();
+			const hints = view.split("\n").filter((line) => line.includes('action: "steer"'));
+			assert.equal(hints.length, 2);
+			assert.ok(hints[0].includes('id: "async-one"'));
+			assert.ok(hints[1].includes('id: "async-two"'));
+			assert.match(view, /queued does not mean consumed/);
+			for (const sessionId of [null, "other-session"]) {
+				state.currentSessionId = sessionId;
+				assert.doesNotMatch(read(), /Async children recorded as running/);
+			}
+			state.currentSessionId = "session";
+			state.workflowControllers.clear();
+			assert.doesNotMatch(read(), /Async children recorded as running/);
+			state.workflowControllers.set(workflowRunId, new AbortController());
+			status.state = "complete";
+			writeJson(statusPath, status);
+			assert.doesNotMatch(read(), /Async children recorded as running/);
+		} finally {
+			cleanup(workflowRunId, asyncDir);
+		}
+	});
+
 	it("rejects ambiguous workflow steering without choosing a foreground child", async () => {
 		const state = createState();
 		const workflowRunId = `workflow-ambiguous-${Date.now().toString(36)}`;


### PR DESCRIPTION
## Summary
Show recorded child run IDs in workflow status and provide exact async-child follow-up commands when locally owned workflow steering cannot find a foreground route.

Closes #2011.

This is actionable guidance, not aggregate routing. The existing refusal remains fail-closed; the explicit child action rechecks its controls. Recorded running state is not proof of current liveness, and queued is not consumed.

## Validation
- Red-before public executor/status regression, then 85 focused steering/status/foreign-owner tests passed.
- Typecheck and diff hygiene passed.
- Retained deletion-first pass removed redundant test lines; fresh exact-candidate review found no issues.
- No new I/O, scans, polling, recovery or ownership changes. The formatter uses only already loaded workflow state.