### PR TITLE
fix: bound rendered transcript previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Show exact recorded async child IDs in workflow status and actionable child steering guidance when an owned workflow has no foreground route, without treating queued messages as consumed (#2011).
+- Bound transcript previews by individual line size and total rendered body size, preserving recent context and full artifact references. Thanks to [@rtbe](https://github.com/rtbe) for #2015.
 - Await a bounded, offline model registry refresh before opening `/subagents` model and thinking pickers, and warn on refresh failures. Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for #2008.
 
 ## [0.66.0] - 2026-09-06

--- a/src/runs/background/fleet-view.ts
+++ b/src/runs/background/fleet-view.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import { safeTerminalText } from "../../shared/display-text.ts";
+import { safeTerminalText, truncateDisplayText } from "../../shared/display-text.ts";
 import { formatDuration, formatModelThinking, formatTokens, shortenPath } from "../../shared/formatters.ts";
 import { formatActivityLabel } from "../../shared/status-format.ts";
 import {
@@ -23,6 +23,10 @@ import { isTrustedRecordedSessionFile } from "../../shared/session-file-trust.ts
 const DEFAULT_TRANSCRIPT_LINES = 80;
 const MAX_TRANSCRIPT_LINES = 500;
 const TRANSCRIPT_TAIL_BYTES = 256 * 1024;
+const MAX_TRANSCRIPT_LINE_CHARS = 2000;
+const MAX_TRANSCRIPT_BODY_BYTES = 32 * 1024;
+const TRANSCRIPT_LINE_OMISSION = "… [content omitted]";
+const TRANSCRIPT_BODY_OMISSION = "  … [earlier lines omitted]";
 
 type ForegroundControl = SubagentState["foregroundControls"] extends Map<string, infer T> ? T : never;
 type ForegroundRun = NonNullable<SubagentState["foregroundRuns"]> extends Map<string, infer T> ? T : never;
@@ -494,7 +498,31 @@ function appendTranscriptBody(lines: string[], sourceLabel: string, sourceLines:
 		lines.push("  (no transcript lines available yet)");
 		return;
 	}
-	for (const line of sourceLines) lines.push(`  ${line}`);
+	// Bound the rendered body, not the raw input: terminal escaping can expand it.
+	// Keep line prefixes (roles/tool names), then prefer whole recent lines. The
+	// byte budget includes indentation, separators and omission markers, but not
+	// the source label, run metadata, warnings or artifact paths above the body.
+	const body: string[] = [];
+	let bytes = 0;
+	for (let index = sourceLines.length - 1; index >= 0; index--) {
+		// Preserve assembled-line binary detection (including indentation). A
+		// binary placeholder replaces the whole line and must not be reindented.
+		const safe = safeTerminalText(`  ${sourceLines[index]!}`);
+		const lineLimit = MAX_TRANSCRIPT_LINE_CHARS + 2;
+		const line = safe.length <= lineLimit
+			? safe
+			: truncateDisplayText(safe, lineLimit - TRANSCRIPT_LINE_OMISSION.length) + TRANSCRIPT_LINE_OMISSION;
+		const size = Buffer.byteLength(line) + 1;
+		if (bytes + size > MAX_TRANSCRIPT_BODY_BYTES) {
+			const markerBytes = Buffer.byteLength(TRANSCRIPT_BODY_OMISSION) + 1;
+			while (bytes + markerBytes > MAX_TRANSCRIPT_BODY_BYTES) bytes -= Buffer.byteLength(body.pop()!) + 1;
+			body.push(TRANSCRIPT_BODY_OMISSION);
+			break;
+		}
+		body.push(line);
+		bytes += size;
+	}
+	lines.push(...body.reverse());
 }
 
 export function formatAsyncRunTranscript(status: AsyncStatus, asyncDir: string, options: TranscriptOptions = {}): string {

--- a/test/unit/run-status.test.ts
+++ b/test/unit/run-status.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import { EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
 import { updateActiveRunIndex } from "../../src/runs/background/active-run-index.ts";
+import { formatAsyncResultTranscript } from "../../src/runs/background/fleet-view.ts";
 import { inspectSubagentStatus } from "../../src/runs/background/run-status.ts";
 import { createNestedRoute, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 import { claimRunFanoutBatch, createRunFanoutBudget, writeRunFanoutBudgetDescriptor } from "../../src/runs/shared/run-fanout-budget.ts";
@@ -23,6 +24,113 @@ function textContent(result: ReturnType<typeof inspectSubagentStatus>): string {
 }
 
 describe("async run status inspection", () => {
+	it("preserves short transcript ANSI escaping and the unindented binary placeholder", () => {
+		const text = formatAsyncResultTranscript({
+			id: "short-preview", state: "complete",
+			output: "\u001b[0m".repeat(4) + "a".repeat(24) + "\nPNG\0payload\nlatest context",
+		}, "/artifacts/result.json");
+		assert.equal(text, [
+			"Run: short-preview", "State: complete", "Artifacts:", "  Result: /artifacts/result.json",
+			"Result transcript tail:",
+			"  [U+001B][0m[U+001B][0m[U+001B][0m[U+001B][0maaaaaaaaaaaaaaaaaaaaaaaa",
+			"[binary content omitted for safe display]",
+			"  latest context",
+		].join("\n"));
+	});
+
+	it("bounds compact JSON session previews without changing short output or stored evidence", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-transcript-preview-"));
+		try {
+			const asyncDir = path.join(root, "runs", "preview");
+			fs.mkdirSync(asyncDir, { recursive: true });
+			const sessionFile = path.join(root, "session.jsonl");
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId: "preview", mode: "single", state: "complete",
+				steps: [{ agent: "worker", status: "complete", sessionFile }],
+			}));
+			const inspect = () => textContent(inspectSubagentStatus({ id: "preview", view: "transcript", lines: 35 }, {
+				asyncDirRoot: path.join(root, "runs"), resultsDir: path.join(root, "results"), sessionRoots: [root],
+			}));
+			const record = (role: string, text: string) => JSON.stringify({ message: { role, content: [{ type: "text", text }] } });
+			fs.writeFileSync(sessionFile, record("assistant", "Short 世界 😀\nsecond line") + "\n");
+			assert.equal(inspect(), [
+				"Run: preview", "State: complete", "Mode: single", "Step: 0 (worker) | complete", "Artifacts:",
+				`  Session: ${sessionFile}`, `Session transcript tail from ${sessionFile}:`, "  assistant: Short 世界 😀", "  second line",
+			].join("\n"));
+			const payload = JSON.stringify({ output: "😀世界\n".repeat(8_000) });
+			const stored = [record("assistant", "before tool"), record("toolResult", payload), "{malformed", record("assistant", "latest context")].join("\n") + "\n";
+			fs.writeFileSync(sessionFile, stored);
+			const text = inspect();
+			const body = text.split(`Session transcript tail from ${sessionFile}:\n`)[1]!;
+			assert.ok(body.length < 3_000, `single-entry preview rendered ${body.length} characters`);
+			assert.ok(body.split("\n").every((line) => line.length <= 2002));
+			assert.match(body, /toolResult: \{"output":/);
+			assert.match(body, /… \[content omitted\]/);
+			assert.match(body, /before tool/);
+			assert.ok(body.endsWith("  assistant: latest context"));
+			assert.doesNotMatch(body, /[\uD800-\uDFFF]|\uFFFD|U\+D[89AB]/u);
+			assert.match(text, /State: complete/);
+			assert.ok(text.includes(`Session: ${sessionFile}`));
+			assert.match(text, /Warnings:\n  Skipped 1 malformed session tail line/);
+			assert.equal(fs.readFileSync(sessionFile, "utf8"), stored);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	for (const source of ["output", "recent", "result", "nested"] as const) {
+		it(`bounds the aggregate rendered ${source} transcript, retaining newest context`, () => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-transcript-body-budget-"));
+			const route = createNestedRoute(`preview-${source}-root`);
+			try {
+				const id = `preview-${source}`;
+				const asyncDir = path.join(root, "runs", id);
+				const resultsDir = path.join(root, "results");
+				if (source !== "nested") fs.mkdirSync(asyncDir, { recursive: true });
+				fs.mkdirSync(resultsDir);
+				// Escaping expands each unsafe code point, so budget the final rendered text.
+				const entries = Array.from({ length: 100 }, (_, i) => `entry-${i}: ${"世界😀\u202e".repeat(70)}`);
+				entries.push("huge: " + "😀".repeat(10_000), "latest context");
+				const sessionFile = path.join(root, "session.jsonl");
+				const outputPath = path.join(asyncDir, "output-0.log");
+				const resultPath = path.join(resultsDir, `${id}.json`);
+				let artifactPath = source === "output" ? outputPath : source === "result" ? resultPath : sessionFile;
+				if (source === "nested") {
+					fs.writeFileSync(sessionFile, entries.map((text) => JSON.stringify({ message: { role: "assistant", content: text } })).join("\n"));
+					writeNestedEvent(route, { type: "subagent.nested.updated", ts: 150, parentRunId: route.rootRunId, parentStepIndex: 0,
+						child: { id, parentRunId: route.rootRunId, parentStepIndex: 0, depth: 1, path: [{ runId: route.rootRunId, stepIndex: 0, agent: "orchestrator" }], state: "complete", mode: "single", agent: "worker", sessionFile, lastUpdate: 150 } });
+				} else if (source === "result") {
+					fs.writeFileSync(resultPath, JSON.stringify({ id, agent: "worker", state: "complete", output: entries.join("\n"), sessionFile }));
+				} else {
+					fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ runId: id, mode: "single", state: "complete",
+						steps: [{ agent: "worker", status: "complete", sessionFile, ...(source === "recent" ? { recentOutput: entries } : {}) }] }));
+					if (source === "output") fs.writeFileSync(outputPath, entries.join("\n"));
+					else artifactPath = path.join(asyncDir, "status.json");
+				}
+				const stored = fs.readFileSync(artifactPath, "utf8");
+				const result = inspectSubagentStatus({ id, view: "transcript", lines: 500 }, {
+					asyncDirRoot: path.join(root, "runs"), resultsDir, sessionRoots: [root],
+				});
+				assert.equal(result.isError, undefined);
+				const text = textContent(result);
+				const body = text.split(/(?:Transcript tail from .*|Recent output from status\.json|Result transcript tail|Session transcript tail from .*):\n/)[1]!;
+				assert.ok(body !== undefined, text);
+				assert.ok(Buffer.byteLength(body) <= 32 * 1024, `${source} body rendered ${Buffer.byteLength(body)} bytes`);
+				assert.ok(body.split("\n").every((line) => line.length <= 2002));
+				assert.match(body, /earlier lines omitted/);
+				assert.match(body, /huge: .*… \[content omitted\]/);
+				assert.match(body, /entry-99:/);
+				assert.doesNotMatch(body, /entry-0:|[\uD800-\uDFFF\u202e]|\uFFFD/u);
+				assert.ok(body.endsWith("latest context"));
+				assert.match(text, /State: complete/);
+				assert.match(text, /Artifacts:/);
+				assert.ok(text.includes(source === "output" ? outputPath : source === "result" ? resultPath : sessionFile));
+				assert.equal(fs.readFileSync(artifactPath, "utf8"), stored);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+				fs.rmSync(path.dirname(route.eventSink), { recursive: true, force: true });
+			}
+		});
+	}
+
 	it("inspects live foreground artifacts on demand with child selection, ownership and bounded tails", () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-live-foreground-transcript-"));
 		try {


### PR DESCRIPTION
## Summary
Bound rendered transcript entries to 2,000 UTF-16 units and transcript bodies to 32 KiB of UTF-8, including omission markers. Keep recent whole lines, metadata and artifact links; preserve short-output sanitization and complete stored logs.

Closes #2015.

Thanks to [@rtbe](https://github.com/rtbe) for the report.

## Validation
- Five regression cases failed before the size fix; focused status and Fleet/Herdr consumer checks pass.
- Fresh review identified one short ANSI-line regression; the narrow correction has a literal expected-output red/green regression and parent verification.
- Final 16 status plus 4 consumer checks, typecheck and diff hygiene passed.
- No extra filesystem reads, scans, configuration or storage changes. Clipping preserves Unicode code points, not whole grapheme clusters.