### PR TITLE
feat: added evidence-auditor agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add default-off, main-only watchdog questions and task-continuity reviews from bounded delivered orchestration evidence (#2010).
+- Add the built-in `evidence-auditor` for independently reviewing important research claims and source support. Thanks to [@Muskos](https://github.com/Muskos) for #1932.
 
 ### Changed
 - Simplify watchdog clarification to a visible question and native orchestrator continuation; remove the reply action, exchange tracking, deadlines and mandatory follow-up reviews.

--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ The extension ships with agents you can use immediately:
 |-------|--------------------------|
 | `scout` | Fast local codebase recon: relevant files, entry points, data flow, risks. |
 | `researcher` | Web/docs research with sources and a concise research brief. |
+| `evidence-auditor` | Independently checks whether important research claims are supported by their sources. |
 | `worker` | Implementation work. Edits files, validates, escalates unapproved decisions instead of guessing. |
 | `reviewer` | Code review and small fixes against the task/plan, tests, edge cases, and simplicity. |
 | `oracle` | A second opinion before acting. Challenges assumptions without editing. |
 | `delegate` | A lightweight general delegate that behaves close to the parent session. |
 
-Rule of thumb: `scout` before you understand the code, `researcher` before you trust external facts, `worker` to implement, `reviewer` to check, and `oracle` when the decision itself feels risky.
+Rule of thumb: `scout` before you understand the code, `researcher` before you trust external facts, `evidence-auditor` before you rely on important research, `worker` to implement, `reviewer` to check, and `oracle` when the decision itself feels risky.
 
 ## Common workflows
 

--- a/agents/evidence-auditor.md
+++ b/agents/evidence-auditor.md
@@ -1,0 +1,34 @@
+---
+name: evidence-auditor
+description: Independent evidence reviewer for checking whether important research claims are supported by their sources
+tools: read, web_search, fetch_content, get_search_content, source_check
+thinking: high
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+---
+
+You are an evidence-auditing subagent.
+
+Given research findings or a brief produced by another agent, independently audit the evidence behind the small set of claims that could change the conclusion. Do not redo the original research or treat a supplied citation as proof. A URL is not evidence by itself: inspect the underlying source for material claims.
+
+Working rules:
+- Identify the decision-critical claims and prioritize claims that materially affect the recommendation or conclusion. Do not audit trivial details.
+- Distinguish evidence, source interpretation, and inference. Check whether the source actually supports the researcher's wording and level of certainty.
+- Prefer original, official, authoritative, and directly relevant sources. Flag material stale, weak, secondary, or circular sourcing.
+- Use `source_check` for important, disputed, surprising, or decision-relevant claims. It can return `supported`, `contradicted`, `unclear`, or `missing-evidence` assessments, source-quality hints, content hashes, and exact passage citations. Treat its result as validation evidence, not as a reason to skip inspecting the source.
+- Use `fetch_content` to inspect cited source pages and `get_search_content` to retrieve bounded slices of stored search or source-check content. Use `web_search` only for targeted follow-up searches needed to verify or challenge a material claim.
+- Record contradictions between claims or sources instead of silently resolving them. Preserve uncertainty when evidence is incomplete or conflicting.
+- Keep verification bounded. Report the material claims audited and any important claims left unverified; do not restart the entire research process.
+
+Output a concise audit with these sections:
+
+1. Verified claims
+2. Contradicted claims
+3. Weak / unclear / unsupported claims
+4. Material source-quality concerns
+5. Missing evidence
+6. Material contradictions
+7. Implications for the original conclusion
+
+For each material claim, include the claim, status (`supported`, `contradicted`, `unclear`, or `missing evidence`), relevant source(s), short reasoning, and confidence where useful. Explicitly label interpretation or inference. Say when no material issues were found.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -39,12 +39,13 @@ Builtins load at the lowest priority, so a user or project agent with the same n
 |-------|--------------------------|
 | `scout` | Fast local codebase recon: relevant files, entry points, data flow, risks, and where another agent should start. |
 | `researcher` | Web/docs research with sources: official docs, specs, benchmarks, recent changes, and a concise research brief. |
+| `evidence-auditor` | Independent evidence review of important claims in an existing research brief. |
 | `worker` | Implementation work, including approved oracle handoffs. It edits files, validates, and escalates unapproved decisions instead of guessing. |
 | `reviewer` | Code review and small fixes. It checks the implementation against the task/plan, tests, edge cases, and simplicity. |
 | `oracle` | A second opinion before acting. It challenges assumptions, catches drift, and recommends the safest next move without editing. |
 | `delegate` | A lightweight general delegate when you want a child agent that behaves close to the parent session. |
 
-Rule of thumb: `scout` before you understand the code, `researcher` before you trust external facts, `worker` to implement, `reviewer` to check, and `oracle` when the decision itself feels risky.
+Rule of thumb: `scout` before you understand the code, `researcher` before you trust external facts, `evidence-auditor` before you rely on important research, `worker` to implement, `reviewer` to check, and `oracle` when the decision itself feels risky.
 
 `oracle` is an advisory reviewer that critiques direction and proposes an execution prompt without editing files. `advisor` is the same bundled role under the Claude Code-compatible name.
 
@@ -184,13 +185,13 @@ Native `oracle` runs inside Pi and can use its configured read tools. The Claude
 | `external-job-requests/` and `external-job-responses/` | Host-mediated provider bridge | pending request, terminal response | Host process writes a matching response and removes the request | Bridge timeout or malformed request response | Requests are operation-scoped. Recovery sends `reattach`/`result`, not `start` or `follow-up`, when job metadata exists. `start` and `follow-up` use durable dispatch claims | Provider not registered, host bridge not loaded, malformed request, provider exception, ambiguous dispatch without a provider job id |
 | Provider artifact path | External provider | provider-defined terminal artifact | Provider returns `artifactPath`, or Pi writes returned text to `external-job-<index>.result.md` | Provider reports failure or no result | Existing artifact path is retained in `status.json` | Missing artifact with no text output returns a terminal message instead of inventing content |
 
-The `researcher` builtin uses `web_search`, `fetch_content`, `get_search_content`, and selective `source_check` validation. Those require [pi-web-access](https://github.com/nicobailon/pi-web-access):
+The `researcher` and `evidence-auditor` builtins use `web_search`, `fetch_content`, `get_search_content`, and selective `source_check` validation. Those require [pi-web-access](https://github.com/nicobailon/pi-web-access):
 
 ```bash
 pi install npm:pi-web-access
 ```
 
-The loaded provider must register all four tools, including `source_check`, before launch; a missing required tool prevents a successful run. Fetched-source inspection is a fallback for a registered `source_check` call failing, not for missing registration.
+The loaded provider must register all four tools, including `source_check`, before either agent launches; a missing required tool prevents a successful run. Fetched-source inspection is a fallback for a registered `source_check` call failing, not for missing registration.
 
 ## Overriding builtins and custom agents
 

--- a/src/agents/builtin-names.ts
+++ b/src/agents/builtin-names.ts
@@ -7,6 +7,7 @@ export const BUILTIN_AGENT_NAMES = [
 	"cursor-agent",
 	"cursor-agent-writer",
 	"delegate",
+	"evidence-auditor",
 	"oracle",
 	"researcher",
 	"reviewer",

--- a/test/unit/evidence-auditor.test.ts
+++ b/test/unit/evidence-auditor.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { clearAgentDiscoveryCache, discoverAgentsAll } from "../../src/agents/agents.ts";
+
+describe("evidence-auditor builtin", () => {
+	let projectDir: string;
+	let homeDir: string;
+	let previousHome: string | undefined;
+	let previousUserProfile: string | undefined;
+
+	beforeEach(() => {
+		projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-evidence-auditor-project-"));
+		homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-evidence-auditor-home-"));
+		previousHome = process.env.HOME;
+		previousUserProfile = process.env.USERPROFILE;
+		process.env.HOME = homeDir;
+		process.env.USERPROFILE = homeDir;
+		clearAgentDiscoveryCache();
+	});
+
+	afterEach(() => {
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+		if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = previousUserProfile;
+		fs.rmSync(projectDir, { recursive: true, force: true });
+		fs.rmSync(homeDir, { recursive: true, force: true });
+		clearAgentDiscoveryCache();
+	});
+
+	it("is discovered with a read-only evidence-review contract", () => {
+		const auditor = discoverAgentsAll(projectDir).builtin.find((agent) => agent.name === "evidence-auditor");
+
+		assert.ok(auditor);
+		assert.deepEqual(auditor.tools, ["read", "web_search", "fetch_content", "get_search_content", "source_check"]);
+		assert.equal(auditor.inheritProjectContext, true);
+		assert.equal(auditor.inheritSkills, false);
+		assert.match(auditor.systemPrompt, /Do not redo the original research/);
+		assert.match(auditor.systemPrompt, /A URL is not evidence by itself/);
+		assert.match(auditor.systemPrompt, /source_check.*supported.*contradicted.*unclear.*missing-evidence/);
+		assert.match(auditor.systemPrompt, /Verified claims[\s\S]*Contradicted claims[\s\S]*Weak \/ unclear \/ unsupported claims/);
+		assert.doesNotMatch(auditor.tools.join(","), /write|edit|bash/);
+	});
+});


### PR DESCRIPTION
**What**
Add a built-in evidence-auditor agent for independently reviewing research findings:
- Review decision-critical claims from existing research briefs.
- Verify important claims against original and authoritative sources.
- Use source_check with exact passage citations and claim-status assessments.
- Detect contradicted, unclear, unsupported, stale, weak, or circular evidence.
- Distinguish source evidence from interpretation and inference.
- Preserve uncertainty and keep the audit bounded.
- Add focused discovery and tool-permission tests.
- Document the new built-in agent.
- Add an Unreleased changelog entry crediting Muskos and PR #1932.

The existing researcher and orchestration behavior remains unchanged.

**Why**
Research findings may contain citations without the cited sources actually supporting the wording or strength of the claims. A separate auditor provides an independent evidence check for the small set of claims that materially affect a conclusion or recommendation.

The repository already provides the required web and source-validation tools, so this PR exposes them through a focused read-only agent without adding new runtime infrastructure.

**Motivation**
Longer term, I’d like to explore a deeper research flow on top of pi-subagents:
```parallel research → evidence audit → synthesis```

_This PR is the second small step: adding an independent evidence-auditor building block. The next PR will focus on the deep-research workflow._