### PR TITLE
fix: cancel final drain when child work resumes

### DIFF
--- a/src/runs/background/run-child-session.ts
+++ b/src/runs/background/run-child-session.ts
@@ -334,6 +334,8 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 		}
 		const applyChildLifecycle = (action: ChildLifecycleAction): void => {
 			if (action === "cancel-drain") {
+				cleanTerminalAssistantStopReceived = false;
+				agentSettledReceived = false;
 				clearFinalDrainTimers();
 				clearWatchdogTailTimer();
 				return;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -746,6 +746,8 @@ async function runSingleAttempt(
 		}
 		const applyChildLifecycle = (action: ChildLifecycleAction): void => {
 			if (action === "cancel-drain") {
+				cleanTerminalAssistantStopReceived = false;
+				agentSettledReceived = false;
 				clearFinalDrainTimers();
 				clearWatchdogTailTimer();
 				return;

--- a/src/runs/shared/child-lifecycle.ts
+++ b/src/runs/shared/child-lifecycle.ts
@@ -14,8 +14,9 @@ export function projectChildLifecycle(event: { type?: string; willRetry?: unknow
 		if (state) state.compactionRetryActive = event.willRetry === true;
 		return event.willRetry === true ? "cancel-drain" : "none";
 	}
-	if (event.type === "agent_start" || event.type === "auto_retry_start") {
+	if (event.type === "agent_start" || event.type === "auto_retry_start" || event.type === "turn_start") {
 		if (state) state.compactionRetryActive = false;
+		return "cancel-drain";
 	}
 	if (event.type === "agent_end" && event.willRetry === true) return "cancel-drain";
 	if (event.type === "agent_end" && state) state.compactionRetryActive = false;

--- a/test/integration/async-execution.part-4.test.ts
+++ b/test/integration/async-execution.part-4.test.ts
@@ -589,6 +589,50 @@ setTimeout(() => process.exit(90), 15000).unref();
 		});
 	});
 
+	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {
+		it(`background keeps resumed work alive after ${type}`, { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+			const id = `async-resumed-${type}-${Date.now().toString(36)}`;
+			mockPi.onCall({
+				steps: [
+					{ jsonl: [events.assistantMessage("before continuation"), { type }] },
+					// Queued steering/follow-up work is allowed to outlive the old final-stop grace.
+					{ delay: 1400, jsonl: [events.assistantMessage("after continuation")] },
+				],
+			});
+			executeAsyncSingle(id, {
+				agent: "worker", task: "Do work", agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2,
+			});
+			const payload = await readAsyncPayload(id);
+			assert.equal(payload.success, true, payload.results[0]?.error);
+			assert.equal(payload.results[0]?.output, "after continuation");
+		});
+	}
+
+	it("background ignores stale watchdog completion after resumed work", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		await withIsolatedWatchdogSettings(tempDir, async () => {
+			writeWatchdogSettings(tempDir);
+			const id = `async-resumed-watchdog-${Date.now().toString(36)}`;
+			mockPi.onCall({
+				steps: [
+					{ jsonl: [events.assistantMessage("before continuation"), { type: "turn_start" }, childWatchdogStatus(id, "idle", 1)] },
+					{ delay: 1400, jsonl: [events.assistantMessage("after continuation")] },
+				],
+			});
+			executeAsyncSingle(id, {
+				agent: "worker", task: "Do work", agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2,
+			});
+			const payload = await readAsyncPayload(id);
+			assert.equal(payload.success, true, payload.results[0]?.error);
+			assert.equal(payload.results[0]?.output, "after continuation");
+		});
+	});
+
 	it("background forced drain after final assistant output is cleanup success", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [events.assistantMessage("async-done-before-drain")],

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MockPi } from "../support/helpers.ts";
-import { createMockPi, createTempDir, makeAgent, makeAgentConfigs, removeTempDir } from "../support/helpers.ts";
+import { createMockPi, createTempDir, events, makeAgent, makeAgentConfigs, removeTempDir } from "../support/helpers.ts";
 import { runSync } from "../../src/runs/foreground/execution.ts";
 import { childSessionFactory, createDefaultChildSessionFactory, disposeChildSessions, type ChildSessionFactory, type ChildSessionLaunch, type PiCodingAgentModule } from "../../src/runs/shared/child-session.ts";
 import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
@@ -109,6 +109,22 @@ describe("in-process foreground child", () => {
 			{ text: "Then update docs.", mode: "followUp" },
 		]);
 	});
+
+	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {
+		it(`foreground keeps resumed work alive after ${type}`, async () => {
+			mockPi.onCall({
+				steps: [
+					{ jsonl: [events.assistantMessage("before continuation"), { type }] },
+					// Queued steering/follow-up work is allowed to outlive the old final-stop grace.
+					{ delay: 1400, jsonl: [events.assistantMessage("after continuation")] },
+				],
+			});
+			const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", { runId: `resumed-${type}` });
+			assert.equal(result.exitCode, 0, result.error);
+			assert.equal(result.finalOutput, "after continuation");
+			assert.equal(mockPi.sessions[0]?.aborted, false);
+		});
+	}
 
 	it("aborts the child session on interrupt and disposes it", async () => {
 		mockPi.onCall({ hangUntilAbort: true });

--- a/test/unit/child-lifecycle.test.ts
+++ b/test/unit/child-lifecycle.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { projectChildLifecycle, type ChildLifecycleState } from "../../src/runs/shared/child-lifecycle.ts";
+
+describe("child lifecycle final drain", () => {
+	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {
+		it(`cancels the previous final drain when resumed work emits ${type}`, () => {
+			const state: ChildLifecycleState = { compactionRetryActive: false };
+			assert.equal(projectChildLifecycle({ type: "message_end" }, true, state), "start-drain");
+			assert.equal(projectChildLifecycle({ type }, false, state), "cancel-drain");
+			assert.equal(projectChildLifecycle({ type: "agent_settled" }, false, state), "start-drain");
+		});
+	}
+
+	it("does not drain compaction settlement before its retry starts", () => {
+		const state: ChildLifecycleState = { compactionRetryActive: false };
+		assert.equal(projectChildLifecycle({ type: "compaction_end", willRetry: true }, false, state), "cancel-drain");
+		assert.equal(projectChildLifecycle({ type: "agent_settled" }, false, state), "none");
+		assert.equal(projectChildLifecycle({ type: "auto_retry_start" }, false, state), "cancel-drain");
+		assert.equal(state.compactionRetryActive, false);
+		assert.equal(projectChildLifecycle({ type: "agent_settled" }, false, state), "start-drain");
+	});
+
+	it("still drains a final message or settled session without resumed work", () => {
+		assert.equal(projectChildLifecycle({ type: "message_end" }, true), "start-drain");
+		assert.equal(projectChildLifecycle({ type: "agent_settled" }), "start-drain");
+		assert.equal(projectChildLifecycle({ type: "message_update" }), "none");
+	});
+});


### PR DESCRIPTION
## Summary

Cancel a child’s previous final-drain window when `turn_start`, `agent_start`, or `auto_retry_start` signals resumed work. Clear the corresponding completion flags in both native hosts so a late watchdog status cannot rearm the obsolete drain.

## Problem

A terminal assistant message does not necessarily mean the child session has finished. Queued steering or follow-up input can immediately start another turn:

1. The child emits a successful assistant message with `stopReason: "stop"`.
2. The host arms the 1,000 ms final-drain timer.
3. Pi consumes queued input and emits `turn_start` for the continuation.
4. The old timer is not cancelled and calls `session.abort()` while that continuation is running.

This was observed as `OpenAI Responses stream ended before a terminal response event`, with an aborted, empty assistant message about 1,000 ms after a successful report. The error is a consequence of the host aborting continued work, not evidence that the preceding report failed to stream.

The shared lifecycle projection previously returned no action for resumed turns; agent/retry starts only reset the compaction flag. Returning `cancel-drain` disarms the existing final-drain and watchdog-tail timers. Resetting both completion flags also prevents a subsequent idle watchdog notification from treating the previous answer as the end of the current work.

The existing final-drain grace period, explicit stop/timeout handling, and provider retry policy are unchanged. No dependency or public API changes are included.

## Tests

Added lifecycle unit tests and scripted integration regressions for both foreground and background native children. The continuation takes 1,400 ms, longer than the old final-drain grace; tests require its output rather than accepting the earlier report. A background watchdog regression covers stale completion flags.

Verified on Node v26.8.1 / macOS against base `e65cbb24835de2c729fa0efe8945959b016bf389`:

- New targeted tests before the production fix: **11 failed, 1 passed, 0 skipped**. Failures were assertion failures: obsolete output or `none` instead of `cancel-drain`.
- Same targeted tests after the fix: **12 passed, 0 failed, 0 skipped**.
- `npm run typecheck`: passed.
- Full unit suite: **2,979 passed, 0 failed, 13 skipped**.
- `test/integration/in-process-child.test.ts` and `test/integration/async-execution.part-4.test.ts`: **57 passed, 0 failed, 0 skipped**, including existing stop/timeout, stuck-session drain, and watchdog-tail cases.
- `git diff --check`: passed; package manifests and lockfile unchanged.

Dependencies were installed with `npm ci --ignore-scripts`. Tests used isolated home/temp directories and scripted child sessions; no live-model test or full integration-suite run is claimed. CI covers the repository’s supported platforms.

## AI assistance

Pi assisted with diagnosis, implementation, regression tests, and an independent review. The submitting author remains responsible for the changes.
