### PR TITLE
fix: preserve resumed child work past final drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Prevent stale final-drain timers from aborting resumed native foreground and background child work. Thanks to [@harche](https://github.com/harche) for #2025.
 - Show exact recorded async child IDs in workflow status and actionable child steering guidance when an owned workflow has no foreground route, without treating queued messages as consumed (#2011).
 - Bound transcript previews by individual line size and total rendered body size, preserving recent context and full artifact references. Thanks to [@rtbe](https://github.com/rtbe) for #2015.
 - Await a bounded, offline model registry refresh before opening `/subagents` model and thinking pickers, and warn on refresh failures. Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for #2008.

--- a/src/runs/background/run-child-session.ts
+++ b/src/runs/background/run-child-session.ts
@@ -334,6 +334,8 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 		}
 		const applyChildLifecycle = (action: ChildLifecycleAction): void => {
 			if (action === "cancel-drain") {
+				cleanTerminalAssistantStopReceived = false;
+				agentSettledReceived = false;
 				clearFinalDrainTimers();
 				clearWatchdogTailTimer();
 				return;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -746,6 +746,8 @@ async function runSingleAttempt(
 		}
 		const applyChildLifecycle = (action: ChildLifecycleAction): void => {
 			if (action === "cancel-drain") {
+				cleanTerminalAssistantStopReceived = false;
+				agentSettledReceived = false;
 				clearFinalDrainTimers();
 				clearWatchdogTailTimer();
 				return;

--- a/src/runs/shared/child-lifecycle.ts
+++ b/src/runs/shared/child-lifecycle.ts
@@ -14,8 +14,9 @@ export function projectChildLifecycle(event: { type?: string; willRetry?: unknow
 		if (state) state.compactionRetryActive = event.willRetry === true;
 		return event.willRetry === true ? "cancel-drain" : "none";
 	}
-	if (event.type === "agent_start" || event.type === "auto_retry_start") {
+	if (event.type === "agent_start" || event.type === "auto_retry_start" || event.type === "turn_start") {
 		if (state) state.compactionRetryActive = false;
+		return "cancel-drain";
 	}
 	if (event.type === "agent_end" && event.willRetry === true) return "cancel-drain";
 	if (event.type === "agent_end" && state) state.compactionRetryActive = false;

--- a/test/integration/async-execution.part-4.test.ts
+++ b/test/integration/async-execution.part-4.test.ts
@@ -589,6 +589,50 @@ setTimeout(() => process.exit(90), 15000).unref();
 		});
 	});
 
+	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {
+		it(`background keeps resumed work alive after ${type}`, { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+			const id = `async-resumed-${type}-${Date.now().toString(36)}`;
+			mockPi.onCall({
+				steps: [
+					{ jsonl: [events.assistantMessage("before continuation"), { type }] },
+					// Queued steering/follow-up work is allowed to outlive the old final-stop grace.
+					{ delay: 1400, jsonl: [events.assistantMessage("after continuation")] },
+				],
+			});
+			executeAsyncSingle(id, {
+				agent: "worker", task: "Do work", agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2,
+			});
+			const payload = await readAsyncPayload(id);
+			assert.equal(payload.success, true, payload.results[0]?.error);
+			assert.equal(payload.results[0]?.output, "after continuation");
+		});
+	}
+
+	it("background ignores stale watchdog completion after resumed work", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		await withIsolatedWatchdogSettings(tempDir, async () => {
+			writeWatchdogSettings(tempDir);
+			const id = `async-resumed-watchdog-${Date.now().toString(36)}`;
+			mockPi.onCall({
+				steps: [
+					{ jsonl: [events.assistantMessage("before continuation"), { type: "turn_start" }, childWatchdogStatus(id, "idle", 1)] },
+					{ delay: 1400, jsonl: [events.assistantMessage("after continuation")] },
+				],
+			});
+			executeAsyncSingle(id, {
+				agent: "worker", task: "Do work", agentConfig: makeAgent("worker"),
+				ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+				artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+				shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2,
+			});
+			const payload = await readAsyncPayload(id);
+			assert.equal(payload.success, true, payload.results[0]?.error);
+			assert.equal(payload.results[0]?.output, "after continuation");
+		});
+	});
+
 	it("background forced drain after final assistant output is cleanup success", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({
 			jsonl: [events.assistantMessage("async-done-before-drain")],

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { MockPi } from "../support/helpers.ts";
-import { createMockPi, createTempDir, makeAgent, makeAgentConfigs, removeTempDir } from "../support/helpers.ts";
+import { createMockPi, createTempDir, events, makeAgent, makeAgentConfigs, removeTempDir } from "../support/helpers.ts";
 import { runSync } from "../../src/runs/foreground/execution.ts";
 import { childSessionFactory, createDefaultChildSessionFactory, disposeChildSessions, type ChildSessionFactory, type ChildSessionLaunch, type PiCodingAgentModule } from "../../src/runs/shared/child-session.ts";
 import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
@@ -109,6 +109,22 @@ describe("in-process foreground child", () => {
 			{ text: "Then update docs.", mode: "followUp" },
 		]);
 	});
+
+	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {
+		it(`foreground keeps resumed work alive after ${type}`, async () => {
+			mockPi.onCall({
+				steps: [
+					{ jsonl: [events.assistantMessage("before continuation"), { type }] },
+					// Queued steering/follow-up work is allowed to outlive the old final-stop grace.
+					{ delay: 1400, jsonl: [events.assistantMessage("after continuation")] },
+				],
+			});
+			const result = await runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", { runId: `resumed-${type}` });
+			assert.equal(result.exitCode, 0, result.error);
+			assert.equal(result.finalOutput, "after continuation");
+			assert.equal(mockPi.sessions[0]?.aborted, false);
+		});
+	}
 
 	it("aborts the child session on interrupt and disposes it", async () => {
 		mockPi.onCall({ hangUntilAbort: true });

--- a/test/unit/child-lifecycle.test.ts
+++ b/test/unit/child-lifecycle.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { projectChildLifecycle, type ChildLifecycleState } from "../../src/runs/shared/child-lifecycle.ts";
+
+describe("child lifecycle final drain", () => {
+	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {
+		it(`cancels the previous final drain when resumed work emits ${type}`, () => {
+			const state: ChildLifecycleState = { compactionRetryActive: false };
+			assert.equal(projectChildLifecycle({ type: "message_end" }, true, state), "start-drain");
+			assert.equal(projectChildLifecycle({ type }, false, state), "cancel-drain");
+			assert.equal(projectChildLifecycle({ type: "agent_settled" }, false, state), "start-drain");
+		});
+	}
+
+	it("does not drain compaction settlement before its retry starts", () => {
+		const state: ChildLifecycleState = { compactionRetryActive: false };
+		assert.equal(projectChildLifecycle({ type: "compaction_end", willRetry: true }, false, state), "cancel-drain");
+		assert.equal(projectChildLifecycle({ type: "agent_settled" }, false, state), "none");
+		assert.equal(projectChildLifecycle({ type: "auto_retry_start" }, false, state), "cancel-drain");
+		assert.equal(state.compactionRetryActive, false);
+		assert.equal(projectChildLifecycle({ type: "agent_settled" }, false, state), "start-drain");
+	});
+
+	it("still drains a final message or settled session without resumed work", () => {
+		assert.equal(projectChildLifecycle({ type: "message_end" }, true), "start-drain");
+		assert.equal(projectChildLifecycle({ type: "agent_settled" }), "start-drain");
+		assert.equal(projectChildLifecycle({ type: "message_update" }), "none");
+	});
+});


### PR DESCRIPTION
## Summary
Preserve @harche's final-drain cancellation fix from #2025 and add the required changelog credit. No source or test changes from the reviewed contributor head `02b1520146eee29a04a23cd5c23c0a9a955446d0`.

- Cancel obsolete drain/watchdog timers when child work resumes.
- Reset stale completion flags in both native hosts.
- Preserve normal completion, stop, and timeout handling.

## Evidence
Fresh read-only semantic review of the exact contributor head passed. Maintainer delta is one changelog line; production/test trees are identical. Local validation: 5 lifecycle unit tests, 57 native-host integration tests, typecheck, and diff hygiene passed. Exact-head CI and Greptile remain merge gates.

## Credit
Thanks to [@harche](https://github.com/harche) for #2025. Original authored commit is preserved. This maintainer-owned branch avoids writing to the contributor's fork. #2025 will be closed as superseded only after this replacement lands.
