### PR TITLE
fix: select chord aliases for supported Pi hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Prevent stale final-drain timers from aborting resumed native foreground and background child work. Thanks to [@harche](https://github.com/harche) for #2025.
+- Avoid requiring chord aliases on pre-0.85 Pi hosts while keeping required host runtime aliases fail-closed (#2026). Thanks to [@samuela](https://github.com/samuela).
 - Show exact recorded async child IDs in workflow status and actionable child steering guidance when an owned workflow has no foreground route, without treating queued messages as consumed (#2011).
 - Bound transcript previews by individual line size and total rendered body size, preserving recent context and full artifact references. Thanks to [@rtbe](https://github.com/rtbe) for #2015.
 - Await a bounded, offline model registry refresh before opening `/subagents` model and thinking pickers, and warn on refresh failures. Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for #2008.

--- a/src/runs/background/runner-aliases.ts
+++ b/src/runs/background/runner-aliases.ts
@@ -21,8 +21,6 @@ export const HOST_PEER_ALIASES: ReadonlyArray<{ specifier: string; pkg: string; 
 	{ specifier: "@earendil-works/pi-coding-agent", pkg: "@earendil-works/pi-coding-agent", subpath: "." },
 	{ specifier: "@earendil-works/pi-agent-core", pkg: "@earendil-works/pi-agent-core", subpath: "." },
 	{ specifier: "@earendil-works/pi-agent-core/node", pkg: "@earendil-works/pi-agent-core", subpath: "./node" },
-	{ specifier: "@earendil-works/chord", pkg: "@earendil-works/chord", subpath: "." },
-	{ specifier: "@earendil-works/chord/context", pkg: "@earendil-works/chord", subpath: "./context" },
 	{ specifier: "@earendil-works/pi-tui", pkg: "@earendil-works/pi-tui", subpath: "." },
 	{ specifier: "@earendil-works/pi-ai", pkg: "@earendil-works/pi-ai", subpath: "./compat" },
 	{ specifier: "@earendil-works/pi-ai/compat", pkg: "@earendil-works/pi-ai", subpath: "./compat" },
@@ -31,6 +29,12 @@ export const HOST_PEER_ALIASES: ReadonlyArray<{ specifier: string; pkg: string; 
 	{ specifier: "typebox", pkg: "typebox", subpath: "." },
 	{ specifier: "typebox/compile", pkg: "typebox", subpath: "./compile" },
 	{ specifier: "typebox/value", pkg: "typebox", subpath: "./value" },
+];
+
+/** Public Pi manifests introduce chord in 0.85.0 (absent through 0.84.4). */
+const CHORD_PEER_ALIASES = [
+	{ specifier: "@earendil-works/chord", pkg: "@earendil-works/chord", subpath: "." },
+	{ specifier: "@earendil-works/chord/context", pkg: "@earendil-works/chord", subpath: "./context" },
 ];
 
 /** Experimental dependencies accidentally published in exactly Pi 0.85.0. */
@@ -137,7 +141,11 @@ export function resolveHostPeerAliases(
 	const supplemental: string[] = [];
 	const hostManifest = readManifest(piPackageRoot);
 	const isPi0850 = hostManifest?.version === "0.85.0";
-	const required = isPi0850 ? [...HOST_PEER_ALIASES, ...PI0850_PEER_ALIASES] : HOST_PEER_ALIASES;
+	// Only known stable pre-chord versions may omit it. Unknown/prerelease
+	// hosts retain the required aliases, rather than hiding a broken install.
+	const stableVersion = typeof hostManifest?.version === "string" ? /^0\.(\d+)\.\d+$/.exec(hostManifest.version) : null;
+	const isPreChord = stableVersion !== null && Number(stableVersion[1]) < 85;
+	const required = [...HOST_PEER_ALIASES, ...(isPreChord ? [] : CHORD_PEER_ALIASES), ...(isPi0850 ? PI0850_PEER_ALIASES : [])];
 	for (const { specifier, pkg, subpath } of required) {
 		const packageDir = findPeerPackageDir(piPackageRoot, pkg, hostManifest?.name);
 		let target = packageDir ? resolvePackageSubpath(packageDir, subpath) : undefined;

--- a/test/smoke/pi085-child.ts
+++ b/test/smoke/pi085-child.ts
@@ -5,6 +5,8 @@ import { BACKGROUND_CONTEXT } from "@earendil-works/pi-agent-core";
 import { createModels } from "@earendil-works/pi-ai";
 
 const state = globalThis.__pi085Smoke = { AgentSession, BACKGROUND_CONTEXT, createModels, started: 0, stopped: 0, faux: undefined };
+// Exercise the runner's reachable watchdog graph, including its runtime TUI import.
+await import(pathToFileURL(`${process.env.SMOKE_EXTENSION}/src/watchdog/tool-actions.ts`).href);
 const { loadRunnerChildSessionFactory } = await import(pathToFileURL(`${process.env.SMOKE_EXTENSION}/src/runs/background/runner-child-sessions.ts`).href);
 const factory = await loadRunnerChildSessionFactory({});
 const errors = [];

--- a/test/smoke/pi085-clean-install.mjs
+++ b/test/smoke/pi085-clean-install.mjs
@@ -1,4 +1,4 @@
-// Run with Node >=22.19.0: node --experimental-strip-types test/smoke/pi085-clean-install.mjs [artifact-dir] [0.85.0|0.85.1]
+// Run with Node >=22.19.0: node --experimental-strip-types test/smoke/pi085-clean-install.mjs [artifact-dir] [0.84.3|0.84.4|0.85.0|0.85.1]
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -8,8 +8,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const source = fileURLToPath(new URL("../../", import.meta.url));
 const version = process.argv[3] ?? "0.85.0";
-assert.ok(["0.85.0", "0.85.1"].includes(version), "requires an explicitly supported smoke version");
+assert.ok(["0.84.3", "0.84.4", "0.85.0", "0.85.1"].includes(version), "requires an explicitly supported smoke version");
 const isPi0850 = version === "0.85.0";
+const isPreChord = version.startsWith("0.84.");
 const root = process.argv[2] ? path.resolve(process.argv[2]) : fs.mkdtempSync(path.join(os.tmpdir(), "pi085-smoke-"));
 fs.mkdirSync(root, { recursive: true });
 const host = path.join(root, "host");
@@ -47,11 +48,18 @@ const { createJiti } = await import(pathToFileURL(path.join(extension, "node_mod
 const jitiLoader = createJiti(import.meta.url, { fsCache: false });
 const { resolveHostPeerAliases, findHostPeerPackageDir, resolvePackageSubpath } = await jitiLoader.import(path.join(installed, "src/runs/background/runner-aliases.ts"));
 assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-server"), undefined, "host must remain missing server");
-if (!isPi0850) assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-client"), undefined, "stable host must remain missing client");
+if (version === "0.85.1") assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-client"), undefined, "stable host must remain missing client");
 const pristine = run("pristine-public-sdk", process.execPath, ["--input-type=module", "-e", `await import(${JSON.stringify(pathToFileURL(resolvePackageSubpath(pi, ".")).href)})`], cwd, {}, !isPi0850);
 if (isPi0850) assert.match(pristine.stderr, /Cannot find package '@earendil-works\/pi-server'/);
 const resolved = resolveHostPeerAliases(pi);
 assert.deepEqual(resolved.missing, []);
+const tui = findHostPeerPackageDir(pi, "@earendil-works/pi-tui");
+assert.ok(tui.startsWith(host + path.sep), "TUI must come from the host install");
+assert.equal(resolved.aliases["@earendil-works/pi-tui"], resolvePackageSubpath(tui, "."));
+if (isPreChord) assert.equal(findHostPeerPackageDir(pi, "@earendil-works/chord"), undefined);
+for (const specifier of ["@earendil-works/chord", "@earendil-works/chord/context"]) {
+	assert.equal(Boolean(resolved.aliases[specifier]), !isPreChord);
+}
 assert.deepEqual(resolved.supplemental, isPi0850 ? ["@earendil-works/pi-server", "@earendil-works/pi-server/unix"] : []);
 if (!isPi0850) {
 	for (const specifier of ["@earendil-works/pi-server", "@earendil-works/pi-server/unix", "@earendil-works/pi-client/unix"]) assert.equal(resolved.aliases[specifier], undefined);
@@ -70,5 +78,5 @@ const preload = resolved.supplemental.length ? ["--import", pathToFileURL(path.j
 const positive = run("child", process.execPath, [...preload, ...args], cwd, childEnv);
 assert.match(positive.stdout, /PASS public SDK\/default child factory/);
 assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-server"), undefined);
-if (!isPi0850) assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-client"), undefined);
+if (version === "0.85.1") assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-client"), undefined);
 console.log(`${positive.stdout.trim()}\nArtifacts: ${root}`);

--- a/test/unit/async-spawn-preload.test.ts
+++ b/test/unit/async-spawn-preload.test.ts
@@ -55,12 +55,17 @@ test("executeAsyncSingle preloads supplemental server aliases before jiti, but n
 			throw new Error("spawn boundary captured");
 		});
 		syncBuiltinESMExports();
-		for (const scenario of ["supplemental", "complete", "stable", "missing-stable"]) {
+		for (const scenario of ["supplemental", "complete", "stable", "pre-chord", "missing-stable"]) {
 			if (scenario === "complete") writeHostPackage(server);
 			if (scenario === "stable") {
 				fs.writeFileSync(path.join(host, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent", version: "0.85.1", exports: { ".": "./index.mjs" } }));
 				for (const pkg of [server, "@earendil-works/pi-client"]) fs.rmSync(path.join(host, "node_modules", pkg), { recursive: true });
 				for (const specifier of [server, `${server}/unix`, "@earendil-works/pi-client/unix"]) delete expectedAliases[specifier];
+			}
+			if (scenario === "pre-chord") {
+				fs.writeFileSync(path.join(host, "package.json"), JSON.stringify({ name: "@earendil-works/pi-coding-agent", version: "0.84.3", exports: { ".": "./index.mjs" } }));
+				fs.rmSync(path.join(host, "node_modules", "@earendil-works/chord"), { recursive: true });
+				for (const specifier of ["@earendil-works/chord", "@earendil-works/chord/context"]) delete expectedAliases[specifier];
 			}
 			if (scenario === "missing-stable") fs.unlinkSync(expectedAliases["@earendil-works/pi-agent-core/node"]!);
 			const result = executeAsyncSingle(`spawn-preload-${scenario}`, {
@@ -72,11 +77,11 @@ test("executeAsyncSingle preloads supplemental server aliases before jiti, but n
 			assert.equal(result.isError, true);
 			if (scenario === "missing-stable") {
 				assert.match(result.content[0]!.text, /@earendil-works\/pi-agent-core\/node/);
-				assert.equal(spawn.mock.callCount(), 3);
+				assert.equal(spawn.mock.callCount(), 4);
 				continue;
 			}
 			assert.match(result.content[0]!.text, /spawn boundary captured/);
-			assert.equal(spawn.mock.callCount(), scenario === "supplemental" ? 1 : scenario === "complete" ? 2 : 3);
+			assert.equal(spawn.mock.callCount(), scenario === "supplemental" ? 1 : scenario === "complete" ? 2 : scenario === "stable" ? 3 : 4);
 			const [command, args, options] = spawn.mock.calls.at(-1)!.arguments;
 			assert.ok(path.isAbsolute(command));
 			assert.equal(options.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV], host);

--- a/test/unit/host-peer-runtime-imports.test.ts
+++ b/test/unit/host-peer-runtime-imports.test.ts
@@ -190,6 +190,56 @@ test("validateStructuredOutputValue validates values against a JSON Schema", asy
 	assert.ok(invalid.status === "invalid" && invalid.message.length > 0);
 });
 
+test("chord is omitted before 0.85, but required host-first on chord-era and unknown hosts (#2026)", () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-chord-alias-"));
+	const host = path.join(root, "host");
+	const extension = path.join(root, "extension");
+	const chord = "@earendil-works/chord";
+	function writePackage(dir: string, name: string, version: string, exports: Record<string, string>) {
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name, version, exports }));
+		for (const target of Object.values(exports)) fs.writeFileSync(path.join(dir, target), "export {};\n");
+	}
+	const hostChord = path.join(host, "node_modules", chord);
+	try {
+		const packages = new Map<string, Record<string, string>>();
+		for (const { pkg, subpath } of HOST_PEER_ALIASES) {
+			const exports = packages.get(pkg) ?? {};
+			exports[subpath] = `./${subpath.replaceAll("/", "-")}.mjs`;
+			packages.set(pkg, exports);
+		}
+		for (const [pkg, exports] of packages) {
+			writePackage(pkg === "@earendil-works/pi-coding-agent" ? host : path.join(host, "node_modules", pkg), pkg, "0.84.3", exports);
+		}
+		const hostExports = packages.get("@earendil-works/pi-coding-agent")!;
+		const preChord = resolveHostPeerAliases(host, extension);
+		assert.deepEqual(preChord.missing, []);
+		assert.equal(preChord.aliases[chord], undefined);
+		assert.equal(preChord.aliases[`${chord}/context`], undefined);
+		// An extension-local copy must never satisfy a missing host chord export.
+		writePackage(path.join(extension, "node_modules", chord), chord, "0.85.1", { ".": "./index.mjs", "./context": "./context.mjs" });
+		for (const version of ["0.85.0", "0.85.1", "1.0.0", "0.84.4-test", "unknown"]) {
+			writePackage(host, "@earendil-works/pi-coding-agent", version, hostExports);
+			const result = resolveHostPeerAliases(host, extension);
+			for (const specifier of [chord, `${chord}/context`]) assert.ok(result.missing.includes(specifier), version);
+		}
+		writePackage(host, "@earendil-works/pi-coding-agent", "0.85.1", hostExports);
+		writePackage(hostChord, chord, "0.85.1", { ".": "./index.mjs", "./context": "./context.mjs" });
+		let result = resolveHostPeerAliases(host, extension);
+		assert.deepEqual(result.missing, []);
+		assert.equal(result.aliases[chord], path.join(hostChord, "index.mjs"));
+		assert.equal(result.aliases[`${chord}/context`], path.join(hostChord, "context.mjs"));
+		fs.unlinkSync(path.join(hostChord, "context.mjs"));
+		assert.deepEqual(resolveHostPeerAliases(host, extension).missing, [`${chord}/context`]);
+		writePackage(host, "@earendil-works/pi-coding-agent", "0.84.3", hostExports);
+		fs.rmSync(path.join(host, "node_modules", "@earendil-works/pi-tui"), { recursive: true });
+		result = resolveHostPeerAliases(host, extension);
+		assert.deepEqual(result.missing, ["@earendil-works/pi-tui"], "pre-chord hosts still require TUI");
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("server supplementation is host-first, missing-only, and restricted to matching 0.85.0", () => {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-server-alias-"));
 	const host = path.join(root, "host");


### PR DESCRIPTION
## Summary
Require chord aliases only for chord-era hosts; public Pi 0.84.3/0.84.4 no longer fail background preflight solely because chord is absent. Preserve required host TUI/SDK identity and the existing exact-0.85.0 server exception. Unknown/prerelease hosts remain fail-closed.

Closes #2026.

## Validation
Public package manifests establish chord's introduction at Pi 0.85.0. Base/current resolver comparison reproduced then fixed the two missing aliases on real 0.84.3/0.84.4 installs. Eight focused tests, typecheck and hygiene pass. Packaged clean-install smokes passed on 0.84.3, 0.84.4, 0.85.0 and 0.85.1, including watchdog/TUI imports and local-provider session lifecycle (no external model calls).

Retained-writer deletion challenge and fresh independent semantic review passed at `7a67ada5f1520e7d99c7a1251a885f5d4d3142b4`. No new dependency or second SDK instance. #2020 remains installation-evidence-blocked; this PR does not claim that separate report fixed.

Thanks to [@samuela](https://github.com/samuela) for #2026; changelog credit included.
