### PR TITLE
fix: defer completion diagnostics for paused background runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Prevent stale final-drain timers from aborting resumed native foreground and background child work. Thanks to [@harche](https://github.com/harche) for #2025.
 - Avoid requiring chord aliases on pre-0.85 Pi hosts while keeping required host runtime aliases fail-closed (#2026). Thanks to [@samuela](https://github.com/samuela).
 - Invoke Worktrunk through `git wt` on Windows to avoid Windows Terminal's conflicting `wt.exe` alias. Thanks to [@Zethu5](https://github.com/Zethu5) for #2033.
+- Defer completion-only failures while background runs are paused, without waiving completion requirements. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2022.
 - Show exact recorded async child IDs in workflow status and actionable child steering guidance when an owned workflow has no foreground route, without treating queued messages as consumed (#2011).
 - Bound transcript previews by individual line size and total rendered body size, preserving recent context and full artifact references. Thanks to [@rtbe](https://github.com/rtbe) for #2015.
 - Await a bounded, offline model registry refresh before opening `/subagents` model and thinking pickers, and warn on refresh failures. Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for #2008.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1213,6 +1213,9 @@ export async function runSingleStepInner(
 			modelResponseAliases: step.modelResponseAliases,
 			mutationTools: step.mutationTools,
 		}));
+		// A parked run still owes completion evidence when it actually finishes.
+		// Stopped/timedOut runs already have terminal failures; checking completion evidence there is meaningless.
+		const completionDiagnosticsEligible = !run.interrupted && !run.stopped && !run.timedOut;
 		const toolDiagnostic = run.exitCode === 0 && !run.error ? launch.capture.toolDiagnostic() : undefined;
 		const toolAvailabilityError = toolDiagnostic ? formatChildToolDiagnostic(toolDiagnostic) : undefined;
 		const runtimeAcknowledgedExtensions = launch.capture.runtimeAcknowledgedExtensions();
@@ -1228,7 +1231,7 @@ export async function runSingleStepInner(
 		let structuredOutput: unknown;
 		let structuredError: string | undefined;
 		let validatedStructuredOutput = false;
-		if (effectiveStructuredOutput && run.exitCode === 0 && !run.error && !toolAvailabilityError && !midToolExitError) {
+		if (completionDiagnosticsEligible && effectiveStructuredOutput && run.exitCode === 0 && !run.error && !toolAvailabilityError && !midToolExitError) {
 			if (!run.structuredOutputToolInvoked) {
 				structuredError = MISSING_STRUCTURED_OUTPUT_CALL_ERROR;
 			} else {
@@ -1250,13 +1253,13 @@ export async function runSingleStepInner(
 		const errorMessages = validatedStructuredOutput
 			? run.messages.slice(run.structuredOutputMessageStartIndex ?? run.messages.length)
 			: run.messages;
-		const hiddenError = run.exitCode === 0 && !run.error && !toolAvailabilityError && !structuredError && !midToolExitError
+		const hiddenError = completionDiagnosticsEligible && run.exitCode === 0 && !run.error && !toolAvailabilityError && !structuredError && !midToolExitError
 			? detectSubagentError(errorMessages)
 			: null;
 		const terminalEmptyAfterUsefulWork = !validatedStructuredOutput
 			&& hasEmptyTerminalAssistantResponse(run.messages)
 			&& (run.toolCount > 0 || Boolean(run.finalOutput.trim()));
-		const emptyOutputError = run.exitCode === 0
+		const emptyOutputError = completionDiagnosticsEligible && run.exitCode === 0
 			&& !run.error
 			&& !toolAvailabilityError
 			&& !structuredError
@@ -1271,7 +1274,7 @@ export async function runSingleStepInner(
 		const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.cwd ?? ctx.cwd);
 		finalMutationEvidence = mutationEvidence;
 		const completionMutationEvidence = ctx.trackedMutationEvidenceForCompletionGuard === false ? undefined : mutationEvidence;
-		const completionGuard = run.exitCode === 0 && !run.error && !structuredError && !hiddenError?.hasError && !midToolExitError && !emptyOutputError && completionGuardEnabled
+		const completionGuard = completionDiagnosticsEligible && run.exitCode === 0 && !run.error && !structuredError && !hiddenError?.hasError && !midToolExitError && !emptyOutputError && completionGuardEnabled
 			? evaluateCompletionMutationGuard(omitUndefinedProperties({
 				agent: step.agent,
 				task: taskForCompletionGuard,
@@ -1313,7 +1316,7 @@ export async function runSingleStepInner(
 				? { kind: "structured" as const, path: effectiveStructuredOutput.outputPath, missing: !fs.existsSync(effectiveStructuredOutput.outputPath) }
 			: undefined;
 		finalRequiredOutputMissing = requiredOutput?.missing;
-		const missingRequiredOutputError = formatRequiredOutputError(requiredOutput);
+		const missingRequiredOutputError = completionDiagnosticsEligible ? formatRequiredOutputError(requiredOutput) : undefined;
 		const missingRequiredOutputAfterMutation = Boolean(missingRequiredOutputError) && (mutationAttemptObserved || Boolean(mutationEvidence.changedFiles.length));
 		const effectiveExitCode = toolAvailabilityError || completionEvidence.legacyFailureError || midToolExitError || structuredError || emptyOutputError || missingRequiredOutputError
 			? 1

--- a/test/integration/async-execution.part-2.test.ts
+++ b/test/integration/async-execution.part-2.test.ts
@@ -198,6 +198,81 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		assert.equal(mockPi.callCount(), 3);
 	});
 
+	for (const diagnostic of ["hidden", "empty", "structured", "file", "mutation"] as const) {
+		for (const interrupted of [true, false]) {
+			it(`${interrupted ? "defers" : "enforces"} ${diagnostic} completion diagnostics ${interrupted ? "while paused" : "on completion"}`, { skip: !isAsyncAvailable() ? "jiti not available" : process.platform === "win32" ? "cross-process interrupt delivery unreliable on Windows CI" : undefined }, async () => {
+				const id = `async-completion-${diagnostic}-${interrupted}-${Date.now().toString(36)}`;
+				const outputPath = path.join(tempDir, `${id}.md`);
+				const jsonl = diagnostic === "hidden"
+					? [events.assistantMessage("Inspecting the task."), events.toolResult("bash", "Blocked by policy. Command exited with code 1", true), events.toolResult("read", "file contents")]
+					: diagnostic === "empty" || diagnostic === "file"
+						? []
+						: [events.assistantMessage("I will inspect the files before proceeding.")];
+				mockPi.onCall({ steps: [
+					{ jsonl },
+					...(interrupted ? [
+						{ jsonl: [events.toolStart("read", { path: "pause-ready" })] },
+						{ waitForPath: path.join(tempDir, `${id}-release`) },
+					] : []),
+				] });
+				const launch = executeAsyncChain(id, {
+					chain: [{
+						agent: "worker",
+						task: diagnostic === "mutation" ? "Implement the fix in src/example.ts." : "Inspect the task and return a report. Do not edit files.",
+						acceptance: false,
+						...(diagnostic === "structured" ? { outputSchema: { type: "object", required: ["ok"], properties: { ok: { type: "boolean" } } } } : {}),
+						...(diagnostic === "file" ? { output: outputPath, outputMode: "file-only" as const } : {}),
+					}],
+					agents: [makeAgent("worker", { tools: ["read", "write"], completionGuard: diagnostic === "mutation" })],
+					ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-completion-diagnostics" },
+					artifactConfig: { enabled: true, includeInput: false, includeOutput: true, includeJsonl: true, includeMetadata: true, cleanupDays: 7 },
+					artifactsDir: path.join(tempDir, "artifacts", id),
+					shareEnabled: false,
+					maxSubagentDepth: 2,
+				});
+				assert.ok(!launch.isError, JSON.stringify(launch));
+				const asyncDir = path.join(ASYNC_DIR, id);
+				if (interrupted) {
+					const running = await waitForAsyncState(id, (status) => status.steps?.[0]?.currentTool === "read");
+					if (diagnostic === "file") assert.equal(fs.existsSync(outputPath), false);
+					deliverInterruptRequest({ asyncDir, pid: running.pid, source: "test" });
+				}
+				const payload = await readAsyncPayload(id);
+				const status = JSON.parse(fs.readFileSync(path.join(asyncDir, "status.json"), "utf-8")) as AsyncStatusPayload;
+				assert.equal(payload.success, false);
+				if (interrupted) {
+					assert.equal(payload.results[0]?.success, false);
+					assert.equal(payload.state, "paused");
+					assert.equal(payload.error, undefined);
+					assert.equal(payload.results[0]?.error, undefined);
+					assert.equal(status.state, "paused");
+					assert.equal(status.error, undefined);
+					assert.equal(status.steps?.[0]?.status, "paused");
+					assert.equal(status.steps?.[0]?.exitCode, 0);
+					assert.equal(status.steps?.[0]?.error, undefined);
+					assert.equal(payload.workflowGraph?.nodes?.[0]?.status, "paused");
+					assert.equal(payload.workflowGraph?.nodes?.[0]?.error, undefined);
+				} else {
+					const expected = {
+						hidden: /bash failed/,
+						empty: /empty|no.*output/i,
+						structured: /structured_output/,
+						file: /Required file-only output was not produced/,
+						mutation: /without making edits/,
+					};
+					assert.match(payload.results[0]?.error ?? "", expected[diagnostic]);
+					assert.equal(status.steps?.[0]?.status, "failed");
+				}
+				if (diagnostic === "hidden") {
+					const transcript = payload.results[0]?.artifactPaths?.transcriptPath;
+					assert.ok(transcript);
+					assert.match(fs.readFileSync(transcript, "utf-8"), /Blocked by policy/);
+				}
+				assert.equal(mockPi.callCount(), 1);
+			});
+		}
+	}
+
 	it("delivers inbox steer requests to the background child session", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const release = path.join(tempDir, "steer-release");
 		mockPi.onCall({ steps: [{ waitForPath: release, jsonl: [events.assistantMessage("steered result")] }] });


### PR DESCRIPTION
## Summary
Do not promote completion-only diagnostics into failures while background children are paused. Preserve actual errors, stop/timeout outcomes, unsuccessful paused state, and required evidence on real completion. No shared scanner heuristic or host-timer changes.

Closes #2022.

## Validation
Five paused variants cover hidden tool errors, empty output, missing structured/file reports and missing mutation. Matching ordinary-completion controls still fail. Status/result/graph agree; historical error remains in the transcript. All five gate-disabled negative controls failed as expected. Focused interruption/stop/timeout and existing recovery/scanner tests: 48 passed. Typecheck and diff hygiene pass.

Retained challenge and fresh independent semantic review passed at `e95cd557f84ddf77c01e3cf66424196bd7ea04bc`. No live-provider retained-session pause/resume claim. Existing #2024 recovery fix remains unchanged.

Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2022; visible changelog credit included.
