### PR TITLE
fix: redirect pi-server and pi-tui via module hooks in background runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Intersect agent frontmatter `tools:` with host-available builtins before spawning children, so hosts with restricted tool menus (e.g. Prime Agent's `ipython`-only set) reject unavailable tools at launch instead of after spawn. Thanks to [@BioInfo](https://github.com/BioInfo) for #2034.
+- Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution (#2020). Thanks to [@kroediger](https://github.com/kroediger).
 - Prevent stale final-drain timers from aborting resumed native foreground and background child work. Thanks to [@harche](https://github.com/harche) for #2025.
 - Avoid requiring chord aliases on pre-0.85 Pi hosts while keeping required host runtime aliases fail-closed (#2026). Thanks to [@samuela](https://github.com/samuela).
 - Invoke Worktrunk through `git wt` on Windows to avoid Windows Terminal's conflicting `wt.exe` alias. Thanks to [@Zethu5](https://github.com/Zethu5) for #2033.

--- a/runner-peer-preload.mjs
+++ b/runner-peer-preload.mjs
@@ -1,11 +1,16 @@
-// Only loaded when the parent supplies Pi 0.85.0's missing server exports.
 import { registerHooks } from "node:module";
 import { pathToFileURL } from "node:url";
 
-const aliases = JSON.parse(process.env.JITI_ALIAS);
+const aliases = JSON.parse(process.env.JITI_ALIAS ?? "{}");
+const redirected = new Set([
+	"@earendil-works/pi-server",
+	"@earendil-works/pi-server/unix",
+	"@earendil-works/pi-tui",
+]);
+
 registerHooks({
 	resolve(specifier, context, nextResolve) {
-		if (specifier === "@earendil-works/pi-server" || specifier === "@earendil-works/pi-server/unix") {
+		if (redirected.has(specifier) && aliases[specifier]) {
 			return nextResolve(pathToFileURL(aliases[specifier]).href, context);
 		}
 		return nextResolve(specifier, context);

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -587,8 +587,8 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Om
 			stdoutFd = fs.openSync(logPaths.stdoutPath, "a");
 			stderrFd = fs.openSync(logPaths.stderrPath, "a");
 		}
-		const preload = hostPeerAliases.supplemental.length > 0
-			? ["--import", new URL("../../../runner-server-preload.mjs", import.meta.url).href]
+		const preload = Object.keys(hostPeerAliases.aliases).length > 0
+			? ["--import", new URL("../../../runner-peer-preload.mjs", import.meta.url).href]
 			: [];
 		const proc = spawn(nodeCommand, [...preload, jitiCliPath, runner, cfgPath], {
 			cwd,

--- a/test/smoke/pi085-clean-install.mjs
+++ b/test/smoke/pi085-clean-install.mjs
@@ -39,7 +39,7 @@ function run(name, command, args, workdir, extra = {}, success = true) {
 fs.writeFileSync(path.join(host, "package.json"), JSON.stringify({ private: true, dependencies: { "@earendil-works/pi-coding-agent": version } }));
 run("host-install", "npm", ["install", "--no-audit", "--no-fund"], host);
 const packed = JSON.parse(run("pack", "npm", ["pack", "--json", "--pack-destination", root], source).stdout)[0];
-assert.ok(packed.files.some(file => file.path === "runner-server-preload.mjs"), "preload must ship");
+assert.ok(packed.files.some(file => file.path === "runner-peer-preload.mjs"), "peer preload must ship");
 fs.writeFileSync(path.join(extension, "package.json"), JSON.stringify({ private: true, dependencies: { "pi-subagents": `file:${path.join(root, packed.filename)}` } }));
 run("extension-install", "npm", ["install", "--no-audit", "--no-fund"], extension);
 const installed = path.join(extension, "node_modules/pi-subagents");
@@ -74,7 +74,7 @@ if (isPi0850) {
 	const negative = run("without-preload", process.execPath, args, cwd, childEnv, false);
 	assert.match(negative.stderr, /Model "pi085-smoke\/local" not found/);
 }
-const preload = resolved.supplemental.length ? ["--import", pathToFileURL(path.join(installed, "runner-server-preload.mjs")).href] : [];
+const preload = Object.keys(resolved.aliases).length ? ["--import", pathToFileURL(path.join(installed, "runner-peer-preload.mjs")).href] : [];
 const positive = run("child", process.execPath, [...preload, ...args], cwd, childEnv);
 assert.match(positive.stdout, /PASS public SDK\/default child factory/);
 assert.equal(findHostPeerPackageDir(pi, "@earendil-works/pi-server"), undefined);

--- a/test/unit/async-spawn-preload.test.ts
+++ b/test/unit/async-spawn-preload.test.ts
@@ -8,7 +8,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
 
-test("executeAsyncSingle preloads supplemental server aliases before jiti, but not for complete hosts", async (t) => {
+test("executeAsyncSingle preloads all peer aliases before jiti when any aliases exist", async (t) => {
 	const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "async-spawn-preload-")));
 	const host = path.join(root, "host");
 	const server = "@earendil-works/pi-server";
@@ -87,16 +87,12 @@ test("executeAsyncSingle preloads supplemental server aliases before jiti, but n
 			assert.equal(options.env[PI_CODING_AGENT_PACKAGE_ROOT_ENV], host);
 			const actualAliases = JSON.parse(options.env.JITI_ALIAS) as Record<string, string>;
 			assert.deepEqual(Object.fromEntries(Object.entries(actualAliases).map(([key, target]) => [key, fs.realpathSync(target)])), expectedAliases);
-			const jitiIndex = scenario === "supplemental" ? 2 : 0;
-			if (scenario !== "supplemental") assert.ok(!args.includes("--import"));
-			else {
-				assert.equal(args[0], "--import");
-				assert.equal(args[1], new URL("../../runner-server-preload.mjs", import.meta.url).href);
-				assert.ok(fs.existsSync(fileURLToPath(args[1])));
-			}
-			assert.match(args[jitiIndex], /[/\\]jiti-cli\.mjs$/);
-			assert.match(args[jitiIndex + 1], /[/\\]subagent-runner\.ts$/);
-			assert.equal(args.length, jitiIndex + 3);
+			assert.equal(args[0], "--import");
+			assert.equal(args[1], new URL("../../runner-peer-preload.mjs", import.meta.url).href);
+			assert.ok(fs.existsSync(fileURLToPath(args[1])));
+			assert.match(args[2], /[/\\]jiti-cli\.mjs$/);
+			assert.match(args[3], /[/\\]subagent-runner\.ts$/);
+			assert.equal(args.length, 5);
 		}
 	} finally {
 		t.mock.restoreAll();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution.

Closes #2020. Thanks to [@kroediger](https://github.com/kroediger) for the report.

## Problem
The reporter experienced `MODULE_NOT_FOUND` for `@earendil-works/pi-tui` when starting subagents. The preflight check passed (the package exists at the computed alias path), but jiti's runtime resolution couldn't find it through standard node_modules traversal.

Previously, only `pi-server` aliases were redirected via module hooks (for Pi 0.85.0). Other packages like `pi-tui` relied on normal node_modules resolution.

## Solution
Add `@earendil-works/pi-tui` to the explicit redirect list in `runner-peer-preload.mjs`, ensuring it uses the validated alias path computed at preflight time.

**Why not redirect all aliases?** Blanket redirection of all aliases breaks extension loading on Pi 0.85, causing "Model not found" failures. The narrower fix (pi-server + pi-tui only) preserves normal resolution for other packages while addressing the specific #2020 issue.

## Validation
Smoke tests verified on all supported Pi versions:
- Pi 0.84.3: PASS
- Pi 0.84.4: PASS  
- Pi 0.85.0: PASS
- Pi 0.85.1: PASS

Unit tests: 2974 pass, 0 fail

## Changes
| File | Change |
|------|--------|
| `runner-peer-preload.mjs` | Add `pi-tui` to explicit redirect list alongside `pi-server` |
| `runner-server-preload.mjs` | Renamed to `runner-peer-preload.mjs` |
| `src/runs/background/async-execution.ts` | Load preload when any aliases exist |
| `test/unit/async-spawn-preload.test.ts` | Updated to expect preload always loaded |
| `test/smoke/pi085-clean-install.mjs` | Updated to use new preload file |
| `CHANGELOG.md` | Added entry with credit to @kroediger |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab771da7-9a02-46fd-a4a3-15d3aebaad16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab771da7-9a02-46fd-a4a3-15d3aebaad16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

