### PR TITLE
fix: send x-opencode-session on internal arbiter/watchdog/prompt-audit calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
+- Send OpenCode session-routing headers on internal helper model calls so task arbitration, watchdog, and prompt audit requests keep the same provider session as ordinary Pi traffic. Thanks to [@IdrisGit](https://github.com/IdrisGit) for #2041.
 - Intersect agent frontmatter `tools:` with host-available builtins before spawning children, so hosts with restricted tool menus (e.g. Prime Agent's `ipython`-only set) reject unavailable tools at launch instead of after spawn. Thanks to [@BioInfo](https://github.com/BioInfo) for #2034.
 - Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution (#2020). Thanks to [@kroediger](https://github.com/kroediger).
 - Prevent stale final-drain timers from aborting resumed native foreground and background child work. Thanks to [@harche](https://github.com/harche) for #2025.

--- a/src/runs/foreground/prompt-audit.ts
+++ b/src/runs/foreground/prompt-audit.ts
@@ -2,6 +2,7 @@ import type { Agent, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-co
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ProviderHeaders } from "@earendil-works/pi-ai";
 import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
+import { opencodeSessionHeaders } from "../../shared/opencode-session-headers.ts";
 import type { ForegroundRunControl } from "../../shared/types.ts";
 export type PromptAuditView = "authored" | "runtime" | "effective";
 
@@ -75,11 +76,12 @@ export async function rewritePromptWithGuidance(input: {
 	const baseStreamFn = input.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === model.api
 		? registeredProvider.streamSimple
 		: streamSimple);
+	const sessionId = input.ctx.sessionManager.getSessionId();
 	const streamFn: StreamFn = (nextModel, context, streamOptions) => baseStreamFn(nextModel, context, {
 		...streamOptions,
 		...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
 		env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
-		headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+		headers: { ...opencodeSessionHeaders(nextModel, sessionId), ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
 	});
 	const ctxThinking = (input.ctx as { getThinkingLevel?: () => ThinkingLevel }).getThinkingLevel?.();
 	const agent = new Agent({

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3889,7 +3889,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			runtimeSnapshotHost: deps.pi,
 			hostAvailableBuiltins: getHostBuiltinToolNames(deps.pi),
 			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
-			llmIntentArbiter: createTaskMutationArbiter(ctx),
+			llmIntentArbiter: createTaskMutationArbiter({ model: ctx.model, modelRegistry: ctx.modelRegistry, sessionId: ctx.sessionManager.getSessionId() }),
 			childRuntime: deps.childRuntime,
 			onChildSession: (controls) => { childSessionControls = controls; },
 			context: data.contextPolicy.contextForAgent(params.agent!),

--- a/src/runs/shared/child-hooks.ts
+++ b/src/runs/shared/child-hooks.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { listBackgroundWorkProviders } from "../../api/background-work.ts";
 import { ReadonlyDrainObservation } from "./readonly-drain-observation.ts";
 import registerFanoutChildSubagentExtension from "../../extension/fanout-child.ts";
@@ -7,6 +7,7 @@ import registerSubagentPromptRuntime from "./subagent-prompt-runtime.ts";
 import type { ChildRuntimeConfig } from "./child-runtime-config.ts";
 import type { ChildToolDiagnostic } from "./tool-availability.ts";
 import type { ChildSessionLaunch } from "./child-session.ts";
+import type { ArbiterModelContext } from "./llm-intent-arbiter.ts";
 import type { ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import { projectRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
 
@@ -130,7 +131,7 @@ export function createChildHooks(config: ChildRuntimeConfig): ChildHookExtension
 export function createCapturedChildHooks(config: ChildRuntimeConfig, runner = false) {
 	let diagnostic: ChildToolDiagnostic | undefined;
 	let acknowledgedIds: string[] | undefined;
-	let completionIntentContext: Pick<ExtensionContext, "model" | "modelRegistry"> | undefined;
+	let completionIntentContext: ArbiterModelContext | undefined;
 	const capture: OwnedCapture = {
 		toolDiagnostic: (value) => { diagnostic = value; },
 		runtimeAcknowledgements: (ids) => { acknowledgedIds = ids; },
@@ -139,8 +140,12 @@ export function createCapturedChildHooks(config: ChildRuntimeConfig, runner = fa
 	const hooks = childHooks(config, capture);
 	if (runner) {
 		hooks.push({ name: "pi-subagents:completion-intent", factory: (pi) => pi.on("session_start", (_event, childCtx) => {
-			// Retain only attempt model services, not the live child session.
-			completionIntentContext = { model: childCtx.model, modelRegistry: childCtx.modelRegistry };
+			// Retain only attempt model services and the session id string, not the live child session.
+			completionIntentContext = {
+				model: childCtx.model,
+				modelRegistry: childCtx.modelRegistry,
+				sessionId: childCtx.sessionManager.getSessionId(),
+			};
 		}) });
 		const proof = promptProofs.get(hooks[0]!.factory);
 		if (proof) proof.factories = hooks.map((hook) => hook.factory);

--- a/src/runs/shared/child-launch.ts
+++ b/src/runs/shared/child-launch.ts
@@ -6,7 +6,6 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ChildWatchdogConfig, ChildWatchdogStatusEvent } from "../../watchdog/child-status.ts";
 import type { ThinkingLevel } from "../../shared/model-info.ts";
 import { intersectThinkingCeilings } from "../../shared/thinking-ceiling.ts";
@@ -35,6 +34,7 @@ import type { ChildRuntimeConfig } from "./child-runtime-config.ts";
 import { createCapturedChildHooks, withChildSessionErrorReporting } from "./child-hooks.ts";
 import type { ChildTranscriptWriter } from "../../shared/child-transcript.ts";
 import type { ChildSessionLaunch, ChildSessionStorage } from "./child-session.ts";
+import type { ArbiterModelContext } from "./llm-intent-arbiter.ts";
 
 /** Environment variable pi-mcp-adapter reads for the tools a child may expose. */
 export const MCP_DIRECT_TOOLS_ENV = "MCP_DIRECT_TOOLS";
@@ -121,7 +121,7 @@ export interface BuildInProcessChildLaunchInput {
 }
 
 export interface InProcessChildCapture {
-	completionIntentContext?(): Pick<ExtensionContext, "model" | "modelRegistry"> | undefined;
+	completionIntentContext?(): ArbiterModelContext | undefined;
 	structuredOutput(): { called: boolean; value?: unknown; acceptanceReport?: unknown; acceptanceReportProvided: boolean };
 	toolDiagnostic(): ChildToolDiagnostic | undefined;
 	runtimeAcknowledgedExtensions(): RuntimeAcknowledgedChildExtensions | undefined;

--- a/src/runs/shared/llm-intent-arbiter.ts
+++ b/src/runs/shared/llm-intent-arbiter.ts
@@ -4,6 +4,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
 import { agentStreamOptions } from "../../shared/agent-stream-options.ts";
+import { opencodeSessionHeaders } from "../../shared/opencode-session-headers.ts";
 
 /**
  * LLM intent arbiter for the completion mutation guard.
@@ -56,6 +57,8 @@ interface ArbiterRuntime {
 	/** Registered provider stream, usable only when its api matches the model. */
 	registeredStreamFn?: StreamFn;
 	registeredApi?: string;
+	/** Session id for OpenCode session-routing headers, when the caller has one. */
+	sessionId?: string;
 	timeoutMs: number;
 }
 
@@ -76,7 +79,11 @@ export interface TaskMutationArbiterOptions {
 const DEFAULT_ARBITER_TIMEOUT_MS = 10_000;
 
 type RegistryModel = ReturnType<NonNullable<ExtensionContext["modelRegistry"]["find"]>>;
-type ArbiterModelContext = Pick<ExtensionContext, "model" | "modelRegistry">;
+/** Model services the arbiter needs, plus the caller's session id for OpenCode session-routing headers. */
+export type ArbiterModelContext = Pick<ExtensionContext, "model" | "modelRegistry"> & {
+	/** Session id the headers attach to (the child's, captured by detached runners; the parent's, passed by foreground callers). */
+	sessionId?: string;
+};
 
 function resolveArbiterModel(
 	ctx: ArbiterModelContext,
@@ -113,6 +120,7 @@ function resolveArbiterRuntime(
 		explicitStreamFn: options?.streamFn,
 		registeredStreamFn: registered?.streamSimple,
 		registeredApi: registered?.api,
+		sessionId: ctx.sessionId,
 		timeoutMs: options?.timeoutMs ?? DEFAULT_ARBITER_TIMEOUT_MS,
 	};
 }
@@ -151,12 +159,13 @@ async function resolveArbiterAuth(
 function authWrappedStreamFn(
 	base: StreamFn,
 	auth: ArbiterAuth,
+	sessionId: string | undefined,
 ): StreamFn {
 	return (model, context, streamOptions) => base(model, context, {
 		...(streamOptions ?? {}),
 		...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
 		...(auth.env || streamOptions?.env ? { env: { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } } : {}),
-		headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+		headers: { ...opencodeSessionHeaders(model, sessionId), ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
 	});
 }
 
@@ -200,7 +209,7 @@ async function runArbitration(
 			tools: [tool],
 		},
 		convertToLlm,
-		...agentStreamOptions(authWrappedStreamFn(streamFn, auth)),
+		...agentStreamOptions(authWrappedStreamFn(streamFn, auth, runtime.sessionId)),
 		getApiKey: (providerName) =>
 			providerName === runtime.model.provider ? auth.apiKey : undefined,
 		beforeToolCall: async ({ toolCall }) =>

--- a/src/shared/opencode-session-headers.ts
+++ b/src/shared/opencode-session-headers.ts
@@ -1,0 +1,30 @@
+import type { Api, Model, ProviderHeaders } from "@earendil-works/pi-ai";
+
+const OPENCODE_HOST = "opencode.ai";
+
+function matchesOpenCodeHost(baseUrl: string): boolean {
+	try {
+		return new URL(baseUrl).hostname === OPENCODE_HOST;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * OpenCode session-routing headers for internal subagent model calls.
+ *
+ * Pi's own session path emits these from coding-agent's provider-attribution
+ * merge, but subagent-internal calls (watchdog review, permission arbiter,
+ * task-mutation arbiter, prompt audit) stream through bare Agents that bypass
+ * that path. Without them OpenCode falls back to client-IP affinity and loses
+ * prompt-cache routing (see pi issue #4847). Returns undefined for every other
+ * provider so non-OpenCode requests stay byte-identical.
+ */
+export function opencodeSessionHeaders(
+	model: Pick<Model<Api>, "provider" | "baseUrl">,
+	sessionId: string | undefined,
+): ProviderHeaders | undefined {
+	if (!sessionId) return undefined;
+	if (model.provider !== "opencode" && model.provider !== "opencode-go" && !matchesOpenCodeHost(model.baseUrl)) return undefined;
+	return { "x-opencode-session": sessionId, "x-opencode-client": "pi" };
+}

--- a/src/watchdog/permission-arbiter.ts
+++ b/src/watchdog/permission-arbiter.ts
@@ -4,6 +4,7 @@ import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type, type Static } from "typebox";
 import { appendPermissionAudit, permissionArgsPreview } from "../runs/shared/permissions.ts";
 import { agentStreamOptions } from "../shared/agent-stream-options.ts";
+import { opencodeSessionHeaders } from "../shared/opencode-session-headers.ts";
 import { decodeChildWatchdogConfig } from "./child-status.ts";
 import { childResolvedConfig } from "./register-child.ts";
 import { resolveWatchdogReviewModel } from "./review.ts";
@@ -94,6 +95,7 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 				const config = childResolvedConfig(childConfig);
 				const selection = await resolveWatchdogReviewModel(request.ctx, config);
 				const auth = selection.auth;
+				const sessionId = request.ctx.sessionManager.getSessionId();
 				const registeredProvider = (request.ctx.modelRegistry as {
 					getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
 				}).getRegisteredProviderConfig?.(selection.model.provider);
@@ -104,7 +106,7 @@ export function createWatchdogPermissionArbiter(options: WatchdogPermissionArbit
 					...streamOptions,
 					...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
 					env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
-					headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+					headers: { ...opencodeSessionHeaders(model, sessionId), ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
 				});
 				agent = new Agent({
 					initialState: {

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -5,6 +5,7 @@ import type { Model, ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
 import { resolveModelCandidate } from "../runs/shared/model-fallback.ts";
 import { agentStreamOptions } from "../shared/agent-stream-options.ts";
+import { opencodeSessionHeaders } from "../shared/opencode-session-headers.ts";
 import { resolveEffectiveThinking, splitKnownThinkingSuffix, THINKING_LEVELS, toModelInfo } from "../shared/model-info.ts";
 import { createWatchdogDiffTool, WATCHDOG_DIFF_TOOL_NAME, type WatchdogDiffBaseline } from "./diff-tool.ts";
 import { loadWatchdogGuidance } from "./guidance.ts";
@@ -270,6 +271,7 @@ export function createMainWatchdogReview(provider: WatchdogContextProvider, opti
 		const baseStreamFn = options.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === selection.model.api
 			? registeredProvider.streamSimple
 			: streamSimple);
+		const sessionId = ctx.sessionManager.getSessionId();
 		const streamFn: StreamFn = (model, context, streamOptions) => {
 			// Agent may enter one final loop iteration after an aborted mixed tool batch.
 			// Never send that iteration to the provider after an intentional yield.
@@ -278,7 +280,7 @@ export function createMainWatchdogReview(provider: WatchdogContextProvider, opti
 				...streamOptions,
 				...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
 				env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
-				headers: { ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+				headers: { ...opencodeSessionHeaders(model, sessionId), ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
 			});
 		};
 		const diffBaseline = options.diffBaseline?.();

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -764,7 +764,7 @@ export default function() {
     },
     resolveCliModel: ({ cliModel }) => { assert.equal(cliModel, "intent-test/child-attempt"); return { model }; },
     createAgentSession: async ({ resourceLoader, model }) => {
-      const ctx = Proxy.revocable({ model, modelRegistry: registry }, {});
+      const ctx = Proxy.revocable({ model, modelRegistry: registry, sessionManager: { getSessionId: () => "intent-child", getSessionFile: () => undefined } }, {});
       let listener;
       const messages = [];
       return { session: {

--- a/test/unit/fleet.test.ts
+++ b/test/unit/fleet.test.ts
@@ -117,6 +117,7 @@ describe("native subagent fleet", () => {
 		const ctx = {
 			model,
 			signal: undefined,
+			sessionManager: { getSessionId: () => "fleet-rewrite-session" },
 			modelRegistry: {
 				async getApiKeyAndHeaders() { return { ok: true as const, apiKey: "test" }; },
 				getRegisteredProviderConfig() { return { api: "faux", streamSimple: streamFn }; },

--- a/test/unit/opencode-session-headers.test.ts
+++ b/test/unit/opencode-session-headers.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Model } from "@earendil-works/pi-ai";
+import { opencodeSessionHeaders } from "../../src/shared/opencode-session-headers.ts";
+
+function model(provider: string, baseUrl: string): Model<any> {
+	return { provider, baseUrl } as Model<any>;
+}
+
+describe("opencodeSessionHeaders", () => {
+	it("emits pi's OpenCode session-routing headers for OpenCode models", () => {
+		assert.deepEqual(
+			opencodeSessionHeaders(model("opencode", "https://opencode.ai/zen/v1"), "session-1"),
+			{ "x-opencode-session": "session-1", "x-opencode-client": "pi" },
+		);
+		assert.deepEqual(
+			opencodeSessionHeaders(model("opencode-go", "https://opencode.ai/go/v1"), "session-1"),
+			{ "x-opencode-session": "session-1", "x-opencode-client": "pi" },
+		);
+		assert.deepEqual(
+			opencodeSessionHeaders(model("custom-gateway", "https://opencode.ai/zen/v1"), "session-1"),
+			{ "x-opencode-session": "session-1", "x-opencode-client": "pi" },
+		);
+	});
+
+	it("returns undefined for every other provider or without a session id", () => {
+		assert.equal(opencodeSessionHeaders(model("opencode", "https://opencode.ai/zen/v1"), undefined), undefined);
+		assert.equal(opencodeSessionHeaders(model("anthropic", "https://api.anthropic.com"), "session-1"), undefined);
+		assert.equal(opencodeSessionHeaders(model("openai-compat", "https://proxy.example/v1"), "session-1"), undefined);
+		assert.equal(opencodeSessionHeaders(model("openai-compat", "https://opencode.ai.evil.example/v1"), "session-1"), undefined);
+	});
+});

--- a/test/unit/prompt-audit-optional-peers.test.ts
+++ b/test/unit/prompt-audit-optional-peers.test.ts
@@ -11,10 +11,12 @@ test("ordinary prompt audit works without optional Pi peers", async () => {
 	const isolatedRoot = await mkdtemp(join(tmpdir(), "pi-subagents-prompt-audit-"));
 	const promptAuditPath = join(isolatedRoot, "src/runs/foreground/prompt-audit.ts");
 	const streamOptionsPath = join(isolatedRoot, "src/shared/agent-stream-options.ts");
+	const opencodeSessionHeadersPath = join(isolatedRoot, "src/shared/opencode-session-headers.ts");
 
 	try {
 		await mkdir(dirname(promptAuditPath), { recursive: true });
 		await mkdir(dirname(streamOptionsPath), { recursive: true });
+		await mkdir(dirname(opencodeSessionHeadersPath), { recursive: true });
 		await writeFile(
 			promptAuditPath,
 			await readFile(join(repositoryRoot, "src/runs/foreground/prompt-audit.ts"), "utf8"),
@@ -22,6 +24,10 @@ test("ordinary prompt audit works without optional Pi peers", async () => {
 		await writeFile(
 			streamOptionsPath,
 			await readFile(join(repositoryRoot, "src/shared/agent-stream-options.ts"), "utf8"),
+		);
+		await writeFile(
+			opencodeSessionHeadersPath,
+			await readFile(join(repositoryRoot, "src/shared/opencode-session-headers.ts"), "utf8"),
 		);
 
 		const promptAudit = await import(pathToFileURL(promptAuditPath).href);

--- a/test/unit/watchdog-permission-arbiter.test.ts
+++ b/test/unit/watchdog-permission-arbiter.test.ts
@@ -16,6 +16,7 @@ function ctx(current = model()) {
 		cwd: "/tmp/watchdog-permission",
 		model: current,
 		signal: undefined,
+		sessionManager: { getSessionId: () => "watchdog-permission-session" },
 		modelRegistry: {
 			getAvailable: () => [current],
 			find: (provider: string, id: string) => provider === current.provider && id === current.id ? current : undefined,

--- a/test/unit/watchdog-review.test.ts
+++ b/test/unit/watchdog-review.test.ts
@@ -69,6 +69,7 @@ function createCtx(input: {
 		model: input.current,
 		...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
 		signal: undefined,
+		sessionManager: { getSessionId: () => "watchdog-review-session" },
 		getSystemPrompt: () => "Parent system prompt",
 		modelRegistry: {
 			getAvailable: () => allModels.filter((entry) => authenticated.has(`${entry.provider}/${entry.id}`)),


### PR DESCRIPTION
Background in earendil-works/pi#4847: pi added this header to its session path; OpenCode enforces it from Sep 6.

## What's happening
Pi emits `x-opencode-session` only inside its own session streamFn. Our four internal call sites (task-mutation arbiter, watchdog review, watchdog permission arbiter, prompt-audit rewrite) build bare Agents over raw streamSimple and skip that path entirely, so helper requests go to OpenCode/OpenCode Go unheadered while normal session traffic carries it.

## The fix
One small helper, `src/shared/opencode-session-headers.ts`: returns the two
headers for OpenCode models only (`opencode` / `opencode-go` providers or an `opencode.ai` baseUrl — detection copied from pi's provider-attribution), `undefined` for everything else.

The four call sites merge it in their existing auth wrappers, ahead of request/auth headers, so configured headers still win — same precedence pi uses. Session id comes from the session whose model services we borrow: the parent's for watchdog review, prompt audit, and the foreground arbiter; the child's for the permission arbiter and the detached runner (captured as a plain string next to the existing `completionIntentContext`, no live session held).

## Scope
Headers only. No prompt/tool/timeout/auth changes, no sessionId in agent state, so request bodies for other providers are untouched. Non-OpenCode requests are byte-identical to before.

fixes #2040