### PR TITLE
Fix child prompt filtering order before bridge capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
-- Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions.
+- Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
 - Intersect agent frontmatter `tools:` with host-available builtins before spawning children, so hosts with restricted tool menus (e.g. Prime Agent's `ipython`-only set) reject unavailable tools at launch instead of after spawn. Thanks to [@BioInfo](https://github.com/BioInfo) for #2034.
 - Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution (#2020). Thanks to [@kroediger](https://github.com/kroediger).
 - Prevent stale final-drain timers from aborting resumed native foreground and background child work. Thanks to [@harche](https://github.com/harche) for #2025.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions.
 - Intersect agent frontmatter `tools:` with host-available builtins before spawning children, so hosts with restricted tool menus (e.g. Prime Agent's `ipython`-only set) reject unavailable tools at launch instead of after spawn. Thanks to [@BioInfo](https://github.com/BioInfo) for #2034.
 - Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution (#2020). Thanks to [@kroediger](https://github.com/kroediger).
 - Prevent stale final-drain timers from aborting resumed native foreground and background child work. Thanks to [@harche](https://github.com/harche) for #2025.

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -124,6 +124,21 @@ export interface DefaultChildSessionFactoryOptions {
 
 type ModelRuntimeInstance = Awaited<ReturnType<PiCodingAgentModule["ModelRuntime"]["create"]>>;
 
+const CHILD_PROMPT_RUNTIME_EXTENSION_PATH = "<inline:pi-subagents:prompt-runtime>";
+
+/** The prompt runtime filters parent-only context before ambient extensions inspect
+ *  the child prompt. Other inline hooks keep their normal position after ambient
+ *  extensions, and ambient extension order stays unchanged. */
+function prioritizeChildPromptRuntime<T extends { extensions: Array<{ path: string }> }>(result: T): T {
+	const index = result.extensions.findIndex(({ path }) => path === CHILD_PROMPT_RUNTIME_EXTENSION_PATH);
+	if (index <= 0) return result;
+	const extensions = [...result.extensions];
+	const [promptRuntime] = extensions.splice(index, 1);
+	if (!promptRuntime) return result;
+	extensions.unshift(promptRuntime);
+	return { ...result, extensions };
+}
+
 /** One launch at a time from env application through `session_start`, so parallel launches never observe each other's `processEnv` while their extensions load and start. */
 let loading: Promise<unknown> = Promise.resolve();
 
@@ -211,6 +226,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 				noContextFiles: launch.noContextFiles,
 				additionalExtensionPaths: launch.extensionPaths,
 				extensionFactories: launch.hooks,
+				extensionsOverride: prioritizeChildPromptRuntime,
 				...(launch.systemPrompt !== undefined ? { systemPrompt: launch.systemPrompt } : {}),
 				...(launch.appendSystemPrompt !== undefined ? { appendSystemPrompt: [launch.appendSystemPrompt] } : {}),
 			});

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -277,7 +277,7 @@ describe("default child session factory", () => {
 
 	it("runs the child prompt rewrite before ambient prompt capture without reordering ambient extensions", async () => {
 		const agentPrompt = '<active_agent name="remotion-editor"/>\n\neditor instructions';
-		const globalPath = path.join(process.env.HOME ?? process.cwd(), ".pi", "agent", "AGENTS.md");
+		const globalPath = path.join(process.env.HOME ?? process.env.USERPROFILE ?? process.cwd(), ".pi", "agent", "AGENTS.md");
 		const projectPath = path.join(process.cwd(), "AGENTS.md");
 		const orchestrationSkill = '<skill><name>pi-subagents</name><location>/skills/pi-subagents/SKILL.md</location></skill>';
 		const assemble = (extra: string) => `${agentPrompt}${extra}`;

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -15,6 +15,7 @@ import { runSync } from "../../src/runs/foreground/execution.ts";
 import { childSessionFactory, createDefaultChildSessionFactory, disposeChildSessions, type ChildSessionFactory, type ChildSessionLaunch, type PiCodingAgentModule } from "../../src/runs/shared/child-session.ts";
 import { createNestedRoute } from "../../src/runs/shared/nested-events.ts";
 import { createStructuredOutputRuntime } from "../../src/runs/shared/structured-output.ts";
+import { rewriteSubagentPrompt } from "../../src/runs/shared/subagent-prompt-runtime.ts";
 import type { ForegroundChildSessionControls, SingleResult } from "../../src/shared/types.ts";
 
 async function waitFor(read: () => boolean, timeoutMs = 5_000): Promise<void> {
@@ -272,6 +273,82 @@ describe("default child session factory", () => {
 		await factory.create(stubLaunch);
 		await factory.create(stubLaunch);
 		assert.deepEqual(flags, [true, true]);
+	});
+
+	it("runs the child prompt rewrite before ambient prompt capture without reordering ambient extensions", async () => {
+		const agentPrompt = '<active_agent name="remotion-editor"/>\n\neditor instructions';
+		const globalPath = path.join(process.env.HOME ?? process.cwd(), ".pi", "agent", "AGENTS.md");
+		const projectPath = path.join(process.cwd(), "AGENTS.md");
+		const orchestrationSkill = '<skill><name>pi-subagents</name><location>/skills/pi-subagents/SKILL.md</location></skill>';
+		const assemble = (extra: string) => `${agentPrompt}${extra}`;
+		const destructivePrompt = assemble([
+			"", "<project_context>",
+			`<project_instructions path="${globalPath}">global parent-only instructions</project_instructions>`,
+			`<project_instructions path="${projectPath}">project instructions</project_instructions>`,
+			"</project_context>", orchestrationSkill,
+		].join("\n\n"));
+		const boundaryOnlyPrompt = assemble("");
+		const orderedPaths: string[][] = [];
+		const captureResults: boolean[] = [];
+		const forwardedPrompts: string[] = [];
+		const pi = stubPi();
+		pi.DefaultResourceLoader = class {
+			loaded = false;
+			private readonly options: { extensionsOverride?: (base: { extensions: Array<{ path: string }>; errors: unknown[]; runtime: object }) => { extensions: Array<{ path: string }>; errors: unknown[]; runtime: object } };
+			private result = { extensions: [] as Array<{ path: string }>, errors: [] as unknown[], runtime: {} };
+			constructor(options: typeof this.options) { this.options = options; }
+			async reload() {
+				const base = {
+					extensions: [
+						{ path: "/ambient/first.ts" },
+						{ path: "/ambient/claude-bridge.ts" },
+						{ path: "/ambient/last.ts" },
+						{ path: "<inline:pi-subagents:prompt-runtime>" },
+						{ path: "<inline:pi-subagents:completion-intent>" },
+					],
+					errors: [] as unknown[],
+					runtime: {},
+				};
+				this.result = this.options.extensionsOverride?.(base) ?? base;
+				orderedPaths.push(this.result.extensions.map(({ path: extensionPath }) => extensionPath));
+				for (const original of [boundaryOnlyPrompt, destructivePrompt]) {
+					let prompt = original;
+					let captured: string | undefined;
+					for (const { path: extensionPath } of this.result.extensions) {
+						if (extensionPath === "<inline:pi-subagents:prompt-runtime>") {
+							prompt = rewriteSubagentPrompt(prompt, { inheritProjectContext: true, inheritGlobalContext: false, inheritSkills: true });
+						}
+						if (extensionPath === "/ambient/claude-bridge.ts") captured = prompt;
+					}
+					captureResults.push(captured === prompt || (captured !== undefined && prompt.includes(captured)));
+					forwardedPrompts.push(prompt);
+				}
+			}
+			getExtensions() { return this.result; }
+		} as unknown as PiCodingAgentModule["DefaultResourceLoader"];
+
+		const factory = createDefaultChildSessionFactory({ loadPiCodingAgent: async () => pi });
+		await factory.create({
+			...stubLaunch,
+			ambientExtensions: true,
+			hooks: [
+				{ name: "pi-subagents:prompt-runtime", factory() {} },
+				{ name: "pi-subagents:completion-intent", factory() {} },
+			],
+		});
+
+		assert.deepEqual(orderedPaths[0], [
+			"<inline:pi-subagents:prompt-runtime>",
+			"/ambient/first.ts",
+			"/ambient/claude-bridge.ts",
+			"/ambient/last.ts",
+			"<inline:pi-subagents:completion-intent>",
+		]);
+		assert.deepEqual(captureResults, [true, true], "bridge-style capture must resolve both wrapping and destructive filtering");
+		assert.match(forwardedPrompts[1]!, /editor instructions/);
+		assert.match(forwardedPrompts[1]!, /project instructions/);
+		assert.doesNotMatch(forwardedPrompts[1]!, /global parent-only instructions/);
+		assert.doesNotMatch(forwardedPrompts[1]!, /<name>pi-subagents<\/name>/);
 	});
 
 	it("resolves models from providers queued during child extension loading", async () => {


### PR DESCRIPTION
## Problem

Native child launches can fail through `pi-claude-bridge` when child prompt filtering removes parent-only context or skills:

```text
prompt-capture: no capture for this ...-char system prompt, and it embeds none of the 1 known
```

Pi loads ambient extensions before inline child hooks. The bridge therefore captures the prompt before `pi-subagents:prompt-runtime` filters it. After filtering, the final prompt no longer contains the captured key. The bridge correctly refuses to continue without matching context.

## Fix

Use the resource loader's `extensionsOverride` hook to place only the child prompt runtime before ambient extensions. Preserve ambient extension order and keep other inline hooks in their existing positions.

The regression checks both wrapping-only prompts and prompts with intentional context removal. It verifies that allowed instructions survive and excluded instructions stay excluded. Bridge capture checks remain unchanged.

## Validation

- Regression failed before the fix and passed afterward.
- `npm run typecheck` passed.
- `npm run test:unit`: 2,988 passed, 13 skipped, zero failures.
- Focused `test/integration/in-process-child.test.ts`: 25 passed, zero failures.
- Bridge package typecheck and 189 unit tests passed.
- A live native child launched through its configured Claude bridge provider, read a fixture file, and confirmed role and project instructions were present. No model override was used.

```sh
node --experimental-strip-types --import ./test/support/register-loader.mjs \
  --test test/integration/in-process-child.test.ts
```

The full integration suite was not run. The change is limited to the child session factory, its regression test, and the changelog.


Fixes #2044
