### PR TITLE
fix(runner): restore standalone Pi background sessions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,3 +81,57 @@ jobs:
             ${{ runner.temp }}/pi0851-smoke/aliases.json
             ${{ runner.temp }}/pi0851-smoke/host/package-lock.json
             ${{ runner.temp }}/pi0851-smoke/extension/package-lock.json
+
+  official-standalone:
+    # Ubuntu 22.04 permits the unprivileged namespaces required by bubblewrap.
+    # This job targets the official release only, not arbitrary standalone forks.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Install controller dependencies and isolation tool
+        run: |
+          npm ci --ignore-scripts
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+      - name: Provision the checksum-pinned official binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="$(node -p 'require("./test/smoke/standalone-release.json").url')"
+          sha="$(node -p 'require("./test/smoke/standalone-release.json").archiveSha256')"
+          mkdir -p "$RUNNER_TEMP/pi-official"
+          curl --fail --location --retry 3 "$url" --output "$RUNNER_TEMP/pi-official/release.tar.gz"
+          printf '%s  %s\n' "$sha" "$RUNNER_TEMP/pi-official/release.tar.gz" | sha256sum --check -
+          tar -xzf "$RUNNER_TEMP/pi-official/release.tar.gz" -C "$RUNNER_TEMP/pi-official"
+      - name: Complete isolated official binary matrix
+        run: node test/smoke/standalone-matrix.mjs "$RUNNER_TEMP/pi-official/pi/pi" "$RUNNER_TEMP/standalone-matrix"
+      - name: Collect bounded lifecycle evidence
+        id: evidence
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/standalone-matrix"
+          find . -type d \( -name package -o -name cache -o -name bun-cache -o -name home -o -name agent -o -name assets -o -name theme -o -name export-html \) -prune -o -type f \( -name '*.log' -o -name '*.jsonl' -o -name status.json -o -name process-terminal.json -o -name identity.json -o -name '*result.json' -o -name '*notification*.json' -o -name '*witness.json' -o -name '*competition.json' -o -name launch.json -o -name '*failure.json' -o -name launch-error.json \) -print0 > "$RUNNER_TEMP/standalone-files"
+          tar --null -czf "$RUNNER_TEMP/standalone-evidence.tar.gz" --files-from "$RUNNER_TEMP/standalone-files"
+          test "$(stat -c %s "$RUNNER_TEMP/standalone-evidence.tar.gz")" -le 33554432
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: official-standalone-receipt
+          path: |
+            ${{ runner.temp }}/standalone-matrix/matrix.json
+            ${{ runner.temp }}/standalone-matrix/inputs.json
+          if-no-files-found: warn
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.evidence.outcome == 'success'
+        with:
+          name: official-standalone-lifecycle
+          path: ${{ runner.temp }}/standalone-evidence.tar.gz
+          if-no-files-found: error
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 pi install npm:pi-subagents
 ```
 
-That is the only required step. Background children require pi installed as the npm package (`@earendil-works/pi-coding-agent`): the detached runner imports pi's packages from that package directory. A standalone single-file pi binary has no package directory and cannot run background children; foreground children (`async: false`) still work there.
+That is the only required step. Background children use the selected host's SDK: npm Pi keeps its detached Node runner, while supported Bun-compiled Pi hosts load the same configured runner through Pi's embedded SDK. Each independent background run has its own host; native sessions inside that run share it. The standalone regression target is the official Pi v0.85.1 Linux x64 release. See [Standalone background execution](docs/standalone-background.md) for tested limits, isolated validation, and a trial without replacing your installation.
 
 ## Try this first
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -392,7 +392,9 @@ Controls nested delegation when no stricter limit is inherited from the launchin
 export PI_SUBAGENT_PI_BINARY=/path/to/pi-or-wrapper
 ```
 
-Overrides the `pi` command pi-subagents spawns for Herdr project panes (`action: "project.open"`) and for the profile model probe. Package wrappers can set this to their own `pi` binary so those launches inherit wrapper flags, environment setup, and bundled resources without relying on `PATH` ordering. Empty or whitespace-only values are ignored. It does not affect children: foreground children are sessions inside the parent Pi process and background children are sessions inside the detached runner process, and neither spawns a `pi` binary. Background children require pi installed as the npm package (`@earendil-works/pi-coding-agent`), because the runner imports pi's packages from that package directory; a standalone pi binary has no package directory, and background launches fail with an error saying so.
+Overrides the `pi` command pi-subagents spawns for Herdr project panes (`action: "project.open"`) and the profile model probe. On a supported Bun-compiled Pi host it also selects the executable for a detached background host. The override must accept Pi's bootstrap arguments and provide the compatible embedded SDK and adjacent release resources; a bare Bun interpreter or unrelated executable is not a substitute. Empty or whitespace-only values are ignored, and a failed launch is not retried with another executable.
+
+Foreground children remain sessions inside the parent. Npm-hosted background children retain their detached Node runner and host-package peer aliases; this variable does not turn an npm host into a binary-backed runner. Binary-backed background children use Pi's extension loader to supply the embedded SDK, with no separate SDK installation. See [Standalone background execution](standalone-background.md) for the tested official target and regression commands.
 
 ## `intercomBridge`
 

--- a/docs/standalone-background.md
+++ b/docs/standalone-background.md
@@ -1,0 +1,89 @@
+# Standalone background execution
+
+Native background children work through the SDK supplied by their Pi host. Npm Pi keeps the detached Node runner and host peer aliases. A supported Bun-compiled Pi instead loads `src/runs/background/binary-bootstrap.ts` through Pi's extension loader and supplies its embedded SDK to the existing configured runner.
+
+## Tested boundary
+
+| Host | Verification |
+| --- | --- |
+| Official `earendil-works/pi` v0.85.1, Linux x64 binary | Complete 18-mode isolated lifecycle matrix |
+| Npm Pi 0.85.0 and 0.85.1 | Real SDK/default-factory smoke, real public background launch, and existing Node regressions |
+
+The binary harness currently requires Linux x64, bubblewrap, Node, npm, tar and ordinary system libraries. Keep the official release's adjacent assets with its executable. The smoke copies those assets; a binary missing its theme or other initialization resources is not an equivalent test environment.
+
+Other operating systems, architectures, Deno, Node SEA and other packagers are not covered by this standalone claim. Repository CI pins the official release only. No extra runner setting or separate Pi SDK installation is needed for the binary path.
+
+Each independent detached run retains its own host. Workflow children that were separate runs remain separate. Multiple native sessions **inside one run** share its configured runner and host; there is no cross-run process pool or per-session CLI/stdout protocol.
+
+## Run the complete binary gate
+
+Run these commands from a source checkout. Dependency installation and release download are provisioning steps, separate from sandboxed execution:
+
+```bash
+npm ci --ignore-scripts
+release_dir="$(mktemp -d)"
+url="$(node -p 'require("./test/smoke/standalone-release.json").url')"
+sha="$(node -p 'require("./test/smoke/standalone-release.json").archiveSha256')"
+curl --fail --location --retry 3 "$url" --output "$release_dir/release.tar.gz"
+printf '%s  %s\n' "$sha" "$release_dir/release.tar.gz" | sha256sum --check -
+tar -xzf "$release_dir/release.tar.gz" -C "$release_dir"
+artifacts="$(mktemp -d)/matrix"
+node test/smoke/standalone-matrix.mjs "$release_dir/pi/pi" "$artifacts"
+```
+
+Install bubblewrap through your platform's package manager if it is absent. Namespace creation must be permitted; an unavailable sandbox fails the gate rather than skipping tests. The harness reads the system dynamic-loader cache where present, so glibc can locate libraries such as `libgcc_s` when workflow threads exit. It does not mount operator configuration or another Pi SDK.
+
+The matrix checks the pinned binary hash, records execution-input hashes, creates fresh stages for all 18 modes and requires every stage to use the same package SHA256. Each stage has fresh home/config/install caches and isolated network/PID namespaces. A separate bare-runtime import must fail, and no filesystem SDK/shim or populated Bun installation cache may appear. `BUN_BE_BUN=1` is used only for that negative control, never to execute accepted child work.
+
+The modes cover single and mixed workflows; multiple sessions in one run; parallel stop; targeted steer/interrupt; child, tool and run deadlines; missing bootstrap; post-spawn persistence/authorization failure; SDK resource initialization failure; bootstrap input/EOF errors with an authorized positive control; and competing revival with handshake and lease-release checks.
+
+The provider is deterministic, but the public tool, Pi SDK, session factory and configured runner are real. Only targeted filesystem writes are faulted for startup-error cases. An installed observer and a real positive control establish that the task could execute. Test file-state checkpoints do not synthesize completion notifications: those still arrive through the real parent's `sendMessage` boundary.
+
+Inspect:
+
+- `matrix.json`: complete/partial receipt, per-mode exit codes and package identity.
+- `inputs.json`: frozen execution inputs. Do not combine passes from different snapshots.
+- `<mode>/identity.json`, `parent.log`, `lifecycle.jsonl` and notification evidence.
+- `<mode>/tmp/**/status.json` and `process-terminal.json`: logical state versus observed process exit.
+- Revival and shared-run witnesses in their mode directories.
+
+A persisted result is not exit proof. The tests separately await the close observation, verify the runner PID no longer exists **before sandbox teardown**, and check SDK shutdown hooks. Failed attempts remain evidence, not passing receipts. The CI job runs this same matrix command and retains selected lifecycle evidence with a 32 MiB compressed limit, separately from the input/receipt files; an overflow fails the job.
+
+For one focused diagnostic, use a fresh directory:
+
+```bash
+node test/smoke/standalone-background.mjs "$release_dir/pi/pi" "$(mktemp -d)/revival" revival
+```
+
+A focused pass is not the complete gate. Stages are retained for inspection and can occupy several GiB; choose a disk-backed artifact directory rather than a small RAM-backed `/tmp`.
+
+## Npm regression checks
+
+Keep npm SDK installs separate from binary stages:
+
+```bash
+npm run typecheck
+npm test
+npm run test:integration
+
+npm_checks="$(mktemp -d)"
+node test/smoke/pi085-clean-install.mjs "$npm_checks/sdk-0.85.0" 0.85.0
+node test/smoke/pi085-clean-install.mjs "$npm_checks/sdk-0.85.1" 0.85.1
+node test/smoke/npm-background.mjs "$npm_checks/sdk-0.85.0" "$npm_checks/launch-0.85.0"
+node test/smoke/npm-background.mjs "$npm_checks/sdk-0.85.1" "$npm_checks/launch-0.85.1"
+```
+
+The first pair provisions clean real SDK installs and verifies the default factory and host peer aliases. The second pair reuses those installs, with no network during execution, to verify the real npm CLI → public subagent tool → detached Node runner → SDK session → normal notification and observed exit. It also requires Linux/bubblewrap. The existing Bun workflow parity command remains in `.github/workflows/test.yml`.
+
+## Try the local candidate without replacing an installation
+
+From the candidate checkout with its npm dependencies installed, start a separate official Pi process with an isolated agent directory:
+
+```bash
+trial_state="$(mktemp -d)"
+PI_CODING_AGENT_DIR="$trial_state" "$release_dir/pi/pi" \
+  --no-extensions --no-skills --no-prompt-templates \
+  --extension "$PWD/index.ts"
+```
+
+Authenticate/configure a provider in that trial session, or explicitly load the provider extension it needs. The isolated directory intentionally does not reuse your normal login/configuration. Ask it to run a read-only agent in the background, then inspect its notification and run evidence. This command loads the checkout only for the new process: it does not install the candidate, alter the existing extension checkout, or switch another running session. Keep that process alive for notifications; shutting down the parent is not a validation of child cleanup.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -20,7 +20,7 @@ import { applyWatchdogLaunchRules, sendRuleViolationWarning } from "../../watchd
 import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveExistingReadInstructionPaths, resolveExistingReadPaths, writeInitialProgressFile, type ChainStep, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import type { ContextMode } from "../shared/context-mode.ts";
-import { PI_CODING_AGENT_PACKAGE, resolveInstalledPiPackageRoot, resolvePiPackageRoot } from "../shared/pi-spawn.ts";
+import { PI_CODING_AGENT_PACKAGE, resolveBunPiExecutable, resolveInstalledPiPackageRoot, resolvePiPackageRoot } from "../shared/pi-spawn.ts";
 import { JITI_ALIAS_ENV, resolveHostPeerAliases } from "./runner-aliases.ts";
 import { preflightLaunchCwd } from "../shared/launch-cwd.ts";
 import { resolveNodeExecutable } from "../../shared/node-executable.ts";
@@ -542,15 +542,35 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Om
 	const cwdError = preflightLaunchCwd(requestedCwd, cwd);
 	if (cwdError) return { error: cwdError };
 
-	if (!jitiCliPath) {
+	// A compiled Pi exposes its SDK through Pi's extension loader, not a disk package.
+	// Use the running executable (which may be renamed, e.g. pi-native), never the
+	// virtual /$bunfs entrypoint or a bare Bun interpreter. The latter can silently
+	// auto-install a different SDK. Preserve #1844's one shared runner per run:
+	// https://github.com/nicobailon/pi-subagents/pull/1844
+	// Real regression: test/smoke/standalone-background.mjs (no disk SDK/network).
+	const binaryHost = resolveBunPiExecutable();
+	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
+	const bootstrap = path.join(path.dirname(runner), "binary-bootstrap.ts");
+	// A successful spawn is not proof that Pi loaded the explicit bootstrap. Reject
+	// a missing packaged asset at the public launch boundary, rather than accepting
+	// a run that cannot enter the configured runner.
+	// Regression: standalone-background.mjs ... missing-bootstrap.
+	if (binaryHost && !fs.existsSync(bootstrap)) return { error: `Background runner bootstrap not found: ${bootstrap}` };
+	if (!binaryHost && !jitiCliPath) {
 		return { error: "upstream jiti for TypeScript execution could not be found; ensure package dependencies are installed" };
 	}
-	if (!piPackageRoot) {
-		return { error: `Background children require pi installed as the npm package (${PI_CODING_AGENT_PACKAGE}); a standalone pi binary has no package directory, so the async runner cannot create child sessions. Run this child in the foreground (async: false) or install pi from npm.` };
+	if (!binaryHost && !piPackageRoot) {
+		return { error: `Background children require a supported standalone Pi host or the installed npm package (${PI_CODING_AGENT_PACKAGE}); neither is available.` };
 	}
-	const hostPeerAliases = resolveHostPeerAliases(piPackageRoot);
+	// Do not apply npm peer aliases to the binary path or remove them from Node:
+	// #2037 repairs a filesystem package graph, not the embedded SDK's identity.
+	// Both paths must keep the same startup barrier and close observer below.
+	// https://github.com/nicobailon/pi-subagents/pull/2037
+	const hostPeerAliases = !binaryHost && piPackageRoot
+		? resolveHostPeerAliases(piPackageRoot)
+		: { aliases: {}, missing: [] };
 	if (hostPeerAliases.missing.length > 0) {
-		return { error: `Background children require pi installed as the npm package (${PI_CODING_AGENT_PACKAGE}) with its dependencies; ${piPackageRoot} does not provide ${hostPeerAliases.missing.join(", ")}, so the async runner cannot create child sessions. A standalone pi binary cannot run background children.` };
+		return { error: `Background children require the host npm package (${PI_CODING_AGENT_PACKAGE}) with its dependencies; ${piPackageRoot} does not provide ${hostPeerAliases.missing.join(", ")}.` };
 	}
 
 	fs.mkdirSync(TEMP_ROOT_DIR, { recursive: true });
@@ -560,8 +580,7 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Om
 	const launchBarrierToken = hasRevivalLease ? undefined : runnerProcessInstanceId;
 	const launchConfig = { ...cfg, runnerProcessInstanceId, ...(launchBarrierToken ? { launchBarrierToken } : {}) };
 	writePrivateAtomicJson(cfgPath, launchConfig);
-	const runner = path.join(path.dirname(fileURLToPath(import.meta.url)), "subagent-runner.ts");
-	const nodeCommand = resolveNodeExecutable();
+	const command = binaryHost ?? resolveNodeExecutable();
 	const launchForStartup = launchConfig as typeof launchConfig & { asyncDir?: unknown; id?: unknown; sessionId?: unknown; completionOwnerId?: unknown; revivalLease?: unknown };
 	const launchAsyncDir = typeof launchForStartup.asyncDir === "string" ? launchForStartup.asyncDir : undefined;
 	const launchRunId = typeof launchForStartup.id === "string" ? launchForStartup.id : suffix;
@@ -590,14 +609,18 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Om
 		const preload = Object.keys(hostPeerAliases.aliases).length > 0
 			? ["--import", new URL("../../../runner-peer-preload.mjs", import.meta.url).href]
 			: [];
-		const proc = spawn(nodeCommand, [...preload, jitiCliPath, runner, cfgPath], {
+		const args = binaryHost
+			? ["--no-extensions", "--no-skills", "--no-prompt-templates", "--no-session", "--mode", "rpc", "--extension", bootstrap]
+			: [...preload, jitiCliPath!, runner, cfgPath];
+		const proc = spawn(command, args, {
 			cwd,
 			...backgroundProcessOptions(),
 			stdio: ["ignore", stdoutFd ?? "ignore", stderrFd ?? "ignore"],
 			env: {
 				...omitExtensionBindingsEnv(process.env),
-				[PI_CODING_AGENT_PACKAGE_ROOT_ENV]: piPackageRoot,
-				[JITI_ALIAS_ENV]: JSON.stringify(hostPeerAliases.aliases),
+				[PI_CODING_AGENT_PACKAGE_ROOT_ENV]: binaryHost ? undefined : piPackageRoot,
+				[JITI_ALIAS_ENV]: binaryHost ? undefined : JSON.stringify(hostPeerAliases.aliases),
+				PI_SUBAGENT_RUNNER_CONFIG: binaryHost ? cfgPath : undefined,
 			},
 		});
 		closeFd(stdoutFd);

--- a/src/runs/background/binary-bootstrap.ts
+++ b/src/runs/background/binary-bootstrap.ts
@@ -1,0 +1,48 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as sdk from "@earendil-works/pi-coding-agent";
+import { runConfiguredSubagent, type SubagentRunConfig } from "./subagent-runner.ts";
+
+/**
+ * This module must be loaded by Pi's extension loader, not Node/jiti or bare Bun.
+ * Only that loader supplies the binary's embedded SDK namespaces. BUN_BE_BUN=1
+ * bypasses it, and an apparent import success can be an auto-downloaded, different
+ * SDK version. The isolated standalone smoke has a negative control for this.
+ * An earlier bare-Bun probe accidentally fetched a different filesystem SDK;
+ * import success alone therefore says nothing about embedded-SDK compatibility.
+ * Bun workflow support has also regressed on Node-only assumptions (#1158),
+ * repaired in #1170 without a Node sidecar. Keep the runner's portable workflow
+ * implementation; this bootstrap changes its host, not its execution protocol.
+ * https://github.com/nicobailon/pi-subagents/issues/1158
+ * https://github.com/nicobailon/pi-subagents/pull/1170
+ *
+ * Keep the host inside extension initialization until the shared runner finishes.
+ * Returning early enters Pi's normal session/RPC loop, where stdin EOF and outer
+ * resource loading would compete with background ownership. Explicit exit follows
+ * configured-runner disposal/lease release, just as in the Node entrypoint.
+ * https://github.com/nicobailon/pi-subagents/pull/1844
+ * Regression gate: node test/smoke/standalone-matrix.mjs <official-pi> <fresh-root>.
+ * This must include real startup failures, two sessions in one host, parallel
+ * stop and competing revival; an import probe or cross-run workflow is not enough.
+ */
+export default async function runBinaryBootstrap(): Promise<never> {
+	const configPath = process.env.PI_SUBAGENT_RUNNER_CONFIG;
+	delete process.env.PI_SUBAGENT_RUNNER_CONFIG;
+	try {
+		if (!configPath || !path.isAbsolute(configPath)) throw new Error("Missing absolute PI_SUBAGENT_RUNNER_CONFIG path");
+		const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as SubagentRunConfig;
+		if (!config || typeof config.id !== "string" || typeof config.asyncDir !== "string" || !Array.isArray(config.steps)) {
+			throw new Error("Invalid binary runner configuration");
+		}
+		try {
+			fs.unlinkSync(configPath);
+		} catch {
+			// Consumption succeeded; temp-config cleanup is best effort, as in the Node entrypoint.
+		}
+		await runConfiguredSubagent(config, { loadPiCodingAgent: async () => sdk });
+		process.exit(0);
+	} catch (error) {
+		console.error("Subagent binary runner error:", error);
+		process.exit(1);
+	}
+}

--- a/src/runs/background/runner-child-sessions.ts
+++ b/src/runs/background/runner-child-sessions.ts
@@ -1,15 +1,22 @@
 /**
  * Child session factory for the detached async runner.
  *
- * The runner imports `@earendil-works/pi-coding-agent` like the parent does;
- * the parent aliases that specifier (and the other host peer packages) to the
- * installed pi package through `JITI_ALIAS` when it spawns the runner, see
- * `runner-aliases.ts`. Tests replace the factory with a scripted one by
- * naming a module in the runner config.
+ * The npm runner imports `@earendil-works/pi-coding-agent` through the parent's
+ * host peer aliases (`runner-aliases.ts`/`JITI_ALIAS`). A Pi-binary bootstrap
+ * instead supplies its embedded SDK loader through the existing factory option.
+ * Keep these ownership paths separate: filesystem peer fixes such as #2037 do
+ * not make a binary's embedded SDK importable by a detached Node process, and
+ * resolving another installed SDK would split provider/extension identities.
+ * Tests may still replace the factory by naming a module in the runner config;
+ * the standalone smoke deliberately does NOT use that seam.
+ * https://github.com/nicobailon/pi-subagents/pull/2037
+ * Regressions: test/smoke/pi085-clean-install.mjs checks real npm host aliases;
+ * test/smoke/standalone-matrix.mjs forbids a filesystem SDK and proves the
+ * injected namespace creates real sessions. Neither gate substitutes for the other.
  */
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { createDefaultChildSessionFactory, type ChildSessionFactory } from "../shared/child-session.ts";
+import { createDefaultChildSessionFactory, type ChildSessionFactory, type DefaultChildSessionFactoryOptions } from "../shared/child-session.ts";
 
 export interface RunnerChildSessionConfig {
 	/** Test seam: module whose default export is a `ChildSessionFactory`, or a function returning one. */
@@ -20,8 +27,8 @@ function isChildSessionFactory(value: unknown): value is ChildSessionFactory {
 	return Boolean(value) && typeof value === "object" && typeof (value as ChildSessionFactory).create === "function" && typeof (value as ChildSessionFactory).dispose === "function";
 }
 
-export async function loadRunnerChildSessionFactory(config: RunnerChildSessionConfig): Promise<ChildSessionFactory> {
-	if (!config.childSessionFactoryModule) return createDefaultChildSessionFactory();
+export async function loadRunnerChildSessionFactory(config: RunnerChildSessionConfig, options?: DefaultChildSessionFactoryOptions): Promise<ChildSessionFactory> {
+	if (!config.childSessionFactoryModule) return createDefaultChildSessionFactory(options);
 	const loaded = await import(pathToFileURL(path.resolve(config.childSessionFactoryModule)).href) as { default?: unknown };
 	const candidate = typeof loaded.default === "function" ? (loaded.default as () => unknown)() : loaded.default;
 	if (!isChildSessionFactory(candidate)) {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -96,7 +96,7 @@ import { applyThinkingSuffix, projectLaunchResolvedChildExtensions, resolvePiLau
 import type { InheritedChildRuntime } from "../shared/child-launch.ts";
 import { buildRunnerChildLaunch } from "./runner-child-launch.ts";
 import { normalizeExtensionBindings } from "../shared/extension-bindings.ts";
-import type { ChildSessionFactory } from "../shared/child-session.ts";
+import type { ChildSessionFactory, DefaultChildSessionFactoryOptions } from "../shared/child-session.ts";
 import { getSettledReadonlyChild, runChildSession, type ChildEvent, type RunChildSessionInput, type RunChildSessionResult, type StepSteerHandler } from "./run-child-session.ts";
 import { planReadonlyModelContinuation, READONLY_CONTINUATION_PROMPT, type LogicalRecoveryState } from "../shared/readonly-model-continuation.ts";
 import { getReadonlySessionEvidence } from "../shared/readonly-session-evidence.ts";
@@ -184,7 +184,7 @@ const INTERCOM_DETACH_RECEIPT = "Detached for intercom coordination before task 
 // child host.
 process.env[SUBAGENT_CHILD_ENV] = "1";
 
-interface SubagentRunConfig {
+export interface SubagentRunConfig {
 	id: string;
 	steps: RunnerStep[];
 	resultPath: string;
@@ -5091,7 +5091,17 @@ async function waitForStartupControl(
 	throw new Error(`Timed out after ${timeoutMs}ms waiting for runner startup control '${action}'.`);
 }
 
-async function runConfiguredSubagent(config: SubagentRunConfig): Promise<void> {
+/**
+ * Shared lifecycle entry for Node and Pi-binary hosts. Do not call runSubagent
+ * directly from a new host: authorization, revival ownership and final disposal
+ * live here. #1837/#1844 deliberately replaced per-child CLI processes with SDK
+ * sessions; adding binary support must not resurrect stdout parsing or duplicate
+ * these safeguards. See test/smoke/standalone-background.mjs and the async
+ * startup/revival integration tests.
+ * https://github.com/nicobailon/pi-subagents/issues/1837
+ * https://github.com/nicobailon/pi-subagents/pull/1844
+ */
+export async function runConfiguredSubagent(config: SubagentRunConfig, options?: DefaultChildSessionFactoryOptions): Promise<void> {
 	let lease: ReturnType<typeof acquireSessionLease> | undefined;
 	let startupCommitted = config.revivalLease === undefined && config.launchBarrierToken === undefined;
 	const startupPath = path.join(config.asyncDir, "runner-startup.json");
@@ -5130,7 +5140,7 @@ async function runConfiguredSubagent(config: SubagentRunConfig): Promise<void> {
 				}
 			}
 		}
-		const childSessions = await loadRunnerChildSessionFactory(config);
+		const childSessions = await loadRunnerChildSessionFactory(config, options);
 		try {
 			await runSubagent(config, childSessions);
 		} finally {

--- a/src/runs/shared/pi-spawn.ts
+++ b/src/runs/shared/pi-spawn.ts
@@ -49,6 +49,7 @@ export interface PiSpawnDeps {
 	platform?: NodeJS.Platform;
 	execPath?: string;
 	argv1?: string;
+	bunVersion?: string;
 	existsSync?: (filePath: string) => boolean;
 	realpathSync?: (filePath: string) => string;
 	readFileSync?: (filePath: string, encoding: "utf-8") => string;
@@ -56,6 +57,24 @@ export interface PiSpawnDeps {
 	resolvePackageEntry?: () => string;
 	piPackageRoot?: string;
 	env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Bun's executable entrypoint is virtual; the actual image may be called anything.
+ * A filename-only check (the earlier standalone fix in #764) misses renamed
+ * images. Require both Bun and its compiled entrypoint before reusing execPath;
+ * ordinary Bun scripts must not be launched as if they were the Pi executable.
+ * https://github.com/nicobailon/pi-subagents/pull/764
+ * Check: node --experimental-strip-types --test test/unit/binary-pi-spawn.test.ts
+ * The real-loader gate is test/smoke/standalone-matrix.mjs; injected process
+ * metadata in these unit tests is not evidence that a packaged SDK executed.
+ */
+export function resolveBunPiExecutable(deps: PiSpawnDeps = {}): string | undefined {
+	const bunVersion = deps.bunVersion ?? process.versions.bun;
+	const entry = deps.argv1 ?? process.argv[1];
+	if (!bunVersion || !entry?.startsWith("/$bunfs/")) return undefined;
+	const env = deps.env ?? process.env;
+	return env[PI_SUBAGENT_PI_BINARY_ENV]?.trim() || (deps.execPath ?? process.execPath);
 }
 
 interface PiSpawnCommand {
@@ -176,6 +195,8 @@ export function getPiSpawnCommand(
 	}
 
 	const execPath = deps.execPath ?? process.execPath;
+	const bunHost = resolveBunPiExecutable(deps);
+	if (bunHost) return { command: bunHost, args };
 	if (isStandalonePiExecutable(execPath)) {
 		return { command: execPath, args };
 	}

--- a/test/smoke/npm-background.mjs
+++ b/test/smoke/npm-background.mjs
@@ -1,0 +1,39 @@
+// Real npm CLI -> public subagent tool -> detached Node runner -> SDK session.
+// Reuse a clean install made by pi085-clean-install.mjs; no installs during this check.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const npmRoot = process.argv[2];
+const root = process.argv[3];
+assert.equal(process.platform, "linux", "this focused real npm launch check requires bubblewrap");
+assert.ok(npmRoot && path.isAbsolute(npmRoot));
+assert.ok(root && path.isAbsolute(root) && !fs.existsSync(root), "fresh artifact root required");
+const installed = path.join(npmRoot, "extension/node_modules/pi-subagents");
+const sdk = "host/node_modules/@earendil-works/pi-coding-agent";
+const version = JSON.parse(fs.readFileSync(path.join(npmRoot, sdk, "package.json"), "utf8")).version;
+assert.ok(["0.85.0", "0.85.1"].includes(version));
+for (const name of ["", "tmp", "home", "agent", "work/.pi/agents"]) fs.mkdirSync(path.join(root, name), { recursive: true });
+fs.cpSync(installed, path.join(root, "package"), { recursive: true });
+fs.mkdirSync(path.join(root, "package/test/smoke"), { recursive: true });
+for (const name of ["standalone-parent.ts", "standalone-provider.ts", "standalone-observer.ts", "standalone-revival.ts", "standalone-shared.ts"]) fs.copyFileSync(new URL(name, import.meta.url), path.join(root, "package/test/smoke", name));
+fs.copyFileSync(process.execPath, path.join(root, "node"));
+fs.writeFileSync(path.join(root, "agent/settings.json"), JSON.stringify({ defaultProvider: "standalone-smoke", defaultModel: "local", packages: [] }));
+fs.writeFileSync(path.join(root, "work/.pi/agents/binary-smoke.md"), "---\nname: binary-smoke\ndescription: Real npm background launch\nmodel: standalone-smoke/local\ntools:\nextensions:\n  - /stage/package/test/smoke/standalone-observer.ts\n  - /stage/package/test/smoke/standalone-provider.ts\ncompletionGuard: false\n---\nReturn the scripted response.\n");
+const aliases = JSON.parse(fs.readFileSync(path.join(npmRoot, "aliases.json"), "utf8")).aliases;
+const mapped = Object.fromEntries(Object.entries(aliases).map(([key, value]) => [key, value.replaceAll(npmRoot, "/npm-fixture")]));
+const args = ["--die-with-parent", "--unshare-net", "--unshare-pid", "--ro-bind", "/usr", "/usr", "--symlink", "usr/bin", "/bin"];
+for (const lib of ["/lib", "/lib64", "/etc/ld.so.cache"]) if (fs.existsSync(lib)) args.push("--ro-bind", lib, lib);
+args.push("--proc", "/proc", "--dev", "/dev", "--bind", root, "/stage", "--bind", path.join(root, "tmp"), "/tmp", "--ro-bind", npmRoot, "/npm-fixture", "--ro-bind", path.join(npmRoot, "extension/node_modules"), "/stage/node_modules", "--chdir", "/stage/work", "--clearenv");
+for (const [key, value] of Object.entries({ PATH: "/stage:/usr/bin:/bin", HOME: "/stage/home", PI_CODING_AGENT_DIR: "/stage/agent", PI_OFFLINE: "1", JITI_FS_CACHE: "false", JITI_ALIAS: JSON.stringify(mapped), TERM: "dumb", PI_STANDALONE_SMOKE_MODE: "single" })) args.push("--setenv", key, value);
+args.push("--", "/stage/node", "--import", "/stage/package/runner-peer-preload.mjs", `/npm-fixture/${sdk}/dist/cli.js`, "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-session", "--mode", "rpc", "--extension", "/stage/package/test/smoke/standalone-provider.ts", "--extension", "/stage/package/test/smoke/standalone-parent.ts");
+const result = spawnSync("bwrap", args, { encoding: "utf8", timeout: 90000, maxBuffer: 10 * 1024 * 1024 });
+fs.writeFileSync(path.join(root, "parent.log"), `${result.stdout ?? ""}${result.stderr ?? ""}`);
+assert.ifError(result.error);
+assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+assert.match(result.stdout + result.stderr, /PASS standalone native async/);
+const lifecycle = fs.readFileSync(path.join(root, "lifecycle.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+assert.ok(lifecycle.filter((event) => event.event === "start").every((event) => event.executable === "/stage/node"));
+fs.writeFileSync(path.join(root, "npm-launch.json"), JSON.stringify({ version, runtime: "Node", publicLaunch: true, network: "unshared" }, null, 2));
+console.log(`PASS npm ${version}: real public background launch, SDK identity, notification and observed runner exit; ${root}`);

--- a/test/smoke/standalone-background.mjs
+++ b/test/smoke/standalone-background.mjs
@@ -1,0 +1,126 @@
+// Linux real-binary smoke; no installed Pi SDK, credentials, or network in the execution sandbox.
+// node test/smoke/standalone-background.mjs /absolute/pi-binary [artifact-directory] [mode]
+// A bare Bun import once appeared to pass by silently installing a mismatched SDK.
+// Never replace the network namespace, empty cache, or negative control with a warm import check.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const source = fileURLToPath(new URL("../../", import.meta.url));
+const binary = process.argv[2];
+const mode = process.argv[4] ?? "single";
+assert.ok(["single", "workflow", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout", "tool-timeout", "sdk-init-failure", "persistence-failure", "authorization-failure", "missing-bootstrap", "revival", "shared-run", "parallel-stop", "bootstrap-errors"].includes(mode), "unknown standalone smoke mode");
+assert.ok(binary && path.isAbsolute(binary) && fs.existsSync(binary), "provide an existing absolute Pi binary path; this test never skips");
+assert.equal(process.platform, "linux", "the isolated smoke currently requires Linux/bubblewrap");
+const root = process.argv[3] ? path.resolve(process.argv[3]) : fs.mkdtempSync(path.join(os.tmpdir(), "pi-standalone-smoke-"));
+fs.mkdirSync(root, { recursive: true });
+assert.ok(!fs.existsSync(path.join(root, "package")), "requires a fresh artifact directory");
+const coreSdk = /(?:^|\/)@earendil-works\/(?:pi-coding-agent|pi-agent-core|pi-ai|pi-tui)(?:\/|$)/;
+function run(name, command, args, options = {}) {
+	const result = spawnSync(command, args, { cwd: source, encoding: "utf8", timeout: 90_000, maxBuffer: 10 * 1024 * 1024, ...options });
+	fs.writeFileSync(path.join(root, `${name}.log`), `${result.stdout ?? ""}${result.stderr ?? ""}`);
+	assert.ifError(result.error);
+	return result;
+}
+const packed = run("pack", "npm", ["pack", "--ignore-scripts", "--json", "--pack-destination", root]);
+assert.equal(packed.status, 0, packed.stderr);
+const tarball = JSON.parse(packed.stdout)[0];
+assert.equal(run("extract", "tar", ["-xf", path.join(root, tarball.filename), "-C", root]).status, 0);
+// Copy rather than symlink: ancestor resolution must not escape into the checkout's dev SDK/shim.
+fs.cpSync(path.join(source, "node_modules"), path.join(root, "package/node_modules"), {
+	recursive: true,
+	filter: (entry) => !coreSdk.test(path.relative(source, entry).split(path.sep).join("/")),
+});
+for (const name of ["home", "agent", "work", "tmp", "cache", "bun-cache", "package/test/smoke"]) fs.mkdirSync(path.join(root, name), { recursive: true });
+fs.copyFileSync(binary, path.join(root, "pi-native"));
+// Standalone distributions still ship non-SDK assets required by session initialization.
+for (const name of ["theme", "assets", "export-html", "photon_rs_bg.wasm"]) {
+	const asset = path.join(path.dirname(binary), name);
+	if (fs.existsSync(asset)) fs.cpSync(asset, path.join(root, name), { recursive: true });
+}
+for (const name of ["standalone-parent.ts", "standalone-provider.ts", "standalone-observer.ts", "standalone-fault.ts", "standalone-revival.ts", "standalone-shared.ts"]) fs.copyFileSync(new URL(name, import.meta.url), path.join(root, "package/test/smoke", name));
+fs.writeFileSync(path.join(root, "work/bunfig.toml"), '[install]\nauto = "disable"\n');
+fs.writeFileSync(path.join(root, "work/negative.ts"), 'import "@earendil-works/pi-coding-agent";\n');
+fs.mkdirSync(path.join(root, "work/.pi/agents"), { recursive: true });
+fs.writeFileSync(path.join(root, "work/.pi/agents/binary-smoke.md"), `---\nname: binary-smoke\ndescription: Isolated native async regression\nmodel: standalone-smoke/local\ntools: ${mode === "tool-timeout" ? "bash" : ""}\nextensions:\n  - /stage/package/test/smoke/standalone-observer.ts\n  - /stage/package/test/smoke/standalone-provider.ts\ncompletionGuard: false\n---\nReturn the scripted response.\n`);
+fs.writeFileSync(path.join(root, "agent/settings.json"), JSON.stringify({ defaultProvider: "standalone-smoke", defaultModel: "local", packages: [] }));
+fs.mkdirSync(path.join(root, "agent/extensions"), { recursive: true });
+fs.writeFileSync(path.join(root, "agent/extensions/ambient-sentinel.ts"), 'import fs from "node:fs"; export default function () { fs.writeFileSync("/stage/ambient-loaded", String(process.pid)); }\n');
+const sandbox = ["--die-with-parent", "--unshare-net", "--unshare-pid", "--ro-bind", "/usr", "/usr", "--symlink", "usr/bin", "/bin"];
+for (const lib of ["/lib", "/lib64"]) if (fs.existsSync(lib)) sandbox.push("--ro-bind", lib, lib);
+// glibc can dlopen libgcc_s when a workflow worker exits. Some distributions
+// keep it below /usr/lib/gcc rather than a default loader directory. Expose only
+// the system loader cache, not operator config or a filesystem Pi SDK.
+if (fs.existsSync("/etc/ld.so.cache")) sandbox.push("--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache");
+sandbox.push("--proc", "/proc", "--dev", "/dev", "--bind", root, "/stage", "--bind", path.join(root, "tmp"), "/tmp", "--chdir", "/stage/work", "--clearenv");
+for (const [key, value] of Object.entries({ PATH: "/usr/bin:/bin", HOME: "/stage/home", PI_CODING_AGENT_DIR: "/stage/agent", XDG_CACHE_HOME: "/stage/cache", BUN_INSTALL_CACHE_DIR: "/stage/bun-cache", JITI_FS_CACHE: "false", PI_OFFLINE: "1", TERM: "dumb", PI_STANDALONE_SMOKE_MODE: mode })) sandbox.push("--setenv", key, value);
+const negative = run("negative", "bwrap", [...sandbox, "--setenv", "BUN_BE_BUN", "1", "--", "/stage/pi-native", "--no-install", "/stage/work/negative.ts"]);
+assert.notEqual(negative.status, 0, "bare Bun must not resolve a downloaded or installed SDK");
+assert.match(negative.stderr, /Cannot find (?:module|package).*pi-coding-agent/);
+const version = run("version", "bwrap", [...sandbox, "--", "/stage/pi-native", "--version"]);
+assert.equal(version.status, 0, version.stderr);
+fs.writeFileSync(path.join(root, "identity.json"), JSON.stringify({ binary, sha256: createHash("sha256").update(fs.readFileSync(binary)).digest("hex"), version: version.stdout.trim(), packed: tarball.filename, network: "unshared", automaticInstall: "disabled; negative control verified" }, null, 2));
+const bootstrap = "/stage/package/src/runs/background/binary-bootstrap.ts";
+if (mode === "missing-bootstrap") fs.renameSync(path.join(root, "package/src/runs/background/binary-bootstrap.ts"), path.join(root, "withheld-binary-bootstrap.ts"));
+const hostArgs = ["/stage/pi-native", "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-session", "--mode", "rpc"];
+console.log(`Artifacts: ${root}`);
+if (mode === "bootstrap-errors") {
+	const nativeStep = {
+		agent: "binary-smoke", task: "Return the scripted response.", context: "fresh", model: "standalone-smoke/local", modelCandidates: ["standalone-smoke/local"],
+		tools: [], extensions: ["/stage/package/test/smoke/standalone-provider.ts"], completionGuard: false,
+		inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+	};
+	const cases = [
+		{ name: "authorization-positive", barrier: true, succeeds: true },
+		{ name: "missing-input", expected: /Missing absolute PI_SUBAGENT_RUNNER_CONFIG/ },
+		{ name: "relative-input", configPath: "relative.json", expected: /Missing absolute PI_SUBAGENT_RUNNER_CONFIG/ },
+		{ name: "missing-file", configPath: "/stage/not-present.json", expected: /ENOENT/ },
+		{ name: "malformed-json", payload: "{", expected: /Subagent binary runner error/ },
+		{ name: "invalid-shape", payload: "{}", expected: /Invalid binary runner configuration/ },
+		{ name: "wrong-authorization", barrier: true, expected: /startup control token does not match/ },
+		{ name: "missing-authorization", barrier: true, expected: /waiting for runner startup control 'proceed'/ },
+	];
+	for (const entry of cases) {
+		const asyncDir = `/stage/${entry.name}`;
+		fs.mkdirSync(path.join(root, entry.name));
+		const payload = entry.barrier ? JSON.stringify({
+			id: entry.name, asyncDir, cwd: "/stage/work", resultPath: `${asyncDir}/result.json`, placeholder: "{previous}",
+			sessionId: "bootstrap-fixture-parent", completionOwnerId: "bootstrap-fixture-owner",
+			steps: [nativeStep], launchBarrierToken: "expected-token", timeoutMs: 20000,
+			artifactConfig: { enabled: false }, sessionDir: `${asyncDir}/sessions`,
+		}) : entry.payload;
+		const configPath = payload === undefined ? entry.configPath : `/stage/${entry.name}.json`;
+		if (payload !== undefined) fs.writeFileSync(path.join(root, `${entry.name}.json`), payload, { mode: 0o600 });
+		if (entry.name === "wrong-authorization" || entry.succeeds) fs.writeFileSync(path.join(root, entry.name, "runner-startup-proceed.json"), JSON.stringify({ action: "proceed", token: entry.succeeds ? "expected-token" : "wrong-token" }));
+		const invocation = run(entry.name, "bwrap", [...sandbox, "--setenv", "PI_STANDALONE_CASE", entry.name, ...(configPath ? ["--setenv", "PI_SUBAGENT_RUNNER_CONFIG", configPath] : []), "--", ...hostArgs, "--extension", "/stage/package/test/smoke/standalone-observer.ts", "--extension", bootstrap]);
+		assert.equal(invocation.status, entry.succeeds ? 0 : 1, invocation.stdout + invocation.stderr);
+		const observed = fs.readFileSync(path.join(root, "bootstrap-observer.jsonl"), "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.case === entry.name);
+		assert.deepEqual(observed.map((event) => event.event), ["observer-ready"], "installed observer must never see an outer session start");
+		const lifecycleFile = path.join(root, "lifecycle.jsonl");
+		const events = fs.existsSync(lifecycleFile) ? fs.readFileSync(lifecycleFile, "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.case === entry.name) : [];
+		if (entry.succeeds) {
+			assert.deepEqual(events.map((event) => event.event), ["start", "request", "shutdown"], "the identical authorized task must actually execute and shut down");
+			const result = JSON.parse(fs.readFileSync(path.join(root, entry.name, "result.json"), "utf8"));
+			assert.equal(result.state, "complete");
+			assert.match(JSON.stringify(result), /standalone child response verified/);
+		} else {
+			assert.match(invocation.stderr, entry.expected);
+			assert.deepEqual(events, [], "the observed positive-control task must not start without authorization");
+			if (entry.barrier) assert.equal(JSON.parse(fs.readFileSync(path.join(root, entry.name, "runner-startup.json"), "utf8")).state, "error");
+		}
+		console.log(`PASS standalone native async bootstrap: ${entry.name}`);
+	}
+} else {
+	const faultExtension = ["persistence-failure", "authorization-failure", "revival"].includes(mode) ? ["--extension", "/stage/package/test/smoke/standalone-fault.ts"] : [];
+	const result = run("parent", "bwrap", [...sandbox, "--", ...hostArgs, "--extension", "/stage/package/test/smoke/standalone-provider.ts", ...faultExtension, "--extension", "/stage/package/test/smoke/standalone-parent.ts"]);
+	assert.equal(result.status, 0, result.stdout + result.stderr);
+	assert.match(result.stdout, /PASS standalone native async/);
+	console.log(result.stdout.split("\n").filter((line) => line.startsWith("PASS ")).join("\n"));
+}
+assert.equal(fs.existsSync(path.join(root, "ambient-loaded")), false, "outer bootstrap must not load ambient extensions");
+assert.deepEqual(fs.readdirSync(root, { recursive: true }).filter((entry) => coreSdk.test(entry)), [], "no staged or downloaded filesystem SDK/shim may appear");
+assert.deepEqual(fs.readdirSync(path.join(root, "bun-cache")), [], "the smoke must not populate Bun's install cache");

--- a/test/smoke/standalone-fault.ts
+++ b/test/smoke/standalone-fault.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { mock } from "bun:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+// On the tested binary, replacing fs's default-object property did not update the
+// atomic writer's named binding, even with earlier loading or syncBuiltinESMExports.
+// A real-loader probe verified this module mock reaches both post-spawn writes.
+// Only renameSync is faulted; the SDK, session factory and runner remain real.
+export default function injectStartupFailure(pi: ExtensionAPI) {
+	const mode = process.env.PI_STANDALONE_SMOKE_MODE;
+	if (!["persistence-failure", "authorization-failure", "revival"].includes(mode ?? "")) throw new Error("unsupported startup hook mode");
+	pi.on("session_start", () => {
+		const originalRename = fs.renameSync;
+		let injected = false;
+		const hook: typeof fs.renameSync = (from, to) => {
+			const target = String(to);
+			const asyncDir = path.dirname(target);
+			if (mode === "revival" && /\/runner-startup-(?:ack|proceed)\.json$/.test(target) && fs.existsSync(path.join(asyncDir, "runner-startup.json"))) {
+				const control = JSON.parse(fs.readFileSync(from, "utf8"));
+				const startup = JSON.parse(fs.readFileSync(path.join(asyncDir, "runner-startup.json"), "utf8"));
+				const events = fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line));
+				const record = { runId: path.basename(asyncDir), action: control.action, stateBefore: startup.state, tokenMatches: control.token === startup.token, childStartedBeforeCommit: events.some((event) => event.event === "start" && event.pid === startup.pid) };
+				originalRename(from, to);
+				fs.appendFileSync("/stage/handshake.jsonl", JSON.stringify(record) + "\n");
+				return;
+			}
+			if (mode !== "revival" && !injected && target.includes("/async-subagent-runs/") && target.endsWith(mode === "persistence-failure" ? "/status.json" : "/runner-startup-proceed.json")) {
+				const status = JSON.parse(fs.readFileSync(mode === "persistence-failure" ? from : path.join(asyncDir, "status.json"), "utf8"));
+				if (typeof status.pid === "number") {
+					assert.notEqual(status.pid, process.pid);
+					process.kill(status.pid, 0);
+					injected = true;
+					fs.renameSync = originalRename;
+					fs.writeFileSync("/stage/failure-injected.json", JSON.stringify({ asyncDir, pid: status.pid, target, mode }));
+					throw new Error(`fixture ${mode} after real spawn`);
+				}
+			}
+			return originalRename(from, to);
+		};
+		fs.renameSync = hook;
+		mock.module("node:fs", () => ({ ...fs, default: fs, renameSync: hook }));
+		fs.writeFileSync("/stage/startup-hook-ready.json", JSON.stringify({ mode, pid: process.pid }));
+	});
+}

--- a/test/smoke/standalone-matrix.mjs
+++ b/test/smoke/standalone-matrix.mjs
@@ -1,0 +1,50 @@
+// Complete official binary gate. Each mode uses the existing fresh-stage driver.
+// Usage: node test/smoke/standalone-matrix.mjs /absolute/official-pi /fresh/artifacts
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const source = fileURLToPath(new URL("../../", import.meta.url));
+const release = JSON.parse(fs.readFileSync(new URL("standalone-release.json", import.meta.url), "utf8"));
+const binary = process.argv[2];
+const root = process.argv[3];
+assert.equal(process.platform, release.platform);
+assert.equal(process.arch, release.arch);
+assert.ok(binary && path.isAbsolute(binary) && fs.existsSync(binary), "official binary is required; never skip");
+assert.ok(root && path.isAbsolute(root) && !fs.existsSync(root), "provide a fresh absolute artifact directory");
+function sha(file) { return createHash("sha256").update(fs.readFileSync(file)).digest("hex"); }
+assert.equal(sha(binary), release.binarySha256, "binary does not match the pinned official release");
+fs.mkdirSync(root, { recursive: true });
+const inputs = ["index.ts", "package.json", "package-lock.json",
+	...fs.readdirSync(source).filter((file) => file.endsWith(".mjs")),
+	...fs.readdirSync(path.join(source, "src"), { recursive: true }).map((file) => `src/${file}`),
+	...fs.readdirSync(path.join(source, "test/smoke")).filter((file) => file.startsWith("standalone-")).map((file) => `test/smoke/${file}`),
+].filter((file) => fs.statSync(path.join(source, file)).isFile()).sort();
+const frozen = Object.fromEntries(inputs.map((file) => [file, sha(path.join(source, file))]));
+fs.writeFileSync(path.join(root, "inputs.json"), JSON.stringify(frozen, null, 2));
+const modes = ["single", "workflow", "shared-run", "parallel-stop", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout", "tool-timeout", "missing-bootstrap", "persistence-failure", "authorization-failure", "sdk-init-failure", "bootstrap-errors", "revival"];
+const receipt = { release, complete: false, cases: [] };
+let packageSha;
+for (const mode of modes) {
+	assert.deepEqual(Object.fromEntries(inputs.map((file) => [file, sha(path.join(source, file))])), frozen, "execution inputs changed during the gate");
+	const startedAt = new Date().toISOString();
+	const result = spawnSync(process.execPath, [path.join(source, "test/smoke/standalone-background.mjs"), binary, path.join(root, mode), mode], { cwd: source, encoding: "utf8", timeout: 180000, maxBuffer: 10 * 1024 * 1024 });
+	fs.writeFileSync(path.join(root, `${mode}.log`), `${result.stdout ?? ""}${result.stderr ?? ""}`);
+	receipt.cases.push({ mode, startedAt, exitCode: result.status, error: result.error?.message });
+	fs.writeFileSync(path.join(root, "matrix.json"), JSON.stringify(receipt, null, 2));
+	assert.ifError(result.error);
+	assert.equal(result.status, 0, `${mode} failed; inspect ${path.join(root, `${mode}.log`)}`);
+	const identity = JSON.parse(fs.readFileSync(path.join(root, mode, "identity.json"), "utf8"));
+	const currentPackageSha = sha(path.join(root, mode, identity.packed));
+	packageSha ??= currentPackageSha;
+	assert.equal(currentPackageSha, packageSha, "matrix modes used different packaged candidates");
+	console.log(`PASS ${mode}`);
+}
+assert.deepEqual(Object.fromEntries(inputs.map((file) => [file, sha(path.join(source, file))])), frozen, "execution inputs changed during the gate");
+receipt.complete = true;
+receipt.packageSha256 = packageSha;
+fs.writeFileSync(path.join(root, "matrix.json"), JSON.stringify(receipt, null, 2));
+console.log(`PASS official ${release.version}: ${modes.length} modes; ${root}`);

--- a/test/smoke/standalone-observer.ts
+++ b/test/smoke/standalone-observer.ts
@@ -1,0 +1,8 @@
+import fs from "node:fs";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function observeBootstrap(pi: ExtensionAPI) {
+	const record = (event: string) => fs.appendFileSync("/stage/bootstrap-observer.jsonl", JSON.stringify({ case: process.env.PI_STANDALONE_CASE, event, pid: process.pid }) + "\n");
+	record("observer-ready");
+	pi.on("session_start", () => { record("session-start"); });
+}

--- a/test/smoke/standalone-parent.ts
+++ b/test/smoke/standalone-parent.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { parseFrontmatter, parseFrontmatterList } from "../../src/agents/frontmatter.ts";
+import registerSubagents from "../../index.ts";
+import { requestAsyncInterrupt, requestAsyncSteer, requestAsyncStop } from "../../src/runs/background/control-channel.ts";
+import { verifyRevival } from "./standalone-revival.ts";
+import { verifySharedRun } from "./standalone-shared.ts";
+
+function waitForFile(file: string, predicate: (text: string) => boolean): Promise<void> {
+	// These are test checkpoints, not synthesized completion notifications. Check
+	// file state even when directory append events are coalesced; sendMessage is
+	// still the independent completion boundary awaited below.
+	return new Promise((resolve) => {
+		const check = () => {
+			if (fs.existsSync(file) && predicate(fs.readFileSync(file, "utf8"))) { fs.unwatchFile(file, check); resolve(); }
+		};
+		fs.watchFile(file, { interval: 25 }, check);
+		check();
+	});
+}
+
+// Register the real extension against the real host API. Capture its public tool
+// and notification boundary only; never replace the runner/session factory.
+export default function registerSmoke(pi: ExtensionAPI) {
+	let tool: Parameters<ExtensionAPI["registerTool"]>[0] | undefined;
+	let notifications = 0;
+	let notify: (message: unknown) => void = () => {};
+	const notification = new Promise<unknown>((resolve) => { notify = resolve; });
+	const host = new Proxy(pi, {
+		get(target, key) {
+			if (key === "registerTool") return (definition: Parameters<ExtensionAPI["registerTool"]>[0]) => {
+				target.registerTool(definition);
+				if (definition.name === "subagent") tool = definition;
+			};
+			if (key === "sendMessage") return (...args: Parameters<ExtensionAPI["sendMessage"]>) => {
+				// Persist normal completion delivery without requesting an unrelated parent model turn.
+				target.sendMessage(args[0], { ...args[1], triggerTurn: false });
+				if (args[0].customType === "subagent-notify") { notifications++; notify(args[0]); }
+			};
+			return Reflect.get(target, key);
+		},
+	});
+	registerSubagents(host);
+	pi.on("session_start", async (_event, ctx) => {
+		const timeout = setTimeout(() => { console.error("Standalone smoke timed out waiting for parent completion"); process.exit(1); }, 45_000);
+		try {
+			assert.ok(tool, "the real extension must register its public subagent tool");
+			const mode = process.env.PI_STANDALONE_SMOKE_MODE ?? "single";
+			assert.ok(["single", "workflow", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout", "tool-timeout", "sdk-init-failure", "persistence-failure", "authorization-failure", "missing-bootstrap", "revival", "shared-run", "parallel-stop"].includes(mode), `unimplemented parent smoke mode: ${mode}`);
+			const expectedTools = mode === "tool-timeout" ? ["bash"] : [];
+			const profile = parseFrontmatter(fs.readFileSync("/stage/work/.pi/agents/binary-smoke.md", "utf8"));
+			assert.deepEqual(parseFrontmatterList(profile.frontmatter.tools), expectedTools, "fixture must use the upstream frontmatter syntax, not YAML flow lists");
+			const workflow = ["workflow", "targeted-controls", "child-timeout"].includes(mode);
+			const expectedState = mode === "interrupt" ? "paused" : mode === "stop" ? "stopped" : mode.endsWith("-timeout") || mode === "child-stop" || mode === "sdk-init-failure" ? "failed" : "complete";
+			const request = mode === "workflow" ? {
+				workflowScript: `const first = await runs.run("first", { agent: "binary-smoke", task: "Return FIRST." }); const siblings = await runs.all([{ key: "left", agent: "binary-smoke", task: "Return LEFT." }, { key: "right", agent: "binary-smoke", task: "Return RIGHT." }]); return { first, siblings };`,
+			} : mode === "targeted-controls" ? {
+				workflowScript: `const left = runs.run("left", { agent: "binary-smoke", task: "Return LEFT." }); const right = runs.run("right", { agent: "binary-smoke", task: "Return RIGHT." }); let interrupted; try { interrupted = await right; } catch (error) { interrupted = String(error); } return { left: await left, right: interrupted };`,
+			} : mode === "child-timeout" ? {
+				workflowScript: `return await runs.run("child-deadline", { agent: "binary-smoke", task: "Wait for cancellation.", timeoutMs: 8000 });`,
+			} : { agent: "binary-smoke", task: "Return the scripted response." };
+			fs.writeFileSync("/stage/parent-initialized", String(process.pid));
+			if (mode === "shared-run" || mode === "parallel-stop") {
+				await verifySharedRun(host, ctx, mode, waitForFile, notification);
+				assert.equal(notifications, 1);
+				console.log(`PASS standalone native async ${mode}: two SDK sessions, one host, observed shutdown`);
+				process.exit(0);
+			}
+			const startupFailure = mode === "persistence-failure" || mode === "authorization-failure";
+			if (startupFailure) assert.equal(JSON.parse(fs.readFileSync("/stage/startup-hook-ready.json", "utf8")).pid, process.pid);
+			const launching = tool.execute("standalone-smoke", {
+				...request, context: "fresh", async: true,
+				model: "standalone-smoke/local", acceptance: false, timeoutMs: mode === "run-timeout" ? 8000 : 20000, output: false,
+				...(mode === "tool-timeout" ? { toolTimeoutMs: 1000 } : {}),
+			}, new AbortController().signal, undefined, ctx);
+			if (mode === "missing-bootstrap") {
+				assert.ok(fs.existsSync("/stage/withheld-binary-bootstrap.ts"), "asset omission must actually be applied");
+				await assert.rejects(launching, /Background runner bootstrap not found/);
+				console.log("PASS standalone native async missing-bootstrap: missing asset rejected at the public launch boundary");
+				process.exit(0);
+			}
+			if (startupFailure) {
+				// Registered tools reject logical failures; internal execution helpers return isError.
+				// Assert the public boundary actually used here, not its internal representation.
+				await assert.rejects(launching, (error: unknown) => {
+					assert.ok(error instanceof Error);
+					assert.match(error.message, new RegExp(`fixture ${mode} after real spawn`));
+					fs.writeFileSync("/stage/launch-error.json", JSON.stringify({ message: error.message }));
+					return true;
+				});
+				assert.ok(fs.existsSync("/stage/failure-injected.json"), "fault must reach the post-spawn persistence/authorization boundary");
+				const injected = JSON.parse(fs.readFileSync("/stage/failure-injected.json", "utf8"));
+				assert.equal(injected.mode, mode);
+				const terminalPath = `${injected.asyncDir}/process-terminal.json`;
+				await waitForFile(terminalPath, (text) => JSON.parse(text).instances?.some((instance: { kind: string; closeObservedAt?: number }) => instance.kind === "runner" && typeof instance.closeObservedAt === "number"));
+				assert.throws(() => process.kill(injected.pid, 0), { code: "ESRCH" });
+				const status = JSON.parse(fs.readFileSync(`${injected.asyncDir}/status.json`, "utf8"));
+				assert.equal(status.state, "failed");
+				assert.equal(fs.existsSync(`${injected.asyncDir}/runner-startup-proceed.json`), false);
+				const events = fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line));
+				assert.ok(events.every((event) => event.pid === process.pid), "same real task as the positive control must never enter a child session");
+				fs.writeFileSync("/stage/startup-failure.json", JSON.stringify({ ...injected, mode, terminal: JSON.parse(fs.readFileSync(terminalPath, "utf8")) }, null, 2));
+				console.log(`PASS standalone native async ${mode}: post-spawn fault observed, no proceed, no child work, runner close observed`);
+				process.exit(0);
+			}
+			const launch = await launching;
+			fs.writeFileSync("/stage/launch.json", JSON.stringify(launch, null, 2));
+			assert.notEqual(launch.isError, true, JSON.stringify(launch));
+			const details = launch.details as { asyncDir: string; asyncId: string };
+			if (["steer", "interrupt", "stop", "child-stop"].includes(mode)) {
+				await waitForFile("/stage/lifecycle.jsonl", (text) => text.includes('"event":"request"'));
+				if (mode === "interrupt") requestAsyncInterrupt(details.asyncDir);
+				if (mode === "stop") requestAsyncStop(details.asyncDir);
+				if (mode === "child-stop") requestAsyncStop(details.asyncDir, { targetIndex: 0, childId: "step:0" });
+				if (mode === "steer") {
+					requestAsyncSteer(details.asyncDir, { id: "binary-steer", targetIndex: 0, message: "UNIQUE_STEERING_MARKER" });
+					await waitForFile(`${details.asyncDir}/events.jsonl`, (text) => text.includes('"type":"subagent.steer.delivered"'));
+					fs.writeFileSync("/stage/release", "go");
+				}
+			}
+			if (mode === "targeted-controls") {
+				await waitForFile("/stage/lifecycle.jsonl", (text) => text.split("\n").filter((line) => line.includes('"event":"request"')).length === 2);
+				const active = JSON.parse(fs.readFileSync(`${details.asyncDir}/status.json`, "utf8"));
+				const [left, right] = active.steps.map((step: { runId: string }) => path.join(path.dirname(details.asyncDir), step.runId));
+				requestAsyncSteer(left, { id: "binary-steer", targetIndex: 0, message: "UNIQUE_STEERING_MARKER" });
+				await waitForFile(`${left}/events.jsonl`, (text) => text.includes('"type":"subagent.steer.delivered"'));
+				requestAsyncInterrupt(right);
+				await waitForFile(`${right}/status.json`, (text) => JSON.parse(text).state === "paused");
+				assert.equal(JSON.parse(fs.readFileSync(`${left}/status.json`, "utf8")).state, "running", "interrupting right must leave left running");
+				fs.writeFileSync("/stage/release", "go");
+			}
+			if (mode === "tool-timeout") await waitForFile("/stage/tool.pid", (text) => /^\d+\s*$/.test(text));
+			const completed = await notification;
+			fs.writeFileSync("/stage/notification.json", JSON.stringify(completed, null, 2));
+			if (expectedState === "complete") assert.match(JSON.stringify(completed), /standalone child response verified/);
+			const lifecycle = fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line));
+			const parentStatus = JSON.parse(fs.readFileSync(`${details.asyncDir}/status.json`, "utf8"));
+			const runIds: string[] = workflow ? parentStatus.steps.map((step: { runId: string }) => step.runId) : [details.asyncId];
+			assert.equal(new Set(runIds).size, mode === "workflow" ? 3 : mode === "targeted-controls" ? 2 : 1, "workflow children retain independent run identities");
+			for (const runId of runIds) {
+				const runDir = path.join(path.dirname(details.asyncDir), runId);
+				const status = JSON.parse(fs.readFileSync(`${runDir}/status.json`, "utf8"));
+				const runState = mode === "targeted-controls" && runIds.indexOf(runId) === 1 ? "paused" : expectedState;
+				const steered = mode === "steer" || (mode === "targeted-controls" && runIds.indexOf(runId) === 0);
+				assert.equal(status.state, runState, JSON.stringify(status));
+				if (mode === "stop" || mode === "child-stop") assert.equal(status.steps[0].status, "stopped");
+				assert.equal(status.sessionId, ctx.sessionManager.getSessionId());
+				assert.equal(status.completionOwnerId, parentStatus.completionOwnerId);
+				assert.equal(status.steps[0].model, "standalone-smoke/local");
+				const descriptor = JSON.parse(fs.readFileSync(`${runDir}/recovery-descriptor.json`, "utf8"));
+				assert.deepEqual(descriptor.tools, expectedTools, "actual launch must preserve the parsed tool selection");
+				const observed = fs.readFileSync("/stage/bootstrap-observer.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.pid === status.pid);
+				assert.deepEqual(observed.map((event) => event.event), mode === "sdk-init-failure" ? ["observer-ready"] : ["observer-ready", "session-start"]);
+				if (mode === "sdk-init-failure") {
+					assert.equal(JSON.parse(fs.readFileSync("/stage/provider-failure.json", "utf8")).pid, status.pid);
+					assert.match(status.error, /Model "standalone-smoke\/local" not found/);
+				} else {
+				const starts = lifecycle.filter((entry) => entry.event === "start" && entry.pid === status.pid);
+				assert.equal(starts.length, 1, "the outer bootstrap must not start an extra provider session");
+				assert.deepEqual(starts[0].tools, expectedTools, "the child must retain its explicit tool policy");
+				assert.equal(starts[0].provider, "standalone-smoke");
+				assert.equal(starts[0].model, "local");
+				if (runState === "complete") {
+					assert.ok(fs.existsSync(status.steps[0].sessionFile), "completed SDK session artifact must be retained");
+					const output = fs.readFileSync(status.steps[0].transcriptPath, "utf8");
+					assert.match(output, /standalone child response verified/);
+					if (mode === "workflow") assert.ok(output.includes(["FIRST", "LEFT", "RIGHT"][runIds.indexOf(runId)]));
+				}
+				if (mode.endsWith("-timeout")) {
+					assert.equal(status.steps[0].timedOut, true);
+					assert.match(status.steps[0].error, mode === "tool-timeout" ? /Tool 'bash' exceeded its timeout of 1000ms/ : /timed out after 8000ms/);
+				}
+				if (steered) {
+					const followup = lifecycle.find((entry) => entry.event === "followup" && entry.pid === status.pid);
+					assert.ok(followup && JSON.stringify(followup.messages).includes("UNIQUE_STEERING_MARKER"), "steering must reach the real SDK model context");
+				}
+				const child = lifecycle.find((entry) => entry.event === "shutdown" && entry.pid === status.pid && entry.calls === (steered ? 2 : 1));
+				assert.ok(child, "each real run must prompt and shut down its child session");
+				}
+				const terminalPath = `${runDir}/process-terminal.json`;
+				const atNotification = JSON.parse(fs.readFileSync(terminalPath, "utf8"));
+				fs.appendFileSync("/stage/notification-terminal.jsonl", JSON.stringify({ runId, state: atNotification.state }) + "\n");
+				// Paused/failed result delivery may precede SDK disposal and process close.
+				// Keep that pending evidence truthful; await the close observer, not a poll or sandbox teardown.
+				if (atNotification.state !== "observed") await waitForFile(terminalPath, (text) => JSON.parse(text).state === "observed");
+				const terminal = JSON.parse(fs.readFileSync(terminalPath, "utf8"));
+				assert.equal(terminal.state, "observed", "completion must include actual exit observation, not only a result");
+				assert.equal(terminal.runId, runId);
+				assert.ok(terminal.instances.some((instance: { kind: string; exitCode: number }) => instance.kind === "runner" && instance.exitCode === 0));
+				assert.throws(() => process.kill(status.pid, 0), { code: "ESRCH" }, "each runner must exit before sandbox teardown");
+			}
+			if (mode === "tool-timeout") {
+				const toolPid = Number(fs.readFileSync("/stage/tool.pid", "utf8"));
+				assert.throws(() => process.kill(toolPid, 0), { code: "ESRCH" }, "the timed-out tool must also exit before sandbox teardown");
+			}
+			assert.equal(notifications, 1, "one logical parent completion, not an extra bootstrap completion");
+			if (mode === "revival") {
+				const deliveries: Record<string, number> = {};
+				await verifyRevival(tool, ctx, details, waitForFile, (text) => new Promise<void>((resolve) => {
+					deliveries[text] = 0;
+					notify = (message) => {
+						if (JSON.stringify(message).includes(text)) {
+							deliveries[text]++;
+							fs.appendFileSync("/stage/revival-notifications.jsonl", JSON.stringify(message) + "\n");
+							resolve();
+						}
+					};
+				}));
+				assert.deepEqual(Object.values(deliveries), [1, 1], "each accepted revival has one normal completion");
+			}
+			console.log(`PASS standalone native async ${mode}: ${runIds.length} run(s), checked SDK lifecycle, observed exits, parent notification`);
+			process.exit(0);
+		} catch (error) {
+			console.error(error);
+			process.exit(1);
+		} finally {
+			clearTimeout(timeout);
+		}
+	});
+}

--- a/test/smoke/standalone-provider.ts
+++ b/test/smoke/standalone-provider.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { fauxProvider, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { SessionManager, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+function waitForRelease(signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const finish = () => { watcher.close(); signal?.removeEventListener("abort", finish); resolve(); };
+		const watcher = fs.watch("/stage", (_event, file) => { if (file === "release") finish(); });
+		signal?.addEventListener("abort", finish, { once: true });
+		if (signal?.aborted || fs.existsSync("/stage/release")) finish();
+	});
+}
+
+export default function registerSmokeProvider(pi: ExtensionAPI) {
+	const mode = process.env.PI_STANDALONE_SMOKE_MODE;
+	if (mode === "sdk-init-failure" && fs.existsSync("/stage/parent-initialized")) {
+		fs.writeFileSync("/stage/provider-failure.json", JSON.stringify({ pid: process.pid, reason: "fixture provider initialization failure" }));
+		throw new Error("fixture provider initialization failure");
+	}
+	const faux = fauxProvider({ provider: "standalone-smoke", models: [{ id: "local" }], tokensPerSecond: 100000 });
+	faux.setResponses([
+		async (context, options) => {
+			const messages = JSON.stringify(context.messages);
+			const revival = mode === "revival" && /REVIVAL_[AB]/.test(messages);
+			const failingRevival = mode === "revival" && messages.includes("REVIVAL_FAIL");
+			const waiting = !failingRevival && (revival || ["shared-run", "parallel-stop", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout"].includes(mode ?? "")) ? waitForRelease(options?.signal) : undefined;
+			fs.appendFileSync("/stage/lifecycle.jsonl", JSON.stringify({ event: "request", case: process.env.PI_STANDALONE_CASE, pid: process.pid, messages: context.messages }) + "\n");
+			await waiting;
+			if (failingRevival) return fauxAssistantMessage("", { stopReason: "error", errorMessage: "fixture revival failure" });
+			if (revival) return fauxAssistantMessage(`standalone child response verified ${messages.includes("REVIVAL_A") ? "REVIVAL_A" : "REVIVAL_B"}`);
+			if (mode === "tool-timeout") return fauxAssistantMessage(fauxToolCall("bash", { command: 'printf "%s\\n" "$$" > /stage/tool.pid; exec sleep 60' }), { stopReason: "toolUse" });
+			const label = ["FIRST", "LEFT", "RIGHT"].find((name) => JSON.stringify(context.messages).includes(name)) ?? "SINGLE";
+			return fauxAssistantMessage(`standalone child response verified ${label}`);
+		},
+		async (context, options) => {
+			const shared = mode === "shared-run" || mode === "parallel-stop";
+			const waiting = shared ? waitForRelease(options?.signal) : undefined;
+			fs.appendFileSync("/stage/lifecycle.jsonl", JSON.stringify({ event: shared ? "request" : "followup", case: process.env.PI_STANDALONE_CASE, pid: process.pid, messages: context.messages }) + "\n");
+			await waiting;
+			if (shared) {
+				const label = ["LEFT", "RIGHT"].find((name) => JSON.stringify(context.messages).includes(name));
+				return fauxAssistantMessage(`standalone child response verified ${label}`);
+			}
+			return fauxAssistantMessage("standalone child response verified after steering");
+		},
+	]);
+	pi.registerProvider(faux.provider);
+	pi.on("session_start", (_event, ctx) => {
+		assert.ok(ctx.sessionManager instanceof SessionManager, "extension and real session must share the embedded SDK identity");
+		fs.appendFileSync("/stage/lifecycle.jsonl", JSON.stringify({ event: "start", sessionId: ctx.sessionManager.getSessionId(), sdkIdentity: ctx.sessionManager instanceof SessionManager, case: process.env.PI_STANDALONE_CASE, pid: process.pid, executable: process.execPath, tools: pi.getActiveTools(), model: ctx.model?.id, provider: ctx.model?.provider }) + "\n");
+	});
+	pi.on("session_shutdown", (_event, ctx) => {
+		fs.appendFileSync("/stage/lifecycle.jsonl", JSON.stringify({ event: "shutdown", sessionId: ctx.sessionManager.getSessionId(), sessionFile: ctx.sessionManager.getSessionFile(), case: process.env.PI_STANDALONE_CASE, pid: process.pid, calls: faux.state.callCount }) + "\n");
+	});
+}

--- a/test/smoke/standalone-release.json
+++ b/test/smoke/standalone-release.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.85.1",
+  "platform": "linux",
+  "arch": "x64",
+  "url": "https://github.com/earendil-works/pi/releases/download/v0.85.1/pi-linux-x64.tar.gz",
+  "archiveSha256": "494e498f47d74d21f40b3386f6a5e921a3d49531a169cab55bbdaca0ea1fe25a",
+  "binarySha256": "443bd83f30e4dbc7bac2eed9c6aa2461b9a15016fd555f48c92a0591d028c403"
+}

--- a/test/smoke/standalone-revival.ts
+++ b/test/smoke/standalone-revival.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { inspectSessionLease } from "../../src/runs/shared/session-lease.ts";
+
+type Run = { asyncId: string; asyncDir: string };
+
+export async function verifyRevival(
+	tool: Parameters<ExtensionAPI["registerTool"]>[0],
+	ctx: ExtensionContext,
+	source: Run,
+	waitForFile: (file: string, predicate: (text: string) => boolean) => Promise<void>,
+	nextCompletion: (text: string) => Promise<void>,
+): Promise<void> {
+	assert.equal(JSON.parse(fs.readFileSync("/stage/startup-hook-ready.json", "utf8")).mode, "revival");
+	const sourceStatus = JSON.parse(fs.readFileSync(`${source.asyncDir}/status.json`, "utf8"));
+	const sessionFile: string = sourceStatus.steps[0].sessionFile;
+	assert.ok(fs.existsSync(sessionFile));
+	assert.equal(inspectSessionLease(sessionFile).state, "free");
+	const root = path.dirname(source.asyncDir);
+	const before = new Set(fs.readdirSync(root));
+	const completed = nextCompletion("standalone child response verified REVIVAL_");
+	// Public resume retains the model/session contract; model overrides are invalid.
+	// Race two valid requests, then hold the winner's real provider call while the
+	// other configured runner attempts to acquire the same canonical session.
+	const attempts = await Promise.allSettled(["REVIVAL_A", "REVIVAL_B"].map((message) => tool.execute(
+		message, { action: "resume", id: source.asyncId, message, acceptance: false, timeoutMs: 20000 },
+		new AbortController().signal, undefined, ctx,
+	)));
+	const winners = attempts.filter((attempt) => attempt.status === "fulfilled");
+	const losers = attempts.filter((attempt) => attempt.status === "rejected");
+	assert.equal(winners.length, 1, "exactly one revival may acquire the session");
+	assert.equal(losers.length, 1);
+	const winner = winners[0].value.details as Run;
+	const lease = inspectSessionLease(sessionFile);
+	assert.equal(lease.state, "owned");
+	assert.ok(lease.state === "owned");
+	assert.equal(lease.owner.runId, winner.asyncId);
+	assert.equal(lease.owner.sourceRunId, source.asyncId);
+	assert.equal(lease.owner.parentSessionId, ctx.sessionManager.getSessionId());
+	assert.match(String(losers[0].reason), /already owned by run/);
+	assert.ok(String(losers[0].reason).includes(winner.asyncId));
+	fs.writeFileSync("/stage/revival-competition.json", JSON.stringify({ winner, refusal: String(losers[0].reason), owner: { runId: lease.owner.runId, sourceRunId: lease.owner.sourceRunId, pid: lease.owner.pid } }, null, 2));
+	await waitForFile("/stage/lifecycle.jsonl", (text) => text.trim().split("\n").map((line) => JSON.parse(line)).some((event) => event.event === "request" && event.pid === lease.owner.pid));
+	const request = fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line)).find((event) => event.event === "request" && event.pid === lease.owner.pid);
+	assert.ok(JSON.stringify(request.messages).includes("standalone child response verified SINGLE"), "revival must load the actual previous SDK conversation");
+	const contenders = fs.readdirSync(root).filter((name) => !before.has(name));
+	assert.equal(contenders.length, 2, "both requests must reach independent configured runners");
+	const losingId = contenders.find((id) => id !== winner.asyncId)!;
+	await waitForFile(`${root}/${losingId}/process-terminal.json`, (text) => JSON.parse(text).state !== "pending");
+	const losingTerminal = JSON.parse(fs.readFileSync(`${root}/${losingId}/process-terminal.json`, "utf8"));
+	assert.equal(losingTerminal.state, "observed");
+	const losingStatus = JSON.parse(fs.readFileSync(`${root}/${losingId}/status.json`, "utf8"));
+	assert.throws(() => process.kill(losingStatus.pid, 0), { code: "ESRCH" });
+	assert.equal(inspectSessionLease(sessionFile).state, "owned", "loser cleanup must not release the winner's lease");
+	assert.ok(!fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line)).some((event) => event.pid === losingStatus.pid), "loser must not enter the provider/session");
+	fs.writeFileSync("/stage/release", "go");
+	await completed;
+	await finish(winner, "complete", lease.owner.token);
+
+	const failedCompletion = nextCompletion("fixture revival failure");
+	const failedLaunch = await tool.execute("revival-failure", { action: "resume", id: winner.asyncId, message: "REVIVAL_FAIL", acceptance: false, timeoutMs: 20000 }, new AbortController().signal, undefined, ctx);
+	const failed = failedLaunch.details as Run;
+	await failedCompletion;
+	await waitForFile(`${failed.asyncDir}/process-terminal.json`, (text) => JSON.parse(text).state !== "pending");
+	const failedCandidate = JSON.parse(fs.readFileSync(`${failed.asyncDir}/process-terminal-candidate.json`, "utf8"));
+	assert.equal(typeof failedCandidate.revivalLeaseToken, "string");
+	await finish(failed, "failed", failedCandidate.revivalLeaseToken);
+	assert.match(JSON.parse(fs.readFileSync(`${failed.asyncDir}/status.json`, "utf8")).error, /fixture revival failure/);
+	fs.writeFileSync("/stage/revival-result.json", JSON.stringify({ source, winner, loser: losingId, failed, sessionFile }, null, 2));
+
+	async function finish(run: Run, state: string, token: string): Promise<void> {
+		await waitForFile(`${run.asyncDir}/process-terminal.json`, (text) => JSON.parse(text).state !== "pending");
+		const status = JSON.parse(fs.readFileSync(`${run.asyncDir}/status.json`, "utf8"));
+		const terminal = JSON.parse(fs.readFileSync(`${run.asyncDir}/process-terminal.json`, "utf8"));
+		const candidate = JSON.parse(fs.readFileSync(`${run.asyncDir}/process-terminal-candidate.json`, "utf8"));
+		assert.equal(status.state, state);
+		assert.equal(status.sessionId, ctx.sessionManager.getSessionId());
+		assert.equal(status.steps[0].sessionFile, sessionFile);
+		assert.equal(terminal.state, "observed");
+		assert.equal(terminal.canonicalSession.leaseDisposition, "released");
+		assert.equal(terminal.canonicalSession.canonicalSessionLeaseReleased, true);
+		assert.equal(candidate.revivalLeaseToken, token);
+		assert.equal(candidate.revivalLeaseReleaseAcknowledged, true);
+		assert.equal(inspectSessionLease(sessionFile).state, "free");
+		assert.throws(() => process.kill(status.pid, 0), { code: "ESRCH" });
+		const handshake = fs.readFileSync("/stage/handshake.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.runId === run.asyncId);
+		assert.deepEqual(handshake.map((event) => [event.action, event.stateBefore]), [["ack", "ready"], ["proceed", "acknowledged"]]);
+		assert.ok(handshake.every((event) => event.tokenMatches && !event.childStartedBeforeCommit));
+		const lifecycle = fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.pid === status.pid);
+		assert.deepEqual(lifecycle.map((event) => event.event), ["start", "request", "shutdown"]);
+	}
+}

--- a/test/smoke/standalone-shared.ts
+++ b/test/smoke/standalone-shared.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { discoverAgents } from "../../src/agents/agents.ts";
+import { executeAsyncChain } from "../../src/runs/background/async-execution.ts";
+import { requestAsyncStop } from "../../src/runs/background/control-channel.ts";
+import { resolveControlConfig } from "../../src/runs/shared/subagent-control.ts";
+import { DEFAULT_ARTIFACT_CONFIG } from "../../src/shared/types.ts";
+
+export async function verifySharedRun(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	mode: string,
+	waitForFile: (file: string, predicate: (text: string) => boolean) => Promise<void>,
+	completed: Promise<unknown>,
+): Promise<void> {
+	// Public workflows deliberately create independent runs. This existing private
+	// execution seam exercises two SDK sessions inside ONE configured runner; it
+	// does not restore the removed public chain API or invent another scheduler.
+	const launch = executeAsyncChain(randomUUID(), {
+		chain: [{ parallel: ["LEFT", "RIGHT"].map((task) => ({ agent: "binary-smoke", task, output: false, acceptance: false })) }],
+		agents: discoverAgents(ctx.cwd, "project").agents,
+		ctx: { pi, cwd: ctx.cwd, currentSessionId: ctx.sessionManager.getSessionId(), parentSessionId: ctx.sessionManager.getSessionId(), currentModel: ctx.model },
+		artifactConfig: DEFAULT_ARTIFACT_CONFIG,
+		artifactsDir: "/stage/shared-artifacts",
+		shareEnabled: false,
+		sessionRoot: "/stage/shared-sessions",
+		maxSubagentDepth: 2,
+		globalConcurrencyLimit: 2,
+		controlConfig: resolveControlConfig(undefined, { enabled: true }),
+		timeoutMs: 20000,
+	});
+	assert.notEqual(launch.isError, true, JSON.stringify(launch));
+	fs.writeFileSync("/stage/launch.json", JSON.stringify(launch, null, 2));
+	const { asyncId, asyncDir } = launch.details;
+	assert.ok(asyncId && asyncDir);
+	await waitForFile("/stage/lifecycle.jsonl", (text) => text.trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.event === "request").length === 2);
+	const active = JSON.parse(fs.readFileSync(`${asyncDir}/status.json`, "utf8"));
+	assert.equal(active.steps.length, 2);
+	assert.equal(active.state, "running");
+	// The provider's two held requests are the execution witness. The ordinary
+	// status projection can lag them; it is not the authority for whether prompt
+	// execution has begun. Neither held session may have shut down before stop.
+	const held = fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.pid === active.pid);
+	assert.equal(held.filter((event) => event.event === "request").length, 2);
+	assert.equal(held.filter((event) => event.event === "shutdown").length, 0);
+	fs.writeFileSync("/stage/shared-active-witness.json", JSON.stringify({ pid: active.pid, heldRequests: 2, shutdowns: 0, projectedSteps: active.steps.map((step: { status: string }) => step.status) }));
+	if (mode === "parallel-stop") fs.writeFileSync("/stage/parallel-control.json", JSON.stringify(requestAsyncStop(asyncDir)));
+	else fs.writeFileSync("/stage/release", "go");
+	await completed;
+	await waitForFile(`${asyncDir}/process-terminal.json`, (text) => JSON.parse(text).state !== "pending");
+	const status = JSON.parse(fs.readFileSync(`${asyncDir}/status.json`, "utf8"));
+	const terminal = JSON.parse(fs.readFileSync(`${asyncDir}/process-terminal.json`, "utf8"));
+	assert.equal(status.state, mode === "parallel-stop" ? "stopped" : "complete");
+	assert.equal(status.sessionId, ctx.sessionManager.getSessionId());
+	assert.equal(status.runId, asyncId);
+	assert.equal(terminal.state, "observed");
+	assert.equal(terminal.instances.length, 1, "one host process, no per-session CLI writers");
+	assert.equal(terminal.instances[0].exitCode, 0);
+	assert.throws(() => process.kill(status.pid, 0), { code: "ESRCH" });
+	const lifecycle = fs.readFileSync("/stage/lifecycle.jsonl", "utf8").trim().split("\n").map((line) => JSON.parse(line)).filter((event) => event.pid !== process.pid);
+	assert.ok(lifecycle.every((event) => event.pid === status.pid));
+	const starts = lifecycle.filter((event) => event.event === "start");
+	const shutdowns = lifecycle.filter((event) => event.event === "shutdown");
+	assert.equal(starts.length, 2);
+	assert.equal(shutdowns.length, 2);
+	assert.equal(new Set(starts.map((event) => event.sessionId)).size, 2);
+	assert.deepEqual(shutdowns.map((event) => event.sessionId).sort(), starts.map((event) => event.sessionId).sort());
+	assert.ok(starts.every((event) => event.sdkIdentity && event.provider === "standalone-smoke" && event.model === "local"));
+	if (mode === "shared-run") {
+		const transcripts = status.steps.map((step: { transcriptPath: string }) => fs.readFileSync(step.transcriptPath, "utf8"));
+		assert.ok(transcripts[0].includes("standalone child response verified LEFT"));
+		assert.ok(transcripts[1].includes("standalone child response verified RIGHT"));
+		const sessions = shutdowns.map((event) => fs.readFileSync(event.sessionFile, "utf8"));
+		assert.equal(new Set(shutdowns.map((event) => event.sessionFile)).size, 2);
+		for (const label of ["LEFT", "RIGHT"]) assert.equal(sessions.filter((text) => text.includes(`standalone child response verified ${label}`)).length, 1);
+	} else {
+		assert.ok(status.steps.every((step: { status: string }) => step.status === "stopped"));
+	}
+	fs.writeFileSync("/stage/shared-result.json", JSON.stringify({ asyncId, asyncDir, mode, sessions: starts.map((event) => event.sessionId), terminal }, null, 2));
+}

--- a/test/unit/binary-pi-spawn.test.ts
+++ b/test/unit/binary-pi-spawn.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getPiSpawnCommand, type PiSpawnDeps } from "../../src/runs/shared/pi-spawn.ts";
+
+describe("compiled Pi invocation", () => {
+	const host = {
+		platform: "linux",
+		execPath: "/opt/standalone/pi-native",
+		argv1: "/$bunfs/root/pi-native",
+		bunVersion: "1.3.14",
+		env: {},
+		existsSync: () => false,
+		readFileSync: () => { throw new Error("No filesystem SDK"); },
+		resolvePackageEntry: () => { throw new Error("No filesystem SDK"); },
+	} satisfies PiSpawnDeps;
+
+	it("launches a renamed compiled host rather than its virtual entrypoint or PATH Pi", () => {
+		assert.deepEqual(getPiSpawnCommand(["--no-session"], host), { command: host.execPath, args: ["--no-session"] });
+	});
+
+	it("does not mistake a manifest-only binary bundle for an npm CLI", () => {
+		assert.deepEqual(getPiSpawnCommand([], {
+			...host, piPackageRoot: "/opt/standalone",
+			existsSync: (file) => file.endsWith("/package.json"),
+			readFileSync: () => JSON.stringify({ name: "@earendil-works/pi-coding-agent", bin: "dist/cli.js" }),
+		}), { command: host.execPath, args: [] });
+	});
+
+	it("retains an explicit Pi executable override", () => {
+		assert.deepEqual(getPiSpawnCommand([], { ...host, env: { PI_SUBAGENT_PI_BINARY: "/custom/pi" } }), { command: "/custom/pi", args: [] });
+	});
+
+	it("does not treat an ordinary Bun script as a compiled Pi host", () => {
+		assert.equal(getPiSpawnCommand([], { ...host, execPath: "/usr/bin/bun", argv1: "/work/script.ts" }).command, "pi");
+	});
+});


### PR DESCRIPTION
## Summary

Restore native background subagents for Bun-compiled Pi without requiring an on-disk core SDK. A dedicated Pi-loaded bootstrap supplies the embedded SDK to the existing configured runner and child-session factory.

- Preserve startup authorization, revival leases, controls, result ownership, disposal and process-close observation.
- Keep one host per independent run, with multiple native sessions sharing that run's runner. Public workflow child-run boundaries remain unchanged.
- Preserve the npm/Node runner and peer aliases. No per-session CLI/stdout protocol, runtime SDK installation or foreground fallback.
- Add checksum-pinned official Linux x64 lifecycle coverage, CI and detailed regression comments.

Follow-up to [#1844](https://github.com/nicobailon/pi-subagents/pull/1844) and [#2037](https://github.com/nicobailon/pi-subagents/pull/2037).

## Validation

[Hosted CI](https://github.com/xz-dev/pi-subagents/actions/runs/34207417816) passed all five jobs on a merge whose Git tree is identical to this patch:

- Official Pi v0.85.1 Linux x64: all 18 isolated modes, including same-run concurrent sessions, parallel stop, startup failures and competing revival.
- Linux and Windows typecheck/unit/integration suites.
- Bun workflow parity.
- Real npm Pi 0.85.0 and 0.85.1 SDK smoke.

Local validation also passed the real public npm CLI-to-detached-runner launch chain for both versions. Binary stages exclude filesystem core SDKs/dev shims, disable automatic installation and deny execution-time network access. Standalone support claims are limited to the official tested Linux x64 release; no Windows/macOS/other-packager claim is added.
