### PR TITLE
fix(scheduled-runs): a manual schedule.run satisfies the next natural fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- A manual `schedule.run` that attaches a run satisfies the next natural fire, so manually-run schedules no longer double-fire (#2052). Thanks to [@brandonmwest](https://github.com/brandonmwest) for #2052.
+
 ## [0.66.0] - 2026-09-06
 
 ### Highlights

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -690,7 +690,34 @@ export class ScheduledRunManager {
 			return textResult(`Skipped schedule ${schedule.id}: current session is not its owner.`, [schedule]);
 		}
 		const run = await this.launch(store, schedule, this.now(), "manual", false);
-		return textResult(`Manual schedule run ${run.id}: ${run.state}${run.asyncId ? ` (async ${run.asyncId})` : ""}.`, [store.get(schedule.id)], [run], run.state === "failed_launch");
+		const updated = store.get(schedule.id);
+		// A manual launch that actually ran satisfies the schedule's next
+		// natural fire: interval schedules defer a full interval, one-shot
+		// schedules are consumed so their own trigger never fires. Overlap-skipped
+		// and failed manual launches leave the natural cadence untouched.
+		if (run.state === "running") this.satisfyManualLaunch(store, updated);
+		return textResult(`Manual schedule run ${run.id}: ${run.state}${run.asyncId ? ` (async ${run.asyncId})` : ""}.\nNext natural fire: ${updated.trigger.nextRunAt ?? "none (schedule satisfied)"}.`, [store.get(schedule.id)], [run], run.state === "failed_launch");
+	}
+
+	/**
+	 * A manual launch satisfies the schedule's next natural fire: interval
+	 * schedules advance nextRunAt a full interval from the manual launch, and
+	 * one-shot schedules clear nextRunAt so their natural trigger never fires.
+	 * Natural fires (timer/run-due) are unaffected.
+	 */
+	private satisfyManualLaunch(store: ScheduleStore, schedule: ScheduleRecord): void {
+		const now = this.now();
+		if (schedule.trigger.kind === "interval") {
+			// Equivalent to nextAfter(trigger, now, now): now + everyMs is already
+			// strictly in the future, so no catch-up stepping applies.
+			schedule.trigger.nextRunAt = timestamp(now + schedule.trigger.everyMs);
+		} else {
+			schedule.trigger.nextRunAt = undefined;
+		}
+		schedule.updatedAt = timestamp(now);
+		store.write(schedule);
+		store.appendEvent(schedule, "schedule.manual_satisfied");
+		this.arm(schedule, store);
 	}
 
 	private async runDue(): Promise<AgentToolResult<Details>> {

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -907,6 +907,64 @@ describe("recurring schedule execution", () => {
 		assert.equal(h.launches.length, 1);
 	});
 
+	it("a successful manual launch on an interval schedule advances the anchor a full interval and re-arms the natural fire", async () => {
+		const h = harness();
+		await h.manager.handleToolCall({ action: "schedule.create", id: "manual-interval", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		h.clock.now += 5 * 60_000;
+		const manual = h.manager.handleToolCall({ action: "schedule.run", id: "manual-interval" }, h.ctx);
+		await flush();
+		h.launches[0]!.resolve({ content: [{ type: "text", text: "Async" }], details: { mode: "single", results: [], asyncId: "manual-async" } });
+		assert.match(text(await manual), /Next natural fire: 2030-01-01T01:05:00.000Z/);
+		assert.match(text(await h.manager.handleToolCall({ action: "schedule.show", id: "manual-interval" }, h.ctx)), /Next: 2030-01-01T01:05:00.000Z/);
+		const events = fs.readFileSync(path.join(scheduledRunStorePath(h.ctx.cwd, undefined, path.join(h.root, "stores")), "manual-interval", "events.jsonl"), "utf-8");
+		assert.match(events, /"event":"schedule.manual_satisfied"/);
+		h.manager.handleAsyncCompletion({ runId: "manual-async", success: true });
+		h.clock.now += 3_600_000;
+		h.timers.fireAll();
+		await flush();
+		assert.equal(h.launches.length, 2, "the re-armed timer fires a natural launch at the advanced anchor");
+	});
+
+	it("a successful manual launch consumes a one-shot schedule so its natural trigger never fires", async () => {
+		const h = harness();
+		await h.manager.handleToolCall({ action: "schedule.create", id: "manual-once", at: "+1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		const manual = h.manager.handleToolCall({ action: "schedule.run", id: "manual-once" }, h.ctx);
+		await flush();
+		h.launches[0]!.resolve({ content: [{ type: "text", text: "Async" }], details: { mode: "single", results: [], asyncId: "once-async" } });
+		assert.match(text(await manual), /Next natural fire: none \(schedule satisfied\)/);
+		assert.match(text(await h.manager.handleToolCall({ action: "schedule.show", id: "manual-once" }, h.ctx)), /Next: none/);
+		h.manager.handleAsyncCompletion({ runId: "once-async", success: true });
+		h.clock.now += 86_400_000;
+		h.timers.fireAll();
+		await flush();
+		assert.equal(h.launches.length, 1, "the consumed one-shot never fires naturally");
+	});
+
+	it("an overlap-skipped manual launch leaves the natural anchor unchanged", async () => {
+		const h = harness();
+		await h.manager.handleToolCall({ action: "schedule.create", id: "manual-skip", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		const first = h.manager.handleToolCall({ action: "schedule.run", id: "manual-skip" }, h.ctx);
+		await flush();
+		const second = await h.manager.handleToolCall({ action: "schedule.run", id: "manual-skip" }, h.ctx);
+		assert.match(text(second), /skipped/);
+		assert.match(text(second), /Next natural fire: 2030-01-01T01:00:00.000Z/);
+		assert.match(text(await h.manager.handleToolCall({ action: "schedule.show", id: "manual-skip" }, h.ctx)), /Next: 2030-01-01T01:00:00.000Z/);
+		h.launches[0]!.resolve({ content: [{ type: "text", text: "Async" }], details: { mode: "single", results: [], asyncId: "skip-async" } });
+		await first;
+	});
+
+	it("a failed manual launch leaves the natural anchor unchanged", async () => {
+		const h = harness();
+		await h.manager.handleToolCall({ action: "schedule.create", id: "manual-failed", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);
+		const manual = h.manager.handleToolCall({ action: "schedule.run", id: "manual-failed" }, h.ctx);
+		await flush();
+		h.launches[0]!.resolve({ content: [{ type: "text", text: "spawn failed" }], details: { mode: "management", results: [] }, isError: true });
+		const result = await manual;
+		assert.match(text(result), /failed_launch/);
+		assert.match(text(result), /Next natural fire: 2030-01-01T01:00:00.000Z/);
+		assert.match(text(await h.manager.handleToolCall({ action: "schedule.show", id: "manual-failed" }, h.ctx)), /Next: 2030-01-01T01:00:00.000Z/);
+	});
+
 	it("distinguishes failed launch from failed async completion", async () => {
 		const h = harness();
 		await h.manager.handleToolCall({ action: "schedule.create", id: "failures", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, h.ctx);


### PR DESCRIPTION
# Upstream PR draft — NOT POSTED (local draft only; user submits manually)

# Summary

`schedule.run` (manual launch) currently launches the workflow but leaves the
schedule's `trigger.nextRunAt` untouched, so the schedule still fires at its
natural trigger. Users who launch a schedule manually — typically because the
natural trigger is imminent or was missed — get a duplicate run minutes later,
and the standard mitigation is to delete the schedule right after the manual
run, paying a delete-and-recreate tax every time.

This PR makes a manual launch satisfy the schedule's next natural fire:

- **interval schedules**: a manual launch that actually runs advances
  `trigger.nextRunAt` a full interval from the manual launch
  (`now + everyMs`), then re-arms the timer. The next natural fire defers a
  full interval instead of firing at the old anchor.
- **one-shot `at` schedules**: a manual launch that actually runs clears
  `trigger.nextRunAt` — the exact representation a natural one-shot fire
  leaves behind — so the scheduled trigger never fires. The manual run record
  still completes normally (state `completed` via the existing async
  completion path), and `events.jsonl` gains a `schedule.manual_satisfied`
  line as the audit record.

Natural fires (timer and `run-due`) are completely unchanged; the patch only
adds a post-launch step on the `schedule.run` path.

# Motivation

Observed live (twice, 2026-09-07, v0.66.0): a schedule created with
`schedule.create({ at: "+1m", ... })` whose workflowScript was executed
manually first still fired its natural trigger a minute later, producing a
duplicate run. The same double-fire happens with interval schedules whose
lane is manually launched between natural fires. Because `overlap: "skip"`
only suppresses *concurrent* runs (the manual run had already finished), the
natural fire launched a genuinely duplicate workflow. The only workaround is
deleting the schedule after every manual run.

# Design

`runManual` already calls `launch(store, schedule, now, "manual", false)`; the
`advance=false` argument is what leaves `nextRunAt` in place. Rather than flip
that flag (which would also advance the anchor on overlap-skipped launches,
including the skip paths inside `launch`), the fix keeps `launch` untouched and
adds one method, `satisfyManualLaunch`, called from `runManual` only when the
manual launch actually attached a run (`run.state === "running"`):

```ts
if (run.state === "running") this.satisfyManualLaunch(store, updated);
```

`satisfyManualLaunch` re-reads the schedule record written by `launch` (so
`activeRunId`/`lastRunId` are preserved), then:

- `interval`: `trigger.nextRunAt = timestamp(now + everyMs)` — equivalent to
  the existing `nextAfter(trigger, now, now)` helper, which for `plannedAt ===
  now` always returns exactly `now + everyMs` (no catch-up stepping can
  apply).
- `once`: `trigger.nextRunAt = undefined` — identical to what a natural
  one-shot fire already does via `launch(..., advance=true)` → `nextAfter`
  returning `undefined`, so no schema or state-machine change.
- then `updatedAt`, `store.write`, a `schedule.manual_satisfied` event line,
  and `arm()` to move the armed timer to the new anchor (or clear it for the
  satisfied one-shot).

The satisfaction runs in the same synchronous block that resumes after
`await this.launch(...)`, so it cannot interleave with async-completion
handling; when a later `finishRun` sees the advanced anchor it behaves exactly
as it does today for an in-flight run (skip-and-advance on overlap, normal
completion otherwise).

## Behavior table

| Scenario | Before | After |
|---|---|---|
| Manual launch, interval schedule, launch attaches | Natural fire still fires at old anchor (duplicate run) | `nextRunAt` = manual launch + full interval; timer re-armed |
| Manual launch, one-shot `at` schedule, launch attaches | Natural fire still fires (duplicate run) | `nextRunAt` cleared; natural trigger never fires; `schedule.manual_satisfied` logged |
| Manual launch skipped (active run in flight) | No advance | No advance (unchanged; the in-flight run owns the cadence) |
| Manual launch fails (`failed_launch`) | No advance | No advance (unchanged; the workflow did not run) |
| Natural timer fire | advance to `nextAfter` | Unchanged |
| `schedule.run-due` catch-up fire | advance / record `missed` | Unchanged |
| Paused schedule, manual run | No advance | Anchor advances/satisfies like an active schedule (paused stays paused; `arm` is a no-op while paused) |

# Backward compatibility

- No schema changes: `ScheduleRecord`/`ScheduleRunRecord` fields and
  `schemaVersion: 1` are untouched. A satisfied one-shot uses the same
  `nextRunAt: undefined` representation that a natural one-shot fire already
  produces, and `parseSchedule` already accepts it.
- No new `dueReason` or `ScheduleRunState` values; the manual run keeps
  `dueReason: "manual"`.
- `overlap: "skip"` semantics are preserved — satisfaction only happens for a
  launch that actually attached (state `running`); skipped launches never
  move the anchor.
- `hasPendingScheduleWork` starts returning `false` for a satisfied one-shot,
  which correctly frees it from the pending-schedule limit, the same as after
  a natural one-shot fire.
- Schedules created before the patch need no migration; the behavior applies
  at the next manual `schedule.run`.

# Tests

Suggested additions to the scheduled-runs suite (the manager's `now`/`timers`
deps make these deterministic):

1. **manual + interval defers a full interval**: create an interval schedule
   with fake timers, `schedule.run`, assert `trigger.nextRunAt === now +
   everyMs` and the armed timer moved (no fire at the old anchor).
2. **manual + once satisfies the schedule**: create `at: "+1m"`, run manually,
   advance fake time past the original `at`, assert no timer fire, no second
   run record, `trigger.nextRunAt === undefined`, and a
   `schedule.manual_satisfied` event in `events.jsonl`.
3. **manual skip does not advance**: start a (fake) active run, call
   `schedule.run`, assert `skipped` and `nextRunAt` unchanged.
4. **failed manual launch does not advance**: stub launch to return an error
   result, assert `failed_launch` and `nextRunAt` unchanged; natural fire
   still occurs.
5. **natural fires unchanged**: existing timer/run-due tests must pass
   unmodified.

**Patch**: applied on branch `fix/manual-schedule-run-satisfies-natural-fire` (branched from tag `v0.66.0`).

`0001-manual-launch-satisfies-schedule.patch` in this directory (unified diff,
`patch -p1`, generated against a registry-fresh `pi-subagents@0.66.0`
tarball; `--dry-run` applies cleanly).
