### PR TITLE
feat: distinct colors per agent in fleet status view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - Forked children keep their requested thinking level after signed Anthropic thinking blocks are stripped from the inherited transcript; fork context no longer forces thinking off for Anthropic-backed children. Requires a Pi host on 0.85.0 or newer, which recovers from signed-thinking mismatches on the transport. Thanks to [@hank-warren](https://github.com/hank-warren) for #2021.
+- Color FleetView agent labels by stable agent identity so multi-agent runs are easier to scan. Thanks to [@savinofiore](https://github.com/savinofiore) for #2056.
 - Simplify watchdog clarification to a visible question and native orchestrator continuation; remove the reply action, exchange tracking, deadlines and mandatory follow-up reviews.
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -16,6 +16,17 @@ export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
 const MAX_AGENT_ROWS = 6;
 const REFRESH_MS = 500;
 
+// Distinct 256-color codes for telling agents apart at a glance; avoids theme's semantic
+// success/error/accent hues so agent identity never collides with state color.
+const AGENT_COLORS = [39, 213, 214, 45, 141, 221, 75, 183];
+
+function agentColor(hashKey: string, text: string): string {
+	let hash = 0;
+	for (let i = 0; i < hashKey.length; i++) hash = (hash * 31 + hashKey.charCodeAt(i)) >>> 0;
+	const code = AGENT_COLORS[hash % AGENT_COLORS.length];
+	return `\x1b[38;5;${code}m${text}\x1b[0m`;
+}
+
 type Theme = ExtensionContext["ui"]["theme"];
 type FleetStatusTui = {
 	requestRender(): void;
@@ -727,7 +738,7 @@ export class SubagentFleetStatus {
 		const checklist = entry.workflowWrapper && entry.workflowChecklist
 			? ` · checklist ${formatWorkflowChecklistSummary(entry.workflowChecklist)}${entry.workflowChecklist.bottleneck ? ` · bottleneck ${formatWorkflowChecklistBottleneck(entry.workflowChecklist.bottleneck)}` : ""}`
 			: "";
-		const left = `${prefix} ${this.bullet(rosterIndex, selectedIndex, theme)} ${theme.fg("muted", agent)} · ${entry.state}${checklist}`;
+		const left = `${prefix} ${this.bullet(rosterIndex, selectedIndex, theme)} ${agentColor(entry.agent, agent)} · ${entry.state}${checklist}`;
 		const elapsed = Date.now() - entry.startedAt;
 		const rightText = entry.projectPane
 			? `${entry.projectPane.summary ?? "—"} · ${formatFleetElapsed(Date.now() - entry.projectPane.refreshedAt)} ago`
@@ -742,7 +753,7 @@ export class SubagentFleetStatus {
 		if (row.overflow !== undefined) return truncateToWidth(`${indent}${marker} ${theme.fg("dim", `+${row.overflow} nested leaves`)}`, width);
 		const modelThinking = row.modelThinking ? ` (${row.modelThinking})` : "";
 		const activity = row.activity ? ` · ${row.activity}` : "";
-		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg("muted", `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
+		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${agentColor(row.name, `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
 		const elapsed = row.startedAt !== undefined ? ` · ${formatFleetElapsed(Date.now() - row.startedAt)}` : "";
 		return truncateToWidth(`${left}${theme.fg("dim", elapsed)}`, width);
 	}

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -37,6 +37,7 @@ type FleetStatusEntry = {
 	parentKey?: string;
 	workflowWrapper?: boolean;
 	agent: string;
+	displayLabel?: string;
 	modelThinking?: string;
 	description?: string;
 	startedAt: number;
@@ -52,6 +53,7 @@ type FleetStatusEntry = {
 
 type FleetNestedRow = {
 	name: string;
+	agentIdentity?: string;
 	state: NestedRunSummary["state"] | NestedStepSummary["status"];
 	modelThinking?: string;
 	activity?: string;
@@ -195,6 +197,7 @@ function nestedFleetRows(children: NestedRunSummary[] | undefined, visibleLimit:
 					const activity = nestedActivity(step);
 					rows.push({
 						name: step.agent,
+						agentIdentity: step.agent,
 						state: step.status,
 						depth,
 						...(modelThinking ? { modelThinking } : {}),
@@ -217,6 +220,7 @@ function nestedFleetRows(children: NestedRunSummary[] | undefined, visibleLimit:
 				const activity = nestedActivity(child);
 				rows.push({
 					name: nestedRunLabel(child),
+					agentIdentity: child.agent ?? child.agents?.join("\0") ?? child.id,
 					state: child.state,
 					depth,
 					...(modelThinking ? { modelThinking } : {}),
@@ -450,7 +454,8 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 			entries.push({
 				key: `async:${job.asyncId}:${index}`,
 				...(linkedParentKey ? { parentKey: linkedParentKey } : {}),
-				agent: step.label ? `${step.label} (${step.agent})` : step.agent,
+				agent: step.agent,
+				...(step.label ? { displayLabel: `${step.label} (${step.agent})` } : {}),
 				...(modelThinking ? { modelThinking } : {}),
 				description: step.description ?? job.description,
 				startedAt: step.startedAt ?? startedAt,
@@ -733,7 +738,8 @@ export class SubagentFleetStatus {
 
 
 	private renderEntry(rosterIndex: number, selectedIndex: number, entry: FleetStatusEntry, width: number, theme: Theme, branch?: string): string {
-		const agent = entry.modelThinking ? `${entry.agent} (${entry.modelThinking})` : entry.agent;
+		const label = entry.displayLabel ?? entry.agent;
+		const agent = entry.modelThinking ? `${label} (${entry.modelThinking})` : label;
 		const prefix = branch ? `    ${branch}` : " ";
 		const checklist = entry.workflowWrapper && entry.workflowChecklist
 			? ` · checklist ${formatWorkflowChecklistSummary(entry.workflowChecklist)}${entry.workflowChecklist.bottleneck ? ` · bottleneck ${formatWorkflowChecklistBottleneck(entry.workflowChecklist.bottleneck)}` : ""}`
@@ -753,7 +759,7 @@ export class SubagentFleetStatus {
 		if (row.overflow !== undefined) return truncateToWidth(`${indent}${marker} ${theme.fg("dim", `+${row.overflow} nested leaves`)}`, width);
 		const modelThinking = row.modelThinking ? ` (${row.modelThinking})` : "";
 		const activity = row.activity ? ` · ${row.activity}` : "";
-		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${agentColor(row.name, `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
+		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${agentColor(row.agentIdentity ?? row.name, `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
 		const elapsed = row.startedAt !== undefined ? ` · ${formatFleetElapsed(Date.now() - row.startedAt)}` : "";
 		return truncateToWidth(`${left}${theme.fg("dim", elapsed)}`, width);
 	}
@@ -864,6 +870,7 @@ export class SubagentFleetStatus {
 					entry.surface,
 					entry.parentKey,
 					entry.agent,
+					entry.displayLabel,
 					entry.state,
 					entry.modelThinking,
 					entry.description,
@@ -900,6 +907,7 @@ export class SubagentFleetStatus {
 					]),
 					nestedFleetRows(entry.nestedChildren, entry.parentKey ? 3 : 4).map((row) => [
 						row.name,
+						row.agentIdentity,
 						row.state,
 						row.modelThinking,
 						row.activity,

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -44,6 +44,10 @@ const theme = {
 	bold: (text: string) => text,
 };
 
+function visibleText(value: string): string {
+	return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
 describe("below-editor subagent FleetView", () => {
 	it("formats elapsed time and token counts like the Claude Code fleet", () => {
 		assert.equal(formatFleetElapsed(10_600), "11s");
@@ -92,7 +96,7 @@ describe("below-editor subagent FleetView", () => {
 			assert.match(compact, /1 active job/);
 			assert.doesNotMatch(compact, /Async runs|tokens/);
 			fleet.handleKey("\x1b[B");
-			const expanded = component.render(80).join("\n");
+			const expanded = visibleText(component.render(80).join("\n"));
 			assert.match(expanded, /external · Dependency review · running/);
 			assert.match(expanded, /11s/);
 			assert.doesNotMatch(expanded.split("\n").find((line) => line.includes("Dependency review"))!, /tokens/);
@@ -190,10 +194,16 @@ describe("below-editor subagent FleetView", () => {
 
 			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
 			const expandedLines = component.render(80);
-			assert.ok(expandedLines.some((line) => line.includes("> main")));
-			assert.ok(expandedLines.some((line) => line.includes("  worker-0")), "unselected agents use blank focus space");
+			const visibleExpandedLines = expandedLines.map(visibleText);
+			assert.ok(visibleExpandedLines.some((line) => line.includes("> main")));
+			const colorCodeFor = (lines: string[], agent: string) => lines
+				.find((line) => visibleText(line).includes(agent))
+				?.match(/\x1b\[38;5;(\d+)m/)?.[1];
+			assert.equal(colorCodeFor(expandedLines, "worker-0"), "213", "agent color is deterministic from the visible agent identity");
+			assert.notEqual(colorCodeFor(expandedLines, "worker-0"), colorCodeFor(expandedLines, "worker-1"), "different agent identities get distinct colors in the roster");
+			assert.ok(visibleExpandedLines.some((line) => line.includes("  worker-0")), "unselected agents use blank focus space");
 			assert.ok(expandedLines.every((line) => !/[⏺◯]/u.test(line)), "selection avoids terminal-ambiguous circle glyphs");
-			assert.ok(expandedLines.some((line) => line.includes("worker-0 (fable-5 · thinking low)")));
+			assert.ok(visibleExpandedLines.some((line) => line.includes("worker-0 (fable-5 · thinking low)")));
 			assert.ok(expandedLines.some((line) => line.includes("11s · ↓ 13.1k tokens")));
 			assert.ok(expandedLines.some((line) => line.includes("↓ 1 more")));
 			for (const line of expandedLines) assert.ok(visibleWidth(line) <= 80, `line exceeded width: ${line}`);
@@ -829,6 +839,8 @@ describe("below-editor subagent FleetView", () => {
 				path: [{ runId: "child-1", stepIndex: 0 }],
 				state: "running",
 				agent: "nested-reviewer",
+				model: "anthropic/fable-5",
+				thinking: "low",
 			}],
 		});
 		state.foregroundControls.set("child-2", {
@@ -876,7 +888,8 @@ describe("below-editor subagent FleetView", () => {
 			assert.match(compact[0]!, /2 active agents/, "workflow wrappers must not be counted as leaf agents");
 			assert.doesNotMatch(compact[0]!, /3 active agents/);
 			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
-			const lines = component.render(120);
+			const rawLines = component.render(120);
+			const lines = rawLines.map(visibleText);
 			const workflowIndex = lines.findIndex((line) => line.includes("workflow · running"));
 			const childIndex = lines.findIndex((line) => line.includes("reviewer · running"));
 			const nestedIndex = lines.findIndex((line) => line.includes("nested-reviewer"));
@@ -887,6 +900,8 @@ describe("below-editor subagent FleetView", () => {
 			assert.ok(secondChildIndex > nestedIndex && secondNestedIndex > secondChildIndex && ownerNestedIndex > secondNestedIndex);
 			assert.match(lines[childIndex]!, /├─.*reviewer/);
 			assert.match(lines[nestedIndex]!, /├─.*nested-reviewer/);
+			assert.ok(lines[nestedIndex]!.includes("nested-reviewer (fable-5 · thinking low)"));
+			assert.match(rawLines[nestedIndex]!, /\x1b\[38;5;45mnested-reviewer \(fable-5 · thinking low\)\x1b\[0m/);
 			assert.match(lines[secondNestedIndex]!, /├─.*nested-tester/);
 			assert.match(lines[ownerNestedIndex]!, /└─.*owner-nested/);
 		} finally {
@@ -1076,7 +1091,7 @@ describe("below-editor subagent FleetView", () => {
 			fleet.setContext(ctx);
 			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
 			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
-			const lines = component.render(140).join("\n");
+			const lines = visibleText(component.render(140).join("\n"));
 			assert.match(lines, /workflow · running/);
 			assert.match(lines, /Plan: scan · Find seams \(scout\) \[fresh\] \(gpt-5\.6-luna · thinking max\) · complete/);
 			assert.match(lines, /Review: review \(reviewer\) \[fork\] · running · tool grep/);
@@ -1360,13 +1375,13 @@ describe("below-editor subagent FleetView", () => {
 			assert.deepEqual(inputHandler!("\x1b[B"), { consume: true }, "custom editors should activate FleetView across jiti boundaries");
 			assert.ok(component.render(100).length > 1, "keyboard activation should expand the roster");
 			assert.deepEqual(inputHandler!("j"), { consume: true }, "active FleetView should navigate down with j");
-			assert.ok(component.render(100).some((line) => line.includes("> worker")));
+			assert.ok(component.render(100).map(visibleText).some((line) => line.includes("> worker")));
 			assert.deepEqual(inputHandler!("k"), { consume: true }, "active FleetView should navigate up with k");
-			assert.ok(component.render(100).some((line) => line.includes("> main")));
+			assert.ok(component.render(100).map(visibleText).some((line) => line.includes("> main")));
 
 			tui.focusedComponent = Object.create(Editor.prototype) as Editor;
 			assert.deepEqual(inputHandler!("\x1b[B"), { consume: true });
-			assert.ok(component.render(100).some((line) => line.includes("> worker")));
+			assert.ok(component.render(100).map(visibleText).some((line) => line.includes("> worker")));
 			assert.deepEqual(inputHandler!("\r"), { consume: true });
 			await Promise.resolve();
 			assert.deepEqual(opened, ["foreground-active:run-worker:0"]);
@@ -1377,7 +1392,7 @@ describe("below-editor subagent FleetView", () => {
 			assert.ok(widgetFactory, "closing should restore the FleetView widget");
 			assert.notEqual(widgetFactory, component, "restoration should install a new component factory");
 			const restoredComponent = widgetFactory!(tui, theme);
-			assert.ok(restoredComponent.render(100).some((line) => line.includes("> worker")), "closing should restore the prior selected roster row");
+			assert.ok(restoredComponent.render(100).map(visibleText).some((line) => line.includes("> worker")), "closing should restore the prior selected roster row");
 			assert.deepEqual(inputHandler!("\x1b"), { consume: true });
 			assert.equal(restoredComponent.render(100).length, 1, "Escape should return to the compact summary");
 		} finally {

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -199,8 +199,8 @@ describe("below-editor subagent FleetView", () => {
 			const colorCodeFor = (lines: string[], agent: string) => lines
 				.find((line) => visibleText(line).includes(agent))
 				?.match(/\x1b\[38;5;(\d+)m/)?.[1];
-			assert.equal(colorCodeFor(expandedLines, "worker-0"), "213", "agent color is deterministic from the visible agent identity");
-			assert.notEqual(colorCodeFor(expandedLines, "worker-0"), colorCodeFor(expandedLines, "worker-1"), "different agent identities get distinct colors in the roster");
+			assert.equal(colorCodeFor(expandedLines, "worker-0"), "213", "agent color is deterministic from the raw agent identity");
+			assert.notEqual(colorCodeFor(expandedLines, "worker-0"), colorCodeFor(expandedLines, "worker-1"), "these identities hash to different fixed-palette colors");
 			assert.ok(visibleExpandedLines.some((line) => line.includes("  worker-0")), "unselected agents use blank focus space");
 			assert.ok(expandedLines.every((line) => !/[⏺◯]/u.test(line)), "selection avoids terminal-ambiguous circle glyphs");
 			assert.ok(visibleExpandedLines.some((line) => line.includes("worker-0 (fable-5 · thinking low)")));
@@ -212,6 +212,49 @@ describe("below-editor subagent FleetView", () => {
 			assert.equal(component.render(80).length, 1);
 			assert.deepEqual(fleet.handleKey("\x1b[D"), { consume: true });
 			assert.ok(component.render(80).length > 1, "Left should also expand the roster");
+		} finally {
+			fleet.dispose();
+		}
+	});
+
+	it("keeps agent color stable when async display labels differ", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("labeled-agents", {
+			asyncId: "labeled-agents",
+			asyncDir: "/tmp/labeled-agents",
+			status: "running",
+			mode: "parallel",
+			startedAt: Date.now() - 1_000,
+			updatedAt: Date.now(),
+			steps: [
+				{ agent: "scout", label: "Find seams", status: "running", index: 0 },
+				{ agent: "scout", label: "Audit API", status: "running", index: 1 },
+			],
+		});
+
+		let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(_key: string, content: typeof widgetFactory | undefined) { if (content) widgetFactory = content; },
+				onTerminalInput() { return () => {}; },
+				getEditorText() { return ""; },
+				requestRender() {},
+				notify() {},
+				theme,
+			},
+		} as unknown as ExtensionContext;
+		const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+		try {
+			fleet.setContext(ctx);
+			const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+			assert.deepEqual(fleet.handleKey("\x1b[B"), { consume: true });
+			const lines = component.render(100);
+			const colorFor = (label: string) => lines
+				.find((line) => visibleText(line).includes(label))
+				?.match(/\x1b\[38;5;(\d+)m/)?.[1];
+			assert.equal(colorFor("Find seams (scout)"), colorFor("Audit API (scout)"));
+			assert.ok(colorFor("Find seams (scout)"), "labeled agents render with an identity color");
 		} finally {
 			fleet.dispose();
 		}


### PR DESCRIPTION
Fleet status renders every agent name in the same muted gray (`theme.fg("muted", agent)`), so in a multi-agent run it's hard to tell which row belongs to which agent without reading the label closely.

This hashes the agent/child name into a fixed palette of 8 ANSI-256 colors, deliberately distinct from the theme's semantic `success`/`error`/`accent` hues so agent identity never collides with state color. Applied at both render sites:
- top-level roster row (`renderEntry`)
- nested descendant rows (`renderNestedRow`)

Hash key is the base agent/name (without the `(modelThinking)` suffix), so the same agent keeps the same color across the roster and its nested rows.

No new deps, no config, no behavior change beyond color.