### PR TITLE
fix: preserve read-only tasks after host clamping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Preserve explicit read-only task intent after host capability clamping, while still blocking implementation tasks that lack mutation tools. Thanks to [@stekman08](https://github.com/stekman08) for #2060.
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
 - Intersect agent frontmatter `tools:` with host-available builtins before spawning children, so hosts with restricted tool menus (e.g. Prime Agent's `ipython`-only set) reject unavailable tools at launch instead of after spawn. Thanks to [@BioInfo](https://github.com/BioInfo) for #2034.
 - Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution (#2020). Thanks to [@kroediger](https://github.com/kroediger).

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -105,11 +105,17 @@ function inferLevel(input: {
 	const inferredReadOnly = readOnlyTask || ((readOnlyAgent || input.acceptanceRole === "read-only") && !taskMayWrite);
 	const roleResolvesReadOnly = input.acceptanceRole !== undefined && inferredReadOnly;
 	const dynamicResolvesReadOnly = inferredReadOnly && !writeTask;
-	const keywordRiskReadOnly = input.acceptanceRole === undefined ? intent.kind === "read-only" : inferredReadOnly;
+	const riskyKeywordPattern = /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/;
+	// A read-only task can still need a checked acceptance review when its
+	// wording names a sensitive area. Keep this legacy keyword safeguard even
+	// though the shared intent classifier now recognizes more read-only forms.
+	const keywordRiskReadOnly = input.acceptanceRole === undefined
+		? intent.kind === "read-only" && !riskyKeywordPattern.test(task)
+		: inferredReadOnly;
 	const risky = Boolean(input.async && writeTask)
 		|| (Boolean(input.dynamic) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
 		|| (Boolean(input.dynamicGroup) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
-		|| (!keywordRiskReadOnly && /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/.test(task));
+		|| (!keywordRiskReadOnly && riskyKeywordPattern.test(task));
 
 	if (risky) {
 		reasons.push(input.async ? "async write-capable or risky run" : "risky write-capable run");

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -98,15 +98,25 @@ export function validateImplementationToolContract(input: {
 	const declaredMutationToolsWereRemoved = requestedMutationTools.length > 0 && !hasBuiltinMutationTool(input.tools);
 	const configuredExtensionCapability = (input.configuredExtensions?.length ?? 0) > 0 && !declaredMutationToolsWereRemoved;
 	if (hasMutationToolCapability(input.tools, input.mcpDirectTools) || configuredExtensionCapability) return undefined;
-	const intent = classifyTaskMutationIntent(input.agent, input.task);
+	// An explicit writer acceptance role replaces the agent-name heuristic used
+	// by the shared classifier, so a reviewer-named writer is still evaluated as
+	// a writer task.
+	const intent = classifyTaskMutationIntent(input.acceptanceRole === "writer" ? "worker" : input.agent, input.task);
+	// Host availability can remove declared mutation tools from a task whose
+	// wording is explicitly read-only. Unknown wording remains conservative when
+	// the requested launch declared mutation-capable tools.
 	if (intent.kind === "read-only") return undefined;
-	const writerTaskMayMutate = isWriterRole(input.agent, input.acceptanceRole)
-		&& (taskMayMutate(input.task) || WRITER_DELIVERY_PATTERN.test(input.task));
+	const writerTaskMayMutate = input.acceptanceRole === "writer"
+		? true
+		: isWriterRole(input.agent, input.acceptanceRole)
+			&& (taskMayMutate(input.task) || WRITER_DELIVERY_PATTERN.test(input.task));
 	if (intent.kind !== "implementation" && !writerTaskMayMutate && !declaredMutationToolsWereRemoved) return undefined;
 	return `Agent '${input.agent}' was given an implementation task, but its tool allowlist has no mutation-capable tools. Add bash, edit, write, or another mutation-capable tool to the agent, or use a read-only task/agent.`;
 }
 
 function hasCheckpointMutationEvidence(message: Message): boolean {
+	// SAFETY: pi-checkpoint custom messages are runtime records outside the
+	// pi-ai Message union; narrow their discriminants before reading payloads.
 	const record = message as unknown as {
 		role?: string;
 		type?: string;

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -18,16 +18,24 @@
  */
 
 const REVIEW_ONLY_PATTERNS = [
-	/\breview only\b/i,
+	/\b(?:review|read)[- ]only\b/i,
+	/\bno\s+(?:source\s+)?edits?\b/i,
+	/\bwithout\s+edits?\b/i,
 	/\bsuggest fixes only\b/i,
 	/\bonly return findings\b/i,
 	/\breturn findings only\b/i,
 ];
 
+// Workflow tasks sometimes state a read-only boundary as a comma-separated
+// noun list (for example, "No source edits, commits, or pushes"). Unlike a
+// blanket prohibition, remove this assertion before checking for a later
+// implementation imperative.
+const NO_EDIT_BOUNDARY_ASSERTION_PATTERN = /\bno\s+(?:source\s+)?edits?\s*,\s*(?:commits?|pushes?|merges?|installs?|changes?|writes?)\b/i;
+
 const REVIEWER_REQUIRED_EDIT_PATTERNS = [
 	/\bmust\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
 	/\brequired\s+to\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
-	/(?:^|[.!?\n]\s*)implement\s+(?:the\s+)?(?:approved|requested|specified|file|code|source|fix(?:es)?|changes?)\b/i,
+	/(?:^|[.!?:;,\n]\s*)implement\s+(?:the\s+)?(?:approved|requested|specified|file|code|source|fix(?:es)?|changes?)\b/i,
 	/\bregardless\s+of\s+findings\b/i,
 	/\balways\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
 	/\bapply\s+(?:the\s+)?fix(?:es)?\s+directly\b/i,
@@ -85,7 +93,7 @@ const RESEARCH_AGENT_PATTERNS = [
 // CLI flags like "--fix" and genuine clause-level dashes like "branch—fix it"),
 // strip the known severity compounds (must|should|needs + dash + verb) from the
 // task text before matching. Dash coverage: ASCII hyphen + U+2010..U+2015.
-const SEVERITY_COMPOUND_PATTERN = /\b(?:must|should|needs)[\-\u2010-\u2015](?:fix|edit|update|add|remove|replace|create|apply|make|do|implement|modify|delete|patch)\b/gi;
+const SEVERITY_COMPOUND_PATTERN = /\b(?:must|should|needs)[-\u2010-\u2015](?:fix|edit|update|add|remove|replace|create|apply|make|do|implement|modify|delete|patch)\b/gi;
 
 function stripSeverityCompounds(task: string): string {
 	return task.replace(SEVERITY_COMPOUND_PATTERN, " ");
@@ -102,6 +110,11 @@ const WORKER_IMPLEMENTATION_PATTERNS = [
 	/\bmake\s+(?:the\s+)?changes\b/i,
 	/\bdo those fixes\b/i,
 ];
+
+// Once an explicit read-only marker has been stripped, keep common imperative
+// verbs visible even when their target is a project-specific noun (for example,
+// "Without edits, update the parser"). Output-only nouns remain excluded.
+const FOLLOW_ON_IMPLEMENTATION_PATTERN = /\b(?:fix|patch|update|add|remove|replace|create|delete)\s+(?!(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?(?:report|summary|findings?|analysis|recommendations?|answer|response|proposal|plan|issue|bug report)\b)(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?[a-z][\w./-]*/i;
 
 const GENERAL_IMPLEMENTATION_PATTERNS = [
 	/\b(?:implement|edit|modify|refactor)\b/i,
@@ -141,10 +154,16 @@ interface NoEditProhibitionAnalysis {
 }
 
 function analyzeNoEditProhibitions(taskText: string): NoEditProhibitionAnalysis {
-	let present = REVIEW_ONLY_PATTERNS.some((pattern) => pattern.test(taskText))
-		|| NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText));
-	let blanket = present;
+	const reviewOnly = REVIEW_ONLY_PATTERNS.some((pattern) => pattern.test(taskText));
+	const noTools = NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText));
+	const readOnlyBoundary = NO_EDIT_BOUNDARY_ASSERTION_PATTERN.test(taskText);
+	let present = reviewOnly || noTools || readOnlyBoundary;
+	// Review-only/no-tool wording is a read-only signal, not a blanket
+	// prohibition: a later imperative such as "implement the fix" must still
+	// win. Explicit file prohibitions are analyzed below and may be blanket.
+	let blanket = false;
 	let strippedText = stripPatterns(taskText, [...REVIEW_ONLY_PATTERNS, ...NO_TOOL_INTENT_PATTERNS]);
+	if (readOnlyBoundary) strippedText = stripPatterns(strippedText, [NO_EDIT_BOUNDARY_ASSERTION_PATTERN]);
 	const stripNoEditProhibition = (match: string, object: string, offset: number, source: string): string => {
 		present = true;
 		if (GENERIC_PROHIBITION_OBJECT.test(object) && !hasScopedProhibitionContinuation(source.slice(offset + match.length))) blanket = true;
@@ -177,7 +196,9 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
 		if (prohibitions.blanket) return { kind: "read-only" };
-		return hasImplementationIntent(agent, prohibitions.strippedText) ? { kind: "implementation" } : { kind: "read-only" };
+		return hasImplementationIntent(agent, prohibitions.strippedText) || FOLLOW_ON_IMPLEMENTATION_PATTERN.test(prohibitions.strippedText)
+			? { kind: "implementation" }
+			: { kind: "read-only" };
 	}
 
 	if (RESEARCH_AGENT_PATTERNS.some((pattern) => pattern.test(agent))) return { kind: "read-only" };

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -10,6 +10,7 @@ import {
 	validateImplementationToolContract,
 } from "../../src/runs/shared/completion-guard.ts";
 import { isMutatingTool } from "../../src/runs/shared/long-running-guard.ts";
+import { resolvePiLaunchToolPlan } from "../../src/runs/shared/child-tool-plan.ts";
 
 function assistantToolCall(name: string, args: Record<string, unknown> = {}): Message {
 	return {
@@ -386,6 +387,73 @@ test("implementation tool contract rejects read-only worker launches", () => {
 	}), undefined);
 });
 
+test("read-only audit tasks survive host-clamped declared mutation tools", () => {
+	const task = "Read-only bug investigation. No source edits, commits, pushes, merges, installs, or state repair. Return concrete findings and a minimal fix proposal.";
+	const requestedTools = ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"];
+	const toolPlan = resolvePiLaunchToolPlan({
+		tools: requestedTools,
+		hostAvailableBuiltins: ["read", "grep", "find", "ls", "contact_supervisor"],
+	});
+
+	assert.deepEqual(toolPlan.effectiveToolAllowlist, ["read", "grep", "find", "ls", "contact_supervisor"]);
+	assert.equal(expectsImplementationMutation("delegate", task), false);
+	assert.equal(validateImplementationToolContract({
+		agent: "delegate",
+		task,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}), undefined);
+	const implementationTask = "No source edits, commits, pushes; implement the requested source fix.";
+	assert.equal(expectsImplementationMutation("delegate", implementationTask), true);
+	assert.match(validateImplementationToolContract({
+		agent: "delegate",
+		task: implementationTask,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+	for (const task of [
+		"Review only; implement the approved fix.",
+		"No tools needed; implement the approved fix.",
+		"Without edits, update the parser.",
+	]) {
+		assert.match(validateImplementationToolContract({
+			agent: "delegate",
+			task,
+			tools: toolPlan.effectiveToolAllowlist,
+			requestedTools: toolPlan.requestedBuiltinTools,
+		}) ?? "", /no mutation-capable tools/, task);
+	}
+	assert.equal(expectsImplementationMutation("reviewer", "Review only; implement the approved fix."), true);
+	assert.match(validateImplementationToolContract({
+		agent: "reviewer",
+		task: "Review only; implement the approved fix.",
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+
+	// Unknown wording remains conservative when the launch explicitly requested
+	// mutation tools that the host removed.
+	const summaryTask = "Create a summary";
+	assert.equal(expectsImplementationMutation("delegate", summaryTask), false);
+	assert.match(validateImplementationToolContract({
+		agent: "delegate",
+		task: summaryTask,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+
+	// A generic worker task remains unknown rather than inheriting writer intent,
+	// but the removed requested mutation tools still keep the launch conservative.
+	const genericWorkerTask = "Inspect the current behavior and report findings.";
+	assert.equal(expectsImplementationMutation("worker", genericWorkerTask), false);
+	assert.match(validateImplementationToolContract({
+		agent: "worker",
+		task: genericWorkerTask,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+});
+
 test("oracle review tasks with bash available do not require mutation", () => {
 	const task = "Review prep findings and determine what to implement with playbooks instead of before.";
 	const result = evaluateCompletionMutationGuard({
@@ -407,6 +475,23 @@ test("review-only, research, and framework output instructions do not expect mut
 	assert.equal(expectsImplementationMutation("worker", "Review only: return findings, do not edit"), false);
 	assert.equal(expectsImplementationMutation("worker", "Do not edit files. Tell me how to fix the bug."), false);
 	assert.equal(expectsImplementationMutation("worker", "Review the diff and suggest fixes only. Do not edit files."), false);
+	for (const task of [
+		"Read-only audit of the current implementation; report findings.",
+		"Review-only pass over the diff; return recommendations.",
+		"No edits; inspect the current behavior and report findings.",
+		"Analyze the current behavior without edits.",
+	]) {
+		assert.equal(expectsImplementationMutation("delegate", task), false, task);
+	}
+	for (const task of [
+		"Review only; implement the approved fix.",
+		"No tools needed; implement the approved fix.",
+		"Read-only review; modify the requested source file.",
+		"Without edits to the report, implement the requested fix.",
+		"Without edits, update the parser.",
+	]) {
+		assert.equal(expectsImplementationMutation("delegate", task), true, task);
+	}
 	assert.equal(expectsImplementationMutation("worker", "Implement this. Do not edit files outside this repo. Do not edit files."), false);
 	assert.equal(expectsImplementationMutation("worker", "Investigate why this failed"), false);
 	assert.equal(expectsImplementationMutation("researcher", "Research the API behavior"), false);
@@ -707,8 +792,26 @@ test("writer-role tasks with unknown implementation wording reject read-only lau
 			task,
 			tools: ["read", "grep", "find", "ls", "contact_supervisor"],
 			requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
-		}), /no mutation-capable tools/, task);
+		}) ?? "", /no mutation-capable tools/, task);
 	}
+});
+
+test("explicit writer acceptance role overrides reviewer agent heuristics", () => {
+	assert.match(validateImplementationToolContract({
+		agent: "reviewer",
+		task: "Handle the authentication flow",
+		acceptanceRole: "writer",
+		tools: ["read", "grep", "find", "ls", "contact_supervisor"],
+		requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+	}) ?? "", /no mutation-capable tools/);
+
+	assert.equal(validateImplementationToolContract({
+		agent: "reviewer",
+		task: "Review only and return findings",
+		acceptanceRole: "writer",
+		tools: ["read", "grep", "find", "ls", "contact_supervisor"],
+		requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+	}), undefined);
 });
 
 test("configured extensions do not rescue clamped-away builtin mutation tools", () => {
@@ -718,7 +821,7 @@ test("configured extensions do not rescue clamped-away builtin mutation tools", 
 		tools: ["read", "grep", "find", "ls", "contact_supervisor"],
 		configuredExtensions: ["/tmp/provider.ts"],
 		requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
-	}), /no mutation-capable tools/);
+	}) ?? "", /no mutation-capable tools/);
 });
 
 test("read-only agents and pure extension workers keep their launch contracts", () => {

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -25,6 +25,16 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\nin src; implement the fix").kind, "implementation");
 	});
 
+	it("does not let read-only markers swallow generic implementation imperatives", () => {
+		for (const task of [
+			"Without edits, update the parser",
+			"Review only; add the missing test",
+		]) {
+			assert.equal(classifyTaskMutationIntent("delegate", task).kind, "implementation", task);
+		}
+		assert.equal(classifyTaskMutationIntent("delegate", "Review only; update the report").kind, "read-only");
+	});
+
 	it("stops the prohibition object before a following implementation clause", () => {
 		for (const task of [
 			"Do not modify tests but implement the fix",


### PR DESCRIPTION
## Summary

Host capability clamping can remove the mutation tools a task requested before launch. This change allows explicitly read-only review/audit tasks to proceed with the remaining tools, while keeping implementation intent and writer intent conservative when mutation tools are unavailable.

The shared intent handling now recognizes common read-only wording and still gives later implementation imperatives precedence. Acceptance inference retains checked review requirements for sensitive keywords even when the task is read-only.

## Verification

- `node --experimental-strip-types --test test/unit/completion-guard.test.ts test/unit/task-intent.test.ts test/unit/acceptance.test.ts` - 125 passed
- `npm run typecheck` - passed
- `npm run test:integration` - 1003 passed, 6 skipped
- `npm test` - 2989 passed, 13 skipped, 1 unrelated `nested-control` timing failure; the isolated nested-control test passes
- Baseline reproduction blocked `Read-only audit of the current implementation; report findings.` after mutation tools were clamped; the fixed contract allows it
