### PR TITLE
feat(orca-progress-tabs): add autoCloseDelaySec to auto-close tabs after completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000).
 - Add default-off, main-only watchdog questions and task-continuity reviews from bounded delivered orchestration evidence (#2010).
 - Add the built-in `evidence-auditor` for independently reviewing important research claims and source support. Thanks to [@Muskos](https://github.com/Muskos) for #2023.
 - Notify the parent as individual async workflow children finish, without waiting for all siblings (#2027). Each child completion delivers a compact notification with the workflow run ID, child key, exact child run ID, outcome, and output reference while the workflow remains running.
@@ -13,6 +14,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000).
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
 - Intersect agent frontmatter `tools:` with host-available builtins before spawning children, so hosts with restricted tool menus (e.g. Prime Agent's `ipython`-only set) reject unavailable tools at launch instead of after spawn. Thanks to [@BioInfo](https://github.com/BioInfo) for #2034.
 - Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution (#2020). Thanks to [@kroediger](https://github.com/kroediger).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000).
+- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000) (#2063).
 - Add default-off, main-only watchdog questions and task-continuity reviews from bounded delivered orchestration evidence (#2010).
 - Add the built-in `evidence-auditor` for independently reviewing important research claims and source support. Thanks to [@Muskos](https://github.com/Muskos) for #2023.
 - Notify the parent as individual async workflow children finish, without waiting for all siblings (#2027). Each child completion delivers a compact notification with the workflow run ID, child key, exact child run ID, outcome, and output reference while the workflow remains running.
@@ -14,7 +14,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
-- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000).
+- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000) (#2063).
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
 - Intersect agent frontmatter `tools:` with host-available builtins before spawning children, so hosts with restricted tool menus (e.g. Prime Agent's `ipython`-only set) reject unavailable tools at launch instead of after spawn. Thanks to [@BioInfo](https://github.com/BioInfo) for #2034.
 - Redirect `@earendil-works/pi-tui` via module hooks in background runners alongside `pi-server`, avoiding MODULE_NOT_FOUND in unusual installation layouts where the package exists in the alias map but cannot be found through standard node_modules resolution (#2020). Thanks to [@kroediger](https://github.com/kroediger).

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -113,10 +113,16 @@ function validateOrcaProgressTabsConfig(value: unknown): void {
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.orcaProgressTabs must be a JSON object");
 	const config = value as Record<string, unknown>;
 	for (const key of Object.keys(config)) {
-		if (key !== "enabled") throw new Error(`config.orcaProgressTabs.${key} is not supported`);
+		if (key !== "enabled" && key !== "autoCloseDelaySec") throw new Error(`config.orcaProgressTabs.${key} is not supported`);
 	}
 	if (config.enabled !== undefined && typeof config.enabled !== "boolean") {
 		throw new Error("config.orcaProgressTabs.enabled must be a boolean");
+	}
+	if (config.autoCloseDelaySec !== undefined
+		&& (typeof config.autoCloseDelaySec !== "number"
+			|| !Number.isFinite(config.autoCloseDelaySec)
+			|| config.autoCloseDelaySec < 0)) {
+		throw new Error("config.orcaProgressTabs.autoCloseDelaySec must be a number >= 0");
 	}
 }
 

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -29,7 +29,7 @@ const ORCA_CREATE_WATCHDOG_SCRIPT = [
 	"function exists(file){try{return fs.existsSync(file)}catch{return false}}",
 	"function keepQueued(){try{const now=new Date();fs.utimesSync(done,now,now)}catch{}}",
 	"function predecessorReady(){if(previous==='-')return true;if(exists(previous.replace(/\\.pending$/,'.ready')))return true;try{return Date.now()-fs.statSync(previous).mtimeMs>=waitTimeout}catch{return true}}",
-	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim().split(/\\r?\\n/).filter(Boolean).at(-1);if(raw){try{payload.orca=JSON.parse(raw)}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n')}catch{}}",
+	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim();if(raw){try{const parsed=JSON.parse(raw);payload.orca=parsed;const t=parsed&&typeof parsed==='object'?(parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed):undefined;if(t&&typeof t==='object'){if(typeof t.handle==='string')payload.orcaHandle=t.handle;if(typeof t.tabId==='string')payload.orcaTabId=t.tabId;if(typeof t.title==='string')payload.orcaTitle=t.title}}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n')}catch{}}",
 	"function start(){",
 	" try{",
 	"  const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});",
@@ -164,6 +164,9 @@ interface OrcaObserverManifest {
 	logPath: string;
 	orca?: unknown;
 	orcaRaw?: string;
+	orcaHandle?: string;
+	orcaTabId?: string;
+	orcaTitle?: string;
 }
 
 function observerManifestPath(cwd: string, stem: string): string | undefined {

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -52,6 +52,15 @@ const ORCA_CLEANUP_WATCHDOG_SCRIPT = [
 	"setInterval(check,1000);check();",
 ].join("");
 
+const ORCA_CLOSE_WATCHDOG_SCRIPT = [
+	"const {spawn}=require('node:child_process');",
+	"const delayMs=Number(process.argv[1]),command=process.argv[2],handle=process.argv[3],expectTitle=process.argv[4],expectTabId=process.argv[5];",
+	"function run(args){return new Promise(resolve=>{try{const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});let stdout='';if(child.stdout)child.stdout.on('data',chunk=>{stdout+=String(chunk);if(stdout.length>65536)stdout=stdout.slice(-65536)});child.once('error',()=>resolve({ok:false,stdout:''}));child.once('close',code=>resolve({ok:code===0,stdout}))}catch{resolve({ok:false,stdout:''})}})}",
+	"function parseJson(raw){try{return JSON.parse(String(raw||'').trim())}catch{return undefined}}",
+	"function pickTerminal(parsed){if(!parsed||typeof parsed!=='object')return undefined;return parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed}",
+	"setTimeout(()=>{void (async()=>{try{const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(expectTitle&&(typeof t.title!=='string'||t.title!==expectTitle))return;if(expectTabId&&expectTabId!=='-'&&(typeof t.tabId!=='string'||t.tabId!==expectTabId))return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
+].join("");
+
 export interface OrcaProgressTab {
 	/** Resolves when the terminal-create watchdog closes, after its final manifest/queue writes (success or failure). Not viewer completion. */
 	readonly creationSettled: Promise<void>;
@@ -305,6 +314,62 @@ function scheduleCleanup(nodeExecutable: string, paths: string[]): void {
 	}
 }
 
+function scheduleTabClose(input: {
+	nodeExecutable: string;
+	orcaCommand: string;
+	handle: string;
+	title: string;
+	tabId?: string;
+	delayMs: number;
+}): void {
+	try {
+		const watchdog = spawn(input.nodeExecutable, [
+			"-e", ORCA_CLOSE_WATCHDOG_SCRIPT,
+			String(input.delayMs),
+			input.orcaCommand,
+			input.handle,
+			input.title,
+			input.tabId ?? "-",
+		], {
+			detached: true,
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		watchdog.once("error", () => {});
+		watchdog.unref();
+	} catch {
+		// Tab auto-close remains best effort for this optional observer.
+	}
+}
+
+function readObserverManifest(manifestPath: string | undefined): OrcaObserverManifest | undefined {
+	if (!manifestPath) return undefined;
+	try {
+		const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+		return parsed as OrcaObserverManifest;
+	} catch {
+		return undefined;
+	}
+}
+
+function extractOrcaHandle(parsed: unknown): { handle?: string; tabId?: string; title?: string } {
+	if (!parsed || typeof parsed !== "object") return {};
+	const record = parsed as Record<string, unknown>;
+	const nested = record.terminal
+		?? (record.result && typeof record.result === "object" && !Array.isArray(record.result)
+			? ((record.result as Record<string, unknown>).terminal ?? record.result)
+			: undefined)
+		?? record;
+	if (!nested || typeof nested !== "object" || Array.isArray(nested)) return {};
+	const terminal = nested as Record<string, unknown>;
+	return {
+		handle: typeof terminal.handle === "string" ? terminal.handle : undefined,
+		tabId: typeof terminal.tabId === "string" ? terminal.tabId : undefined,
+		title: typeof terminal.title === "string" ? terminal.title : undefined,
+	};
+}
+
 function loadOrcaProgressTabsConfig(): OrcaProgressTabsConfig | undefined {
 	try {
 		const configPath = path.join(getAgentDir(), "extensions", "subagent", "config.json");
@@ -313,8 +378,15 @@ function loadOrcaProgressTabsConfig(): OrcaProgressTabsConfig | undefined {
 		const value = (parsed as Record<string, unknown>).orcaProgressTabs;
 		if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
 		const config = value as Record<string, unknown>;
-		if (Object.keys(config).some((key) => key !== "enabled") || typeof config.enabled !== "boolean") return undefined;
-		return { enabled: config.enabled };
+		const extraKeys = Object.keys(config).filter((key) => key !== "enabled" && key !== "autoCloseDelaySec");
+		if (extraKeys.length > 0) return undefined;
+		if (config.enabled !== undefined && typeof config.enabled !== "boolean") return undefined;
+		const autoCloseDelaySec = config.autoCloseDelaySec;
+		if (autoCloseDelaySec !== undefined && (typeof autoCloseDelaySec !== "number" || !Number.isFinite(autoCloseDelaySec) || autoCloseDelaySec < 0)) return undefined;
+		const loaded: OrcaProgressTabsConfig = {};
+		if (typeof config.enabled === "boolean") loaded.enabled = config.enabled;
+		if (typeof autoCloseDelaySec === "number") loaded.autoCloseDelaySec = autoCloseDelaySec;
+		return loaded;
 	} catch {
 		return undefined;
 	}
@@ -504,6 +576,28 @@ export function createOrcaProgressTab(input: {
 						try { fs.writeFileSync(donePath, `${status}\n`, { encoding: "utf-8", mode: 0o600 }); } catch { /* best effort */ }
 						cleanupPaths = [logPath, donePath];
 						scheduleDeferredCleanup();
+						const delaySec = config?.autoCloseDelaySec;
+						if (status === "completed" && typeof delaySec === "number" && delaySec > 0) {
+							const manifest = readObserverManifest(manifestPath);
+							const extracted = extractOrcaHandle(manifest?.orca);
+							const handle = (typeof manifest?.orcaHandle === "string" && manifest.orcaHandle)
+								|| extracted.handle;
+							const tabId = (typeof manifest?.orcaTabId === "string" && manifest.orcaTabId)
+								|| extracted.tabId;
+							const expectedTitle = (typeof manifest?.orcaTitle === "string" && manifest.orcaTitle)
+								|| extracted.title
+								|| title;
+							if (handle) {
+								scheduleTabClose({
+									nodeExecutable,
+									orcaCommand: command,
+									handle,
+									title: expectedTitle,
+									tabId,
+									delayMs: delaySec * 1000,
+								});
+							}
+						}
 					}
 					resolve();
 				});

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -20,16 +20,28 @@ const COUNTER_LOCK_RETRIES = 200;
 const COUNTER_LOCK_RETRY_MS = 10;
 const ORCA_CREATE_WAIT_TIMEOUT_MS = ORCA_CREATE_TIMEOUT_MS + ORCA_KILL_GRACE_MS + 3_000;
 
+const ORCA_CLOSE_WATCHDOG_SCRIPT = [
+	"const {spawn}=require('node:child_process');",
+	"const delayMs=Number(process.argv[1]),command=process.argv[2],handle=process.argv[3],expectTitle=process.argv[4],expectTabId=process.argv[5];",
+	"function run(args){return new Promise(resolve=>{try{const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});let stdout='';if(child.stdout)child.stdout.on('data',chunk=>{stdout+=String(chunk);if(stdout.length>65536)stdout=stdout.slice(-65536)});child.once('error',()=>resolve({ok:false,stdout:''}));child.once('close',code=>resolve({ok:code===0,stdout}))}catch{resolve({ok:false,stdout:''})}})}",
+	"function parseJson(raw){try{return JSON.parse(String(raw||'').trim())}catch{return undefined}}",
+	"function pickTerminal(parsed){if(!parsed||typeof parsed!=='object')return undefined;return parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed}",
+	"setTimeout(()=>{void (async()=>{try{const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(expectTitle&&(typeof t.title!=='string'||t.title!==expectTitle))return;if(expectTabId&&expectTabId!=='-'&&(typeof t.tabId!=='string'||t.tabId!==expectTabId))return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
+].join("");
+
 const ORCA_CREATE_WATCHDOG_SCRIPT = [
 	"const {spawn}=require('node:child_process');",
 	"const fs=require('node:fs');",
 	"const timeout=Number(process.argv[1]),grace=Number(process.argv[2]),waitTimeout=Number(process.argv[3]);",
 	"const previous=process.argv[4],done=process.argv[5],manifest=process.argv[6],command=process.argv[7],args=process.argv.slice(8);",
+	`const closeScript=${JSON.stringify(ORCA_CLOSE_WATCHDOG_SCRIPT)};`,
 	"function mark(){try{fs.writeFileSync(done.replace(/\\.pending$/,'.ready'),'')}catch{}}",
 	"function exists(file){try{return fs.existsSync(file)}catch{return false}}",
 	"function keepQueued(){try{const now=new Date();fs.utimesSync(done,now,now)}catch{}}",
 	"function predecessorReady(){if(previous==='-')return true;if(exists(previous.replace(/\\.pending$/,'.ready')))return true;try{return Date.now()-fs.statSync(previous).mtimeMs>=waitTimeout}catch{return true}}",
-	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim();if(raw){try{const parsed=JSON.parse(raw);payload.orca=parsed;const t=parsed&&typeof parsed==='object'?(parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed):undefined;if(t&&typeof t==='object'){if(typeof t.handle==='string')payload.orcaHandle=t.handle;if(typeof t.tabId==='string')payload.orcaTabId=t.tabId;if(typeof t.title==='string')payload.orcaTitle=t.title}}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n')}catch{}}",
+	"function claimAutoClose(){if(manifest==='-')return false;try{fs.writeFileSync(manifest.replace(/\\.json$/,'.autoclose'),'',{flag:'wx',mode:0o600});return true}catch{return false}}",
+	"function catchupAutoClose(payload){if(!payload||payload.state!=='open')return;const handle=typeof payload.orcaHandle==='string'?payload.orcaHandle:'';if(!handle)return;const delay=payload.autoCloseDelaySec;if(typeof delay!=='number'||!(delay>0))return;let status='';try{status=String(fs.readFileSync(String(payload.logPath||'').replace(/\\.log$/,'.done'),'utf8')).trim()}catch{return}if(status!=='completed')return;if(!claimAutoClose())return;try{const w=spawn(process.execPath,['-e',closeScript,String(delay*1000),command,handle,typeof payload.orcaTitle==='string'?payload.orcaTitle:'',typeof payload.orcaTabId==='string'?payload.orcaTabId:'-'],{detached:true,stdio:'ignore',windowsHide:true});w.unref()}catch{}}",
+	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim();if(raw){try{const parsed=JSON.parse(raw);payload.orca=parsed;const t=parsed&&typeof parsed==='object'?(parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed):undefined;if(t&&typeof t==='object'){if(typeof t.handle==='string')payload.orcaHandle=t.handle;if(typeof t.tabId==='string')payload.orcaTabId=t.tabId;if(typeof t.title==='string')payload.orcaTitle=t.title}}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n');catchupAutoClose(payload)}catch{}}",
 	"function start(){",
 	" try{",
 	"  const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});",
@@ -50,15 +62,6 @@ const ORCA_CLEANUP_WATCHDOG_SCRIPT = [
 	"const deadline=Date.now()+Number(process.argv[1]),files=process.argv.slice(2);",
 	"function check(){if(!files.some(file=>fs.existsSync(file)))process.exit(0);if(Date.now()<deadline)return;for(const file of files){try{fs.rmSync(file,{force:true})}catch{}}process.exit(0)}",
 	"setInterval(check,1000);check();",
-].join("");
-
-const ORCA_CLOSE_WATCHDOG_SCRIPT = [
-	"const {spawn}=require('node:child_process');",
-	"const delayMs=Number(process.argv[1]),command=process.argv[2],handle=process.argv[3],expectTitle=process.argv[4],expectTabId=process.argv[5];",
-	"function run(args){return new Promise(resolve=>{try{const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});let stdout='';if(child.stdout)child.stdout.on('data',chunk=>{stdout+=String(chunk);if(stdout.length>65536)stdout=stdout.slice(-65536)});child.once('error',()=>resolve({ok:false,stdout:''}));child.once('close',code=>resolve({ok:code===0,stdout}))}catch{resolve({ok:false,stdout:''})}})}",
-	"function parseJson(raw){try{return JSON.parse(String(raw||'').trim())}catch{return undefined}}",
-	"function pickTerminal(parsed){if(!parsed||typeof parsed!=='object')return undefined;return parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed}",
-	"setTimeout(()=>{void (async()=>{try{const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(expectTitle&&(typeof t.title!=='string'||t.title!==expectTitle))return;if(expectTabId&&expectTabId!=='-'&&(typeof t.tabId!=='string'||t.tabId!==expectTabId))return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
 ].join("");
 
 export interface OrcaProgressTab {
@@ -176,6 +179,7 @@ interface OrcaObserverManifest {
 	orcaHandle?: string;
 	orcaTabId?: string;
 	orcaTitle?: string;
+	autoCloseDelaySec?: number;
 }
 
 function observerManifestPath(cwd: string, stem: string): string | undefined {
@@ -342,6 +346,16 @@ function scheduleTabClose(input: {
 	}
 }
 
+function claimAutoClose(manifestPath: string | undefined): boolean {
+	if (!manifestPath) return false;
+	try {
+		fs.writeFileSync(manifestPath.replace(/\.json$/, ".autoclose"), "", { flag: "wx", encoding: "utf-8", mode: 0o600 });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function readObserverManifest(manifestPath: string | undefined): OrcaObserverManifest | undefined {
 	if (!manifestPath) return undefined;
 	try {
@@ -442,6 +456,7 @@ export function createOrcaProgressTab(input: {
 		state: "opening",
 		createdAt: new Date().toISOString(),
 		logPath,
+		...(typeof config?.autoCloseDelaySec === "number" ? { autoCloseDelaySec: config.autoCloseDelaySec } : {}),
 	});
 	try {
 		fs.writeFileSync(logPath, `pi-subagents / ${agent}\nrun ${runId} · ${stepCount === 1 ? "1 child" : `${stepCount} children`}\n${"─".repeat(48)}\n`, { encoding: "utf-8", mode: 0o600 });
@@ -587,7 +602,7 @@ export function createOrcaProgressTab(input: {
 							const expectedTitle = (typeof manifest?.orcaTitle === "string" && manifest.orcaTitle)
 								|| extracted.title
 								|| title;
-							if (handle) {
+							if (handle && claimAutoClose(manifestPath)) {
 								scheduleTabClose({
 									nodeExecutable,
 									orcaCommand: command,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2534,6 +2534,8 @@ export type FleetKeybindingsConfig = Partial<Record<FleetKeybindingAction, strin
 export interface OrcaProgressTabsConfig {
 	/** Create one Orca observer tab per top-level subagent call. Experimental and opt-in. */
 	enabled?: boolean;
+	/** Seconds to wait after a successful run before closing the observer tab. 0 or omit = leave the tab open. */
+	autoCloseDelaySec?: number;
 }
 
 export interface MainWindowRendererConfig {

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -37,6 +37,7 @@ afterEach(() => {
 	removeProgressFiles("progress-");
 	removeProgressFiles("disabled-run-");
 	removeProgressFiles("standalone-pi-");
+	removeProgressFiles("autoclose-");
 });
 
 function tempDir(): string {
@@ -557,6 +558,69 @@ test("create stdout pretty-printed JSON lands handle/tabId/title in the observer
 	assert.equal(manifest.orcaTitle, "subagents · worker · 1");
 	assert.equal(manifest.orcaRaw, undefined);
 	tab.finish("failed");
+});
+
+function writeLifecycleOrca(dir: string): string {
+	return writeNodeCommand(dir, "orca", [
+		"const fs=require('fs');",
+		"const path=require('path');",
+		"const args=process.argv.slice(2);",
+		"const action=args[1];",
+		"if(action==='create'){",
+		"  const title=args[args.indexOf('--title')+1];",
+		"  process.stdout.write(JSON.stringify({terminal:{handle:'term-1',tabId:'tab-1',title}},null,2)+'\\n');",
+		"} else if(action==='show'){",
+		"  process.stdout.write(fs.readFileSync(path.join(__dirname,'show-payload.json'),'utf8'));",
+		"} else if(action==='close'){",
+		"  fs.writeFileSync(path.join(__dirname,'close.json'), JSON.stringify(args));",
+		"}",
+	].join(""));
+}
+
+async function waitClosedOrNot(file: string, timeoutMs = 2_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fs.existsSync(file)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	return false;
+}
+
+async function runAutoCloseCase(input: {
+	dir: string;
+	status: "completed" | "failed" | "stopped";
+	show: unknown;
+	delaySec?: number;
+}): Promise<"CLOSED" | "NOT_CLOSED"> {
+	const closeFile = path.join(input.dir, "close.json");
+	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify(input.show));
+	const fakeOrca = writeLifecycleOrca(input.dir);
+	const runId = `autoclose-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+	const tab = createOrcaProgressTab({
+		cwd: input.dir,
+		runId,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true, autoCloseDelaySec: input.delaySec ?? 0.05 },
+		command: fakeOrca,
+	});
+	assert.ok(tab);
+	await tab.creationSettled;
+	await tab.finish(input.status);
+	return await waitClosedOrNot(closeFile) ? "CLOSED" : "NOT_CLOSED";
+}
+
+test("auto-close watchdog closes only on exact title/tabId match after completed runs", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	const title = "subagents · worker · 1";
+	const matching = { terminal: { handle: "term-1", tabId: "tab-1", title } };
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching }), "CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "failed", show: matching }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "stopped", show: matching }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", title } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: 1 } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: "other" } } }), "NOT_CLOSED");
 });
 
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -526,6 +526,39 @@ test("queued tabs defer cleanup until their terminal create settles", { skip: pr
 	}
 });
 
+test("create stdout pretty-printed JSON lands handle/tabId/title in the observer manifest", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	const dir = tempDir();
+	const capture = path.join(dir, "capture.json");
+	const fakeOrca = writeNodeCommand(dir, "orca", [
+		"const fs=require('fs');",
+		"fs.writeFileSync(process.env.ORCA_TEST_CAPTURE, JSON.stringify(process.argv.slice(2)));",
+		"const title=process.argv.slice(2)[process.argv.slice(2).indexOf('--title')+1];",
+		"process.stdout.write(JSON.stringify({terminal:{handle:'term-pretty',tabId:'tab-pretty',title}},null,2)+'\\n');",
+	].join(""));
+	const runId = `progress-pretty-json-${Date.now()}`;
+	const tab = createOrcaProgressTab({
+		cwd: dir,
+		runId,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true },
+		command: fakeOrca,
+		env: { ...process.env, ORCA_TEST_CAPTURE: capture },
+	});
+	assert.ok(tab);
+	await tab.creationSettled;
+	const manifestDir = path.join(dir, ".pi", "subagents", "views", "orca");
+	const manifestName = fs.readdirSync(manifestDir).find((name) => name.startsWith(`${runId}-0-`) && name.endsWith(".json"));
+	assert.ok(manifestName);
+	const manifest = JSON.parse(fs.readFileSync(path.join(manifestDir, manifestName), "utf-8")) as Record<string, unknown>;
+	assert.equal(manifest.state, "open");
+	assert.equal(manifest.orcaHandle, "term-pretty");
+	assert.equal(manifest.orcaTabId, "tab-pretty");
+	assert.equal(manifest.orcaTitle, "subagents · worker · 1");
+	assert.equal(manifest.orcaRaw, undefined);
+	tab.finish("failed");
+});
+
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
 	const dir = tempDir();
 	const capture = path.join(dir, "capture.json");

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -623,6 +623,59 @@ test("auto-close watchdog closes only on exact title/tabId match after completed
 	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: "other" } } }), "NOT_CLOSED");
 });
 
+function writeSlowCreateOrca(dir: string, delayMs: number): string {
+	return writeNodeCommand(dir, "orca", [
+		"const fs=require('fs');",
+		"const path=require('path');",
+		"const args=process.argv.slice(2);",
+		"const action=args[1];",
+		"if(action==='create'){",
+		`  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,${delayMs});`,
+		"  const title=args[args.indexOf('--title')+1];",
+		"  process.stdout.write(JSON.stringify({terminal:{handle:'term-1',tabId:'tab-1',title}},null,2)+'\\n');",
+		"} else if(action==='show'){",
+		"  process.stdout.write(fs.readFileSync(path.join(__dirname,'show-payload.json'),'utf8'));",
+		"} else if(action==='close'){",
+		"  fs.writeFileSync(path.join(__dirname,'close.json'), JSON.stringify(args));",
+		"}",
+	].join(""));
+}
+
+async function runAutoCloseRace(input: {
+	dir: string;
+	status: "completed" | "failed" | "stopped";
+	createDelayMs?: number;
+}): Promise<"CLOSED" | "NOT_CLOSED"> {
+	const title = "subagents · worker · 1";
+	const closeFile = path.join(input.dir, "close.json");
+	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify({ terminal: { handle: "term-1", tabId: "tab-1", title } }));
+	const fakeOrca = writeSlowCreateOrca(input.dir, input.createDelayMs ?? 400);
+	const runId = `autoclose-race-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+	const tab = createOrcaProgressTab({
+		cwd: input.dir,
+		runId,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true, autoCloseDelaySec: 0.05 },
+		command: fakeOrca,
+	});
+	assert.ok(tab);
+	await tab.finish(input.status);
+	const manifestDir = path.join(input.dir, ".pi", "subagents", "views", "orca");
+	const manifestName = fs.readdirSync(manifestDir).find((name) => name.startsWith(`${runId}-0-`) && name.endsWith(".json"));
+	assert.ok(manifestName);
+	const manifest = JSON.parse(fs.readFileSync(path.join(manifestDir, manifestName), "utf-8")) as Record<string, unknown>;
+	assert.equal(manifest.orcaHandle, undefined, "finish() raced ahead of create; handle must still be missing");
+	await tab.creationSettled;
+	return await waitClosedOrNot(closeFile, 3_000) ? "CLOSED" : "NOT_CLOSED";
+}
+
+test("auto-close catch-up closes when create lands the handle after a completed finish", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed" }), "CLOSED");
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "failed" }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "stopped" }), "NOT_CLOSED");
+});
+
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
 	const dir = tempDir();
 	const capture = path.join(dir, "capture.json");

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -411,11 +411,23 @@ Package skill content.
 		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true } }));
 		assert.deepEqual(loadConfig().orcaProgressTabs, { enabled: true });
 
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true, autoCloseDelaySec: 30 } }));
+		assert.deepEqual(loadConfig().orcaProgressTabs, { enabled: true, autoCloseDelaySec: 30 });
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true, autoCloseDelaySec: 0 } }));
+		assert.deepEqual(loadConfig().orcaProgressTabs, { enabled: true, autoCloseDelaySec: 0 });
+
 		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: "yes" } }));
 		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.enabled must be a boolean/);
 
 		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true, focus: true } }));
 		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.focus is not supported/);
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { autoCloseDelaySec: -1 } }));
+		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.autoCloseDelaySec must be a number >= 0/);
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { autoCloseDelaySec: "30" } }));
+		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.autoCloseDelaySec must be a number >= 0/);
 	});
 
 	it("hardens and redacts existing run history while recording", () => {


### PR DESCRIPTION
## Summary

- **fix**: parse the full stdout of `orca terminal create --json` (pretty-printed,
  multi-line) instead of only the last line, so `orcaHandle` / `orcaTabId` /
  `orcaTitle` land in the observer manifest (previously only `orcaRaw: "}"`).
- **feat**: new opt-in `orcaProgressTabs.autoCloseDelaySec` (seconds; 0/absent =
  disabled, current behavior unchanged). On `finish()` with status `completed`
  only, a detached watchdog sleeps the delay, re-validates the tab via
  `terminal show` (expected title/tabId must be present and match; missing fields
  are treated as mismatch → abort), then closes it via
  `terminal close --terminal <handle> --tab`.
- `failed`/`stopped` runs keep their tabs for inspection; stale/already-closed
  handles (`terminal_handle_stale`) are swallowed silently.

## Design

- Watchdog = detached + unref'd node child (same pattern as `scheduleCleanup()`);
  never blocks parent/runner; survives runner exit; all values passed via spawn
  argv (no string interpolation, no shell).
- Config validation rejects negative/NaN/non-number; unknown keys still rejected.
- No change to the tab content/rendering path (orthogonal to the escape-injection
  concern from #1080).
- CHANGELOG `## [Unreleased]` entry with contributor credit included.

## Validation

- `npm run typecheck`: pass
- `npm run test:all`: unit 3003 tests / 2989 pass / 0 fail / 14 skipped; integration 1010 tests / 1004 pass / 0 fail / 6 skipped
- Live e2e (pi 0.85.1 + Orca): subagent runs with `"autoCloseDelaySec": 30` had
  their tabs self-close ~30s after completion; a failed run kept its tab.
- Watchdog hardening covered by mock-orca cases: missing title / missing tabId /
  both missing / non-string type / value mismatch → NOT_CLOSED; exact match →
  CLOSED.

Closes #2062
