### PR TITLE
feat(orca-progress-tabs): safely auto-close completed tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000) (#2063).
+- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000) for #2063.
 - Add default-off, main-only watchdog questions and task-continuity reviews from bounded delivered orchestration evidence (#2010).
 - Add the built-in `evidence-auditor` for independently reviewing important research claims and source support. Thanks to [@Muskos](https://github.com/Muskos) for #2023.
 - Notify the parent as individual async workflow children finish, without waiting for all siblings (#2027). Each child completion delivers a compact notification with the workflow run ID, child key, exact child run ID, outcome, and output reference while the workflow remains running.
@@ -15,7 +15,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
-- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000) (#2063).
+- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000) for #2063.
 - Keep workflow child tool exposure aligned with advertised agent tools when auto-discovered extensions wrap Pi builtins, and relocate auto-selected extension-repo worktrees outside Pi's extension auto-discovery directory (#2059).
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
 - Send OpenCode session-routing headers on internal helper model calls so task arbitration, watchdog, and prompt audit requests keep the same provider session as ordinary Pi traffic. Thanks to [@IdrisGit](https://github.com/IdrisGit) for #2041.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000).
 - Add default-off, main-only watchdog questions and task-continuity reviews from bounded delivered orchestration evidence (#2010).
 - Add the built-in `evidence-auditor` for independently reviewing important research claims and source support. Thanks to [@Muskos](https://github.com/Muskos) for #2023.
 - Notify the parent as individual async workflow children finish, without waiting for all siblings (#2027). Each child completion delivers a compact notification with the workflow run ID, child key, exact child run ID, outcome, and output reference while the workflow remains running.
@@ -14,6 +15,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000).
 - Keep workflow child tool exposure aligned with advertised agent tools when auto-discovered extensions wrap Pi builtins, and relocate auto-selected extension-repo worktrees outside Pi's extension auto-discovery directory (#2059).
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
 - Send OpenCode session-routing headers on internal helper model calls so task arbitration, watchdog, and prompt audit requests keep the same provider session as ordinary Pi traffic. Thanks to [@IdrisGit](https://github.com/IdrisGit) for #2041.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000).
+- Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000) (#2063).
 - Add default-off, main-only watchdog questions and task-continuity reviews from bounded delivered orchestration evidence (#2010).
 - Add the built-in `evidence-auditor` for independently reviewing important research claims and source support. Thanks to [@Muskos](https://github.com/Muskos) for #2023.
 - Notify the parent as individual async workflow children finish, without waiting for all siblings (#2027). Each child completion delivers a compact notification with the workflow run ID, child key, exact child run ID, outcome, and output reference while the workflow remains running.
@@ -15,7 +15,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
-- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000).
+- Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000) (#2063).
 - Keep workflow child tool exposure aligned with advertised agent tools when auto-discovered extensions wrap Pi builtins, and relocate auto-selected extension-repo worktrees outside Pi's extension auto-discovery directory (#2059).
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.
 - Send OpenCode session-routing headers on internal helper model calls so task arbitration, watchdog, and prompt audit requests keep the same provider session as ordinary Pi traffic. Thanks to [@IdrisGit](https://github.com/IdrisGit) for #2041.

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -113,10 +113,16 @@ function validateOrcaProgressTabsConfig(value: unknown): void {
 	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("config.orcaProgressTabs must be a JSON object");
 	const config = value as Record<string, unknown>;
 	for (const key of Object.keys(config)) {
-		if (key !== "enabled") throw new Error(`config.orcaProgressTabs.${key} is not supported`);
+		if (key !== "enabled" && key !== "autoCloseDelaySec") throw new Error(`config.orcaProgressTabs.${key} is not supported`);
 	}
 	if (config.enabled !== undefined && typeof config.enabled !== "boolean") {
 		throw new Error("config.orcaProgressTabs.enabled must be a boolean");
+	}
+	if (config.autoCloseDelaySec !== undefined
+		&& (typeof config.autoCloseDelaySec !== "number"
+			|| !Number.isFinite(config.autoCloseDelaySec)
+			|| config.autoCloseDelaySec < 0)) {
+		throw new Error("config.orcaProgressTabs.autoCloseDelaySec must be a number >= 0");
 	}
 }
 

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -29,7 +29,7 @@ const ORCA_CREATE_WATCHDOG_SCRIPT = [
 	"function exists(file){try{return fs.existsSync(file)}catch{return false}}",
 	"function keepQueued(){try{const now=new Date();fs.utimesSync(done,now,now)}catch{}}",
 	"function predecessorReady(){if(previous==='-')return true;if(exists(previous.replace(/\\.pending$/,'.ready')))return true;try{return Date.now()-fs.statSync(previous).mtimeMs>=waitTimeout}catch{return true}}",
-	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim().split(/\\r?\\n/).filter(Boolean).at(-1);if(raw){try{payload.orca=JSON.parse(raw)}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n')}catch{}}",
+	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim();if(raw){try{const parsed=JSON.parse(raw);payload.orca=parsed;const t=parsed&&typeof parsed==='object'?(parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed):undefined;if(t&&typeof t==='object'){if(typeof t.handle==='string')payload.orcaHandle=t.handle;if(typeof t.tabId==='string')payload.orcaTabId=t.tabId;if(typeof t.title==='string')payload.orcaTitle=t.title}}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n')}catch{}}",
 	"function start(){",
 	" try{",
 	"  const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});",
@@ -164,6 +164,9 @@ interface OrcaObserverManifest {
 	logPath: string;
 	orca?: unknown;
 	orcaRaw?: string;
+	orcaHandle?: string;
+	orcaTabId?: string;
+	orcaTitle?: string;
 }
 
 function observerManifestPath(cwd: string, stem: string): string | undefined {

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -26,7 +26,7 @@ const ORCA_CLOSE_WATCHDOG_SCRIPT = [
 	"function run(args){return new Promise(resolve=>{try{const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});let stdout='';if(child.stdout)child.stdout.on('data',chunk=>{stdout+=String(chunk);if(stdout.length>65536)stdout=stdout.slice(-65536)});child.once('error',()=>resolve({ok:false,stdout:''}));child.once('close',code=>resolve({ok:code===0,stdout}))}catch{resolve({ok:false,stdout:''})}})}",
 	"function parseJson(raw){try{return JSON.parse(String(raw||'').trim())}catch{return undefined}}",
 	"function pickTerminal(parsed){if(!parsed||typeof parsed!=='object')return undefined;return parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed}",
-	"setTimeout(()=>{void (async()=>{try{const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(expectTitle&&(typeof t.title!=='string'||t.title!==expectTitle))return;if(expectTabId&&expectTabId!=='-'&&(typeof t.tabId!=='string'||t.tabId!==expectTabId))return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
+	"setTimeout(()=>{void (async()=>{try{if(!expectTitle||!expectTabId)return;const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(typeof t.title!=='string'||t.title!==expectTitle)return;if(typeof t.tabId!=='string'||t.tabId!==expectTabId)return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
 ].join("");
 
 const ORCA_CREATE_WATCHDOG_SCRIPT = [
@@ -40,7 +40,7 @@ const ORCA_CREATE_WATCHDOG_SCRIPT = [
 	"function keepQueued(){try{const now=new Date();fs.utimesSync(done,now,now)}catch{}}",
 	"function predecessorReady(){if(previous==='-')return true;if(exists(previous.replace(/\\.pending$/,'.ready')))return true;try{return Date.now()-fs.statSync(previous).mtimeMs>=waitTimeout}catch{return true}}",
 	"function claimAutoClose(){if(manifest==='-')return false;try{fs.writeFileSync(manifest.replace(/\\.json$/,'.autoclose'),'',{flag:'wx',mode:0o600});return true}catch{return false}}",
-	"function catchupAutoClose(payload){if(!payload||payload.state!=='open')return;const handle=typeof payload.orcaHandle==='string'?payload.orcaHandle:'';if(!handle)return;const delay=payload.autoCloseDelaySec;if(typeof delay!=='number'||!(delay>0))return;let status='';try{status=String(fs.readFileSync(String(payload.logPath||'').replace(/\\.log$/,'.done'),'utf8')).trim()}catch{return}if(status!=='completed')return;if(!claimAutoClose())return;try{const w=spawn(process.execPath,['-e',closeScript,String(delay*1000),command,handle,typeof payload.orcaTitle==='string'?payload.orcaTitle:'',typeof payload.orcaTabId==='string'?payload.orcaTabId:'-'],{detached:true,stdio:'ignore',windowsHide:true});w.unref()}catch{}}",
+	"function catchupAutoClose(payload){if(!payload||payload.state!=='open')return;const handle=typeof payload.orcaHandle==='string'?payload.orcaHandle:'';const title=typeof payload.orcaTitle==='string'?payload.orcaTitle:'';const tabId=typeof payload.orcaTabId==='string'?payload.orcaTabId:'';if(!handle||!title||!tabId)return;const delay=payload.autoCloseDelaySec;if(typeof delay!=='number'||!(delay>0))return;let status='';try{status=String(fs.readFileSync(String(payload.logPath||'').replace(/\\.log$/,'.done'),'utf8')).trim()}catch{return}if(status!=='completed')return;if(!claimAutoClose())return;try{const w=spawn(process.execPath,['-e',closeScript,String(delay*1000),command,handle,title,tabId],{detached:true,stdio:'ignore',windowsHide:true});w.unref()}catch{}}",
 	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim();if(raw){try{const parsed=JSON.parse(raw);payload.orca=parsed;const t=parsed&&typeof parsed==='object'?(parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed):undefined;if(t&&typeof t==='object'){if(typeof t.handle==='string')payload.orcaHandle=t.handle;if(typeof t.tabId==='string')payload.orcaTabId=t.tabId;if(typeof t.title==='string')payload.orcaTitle=t.title}}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n');catchupAutoClose(payload)}catch{}}",
 	"function start(){",
 	" try{",
@@ -323,7 +323,7 @@ function scheduleTabClose(input: {
 	orcaCommand: string;
 	handle: string;
 	title: string;
-	tabId?: string;
+	tabId: string;
 	delayMs: number;
 }): void {
 	try {
@@ -333,7 +333,7 @@ function scheduleTabClose(input: {
 			input.orcaCommand,
 			input.handle,
 			input.title,
-			input.tabId ?? "-",
+			input.tabId,
 		], {
 			detached: true,
 			stdio: "ignore",
@@ -600,9 +600,8 @@ export function createOrcaProgressTab(input: {
 							const tabId = (typeof manifest?.orcaTabId === "string" && manifest.orcaTabId)
 								|| extracted.tabId;
 							const expectedTitle = (typeof manifest?.orcaTitle === "string" && manifest.orcaTitle)
-								|| extracted.title
-								|| title;
-							if (handle && claimAutoClose(manifestPath)) {
+								|| extracted.title;
+							if (handle && expectedTitle && tabId && claimAutoClose(manifestPath)) {
 								scheduleTabClose({
 									nodeExecutable,
 									orcaCommand: command,

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -318,34 +318,6 @@ function scheduleCleanup(nodeExecutable: string, paths: string[]): void {
 	}
 }
 
-function scheduleTabClose(input: {
-	nodeExecutable: string;
-	orcaCommand: string;
-	handle: string;
-	title: string;
-	tabId: string;
-	delayMs: number;
-}): void {
-	try {
-		const watchdog = spawn(input.nodeExecutable, [
-			"-e", ORCA_CLOSE_WATCHDOG_SCRIPT,
-			String(input.delayMs),
-			input.orcaCommand,
-			input.handle,
-			input.title,
-			input.tabId,
-		], {
-			detached: true,
-			stdio: "ignore",
-			windowsHide: true,
-		});
-		watchdog.once("error", () => {});
-		watchdog.unref();
-	} catch {
-		// Tab auto-close remains best effort for this optional observer.
-	}
-}
-
 function claimAutoClose(manifestPath: string | undefined): boolean {
 	if (!manifestPath) return false;
 	try {
@@ -365,23 +337,6 @@ function readObserverManifest(manifestPath: string | undefined): OrcaObserverMan
 	} catch {
 		return undefined;
 	}
-}
-
-function extractOrcaHandle(parsed: unknown): { handle?: string; tabId?: string; title?: string } {
-	if (!parsed || typeof parsed !== "object") return {};
-	const record = parsed as Record<string, unknown>;
-	const nested = record.terminal
-		?? (record.result && typeof record.result === "object" && !Array.isArray(record.result)
-			? ((record.result as Record<string, unknown>).terminal ?? record.result)
-			: undefined)
-		?? record;
-	if (!nested || typeof nested !== "object" || Array.isArray(nested)) return {};
-	const terminal = nested as Record<string, unknown>;
-	return {
-		handle: typeof terminal.handle === "string" ? terminal.handle : undefined,
-		tabId: typeof terminal.tabId === "string" ? terminal.tabId : undefined,
-		title: typeof terminal.title === "string" ? terminal.title : undefined,
-	};
 }
 
 function loadOrcaProgressTabsConfig(): OrcaProgressTabsConfig | undefined {
@@ -594,22 +549,28 @@ export function createOrcaProgressTab(input: {
 						const delaySec = config?.autoCloseDelaySec;
 						if (status === "completed" && typeof delaySec === "number" && delaySec > 0) {
 							const manifest = readObserverManifest(manifestPath);
-							const extracted = extractOrcaHandle(manifest?.orca);
-							const handle = (typeof manifest?.orcaHandle === "string" && manifest.orcaHandle)
-								|| extracted.handle;
-							const tabId = (typeof manifest?.orcaTabId === "string" && manifest.orcaTabId)
-								|| extracted.tabId;
-							const expectedTitle = (typeof manifest?.orcaTitle === "string" && manifest.orcaTitle)
-								|| extracted.title;
-							if (handle && expectedTitle && tabId && claimAutoClose(manifestPath)) {
-								scheduleTabClose({
-									nodeExecutable,
-									orcaCommand: command,
-									handle,
-									title: expectedTitle,
-									tabId,
-									delayMs: delaySec * 1000,
-								});
+							const handle = typeof manifest?.orcaHandle === "string" ? manifest.orcaHandle : "";
+							const title = typeof manifest?.orcaTitle === "string" ? manifest.orcaTitle : "";
+							const tabId = typeof manifest?.orcaTabId === "string" ? manifest.orcaTabId : "";
+							if (handle && title && tabId && claimAutoClose(manifestPath)) {
+								try {
+									const watchdog = spawn(nodeExecutable, [
+										"-e", ORCA_CLOSE_WATCHDOG_SCRIPT,
+										String(delaySec * 1000),
+										command,
+										handle,
+										title,
+										tabId,
+									], {
+										detached: true,
+										stdio: "ignore",
+										windowsHide: true,
+									});
+									watchdog.once("error", () => {});
+									watchdog.unref();
+								} catch {
+									// Tab auto-close remains best effort for this optional observer.
+								}
 							}
 						}
 					}

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -52,6 +52,15 @@ const ORCA_CLEANUP_WATCHDOG_SCRIPT = [
 	"setInterval(check,1000);check();",
 ].join("");
 
+const ORCA_CLOSE_WATCHDOG_SCRIPT = [
+	"const {spawn}=require('node:child_process');",
+	"const delayMs=Number(process.argv[1]),command=process.argv[2],handle=process.argv[3],expectTitle=process.argv[4],expectTabId=process.argv[5];",
+	"function run(args){return new Promise(resolve=>{try{const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});let stdout='';if(child.stdout)child.stdout.on('data',chunk=>{stdout+=String(chunk);if(stdout.length>65536)stdout=stdout.slice(-65536)});child.once('error',()=>resolve({ok:false,stdout:''}));child.once('close',code=>resolve({ok:code===0,stdout}))}catch{resolve({ok:false,stdout:''})}})}",
+	"function parseJson(raw){try{return JSON.parse(String(raw||'').trim())}catch{return undefined}}",
+	"function pickTerminal(parsed){if(!parsed||typeof parsed!=='object')return undefined;return parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed}",
+	"setTimeout(()=>{void (async()=>{try{const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(expectTitle&&(typeof t.title!=='string'||t.title!==expectTitle))return;if(expectTabId&&expectTabId!=='-'&&(typeof t.tabId!=='string'||t.tabId!==expectTabId))return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
+].join("");
+
 export interface OrcaProgressTab {
 	/** Resolves when the terminal-create watchdog closes, after its final manifest/queue writes (success or failure). Not viewer completion. */
 	readonly creationSettled: Promise<void>;
@@ -305,6 +314,62 @@ function scheduleCleanup(nodeExecutable: string, paths: string[]): void {
 	}
 }
 
+function scheduleTabClose(input: {
+	nodeExecutable: string;
+	orcaCommand: string;
+	handle: string;
+	title: string;
+	tabId?: string;
+	delayMs: number;
+}): void {
+	try {
+		const watchdog = spawn(input.nodeExecutable, [
+			"-e", ORCA_CLOSE_WATCHDOG_SCRIPT,
+			String(input.delayMs),
+			input.orcaCommand,
+			input.handle,
+			input.title,
+			input.tabId ?? "-",
+		], {
+			detached: true,
+			stdio: "ignore",
+			windowsHide: true,
+		});
+		watchdog.once("error", () => {});
+		watchdog.unref();
+	} catch {
+		// Tab auto-close remains best effort for this optional observer.
+	}
+}
+
+function readObserverManifest(manifestPath: string | undefined): OrcaObserverManifest | undefined {
+	if (!manifestPath) return undefined;
+	try {
+		const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+		return parsed as OrcaObserverManifest;
+	} catch {
+		return undefined;
+	}
+}
+
+function extractOrcaHandle(parsed: unknown): { handle?: string; tabId?: string; title?: string } {
+	if (!parsed || typeof parsed !== "object") return {};
+	const record = parsed as Record<string, unknown>;
+	const nested = record.terminal
+		?? (record.result && typeof record.result === "object" && !Array.isArray(record.result)
+			? ((record.result as Record<string, unknown>).terminal ?? record.result)
+			: undefined)
+		?? record;
+	if (!nested || typeof nested !== "object" || Array.isArray(nested)) return {};
+	const terminal = nested as Record<string, unknown>;
+	return {
+		handle: typeof terminal.handle === "string" ? terminal.handle : undefined,
+		tabId: typeof terminal.tabId === "string" ? terminal.tabId : undefined,
+		title: typeof terminal.title === "string" ? terminal.title : undefined,
+	};
+}
+
 function loadOrcaProgressTabsConfig(): OrcaProgressTabsConfig | undefined {
 	try {
 		const configPath = path.join(getAgentDir(), "extensions", "subagent", "config.json");
@@ -313,8 +378,15 @@ function loadOrcaProgressTabsConfig(): OrcaProgressTabsConfig | undefined {
 		const value = (parsed as Record<string, unknown>).orcaProgressTabs;
 		if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
 		const config = value as Record<string, unknown>;
-		if (Object.keys(config).some((key) => key !== "enabled") || typeof config.enabled !== "boolean") return undefined;
-		return { enabled: config.enabled };
+		const extraKeys = Object.keys(config).filter((key) => key !== "enabled" && key !== "autoCloseDelaySec");
+		if (extraKeys.length > 0) return undefined;
+		if (config.enabled !== undefined && typeof config.enabled !== "boolean") return undefined;
+		const autoCloseDelaySec = config.autoCloseDelaySec;
+		if (autoCloseDelaySec !== undefined && (typeof autoCloseDelaySec !== "number" || !Number.isFinite(autoCloseDelaySec) || autoCloseDelaySec < 0)) return undefined;
+		const loaded: OrcaProgressTabsConfig = {};
+		if (typeof config.enabled === "boolean") loaded.enabled = config.enabled;
+		if (typeof autoCloseDelaySec === "number") loaded.autoCloseDelaySec = autoCloseDelaySec;
+		return loaded;
 	} catch {
 		return undefined;
 	}
@@ -504,6 +576,28 @@ export function createOrcaProgressTab(input: {
 						try { fs.writeFileSync(donePath, `${status}\n`, { encoding: "utf-8", mode: 0o600 }); } catch { /* best effort */ }
 						cleanupPaths = [logPath, donePath];
 						scheduleDeferredCleanup();
+						const delaySec = config?.autoCloseDelaySec;
+						if (status === "completed" && typeof delaySec === "number" && delaySec > 0) {
+							const manifest = readObserverManifest(manifestPath);
+							const extracted = extractOrcaHandle(manifest?.orca);
+							const handle = (typeof manifest?.orcaHandle === "string" && manifest.orcaHandle)
+								|| extracted.handle;
+							const tabId = (typeof manifest?.orcaTabId === "string" && manifest.orcaTabId)
+								|| extracted.tabId;
+							const expectedTitle = (typeof manifest?.orcaTitle === "string" && manifest.orcaTitle)
+								|| extracted.title
+								|| title;
+							if (handle) {
+								scheduleTabClose({
+									nodeExecutable,
+									orcaCommand: command,
+									handle,
+									title: expectedTitle,
+									tabId,
+									delayMs: delaySec * 1000,
+								});
+							}
+						}
 					}
 					resolve();
 				});

--- a/src/runs/shared/orca-progress-tabs.ts
+++ b/src/runs/shared/orca-progress-tabs.ts
@@ -20,16 +20,28 @@ const COUNTER_LOCK_RETRIES = 200;
 const COUNTER_LOCK_RETRY_MS = 10;
 const ORCA_CREATE_WAIT_TIMEOUT_MS = ORCA_CREATE_TIMEOUT_MS + ORCA_KILL_GRACE_MS + 3_000;
 
+const ORCA_CLOSE_WATCHDOG_SCRIPT = [
+	"const {spawn}=require('node:child_process');",
+	"const delayMs=Number(process.argv[1]),command=process.argv[2],handle=process.argv[3],expectTitle=process.argv[4],expectTabId=process.argv[5];",
+	"function run(args){return new Promise(resolve=>{try{const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});let stdout='';if(child.stdout)child.stdout.on('data',chunk=>{stdout+=String(chunk);if(stdout.length>65536)stdout=stdout.slice(-65536)});child.once('error',()=>resolve({ok:false,stdout:''}));child.once('close',code=>resolve({ok:code===0,stdout}))}catch{resolve({ok:false,stdout:''})}})}",
+	"function parseJson(raw){try{return JSON.parse(String(raw||'').trim())}catch{return undefined}}",
+	"function pickTerminal(parsed){if(!parsed||typeof parsed!=='object')return undefined;return parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed}",
+	"setTimeout(()=>{void (async()=>{try{const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(expectTitle&&(typeof t.title!=='string'||t.title!==expectTitle))return;if(expectTabId&&expectTabId!=='-'&&(typeof t.tabId!=='string'||t.tabId!==expectTabId))return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
+].join("");
+
 const ORCA_CREATE_WATCHDOG_SCRIPT = [
 	"const {spawn}=require('node:child_process');",
 	"const fs=require('node:fs');",
 	"const timeout=Number(process.argv[1]),grace=Number(process.argv[2]),waitTimeout=Number(process.argv[3]);",
 	"const previous=process.argv[4],done=process.argv[5],manifest=process.argv[6],command=process.argv[7],args=process.argv.slice(8);",
+	`const closeScript=${JSON.stringify(ORCA_CLOSE_WATCHDOG_SCRIPT)};`,
 	"function mark(){try{fs.writeFileSync(done.replace(/\\.pending$/,'.ready'),'')}catch{}}",
 	"function exists(file){try{return fs.existsSync(file)}catch{return false}}",
 	"function keepQueued(){try{const now=new Date();fs.utimesSync(done,now,now)}catch{}}",
 	"function predecessorReady(){if(previous==='-')return true;if(exists(previous.replace(/\\.pending$/,'.ready')))return true;try{return Date.now()-fs.statSync(previous).mtimeMs>=waitTimeout}catch{return true}}",
-	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim();if(raw){try{const parsed=JSON.parse(raw);payload.orca=parsed;const t=parsed&&typeof parsed==='object'?(parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed):undefined;if(t&&typeof t==='object'){if(typeof t.handle==='string')payload.orcaHandle=t.handle;if(typeof t.tabId==='string')payload.orcaTabId=t.tabId;if(typeof t.title==='string')payload.orcaTitle=t.title}}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n')}catch{}}",
+	"function claimAutoClose(){if(manifest==='-')return false;try{fs.writeFileSync(manifest.replace(/\\.json$/,'.autoclose'),'',{flag:'wx',mode:0o600});return true}catch{return false}}",
+	"function catchupAutoClose(payload){if(!payload||payload.state!=='open')return;const handle=typeof payload.orcaHandle==='string'?payload.orcaHandle:'';if(!handle)return;const delay=payload.autoCloseDelaySec;if(typeof delay!=='number'||!(delay>0))return;let status='';try{status=String(fs.readFileSync(String(payload.logPath||'').replace(/\\.log$/,'.done'),'utf8')).trim()}catch{return}if(status!=='completed')return;if(!claimAutoClose())return;try{const w=spawn(process.execPath,['-e',closeScript,String(delay*1000),command,handle,typeof payload.orcaTitle==='string'?payload.orcaTitle:'',typeof payload.orcaTabId==='string'?payload.orcaTabId:'-'],{detached:true,stdio:'ignore',windowsHide:true});w.unref()}catch{}}",
+	"function updateManifest(state,stdout=''){if(manifest==='-')return;try{const payload=JSON.parse(fs.readFileSync(manifest,'utf8'));payload.state=state;payload.updatedAt=new Date().toISOString();const raw=stdout.trim();if(raw){try{const parsed=JSON.parse(raw);payload.orca=parsed;const t=parsed&&typeof parsed==='object'?(parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed):undefined;if(t&&typeof t==='object'){if(typeof t.handle==='string')payload.orcaHandle=t.handle;if(typeof t.tabId==='string')payload.orcaTabId=t.tabId;if(typeof t.title==='string')payload.orcaTitle=t.title}}catch{payload.orcaRaw=raw.slice(0,4096)}}fs.writeFileSync(manifest,JSON.stringify(payload,null,2)+'\\n');catchupAutoClose(payload)}catch{}}",
 	"function start(){",
 	" try{",
 	"  const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});",
@@ -50,15 +62,6 @@ const ORCA_CLEANUP_WATCHDOG_SCRIPT = [
 	"const deadline=Date.now()+Number(process.argv[1]),files=process.argv.slice(2);",
 	"function check(){if(!files.some(file=>fs.existsSync(file)))process.exit(0);if(Date.now()<deadline)return;for(const file of files){try{fs.rmSync(file,{force:true})}catch{}}process.exit(0)}",
 	"setInterval(check,1000);check();",
-].join("");
-
-const ORCA_CLOSE_WATCHDOG_SCRIPT = [
-	"const {spawn}=require('node:child_process');",
-	"const delayMs=Number(process.argv[1]),command=process.argv[2],handle=process.argv[3],expectTitle=process.argv[4],expectTabId=process.argv[5];",
-	"function run(args){return new Promise(resolve=>{try{const child=spawn(command,args,{stdio:['ignore','pipe','ignore'],windowsHide:true});let stdout='';if(child.stdout)child.stdout.on('data',chunk=>{stdout+=String(chunk);if(stdout.length>65536)stdout=stdout.slice(-65536)});child.once('error',()=>resolve({ok:false,stdout:''}));child.once('close',code=>resolve({ok:code===0,stdout}))}catch{resolve({ok:false,stdout:''})}})}",
-	"function parseJson(raw){try{return JSON.parse(String(raw||'').trim())}catch{return undefined}}",
-	"function pickTerminal(parsed){if(!parsed||typeof parsed!=='object')return undefined;return parsed.terminal||(parsed.result&&(parsed.result.terminal||parsed.result))||parsed}",
-	"setTimeout(()=>{void (async()=>{try{const shown=await run(['terminal','show','--terminal',handle,'--json']);const parsed=parseJson(shown.stdout);const t=pickTerminal(parsed);if(!t||typeof t!=='object')return;if(expectTitle&&(typeof t.title!=='string'||t.title!==expectTitle))return;if(expectTabId&&expectTabId!=='-'&&(typeof t.tabId!=='string'||t.tabId!==expectTabId))return;await run(['terminal','close','--terminal',handle,'--tab','--json'])}catch{}finally{process.exit(0)}})()},Number.isFinite(delayMs)&&delayMs>0?delayMs:0);",
 ].join("");
 
 export interface OrcaProgressTab {
@@ -176,6 +179,7 @@ interface OrcaObserverManifest {
 	orcaHandle?: string;
 	orcaTabId?: string;
 	orcaTitle?: string;
+	autoCloseDelaySec?: number;
 }
 
 function observerManifestPath(cwd: string, stem: string): string | undefined {
@@ -342,6 +346,16 @@ function scheduleTabClose(input: {
 	}
 }
 
+function claimAutoClose(manifestPath: string | undefined): boolean {
+	if (!manifestPath) return false;
+	try {
+		fs.writeFileSync(manifestPath.replace(/\.json$/, ".autoclose"), "", { flag: "wx", encoding: "utf-8", mode: 0o600 });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function readObserverManifest(manifestPath: string | undefined): OrcaObserverManifest | undefined {
 	if (!manifestPath) return undefined;
 	try {
@@ -442,6 +456,7 @@ export function createOrcaProgressTab(input: {
 		state: "opening",
 		createdAt: new Date().toISOString(),
 		logPath,
+		...(typeof config?.autoCloseDelaySec === "number" ? { autoCloseDelaySec: config.autoCloseDelaySec } : {}),
 	});
 	try {
 		fs.writeFileSync(logPath, `pi-subagents / ${agent}\nrun ${runId} · ${stepCount === 1 ? "1 child" : `${stepCount} children`}\n${"─".repeat(48)}\n`, { encoding: "utf-8", mode: 0o600 });
@@ -587,7 +602,7 @@ export function createOrcaProgressTab(input: {
 							const expectedTitle = (typeof manifest?.orcaTitle === "string" && manifest.orcaTitle)
 								|| extracted.title
 								|| title;
-							if (handle) {
+							if (handle && claimAutoClose(manifestPath)) {
 								scheduleTabClose({
 									nodeExecutable,
 									orcaCommand: command,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2534,6 +2534,8 @@ export type FleetKeybindingsConfig = Partial<Record<FleetKeybindingAction, strin
 export interface OrcaProgressTabsConfig {
 	/** Create one Orca observer tab per top-level subagent call. Experimental and opt-in. */
 	enabled?: boolean;
+	/** Seconds to wait after a successful run before closing the observer tab. 0 or omit = leave the tab open. */
+	autoCloseDelaySec?: number;
 }
 
 export interface MainWindowRendererConfig {

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -37,6 +37,7 @@ afterEach(() => {
 	removeProgressFiles("progress-");
 	removeProgressFiles("disabled-run-");
 	removeProgressFiles("standalone-pi-");
+	removeProgressFiles("autoclose-");
 });
 
 function tempDir(): string {
@@ -557,6 +558,69 @@ test("create stdout pretty-printed JSON lands handle/tabId/title in the observer
 	assert.equal(manifest.orcaTitle, "subagents · worker · 1");
 	assert.equal(manifest.orcaRaw, undefined);
 	tab.finish("failed");
+});
+
+function writeLifecycleOrca(dir: string): string {
+	return writeNodeCommand(dir, "orca", [
+		"const fs=require('fs');",
+		"const path=require('path');",
+		"const args=process.argv.slice(2);",
+		"const action=args[1];",
+		"if(action==='create'){",
+		"  const title=args[args.indexOf('--title')+1];",
+		"  process.stdout.write(JSON.stringify({terminal:{handle:'term-1',tabId:'tab-1',title}},null,2)+'\\n');",
+		"} else if(action==='show'){",
+		"  process.stdout.write(fs.readFileSync(path.join(__dirname,'show-payload.json'),'utf8'));",
+		"} else if(action==='close'){",
+		"  fs.writeFileSync(path.join(__dirname,'close.json'), JSON.stringify(args));",
+		"}",
+	].join(""));
+}
+
+async function waitClosedOrNot(file: string, timeoutMs = 2_000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fs.existsSync(file)) return true;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	return false;
+}
+
+async function runAutoCloseCase(input: {
+	dir: string;
+	status: "completed" | "failed" | "stopped";
+	show: unknown;
+	delaySec?: number;
+}): Promise<"CLOSED" | "NOT_CLOSED"> {
+	const closeFile = path.join(input.dir, "close.json");
+	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify(input.show));
+	const fakeOrca = writeLifecycleOrca(input.dir);
+	const runId = `autoclose-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+	const tab = createOrcaProgressTab({
+		cwd: input.dir,
+		runId,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true, autoCloseDelaySec: input.delaySec ?? 0.05 },
+		command: fakeOrca,
+	});
+	assert.ok(tab);
+	await tab.creationSettled;
+	await tab.finish(input.status);
+	return await waitClosedOrNot(closeFile) ? "CLOSED" : "NOT_CLOSED";
+}
+
+test("auto-close watchdog closes only on exact title/tabId match after completed runs", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	const title = "subagents · worker · 1";
+	const matching = { terminal: { handle: "term-1", tabId: "tab-1", title } };
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching }), "CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "failed", show: matching }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "stopped", show: matching }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", title } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: 1 } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: "other" } } }), "NOT_CLOSED");
 });
 
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -568,7 +568,8 @@ function writeLifecycleOrca(dir: string): string {
 		"const action=args[1];",
 		"if(action==='create'){",
 		"  const title=args[args.indexOf('--title')+1];",
-		"  process.stdout.write(JSON.stringify({terminal:{handle:'term-1',tabId:'tab-1',title}},null,2)+'\\n');",
+		"  const payload=process.env.ORCA_TEST_CREATE?JSON.parse(process.env.ORCA_TEST_CREATE):{terminal:{handle:'term-1',tabId:'tab-1',title}};",
+		"  process.stdout.write(JSON.stringify(payload,null,2)+'\\n');",
 		"} else if(action==='show'){",
 		"  process.stdout.write(fs.readFileSync(path.join(__dirname,'show-payload.json'),'utf8'));",
 		"} else if(action==='close'){",
@@ -591,6 +592,7 @@ async function runAutoCloseCase(input: {
 	status: "completed" | "failed" | "stopped";
 	show: unknown;
 	delaySec?: number;
+	create?: unknown;
 }): Promise<"CLOSED" | "NOT_CLOSED"> {
 	const closeFile = path.join(input.dir, "close.json");
 	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify(input.show));
@@ -603,6 +605,7 @@ async function runAutoCloseCase(input: {
 		index: 0,
 		config: { enabled: true, autoCloseDelaySec: input.delaySec ?? 0.05 },
 		command: fakeOrca,
+		env: input.create === undefined ? process.env : { ...process.env, ORCA_TEST_CREATE: JSON.stringify(input.create) },
 	});
 	assert.ok(tab);
 	await tab.creationSettled;
@@ -621,6 +624,10 @@ test("auto-close watchdog closes only on exact title/tabId match after completed
 	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1" } } }), "NOT_CLOSED");
 	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: 1 } } }), "NOT_CLOSED");
 	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: "other" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "other", title } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching, create: { terminal: { handle: "term-1", title } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching, create: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching, create: { terminal: { handle: "term-1", tabId: "tab-1", title: "" } } }), "NOT_CLOSED");
 });
 
 function writeSlowCreateOrca(dir: string, delayMs: number): string {
@@ -632,7 +639,8 @@ function writeSlowCreateOrca(dir: string, delayMs: number): string {
 		"if(action==='create'){",
 		`  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,${delayMs});`,
 		"  const title=args[args.indexOf('--title')+1];",
-		"  process.stdout.write(JSON.stringify({terminal:{handle:'term-1',tabId:'tab-1',title}},null,2)+'\\n');",
+		"  const payload=process.env.ORCA_TEST_CREATE?JSON.parse(process.env.ORCA_TEST_CREATE):{terminal:{handle:'term-1',tabId:'tab-1',title}};",
+		"  process.stdout.write(JSON.stringify(payload,null,2)+'\\n');",
 		"} else if(action==='show'){",
 		"  process.stdout.write(fs.readFileSync(path.join(__dirname,'show-payload.json'),'utf8'));",
 		"} else if(action==='close'){",
@@ -645,6 +653,7 @@ async function runAutoCloseRace(input: {
 	dir: string;
 	status: "completed" | "failed" | "stopped";
 	createDelayMs?: number;
+	create?: unknown;
 }): Promise<"CLOSED" | "NOT_CLOSED"> {
 	const title = "subagents · worker · 1";
 	const closeFile = path.join(input.dir, "close.json");
@@ -658,6 +667,7 @@ async function runAutoCloseRace(input: {
 		index: 0,
 		config: { enabled: true, autoCloseDelaySec: 0.05 },
 		command: fakeOrca,
+		env: input.create === undefined ? process.env : { ...process.env, ORCA_TEST_CREATE: JSON.stringify(input.create) },
 	});
 	assert.ok(tab);
 	await tab.finish(input.status);
@@ -674,6 +684,9 @@ test("auto-close catch-up closes when create lands the handle after a completed 
 	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed" }), "CLOSED");
 	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "failed" }), "NOT_CLOSED");
 	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "stopped" }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", title: "subagents · worker · 1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", tabId: "tab-1", title: "" } } }), "NOT_CLOSED");
 });
 
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -526,6 +526,39 @@ test("queued tabs defer cleanup until their terminal create settles", { skip: pr
 	}
 });
 
+test("create stdout pretty-printed JSON lands handle/tabId/title in the observer manifest", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	const dir = tempDir();
+	const capture = path.join(dir, "capture.json");
+	const fakeOrca = writeNodeCommand(dir, "orca", [
+		"const fs=require('fs');",
+		"fs.writeFileSync(process.env.ORCA_TEST_CAPTURE, JSON.stringify(process.argv.slice(2)));",
+		"const title=process.argv.slice(2)[process.argv.slice(2).indexOf('--title')+1];",
+		"process.stdout.write(JSON.stringify({terminal:{handle:'term-pretty',tabId:'tab-pretty',title}},null,2)+'\\n');",
+	].join(""));
+	const runId = `progress-pretty-json-${Date.now()}`;
+	const tab = createOrcaProgressTab({
+		cwd: dir,
+		runId,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true },
+		command: fakeOrca,
+		env: { ...process.env, ORCA_TEST_CAPTURE: capture },
+	});
+	assert.ok(tab);
+	await tab.creationSettled;
+	const manifestDir = path.join(dir, ".pi", "subagents", "views", "orca");
+	const manifestName = fs.readdirSync(manifestDir).find((name) => name.startsWith(`${runId}-0-`) && name.endsWith(".json"));
+	assert.ok(manifestName);
+	const manifest = JSON.parse(fs.readFileSync(path.join(manifestDir, manifestName), "utf-8")) as Record<string, unknown>;
+	assert.equal(manifest.state, "open");
+	assert.equal(manifest.orcaHandle, "term-pretty");
+	assert.equal(manifest.orcaTabId, "tab-pretty");
+	assert.equal(manifest.orcaTitle, "subagents · worker · 1");
+	assert.equal(manifest.orcaRaw, undefined);
+	tab.finish("failed");
+});
+
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
 	const dir = tempDir();
 	const capture = path.join(dir, "capture.json");

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -623,6 +623,59 @@ test("auto-close watchdog closes only on exact title/tabId match after completed
 	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: "other" } } }), "NOT_CLOSED");
 });
 
+function writeSlowCreateOrca(dir: string, delayMs: number): string {
+	return writeNodeCommand(dir, "orca", [
+		"const fs=require('fs');",
+		"const path=require('path');",
+		"const args=process.argv.slice(2);",
+		"const action=args[1];",
+		"if(action==='create'){",
+		`  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,${delayMs});`,
+		"  const title=args[args.indexOf('--title')+1];",
+		"  process.stdout.write(JSON.stringify({terminal:{handle:'term-1',tabId:'tab-1',title}},null,2)+'\\n');",
+		"} else if(action==='show'){",
+		"  process.stdout.write(fs.readFileSync(path.join(__dirname,'show-payload.json'),'utf8'));",
+		"} else if(action==='close'){",
+		"  fs.writeFileSync(path.join(__dirname,'close.json'), JSON.stringify(args));",
+		"}",
+	].join(""));
+}
+
+async function runAutoCloseRace(input: {
+	dir: string;
+	status: "completed" | "failed" | "stopped";
+	createDelayMs?: number;
+}): Promise<"CLOSED" | "NOT_CLOSED"> {
+	const title = "subagents · worker · 1";
+	const closeFile = path.join(input.dir, "close.json");
+	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify({ terminal: { handle: "term-1", tabId: "tab-1", title } }));
+	const fakeOrca = writeSlowCreateOrca(input.dir, input.createDelayMs ?? 400);
+	const runId = `autoclose-race-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+	const tab = createOrcaProgressTab({
+		cwd: input.dir,
+		runId,
+		agent: "worker",
+		index: 0,
+		config: { enabled: true, autoCloseDelaySec: 0.05 },
+		command: fakeOrca,
+	});
+	assert.ok(tab);
+	await tab.finish(input.status);
+	const manifestDir = path.join(input.dir, ".pi", "subagents", "views", "orca");
+	const manifestName = fs.readdirSync(manifestDir).find((name) => name.startsWith(`${runId}-0-`) && name.endsWith(".json"));
+	assert.ok(manifestName);
+	const manifest = JSON.parse(fs.readFileSync(path.join(manifestDir, manifestName), "utf-8")) as Record<string, unknown>;
+	assert.equal(manifest.orcaHandle, undefined, "finish() raced ahead of create; handle must still be missing");
+	await tab.creationSettled;
+	return await waitClosedOrNot(closeFile, 3_000) ? "CLOSED" : "NOT_CLOSED";
+}
+
+test("auto-close catch-up closes when create lands the handle after a completed finish", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed" }), "CLOSED");
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "failed" }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "stopped" }), "NOT_CLOSED");
+});
+
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
 	const dir = tempDir();
 	const capture = path.join(dir, "capture.json");

--- a/test/unit/orca-progress-tabs.test.ts
+++ b/test/unit/orca-progress-tabs.test.ts
@@ -560,13 +560,14 @@ test("create stdout pretty-printed JSON lands handle/tabId/title in the observer
 	tab.finish("failed");
 });
 
-function writeLifecycleOrca(dir: string): string {
+function writeLifecycleOrca(dir: string, createDelayMs = 0): string {
 	return writeNodeCommand(dir, "orca", [
 		"const fs=require('fs');",
 		"const path=require('path');",
 		"const args=process.argv.slice(2);",
 		"const action=args[1];",
 		"if(action==='create'){",
+		`  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,${createDelayMs});`,
 		"  const title=args[args.indexOf('--title')+1];",
 		"  const payload=process.env.ORCA_TEST_CREATE?JSON.parse(process.env.ORCA_TEST_CREATE):{terminal:{handle:'term-1',tabId:'tab-1',title}};",
 		"  process.stdout.write(JSON.stringify(payload,null,2)+'\\n');",
@@ -590,76 +591,15 @@ async function waitClosedOrNot(file: string, timeoutMs = 2_000): Promise<boolean
 async function runAutoCloseCase(input: {
 	dir: string;
 	status: "completed" | "failed" | "stopped";
-	show: unknown;
-	delaySec?: number;
+	show?: unknown;
 	create?: unknown;
-}): Promise<"CLOSED" | "NOT_CLOSED"> {
-	const closeFile = path.join(input.dir, "close.json");
-	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify(input.show));
-	const fakeOrca = writeLifecycleOrca(input.dir);
-	const runId = `autoclose-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
-	const tab = createOrcaProgressTab({
-		cwd: input.dir,
-		runId,
-		agent: "worker",
-		index: 0,
-		config: { enabled: true, autoCloseDelaySec: input.delaySec ?? 0.05 },
-		command: fakeOrca,
-		env: input.create === undefined ? process.env : { ...process.env, ORCA_TEST_CREATE: JSON.stringify(input.create) },
-	});
-	assert.ok(tab);
-	await tab.creationSettled;
-	await tab.finish(input.status);
-	return await waitClosedOrNot(closeFile) ? "CLOSED" : "NOT_CLOSED";
-}
-
-test("auto-close watchdog closes only on exact title/tabId match after completed runs", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
-	const title = "subagents · worker · 1";
-	const matching = { terminal: { handle: "term-1", tabId: "tab-1", title } };
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching }), "CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "failed", show: matching }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "stopped", show: matching }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", title } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1" } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: 1 } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "tab-1", title: "other" } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: { terminal: { handle: "term-1", tabId: "other", title } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching, create: { terminal: { handle: "term-1", title } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching, create: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", show: matching, create: { terminal: { handle: "term-1", tabId: "tab-1", title: "" } } }), "NOT_CLOSED");
-});
-
-function writeSlowCreateOrca(dir: string, delayMs: number): string {
-	return writeNodeCommand(dir, "orca", [
-		"const fs=require('fs');",
-		"const path=require('path');",
-		"const args=process.argv.slice(2);",
-		"const action=args[1];",
-		"if(action==='create'){",
-		`  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,${delayMs});`,
-		"  const title=args[args.indexOf('--title')+1];",
-		"  const payload=process.env.ORCA_TEST_CREATE?JSON.parse(process.env.ORCA_TEST_CREATE):{terminal:{handle:'term-1',tabId:'tab-1',title}};",
-		"  process.stdout.write(JSON.stringify(payload,null,2)+'\\n');",
-		"} else if(action==='show'){",
-		"  process.stdout.write(fs.readFileSync(path.join(__dirname,'show-payload.json'),'utf8'));",
-		"} else if(action==='close'){",
-		"  fs.writeFileSync(path.join(__dirname,'close.json'), JSON.stringify(args));",
-		"}",
-	].join(""));
-}
-
-async function runAutoCloseRace(input: {
-	dir: string;
-	status: "completed" | "failed" | "stopped";
 	createDelayMs?: number;
-	create?: unknown;
 }): Promise<"CLOSED" | "NOT_CLOSED"> {
 	const title = "subagents · worker · 1";
 	const closeFile = path.join(input.dir, "close.json");
-	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify({ terminal: { handle: "term-1", tabId: "tab-1", title } }));
-	const fakeOrca = writeSlowCreateOrca(input.dir, input.createDelayMs ?? 400);
-	const runId = `autoclose-race-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+	fs.writeFileSync(path.join(input.dir, "show-payload.json"), JSON.stringify(input.show ?? { terminal: { handle: "term-1", tabId: "tab-1", title } }));
+	const fakeOrca = writeLifecycleOrca(input.dir, input.createDelayMs ?? 0);
+	const runId = `autoclose-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
 	const tab = createOrcaProgressTab({
 		cwd: input.dir,
 		runId,
@@ -670,23 +610,37 @@ async function runAutoCloseRace(input: {
 		env: input.create === undefined ? process.env : { ...process.env, ORCA_TEST_CREATE: JSON.stringify(input.create) },
 	});
 	assert.ok(tab);
-	await tab.finish(input.status);
-	const manifestDir = path.join(input.dir, ".pi", "subagents", "views", "orca");
-	const manifestName = fs.readdirSync(manifestDir).find((name) => name.startsWith(`${runId}-0-`) && name.endsWith(".json"));
-	assert.ok(manifestName);
-	const manifest = JSON.parse(fs.readFileSync(path.join(manifestDir, manifestName), "utf-8")) as Record<string, unknown>;
-	assert.equal(manifest.orcaHandle, undefined, "finish() raced ahead of create; handle must still be missing");
+	if (input.createDelayMs) {
+		await tab.finish(input.status);
+		const manifestDir = path.join(input.dir, ".pi", "subagents", "views", "orca");
+		const manifestName = fs.readdirSync(manifestDir).find((name) => name.startsWith(`${runId}-0-`) && name.endsWith(".json"));
+		assert.ok(manifestName);
+		const manifest = JSON.parse(fs.readFileSync(path.join(manifestDir, manifestName), "utf-8")) as Record<string, unknown>;
+		assert.equal(manifest.orcaHandle, undefined, "finish() raced ahead of create; handle must still be missing");
+		await tab.creationSettled;
+		return await waitClosedOrNot(closeFile, 3_000) ? "CLOSED" : "NOT_CLOSED";
+	}
 	await tab.creationSettled;
-	return await waitClosedOrNot(closeFile, 3_000) ? "CLOSED" : "NOT_CLOSED";
+	await tab.finish(input.status);
+	return await waitClosedOrNot(closeFile) ? "CLOSED" : "NOT_CLOSED";
 }
 
-test("auto-close catch-up closes when create lands the handle after a completed finish", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
-	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed" }), "CLOSED");
-	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "failed" }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "stopped" }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", title: "subagents · worker · 1" } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
-	assert.equal(await runAutoCloseRace({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", tabId: "tab-1", title: "" } } }), "NOT_CLOSED");
+test("auto-close watchdog closes only completed runs after title and tabId match", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed" }), "CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "failed" }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "stopped" }), "NOT_CLOSED");
+});
+
+test("missing or empty create title or tabId aborts auto-close", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", title: "subagents · worker · 1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", tabId: "tab-1" } } }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", create: { terminal: { handle: "term-1", tabId: "tab-1", title: "" } } }), "NOT_CLOSED");
+});
+
+test("auto-close catch-up closes when create lands complete identity after a completed finish", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", createDelayMs: 400 }), "CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "failed", createDelayMs: 400 }), "NOT_CLOSED");
+	assert.equal(await runAutoCloseCase({ dir: tempDir(), status: "completed", createDelayMs: 400, create: { terminal: { handle: "term-1", title: "subagents · worker · 1" } } }), "NOT_CLOSED");
 });
 
 test("mirror output truncates at a finite byte bound", { skip: process.platform === "win32" ? "Orca progress tabs are not supported on Windows" : undefined }, async () => {

--- a/test/unit/pi-coding-agent-dir.test.ts
+++ b/test/unit/pi-coding-agent-dir.test.ts
@@ -411,11 +411,23 @@ Package skill content.
 		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true } }));
 		assert.deepEqual(loadConfig().orcaProgressTabs, { enabled: true });
 
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true, autoCloseDelaySec: 30 } }));
+		assert.deepEqual(loadConfig().orcaProgressTabs, { enabled: true, autoCloseDelaySec: 30 });
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true, autoCloseDelaySec: 0 } }));
+		assert.deepEqual(loadConfig().orcaProgressTabs, { enabled: true, autoCloseDelaySec: 0 });
+
 		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: "yes" } }));
 		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.enabled must be a boolean/);
 
 		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { enabled: true, focus: true } }));
 		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.focus is not supported/);
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { autoCloseDelaySec: -1 } }));
+		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.autoCloseDelaySec must be a number >= 0/);
+
+		writeFile(configPath, JSON.stringify({ orcaProgressTabs: { autoCloseDelaySec: "30" } }));
+		assert.throws(() => updateConfig((config) => config), /config\.orcaProgressTabs\.autoCloseDelaySec must be a number >= 0/);
 	});
 
 	it("hardens and redacts existing run history while recording", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This maintainer replacement preserves the contribution from @G0-0000 in #2063, reviewed at exact original head `59884e0f638f1b29e14d7d4a172cb954b17a6d29`.

- Parses the full stdout of `orca terminal create --json`, recording `orcaHandle`, `orcaTabId`, and `orcaTitle` in the observer manifest.
- Adds opt-in `orcaProgressTabs.autoCloseDelaySec`; `0` or absence leaves tabs open.
- Keeps failed and stopped tabs open and leaves tab content/rendering unchanged.
- Keeps the watchdog as a detached, unref'd Node child, with arguments passed through spawn argv and no shell.
- Preserves strict config validation for negative, NaN, non-number, and unknown values.
- Fails closed unless create metadata provides a non-empty expected title and tab ID, then re-validates both exact values through `terminal show` after a completed finish and the configured delay before closing.
- Finish and catch-up both read the same top-level manifest identity fields; incomplete create metadata is refused on the existing close path.

Thanks to [@G0-0000](https://github.com/G0-0000) for the original contribution.

Replaces #2063.

## Validation

- `npm run typecheck`
- Focused `test/unit/orca-progress-tabs.test.ts`

Closes #2062
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-748ff93a-703d-48be-b00f-6eac43816b31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-748ff93a-703d-48be-b00f-6eac43816b31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

