### PR TITLE
fix: preserve read-only tasks after host clamping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Preserve explicit read-only task intent after host capability clamping, while still blocking implementation tasks that lack mutation tools. Thanks to [@stekman08](https://github.com/stekman08) for #2060.
 - Parse the full stdout of `orca terminal create --json` so the observer manifest stores `orcaHandle` / `orcaTabId` / `orcaTitle` instead of `orcaRaw: "}"`. Thanks to [@G0-0000](https://github.com/G0-0000) for #2063.
 - Keep workflow child tool exposure aligned with advertised agent tools when auto-discovered extensions wrap Pi builtins, and relocate auto-selected extension-repo worktrees outside Pi's extension auto-discovery directory (#2059).
 - Run the child prompt filter before ambient extensions inspect the system prompt. This keeps provider bridges aligned with the final child-visible context while preserving intentional global-context and parent-only skill exclusions. Thanks to [@leftytennis](https://github.com/leftytennis) for #2043.

--- a/src/runs/background/active-async-capacity.ts
+++ b/src/runs/background/active-async-capacity.ts
@@ -280,6 +280,10 @@ function workflowReleaseVerdict(owner: ActiveAsyncCapacityOwner, status: AsyncSt
 		if (!childStatus) return { state: "retained", reason: `async workflow child ${label} status is missing or unreadable` };
 		if (!terminalState(childStatus.state)) return { state: "retained", reason: `async workflow child ${label} is still ${childStatus.state}` };
 		if (!childStatus.processTerminal?.runnerProcessInstanceId) return { state: "retained", reason: `async workflow child ${label} has no runner process identity` };
+		if (childStatus.processTerminal.state === "not-started"
+			&& childStatus.processTerminal.runId === step.runId
+			&& typeof childStatus.error === "string"
+			&& childStatus.error) continue;
 		const proof = readProcessTerminal(childDir, {
 			runId: step.runId,
 			runnerProcessInstanceId: childStatus.processTerminal.runnerProcessInstanceId,

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -105,11 +105,17 @@ function inferLevel(input: {
 	const inferredReadOnly = readOnlyTask || ((readOnlyAgent || input.acceptanceRole === "read-only") && !taskMayWrite);
 	const roleResolvesReadOnly = input.acceptanceRole !== undefined && inferredReadOnly;
 	const dynamicResolvesReadOnly = inferredReadOnly && !writeTask;
-	const keywordRiskReadOnly = input.acceptanceRole === undefined ? intent.kind === "read-only" : inferredReadOnly;
+	const riskyKeywordPattern = /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/;
+	// A read-only task can still need a checked acceptance review when its
+	// wording names a sensitive area. Keep this legacy keyword safeguard even
+	// though the shared intent classifier now recognizes more read-only forms.
+	const keywordRiskReadOnly = input.acceptanceRole === undefined
+		? intent.kind === "read-only" && !riskyKeywordPattern.test(task)
+		: inferredReadOnly;
 	const risky = Boolean(input.async && writeTask)
 		|| (Boolean(input.dynamic) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
 		|| (Boolean(input.dynamicGroup) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
-		|| (!keywordRiskReadOnly && /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/.test(task));
+		|| (!keywordRiskReadOnly && riskyKeywordPattern.test(task));
 
 	if (risky) {
 		reasons.push(input.async ? "async write-capable or risky run" : "risky write-capable run");

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -106,9 +106,6 @@ function inferLevel(input: {
 	const roleResolvesReadOnly = input.acceptanceRole !== undefined && inferredReadOnly;
 	const dynamicResolvesReadOnly = inferredReadOnly && !writeTask;
 	const riskyKeywordPattern = /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/;
-	// A read-only task can still need a checked acceptance review when its
-	// wording names a sensitive area. Keep this legacy keyword safeguard even
-	// though the shared intent classifier now recognizes more read-only forms.
 	const keywordRiskReadOnly = input.acceptanceRole === undefined
 		? intent.kind === "read-only" && !riskyKeywordPattern.test(task)
 		: inferredReadOnly;

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -98,13 +98,7 @@ export function validateImplementationToolContract(input: {
 	const declaredMutationToolsWereRemoved = requestedMutationTools.length > 0 && !hasBuiltinMutationTool(input.tools);
 	const configuredExtensionCapability = (input.configuredExtensions?.length ?? 0) > 0 && !declaredMutationToolsWereRemoved;
 	if (hasMutationToolCapability(input.tools, input.mcpDirectTools) || configuredExtensionCapability) return undefined;
-	// An explicit writer acceptance role replaces the agent-name heuristic used
-	// by the shared classifier, so a reviewer-named writer is still evaluated as
-	// a writer task.
 	const intent = classifyTaskMutationIntent(input.acceptanceRole === "writer" ? "worker" : input.agent, input.task);
-	// Host availability can remove declared mutation tools from a task whose
-	// wording is explicitly read-only. Unknown wording remains conservative when
-	// the requested launch declared mutation-capable tools.
 	if (intent.kind === "read-only") return undefined;
 	const writerTaskMayMutate = input.acceptanceRole === "writer"
 		? true
@@ -115,8 +109,6 @@ export function validateImplementationToolContract(input: {
 }
 
 function hasCheckpointMutationEvidence(message: Message): boolean {
-	// SAFETY: pi-checkpoint custom messages are runtime records outside the
-	// pi-ai Message union; narrow their discriminants before reading payloads.
 	const record = message as unknown as {
 		role?: string;
 		type?: string;

--- a/src/runs/shared/completion-guard.ts
+++ b/src/runs/shared/completion-guard.ts
@@ -98,15 +98,25 @@ export function validateImplementationToolContract(input: {
 	const declaredMutationToolsWereRemoved = requestedMutationTools.length > 0 && !hasBuiltinMutationTool(input.tools);
 	const configuredExtensionCapability = (input.configuredExtensions?.length ?? 0) > 0 && !declaredMutationToolsWereRemoved;
 	if (hasMutationToolCapability(input.tools, input.mcpDirectTools) || configuredExtensionCapability) return undefined;
-	const intent = classifyTaskMutationIntent(input.agent, input.task);
+	// An explicit writer acceptance role replaces the agent-name heuristic used
+	// by the shared classifier, so a reviewer-named writer is still evaluated as
+	// a writer task.
+	const intent = classifyTaskMutationIntent(input.acceptanceRole === "writer" ? "worker" : input.agent, input.task);
+	// Host availability can remove declared mutation tools from a task whose
+	// wording is explicitly read-only. Unknown wording remains conservative when
+	// the requested launch declared mutation-capable tools.
 	if (intent.kind === "read-only") return undefined;
-	const writerTaskMayMutate = isWriterRole(input.agent, input.acceptanceRole)
-		&& (taskMayMutate(input.task) || WRITER_DELIVERY_PATTERN.test(input.task));
+	const writerTaskMayMutate = input.acceptanceRole === "writer"
+		? true
+		: isWriterRole(input.agent, input.acceptanceRole)
+			&& (taskMayMutate(input.task) || WRITER_DELIVERY_PATTERN.test(input.task));
 	if (intent.kind !== "implementation" && !writerTaskMayMutate && !declaredMutationToolsWereRemoved) return undefined;
 	return `Agent '${input.agent}' was given an implementation task, but its tool allowlist has no mutation-capable tools. Add bash, edit, write, or another mutation-capable tool to the agent, or use a read-only task/agent.`;
 }
 
 function hasCheckpointMutationEvidence(message: Message): boolean {
+	// SAFETY: pi-checkpoint custom messages are runtime records outside the
+	// pi-ai Message union; narrow their discriminants before reading payloads.
 	const record = message as unknown as {
 		role?: string;
 		type?: string;

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -26,10 +26,6 @@ const REVIEW_ONLY_PATTERNS = [
 	/\breturn findings only\b/i,
 ];
 
-// Workflow tasks sometimes state a read-only boundary as a comma-separated
-// noun list (for example, "No source edits, commits, or pushes"). Unlike a
-// blanket prohibition, remove this assertion before checking for a later
-// implementation imperative.
 const NO_EDIT_BOUNDARY_ASSERTION_PATTERN = /\bno\s+(?:source\s+)?edits?\s*,\s*(?:commits?|pushes?|merges?|installs?|changes?|writes?)\b/i;
 
 const REVIEWER_REQUIRED_EDIT_PATTERNS = [
@@ -111,13 +107,7 @@ const WORKER_IMPLEMENTATION_PATTERNS = [
 	/\bdo those fixes\b/i,
 ];
 
-// Once an explicit read-only marker has been stripped, keep common imperative
-// verbs visible even when their target is a project-specific noun (for example,
-// "Without edits, update the parser"). Output-only nouns remain excluded.
 const FOLLOW_ON_IMPLEMENTATION_PATTERN = /\b(?:fix|patch|update|add|remove|replace|create|delete)\s+(?!(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?(?:report|summary|findings?|analysis|recommendations?|answer|response|proposal|plan|issue|bug report)\b)(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?[a-z][\w./-]*/i;
-
-// Advisory how-to wording is stripped with other non-imperative markers so
-// "explain how to update" cannot leak into the later write-intent match.
 const ADVISORY_INFINITIVE_PATTERN = /\b(?:explain|recommend|describe)\s+how\s+to\s+(?:fix|patch|update|add|remove|replace|create|delete|implement|edit|modify|refactor)\b/i;
 
 const GENERAL_IMPLEMENTATION_PATTERNS = [
@@ -158,13 +148,10 @@ interface NoEditProhibitionAnalysis {
 }
 
 function analyzeNoEditProhibitions(taskText: string): NoEditProhibitionAnalysis {
-	const reviewOnly = REVIEW_ONLY_PATTERNS.some((pattern) => pattern.test(taskText));
-	const noTools = NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText));
 	const readOnlyBoundary = NO_EDIT_BOUNDARY_ASSERTION_PATTERN.test(taskText);
-	let present = reviewOnly || noTools || readOnlyBoundary;
-	// Review-only/no-tool wording is a read-only signal, not a blanket
-	// prohibition: a later imperative such as "implement the fix" must still
-	// win. Explicit file prohibitions are analyzed below and may be blanket.
+	let present = REVIEW_ONLY_PATTERNS.some((pattern) => pattern.test(taskText))
+		|| NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText))
+		|| readOnlyBoundary;
 	let blanket = false;
 	let strippedText = stripPatterns(taskText, [...REVIEW_ONLY_PATTERNS, ...NO_TOOL_INTENT_PATTERNS, ADVISORY_INFINITIVE_PATTERN]);
 	if (readOnlyBoundary) strippedText = stripPatterns(strippedText, [NO_EDIT_BOUNDARY_ASSERTION_PATTERN]);

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -18,16 +18,24 @@
  */
 
 const REVIEW_ONLY_PATTERNS = [
-	/\breview only\b/i,
+	/\b(?:review|read)[- ]only\b/i,
+	/\bno\s+(?:source\s+)?edits?\b/i,
+	/\bwithout\s+edits?\b/i,
 	/\bsuggest fixes only\b/i,
 	/\bonly return findings\b/i,
 	/\breturn findings only\b/i,
 ];
 
+// Workflow tasks sometimes state a read-only boundary as a comma-separated
+// noun list (for example, "No source edits, commits, or pushes"). Unlike a
+// blanket prohibition, remove this assertion before checking for a later
+// implementation imperative.
+const NO_EDIT_BOUNDARY_ASSERTION_PATTERN = /\bno\s+(?:source\s+)?edits?\s*,\s*(?:commits?|pushes?|merges?|installs?|changes?|writes?)\b/i;
+
 const REVIEWER_REQUIRED_EDIT_PATTERNS = [
 	/\bmust\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
 	/\brequired\s+to\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
-	/(?:^|[.!?\n]\s*)implement\s+(?:the\s+)?(?:approved|requested|specified|file|code|source|fix(?:es)?|changes?)\b/i,
+	/(?:^|[.!?:;,\n]\s*)implement\s+(?:the\s+)?(?:approved|requested|specified|file|code|source|fix(?:es)?|changes?)\b/i,
 	/\bregardless\s+of\s+findings\b/i,
 	/\balways\s+(?:edit|modify|change|fix|patch|apply|implement)\b/i,
 	/\bapply\s+(?:the\s+)?fix(?:es)?\s+directly\b/i,
@@ -85,7 +93,7 @@ const RESEARCH_AGENT_PATTERNS = [
 // CLI flags like "--fix" and genuine clause-level dashes like "branch—fix it"),
 // strip the known severity compounds (must|should|needs + dash + verb) from the
 // task text before matching. Dash coverage: ASCII hyphen + U+2010..U+2015.
-const SEVERITY_COMPOUND_PATTERN = /\b(?:must|should|needs)[\-\u2010-\u2015](?:fix|edit|update|add|remove|replace|create|apply|make|do|implement|modify|delete|patch)\b/gi;
+const SEVERITY_COMPOUND_PATTERN = /\b(?:must|should|needs)[-\u2010-\u2015](?:fix|edit|update|add|remove|replace|create|apply|make|do|implement|modify|delete|patch)\b/gi;
 
 function stripSeverityCompounds(task: string): string {
 	return task.replace(SEVERITY_COMPOUND_PATTERN, " ");
@@ -102,6 +110,11 @@ const WORKER_IMPLEMENTATION_PATTERNS = [
 	/\bmake\s+(?:the\s+)?changes\b/i,
 	/\bdo those fixes\b/i,
 ];
+
+// Once an explicit read-only marker has been stripped, keep common imperative
+// verbs visible even when their target is a project-specific noun (for example,
+// "Without edits, update the parser"). Output-only nouns remain excluded.
+const FOLLOW_ON_IMPLEMENTATION_PATTERN = /\b(?:fix|patch|update|add|remove|replace|create|delete)\s+(?!(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?(?:report|summary|findings?|analysis|recommendations?|answer|response|proposal|plan|issue|bug report)\b)(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?[a-z][\w./-]*/i;
 
 const GENERAL_IMPLEMENTATION_PATTERNS = [
 	/\b(?:implement|edit|modify|refactor)\b/i,
@@ -141,10 +154,16 @@ interface NoEditProhibitionAnalysis {
 }
 
 function analyzeNoEditProhibitions(taskText: string): NoEditProhibitionAnalysis {
-	let present = REVIEW_ONLY_PATTERNS.some((pattern) => pattern.test(taskText))
-		|| NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText));
-	let blanket = present;
+	const reviewOnly = REVIEW_ONLY_PATTERNS.some((pattern) => pattern.test(taskText));
+	const noTools = NO_TOOL_INTENT_PATTERNS.some((pattern) => pattern.test(taskText));
+	const readOnlyBoundary = NO_EDIT_BOUNDARY_ASSERTION_PATTERN.test(taskText);
+	let present = reviewOnly || noTools || readOnlyBoundary;
+	// Review-only/no-tool wording is a read-only signal, not a blanket
+	// prohibition: a later imperative such as "implement the fix" must still
+	// win. Explicit file prohibitions are analyzed below and may be blanket.
+	let blanket = false;
 	let strippedText = stripPatterns(taskText, [...REVIEW_ONLY_PATTERNS, ...NO_TOOL_INTENT_PATTERNS]);
+	if (readOnlyBoundary) strippedText = stripPatterns(strippedText, [NO_EDIT_BOUNDARY_ASSERTION_PATTERN]);
 	const stripNoEditProhibition = (match: string, object: string, offset: number, source: string): string => {
 		present = true;
 		if (GENERIC_PROHIBITION_OBJECT.test(object) && !hasScopedProhibitionContinuation(source.slice(offset + match.length))) blanket = true;
@@ -177,7 +196,9 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
 		if (prohibitions.blanket) return { kind: "read-only" };
-		return hasImplementationIntent(agent, prohibitions.strippedText) ? { kind: "implementation" } : { kind: "read-only" };
+		return hasImplementationIntent(agent, prohibitions.strippedText) || FOLLOW_ON_IMPLEMENTATION_PATTERN.test(prohibitions.strippedText)
+			? { kind: "implementation" }
+			: { kind: "read-only" };
 	}
 
 	if (RESEARCH_AGENT_PATTERNS.some((pattern) => pattern.test(agent))) return { kind: "read-only" };

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -115,6 +115,7 @@ const WORKER_IMPLEMENTATION_PATTERNS = [
 // verbs visible even when their target is a project-specific noun (for example,
 // "Without edits, update the parser"). Output-only nouns remain excluded.
 const FOLLOW_ON_IMPLEMENTATION_PATTERN = /\b(?:fix|patch|update|add|remove|replace|create|delete)\s+(?!(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?(?:report|summary|findings?|analysis|recommendations?|answer|response|proposal|plan|issue|bug report)\b)(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?[a-z][\w./-]*/i;
+const ADVISORY_INFINITIVE_PATTERN = /\b(?:explain|recommend|describe)\s+how\s+to\s+(?:fix|patch|update|add|remove|replace|create|delete|implement|edit|modify|refactor)\b/gi;
 
 const GENERAL_IMPLEMENTATION_PATTERNS = [
 	/\b(?:implement|edit|modify|refactor)\b/i,
@@ -196,7 +197,8 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
 		if (prohibitions.blanket) return { kind: "read-only" };
-		return hasImplementationIntent(agent, prohibitions.strippedText) || FOLLOW_ON_IMPLEMENTATION_PATTERN.test(prohibitions.strippedText)
+		const imperativeText = prohibitions.strippedText.replace(ADVISORY_INFINITIVE_PATTERN, " ");
+		return hasImplementationIntent(agent, imperativeText) || FOLLOW_ON_IMPLEMENTATION_PATTERN.test(imperativeText)
 			? { kind: "implementation" }
 			: { kind: "read-only" };
 	}

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -115,7 +115,10 @@ const WORKER_IMPLEMENTATION_PATTERNS = [
 // verbs visible even when their target is a project-specific noun (for example,
 // "Without edits, update the parser"). Output-only nouns remain excluded.
 const FOLLOW_ON_IMPLEMENTATION_PATTERN = /\b(?:fix|patch|update|add|remove|replace|create|delete)\s+(?!(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?(?:report|summary|findings?|analysis|recommendations?|answer|response|proposal|plan|issue|bug report)\b)(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?[a-z][\w./-]*/i;
-const ADVISORY_INFINITIVE_PATTERN = /\b(?:explain|recommend|describe)\s+how\s+to\s+(?:fix|patch|update|add|remove|replace|create|delete|implement|edit|modify|refactor)\b/gi;
+
+// Advisory how-to wording is stripped with other non-imperative markers so
+// "explain how to update" cannot leak into the later write-intent match.
+const ADVISORY_INFINITIVE_PATTERN = /\b(?:explain|recommend|describe)\s+how\s+to\s+(?:fix|patch|update|add|remove|replace|create|delete|implement|edit|modify|refactor)\b/i;
 
 const GENERAL_IMPLEMENTATION_PATTERNS = [
 	/\b(?:implement|edit|modify|refactor)\b/i,
@@ -163,7 +166,7 @@ function analyzeNoEditProhibitions(taskText: string): NoEditProhibitionAnalysis 
 	// prohibition: a later imperative such as "implement the fix" must still
 	// win. Explicit file prohibitions are analyzed below and may be blanket.
 	let blanket = false;
-	let strippedText = stripPatterns(taskText, [...REVIEW_ONLY_PATTERNS, ...NO_TOOL_INTENT_PATTERNS]);
+	let strippedText = stripPatterns(taskText, [...REVIEW_ONLY_PATTERNS, ...NO_TOOL_INTENT_PATTERNS, ADVISORY_INFINITIVE_PATTERN]);
 	if (readOnlyBoundary) strippedText = stripPatterns(strippedText, [NO_EDIT_BOUNDARY_ASSERTION_PATTERN]);
 	const stripNoEditProhibition = (match: string, object: string, offset: number, source: string): string => {
 		present = true;
@@ -197,8 +200,7 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
 		if (prohibitions.blanket) return { kind: "read-only" };
-		const imperativeText = prohibitions.strippedText.replace(ADVISORY_INFINITIVE_PATTERN, " ");
-		return hasImplementationIntent(agent, imperativeText) || FOLLOW_ON_IMPLEMENTATION_PATTERN.test(imperativeText)
+		return hasImplementationIntent(agent, prohibitions.strippedText) || FOLLOW_ON_IMPLEMENTATION_PATTERN.test(prohibitions.strippedText)
 			? { kind: "implementation" }
 			: { kind: "read-only" };
 	}

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -44,7 +44,7 @@ const REVIEWER_REQUIRED_EDIT_PATTERNS = [
 // being swallowed as the object.
 // Accept serialized line separators too: workflow prompts can carry literal
 // `\\n`/`\\r\\n` between clauses instead of decoded newlines.
-const NO_EDIT_PROHIBITION_PATTERN = /(?:\b|\\(?:r\\n|n))(?:do not|don't|must not)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b((?:(?!\b(?:but|and|then)\b|\\(?:r\\n|n))[^.;,:!?\n–—-])*)/gi;
+const NO_EDIT_PROHIBITION_PATTERN = /(?:\b|\\(?:r\\n|n))(?:do not|don't|must not)\s+(?:edit|modify|write(?:\s+to)?|touch|change|implement)\b((?:(?!\b(?:but|and|then)\b|\\(?:r\\n|n))[^.;,:!?\n–—-])*)/gi;
 const COORDINATED_NO_EDIT_PROHIBITION_PATTERN = /(?:\b|\\(?:r\\n|n))(?:do not|don't|must not)\s+((?=(?:(?!\\(?:r\\n|n))[^.;:!?\n–—-])*\b(?:and|or)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b)(?:(?!\\(?:r\\n|n))[^.;:!?\n–—-])*?\b(?:and|or)\s+(?:edit|modify|write(?:\s+to)?|touch|change)\b(?:(?!\b(?:but|and|then)\b|\\(?:r\\n|n))[^.;,:!?\n–—-])*)/gi;
 
 /** Objects of a no-edit prohibition that mean "the codebase in general" rather than a named scope. */
@@ -107,15 +107,18 @@ const WORKER_IMPLEMENTATION_PATTERNS = [
 	/\bdo those fixes\b/i,
 ];
 
-const FOLLOW_ON_IMPLEMENTATION_PATTERN = /\b(?:fix|patch|update|add|remove|replace|create|delete)\s+(?!(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?(?:report|summary|findings?|analysis|recommendations?|answer|response|proposal|plan|issue|bug report)\b)(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)?[a-z][\w./-]*/i;
+const FOLLOW_ON_IMPLEMENTATION_PATTERN = /(?:^|[.!?:;,\n])\s*(?:fix|patch|update|add|remove|replace|create|delete)\s+(?:(?:the|a|an|this|that|these|those|requested|specified|current|existing|approved|your|our)\s+)(?!(?:report|summary|findings?|analysis|recommendations?|answer|response|proposal|plan|issue|bug report)\b)[a-z][\w./-]*/i;
 const ADVISORY_INFINITIVE_PATTERN = /\b(?:explain|recommend|describe)\s+how\s+to\s+(?:fix|patch|update|add|remove|replace|create|delete|implement|edit|modify|refactor)\b/i;
-
-const GENERAL_IMPLEMENTATION_PATTERNS = [
+const EXPLICIT_IMPLEMENTATION_PATTERNS = [
 	/\b(?:implement|edit|modify|refactor)\b/i,
-	FIX_OR_PATCH_IMPLEMENTATION_PATTERN,
 	/\bapply\s+(?:the\s+)?(?:(?:suggested|proposed|recommended)\s+)?(?:changes?|fix(?:es)?|patch)\b/i,
 	/\bmake\s+(?:the\s+)?changes\b/i,
 	/\bdo those fixes\b/i,
+];
+
+const GENERAL_IMPLEMENTATION_PATTERNS = [
+	...EXPLICIT_IMPLEMENTATION_PATTERNS,
+	FIX_OR_PATCH_IMPLEMENTATION_PATTERN,
 	/\b(?:update|add|remove|replace|delete|create)\s+(?:the\s+)?(?:file|files|code|source|implementation|test|tests|component|function|module|class|method|logic|import|imports|readme|docs?|changelog|package\.json|config|manifest|extension|prompt|command)\b/i,
 ];
 
@@ -187,7 +190,12 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
 		if (prohibitions.blanket) return { kind: "read-only" };
-		return hasImplementationIntent(agent, prohibitions.strippedText) || FOLLOW_ON_IMPLEMENTATION_PATTERN.test(prohibitions.strippedText)
+		const remaining = prohibitions.strippedText;
+		if (isReviewerStyleAgent(agent)) {
+			return hasImplementationIntent(agent, remaining) ? { kind: "implementation" } : { kind: "read-only" };
+		}
+		return EXPLICIT_IMPLEMENTATION_PATTERNS.some((pattern) => pattern.test(remaining))
+			|| FOLLOW_ON_IMPLEMENTATION_PATTERN.test(remaining)
 			? { kind: "implementation" }
 			: { kind: "read-only" };
 	}

--- a/test/unit/active-async-capacity.test.ts
+++ b/test/unit/active-async-capacity.test.ts
@@ -371,24 +371,6 @@ describe("active async capacity", () => {
 		}
 	});
 
-	it("releases terminal workflows when a resumed async child failed before startup", () => {
-		const rootDir = tempRoot();
-		const asyncRoot = path.join(rootDir, "runs");
-		const workflowDir = path.join(asyncRoot, "workflow");
-		const childDir = path.join(asyncRoot, "revived-child");
-		try {
-			const workflow = acquireActiveAsyncCapacity({ sessionId: "session-a", limit: 1, runId: "workflow", kind: "workflow", asyncDir: workflowDir }, { rootDir });
-			assert.ok(workflow);
-			workflow.markWorkflowStarted();
-			writeJson(path.join(workflowDir, "status.json"), { runId: "workflow", sessionId: "session-a", mode: "workflow", state: "failed", startedAt: 100, steps: [{ agent: "worker", workflowKey: "resume", runId: "revived-child", async: true, status: "failed" }] });
-			writeJson(path.join(childDir, "status.json"), { runId: "revived-child", sessionId: "session-a", mode: "single", state: "failed", startedAt: 100, error: "already owned by run 'workflow-competing-revival'", processTerminal: { version: 1, state: "not-started", runId: "revived-child", runnerProcessInstanceId: "runner-child" } });
-
-			assert.deepEqual(getActiveAsyncCapacitySnapshot("session-a", 1, { rootDir }), { used: 0, limit: 1 });
-		} finally {
-			fs.rmSync(rootDir, { recursive: true, force: true });
-		}
-	});
-
 	it("retains terminal workflows while a resumed async child lacks observed proof", () => {
 		const rootDir = tempRoot();
 		const asyncRoot = path.join(rootDir, "runs");

--- a/test/unit/active-async-capacity.test.ts
+++ b/test/unit/active-async-capacity.test.ts
@@ -371,6 +371,24 @@ describe("active async capacity", () => {
 		}
 	});
 
+	it("releases terminal workflows when a resumed async child failed before startup", () => {
+		const rootDir = tempRoot();
+		const asyncRoot = path.join(rootDir, "runs");
+		const workflowDir = path.join(asyncRoot, "workflow");
+		const childDir = path.join(asyncRoot, "revived-child");
+		try {
+			const workflow = acquireActiveAsyncCapacity({ sessionId: "session-a", limit: 1, runId: "workflow", kind: "workflow", asyncDir: workflowDir }, { rootDir });
+			assert.ok(workflow);
+			workflow.markWorkflowStarted();
+			writeJson(path.join(workflowDir, "status.json"), { runId: "workflow", sessionId: "session-a", mode: "workflow", state: "failed", startedAt: 100, steps: [{ agent: "worker", workflowKey: "resume", runId: "revived-child", async: true, status: "failed" }] });
+			writeJson(path.join(childDir, "status.json"), { runId: "revived-child", sessionId: "session-a", mode: "single", state: "failed", startedAt: 100, error: "already owned by run 'workflow-competing-revival'", processTerminal: { version: 1, state: "not-started", runId: "revived-child", runnerProcessInstanceId: "runner-child" } });
+
+			assert.deepEqual(getActiveAsyncCapacitySnapshot("session-a", 1, { rootDir }), { used: 0, limit: 1 });
+		} finally {
+			fs.rmSync(rootDir, { recursive: true, force: true });
+		}
+	});
+
 	it("retains terminal workflows while a resumed async child lacks observed proof", () => {
 		const rootDir = tempRoot();
 		const asyncRoot = path.join(rootDir, "runs");

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -10,6 +10,7 @@ import {
 	validateImplementationToolContract,
 } from "../../src/runs/shared/completion-guard.ts";
 import { isMutatingTool } from "../../src/runs/shared/long-running-guard.ts";
+import { resolvePiLaunchToolPlan } from "../../src/runs/shared/child-tool-plan.ts";
 
 function assistantToolCall(name: string, args: Record<string, unknown> = {}): Message {
 	return {
@@ -386,6 +387,73 @@ test("implementation tool contract rejects read-only worker launches", () => {
 	}), undefined);
 });
 
+test("read-only audit tasks survive host-clamped declared mutation tools", () => {
+	const task = "Read-only bug investigation. No source edits, commits, pushes, merges, installs, or state repair. Return concrete findings and a minimal fix proposal.";
+	const requestedTools = ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"];
+	const toolPlan = resolvePiLaunchToolPlan({
+		tools: requestedTools,
+		hostAvailableBuiltins: ["read", "grep", "find", "ls", "contact_supervisor"],
+	});
+
+	assert.deepEqual(toolPlan.effectiveToolAllowlist, ["read", "grep", "find", "ls", "contact_supervisor"]);
+	assert.equal(expectsImplementationMutation("delegate", task), false);
+	assert.equal(validateImplementationToolContract({
+		agent: "delegate",
+		task,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}), undefined);
+	const implementationTask = "No source edits, commits, pushes; implement the requested source fix.";
+	assert.equal(expectsImplementationMutation("delegate", implementationTask), true);
+	assert.match(validateImplementationToolContract({
+		agent: "delegate",
+		task: implementationTask,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+	for (const task of [
+		"Review only; implement the approved fix.",
+		"No tools needed; implement the approved fix.",
+		"Without edits, update the parser.",
+	]) {
+		assert.match(validateImplementationToolContract({
+			agent: "delegate",
+			task,
+			tools: toolPlan.effectiveToolAllowlist,
+			requestedTools: toolPlan.requestedBuiltinTools,
+		}) ?? "", /no mutation-capable tools/, task);
+	}
+	assert.equal(expectsImplementationMutation("reviewer", "Review only; implement the approved fix."), true);
+	assert.match(validateImplementationToolContract({
+		agent: "reviewer",
+		task: "Review only; implement the approved fix.",
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+
+	// Unknown wording remains conservative when the launch explicitly requested
+	// mutation tools that the host removed.
+	const summaryTask = "Create a summary";
+	assert.equal(expectsImplementationMutation("delegate", summaryTask), false);
+	assert.match(validateImplementationToolContract({
+		agent: "delegate",
+		task: summaryTask,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+
+	// A generic worker task remains unknown rather than inheriting writer intent,
+	// but the removed requested mutation tools still keep the launch conservative.
+	const genericWorkerTask = "Inspect the current behavior and report findings.";
+	assert.equal(expectsImplementationMutation("worker", genericWorkerTask), false);
+	assert.match(validateImplementationToolContract({
+		agent: "worker",
+		task: genericWorkerTask,
+		tools: toolPlan.effectiveToolAllowlist,
+		requestedTools: toolPlan.requestedBuiltinTools,
+	}) ?? "", /no mutation-capable tools/);
+});
+
 test("oracle review tasks with bash available do not require mutation", () => {
 	const task = "Review prep findings and determine what to implement with playbooks instead of before.";
 	const result = evaluateCompletionMutationGuard({
@@ -407,6 +475,23 @@ test("review-only, research, and framework output instructions do not expect mut
 	assert.equal(expectsImplementationMutation("worker", "Review only: return findings, do not edit"), false);
 	assert.equal(expectsImplementationMutation("worker", "Do not edit files. Tell me how to fix the bug."), false);
 	assert.equal(expectsImplementationMutation("worker", "Review the diff and suggest fixes only. Do not edit files."), false);
+	for (const task of [
+		"Read-only audit of the current implementation; report findings.",
+		"Review-only pass over the diff; return recommendations.",
+		"No edits; inspect the current behavior and report findings.",
+		"Analyze the current behavior without edits.",
+	]) {
+		assert.equal(expectsImplementationMutation("delegate", task), false, task);
+	}
+	for (const task of [
+		"Review only; implement the approved fix.",
+		"No tools needed; implement the approved fix.",
+		"Read-only review; modify the requested source file.",
+		"Without edits to the report, implement the requested fix.",
+		"Without edits, update the parser.",
+	]) {
+		assert.equal(expectsImplementationMutation("delegate", task), true, task);
+	}
 	assert.equal(expectsImplementationMutation("worker", "Implement this. Do not edit files outside this repo. Do not edit files."), false);
 	assert.equal(expectsImplementationMutation("worker", "Investigate why this failed"), false);
 	assert.equal(expectsImplementationMutation("researcher", "Research the API behavior"), false);
@@ -707,8 +792,26 @@ test("writer-role tasks with unknown implementation wording reject read-only lau
 			task,
 			tools: ["read", "grep", "find", "ls", "contact_supervisor"],
 			requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
-		}), /no mutation-capable tools/, task);
+		}) ?? "", /no mutation-capable tools/, task);
 	}
+});
+
+test("explicit writer acceptance role overrides reviewer agent heuristics", () => {
+	assert.match(validateImplementationToolContract({
+		agent: "reviewer",
+		task: "Handle the authentication flow",
+		acceptanceRole: "writer",
+		tools: ["read", "grep", "find", "ls", "contact_supervisor"],
+		requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+	}) ?? "", /no mutation-capable tools/);
+
+	assert.equal(validateImplementationToolContract({
+		agent: "reviewer",
+		task: "Review only and return findings",
+		acceptanceRole: "writer",
+		tools: ["read", "grep", "find", "ls", "contact_supervisor"],
+		requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+	}), undefined);
 });
 
 test("configured extensions do not rescue clamped-away builtin mutation tools", () => {
@@ -718,7 +821,7 @@ test("configured extensions do not rescue clamped-away builtin mutation tools", 
 		tools: ["read", "grep", "find", "ls", "contact_supervisor"],
 		configuredExtensions: ["/tmp/provider.ts"],
 		requestedTools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
-	}), /no mutation-capable tools/);
+	}) ?? "", /no mutation-capable tools/);
 });
 
 test("read-only agents and pure extension workers keep their launch contracts", () => {

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -10,7 +10,6 @@ import {
 	validateImplementationToolContract,
 } from "../../src/runs/shared/completion-guard.ts";
 import { isMutatingTool } from "../../src/runs/shared/long-running-guard.ts";
-import { resolvePiLaunchToolPlan } from "../../src/runs/shared/child-tool-plan.ts";
 
 function assistantToolCall(name: string, args: Record<string, unknown> = {}): Message {
 	return {
@@ -388,82 +387,26 @@ test("implementation tool contract rejects read-only worker launches", () => {
 });
 
 test("read-only audit tasks survive host-clamped declared mutation tools", () => {
-	const task = "Read-only bug investigation. No source edits, commits, pushes, merges, installs, or state repair. Return concrete findings and a minimal fix proposal.";
+	const tools = ["read", "grep", "find", "ls", "contact_supervisor"];
 	const requestedTools = ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"];
-	const toolPlan = resolvePiLaunchToolPlan({
-		tools: requestedTools,
-		hostAvailableBuiltins: ["read", "grep", "find", "ls", "contact_supervisor"],
-	});
-
-	assert.deepEqual(toolPlan.effectiveToolAllowlist, ["read", "grep", "find", "ls", "contact_supervisor"]);
-	assert.equal(expectsImplementationMutation("delegate", task), false);
 	assert.equal(validateImplementationToolContract({
 		agent: "delegate",
-		task,
-		tools: toolPlan.effectiveToolAllowlist,
-		requestedTools: toolPlan.requestedBuiltinTools,
+		task: "Read-only bug investigation. No source edits, commits, pushes, merges, installs, or state repair. Return concrete findings and a minimal fix proposal.",
+		tools,
+		requestedTools,
 	}), undefined);
-	const implementationTask = "No source edits, commits, pushes; implement the requested source fix.";
-	assert.equal(expectsImplementationMutation("delegate", implementationTask), true);
-	assert.match(validateImplementationToolContract({
-		agent: "delegate",
-		task: implementationTask,
-		tools: toolPlan.effectiveToolAllowlist,
-		requestedTools: toolPlan.requestedBuiltinTools,
-	}) ?? "", /no mutation-capable tools/);
 	for (const task of [
 		"Review only; implement the approved fix.",
-		"No tools needed; implement the approved fix.",
 		"Without edits, update the parser.",
+		"Create a summary",
 	]) {
 		assert.match(validateImplementationToolContract({
 			agent: "delegate",
 			task,
-			tools: toolPlan.effectiveToolAllowlist,
-			requestedTools: toolPlan.requestedBuiltinTools,
+			tools,
+			requestedTools,
 		}) ?? "", /no mutation-capable tools/, task);
 	}
-	for (const task of [
-		"Review only; explain how to update the parser.",
-		"Read-only audit; recommend how to fix the parser.",
-		"Review only; describe how to implement the approved fix.",
-	]) {
-		assert.equal(validateImplementationToolContract({
-			agent: "delegate",
-			task,
-			tools: toolPlan.effectiveToolAllowlist,
-			requestedTools: toolPlan.requestedBuiltinTools,
-		}), undefined, task);
-	}
-	assert.equal(expectsImplementationMutation("reviewer", "Review only; implement the approved fix."), true);
-	assert.match(validateImplementationToolContract({
-		agent: "reviewer",
-		task: "Review only; implement the approved fix.",
-		tools: toolPlan.effectiveToolAllowlist,
-		requestedTools: toolPlan.requestedBuiltinTools,
-	}) ?? "", /no mutation-capable tools/);
-
-	// Unknown wording remains conservative when the launch explicitly requested
-	// mutation tools that the host removed.
-	const summaryTask = "Create a summary";
-	assert.equal(expectsImplementationMutation("delegate", summaryTask), false);
-	assert.match(validateImplementationToolContract({
-		agent: "delegate",
-		task: summaryTask,
-		tools: toolPlan.effectiveToolAllowlist,
-		requestedTools: toolPlan.requestedBuiltinTools,
-	}) ?? "", /no mutation-capable tools/);
-
-	// A generic worker task remains unknown rather than inheriting writer intent,
-	// but the removed requested mutation tools still keep the launch conservative.
-	const genericWorkerTask = "Inspect the current behavior and report findings.";
-	assert.equal(expectsImplementationMutation("worker", genericWorkerTask), false);
-	assert.match(validateImplementationToolContract({
-		agent: "worker",
-		task: genericWorkerTask,
-		tools: toolPlan.effectiveToolAllowlist,
-		requestedTools: toolPlan.requestedBuiltinTools,
-	}) ?? "", /no mutation-capable tools/);
 });
 
 test("oracle review tasks with bash available do not require mutation", () => {
@@ -487,23 +430,6 @@ test("review-only, research, and framework output instructions do not expect mut
 	assert.equal(expectsImplementationMutation("worker", "Review only: return findings, do not edit"), false);
 	assert.equal(expectsImplementationMutation("worker", "Do not edit files. Tell me how to fix the bug."), false);
 	assert.equal(expectsImplementationMutation("worker", "Review the diff and suggest fixes only. Do not edit files."), false);
-	for (const task of [
-		"Read-only audit of the current implementation; report findings.",
-		"Review-only pass over the diff; return recommendations.",
-		"No edits; inspect the current behavior and report findings.",
-		"Analyze the current behavior without edits.",
-	]) {
-		assert.equal(expectsImplementationMutation("delegate", task), false, task);
-	}
-	for (const task of [
-		"Review only; implement the approved fix.",
-		"No tools needed; implement the approved fix.",
-		"Read-only review; modify the requested source file.",
-		"Without edits to the report, implement the requested fix.",
-		"Without edits, update the parser.",
-	]) {
-		assert.equal(expectsImplementationMutation("delegate", task), true, task);
-	}
 	assert.equal(expectsImplementationMutation("worker", "Implement this. Do not edit files outside this repo. Do not edit files."), false);
 	assert.equal(expectsImplementationMutation("worker", "Investigate why this failed"), false);
 	assert.equal(expectsImplementationMutation("researcher", "Research the API behavior"), false);

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -423,6 +423,18 @@ test("read-only audit tasks survive host-clamped declared mutation tools", () =>
 			requestedTools: toolPlan.requestedBuiltinTools,
 		}) ?? "", /no mutation-capable tools/, task);
 	}
+	for (const task of [
+		"Review only; explain how to update the parser.",
+		"Read-only audit; recommend how to fix the parser.",
+		"Review only; describe how to implement the approved fix.",
+	]) {
+		assert.equal(validateImplementationToolContract({
+			agent: "delegate",
+			task,
+			tools: toolPlan.effectiveToolAllowlist,
+			requestedTools: toolPlan.requestedBuiltinTools,
+		}), undefined, task);
+	}
 	assert.equal(expectsImplementationMutation("reviewer", "Review only; implement the approved fix."), true);
 	assert.match(validateImplementationToolContract({
 		agent: "reviewer",

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -396,23 +396,6 @@ test("read-only audit tasks survive host-clamped declared mutation tools", () =>
 		requestedTools,
 	}), undefined);
 	for (const task of [
-		"Review only and fix any real issues",
-		"Review only. Check the update handler.",
-		"Review only. Inspect the create function.",
-		"Review-only: flag issues and suggest how to fix them",
-		"Read-only review of the add user endpoint",
-		"Review only. Determine whether they add tests.",
-		"Review only. Do not implement anything.",
-		"Review only; do not implement the approved fix.",
-	]) {
-		assert.equal(validateImplementationToolContract({
-			agent: "delegate",
-			task,
-			tools,
-			requestedTools,
-		}), undefined, task);
-	}
-	for (const task of [
 		"Review only; implement the approved fix.",
 		"Without edits, update the parser.",
 		"Create a summary",

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -396,6 +396,23 @@ test("read-only audit tasks survive host-clamped declared mutation tools", () =>
 		requestedTools,
 	}), undefined);
 	for (const task of [
+		"Review only and fix any real issues",
+		"Review only. Check the update handler.",
+		"Review only. Inspect the create function.",
+		"Review-only: flag issues and suggest how to fix them",
+		"Read-only review of the add user endpoint",
+		"Review only. Determine whether they add tests.",
+		"Review only. Do not implement anything.",
+		"Review only; do not implement the approved fix.",
+	]) {
+		assert.equal(validateImplementationToolContract({
+			agent: "delegate",
+			task,
+			tools,
+			requestedTools,
+		}), undefined, task);
+	}
+	for (const task of [
 		"Review only; implement the approved fix.",
 		"Without edits, update the parser.",
 		"Create a summary",

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -26,12 +26,8 @@ describe("classifyTaskMutationIntent", () => {
 	});
 
 	it("does not let read-only markers swallow generic implementation imperatives", () => {
-		for (const task of [
-			"Without edits, update the parser",
-			"Review only; add the missing test",
-		]) {
-			assert.equal(classifyTaskMutationIntent("delegate", task).kind, "implementation", task);
-		}
+		assert.equal(classifyTaskMutationIntent("delegate", "Without edits, update the parser").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("delegate", "Review only; implement the approved fix").kind, "implementation");
 		assert.equal(classifyTaskMutationIntent("delegate", "Review only; update the report").kind, "read-only");
 	});
 

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -45,6 +45,24 @@ describe("classifyTaskMutationIntent", () => {
 		);
 	});
 
+	it("does not treat review nouns or negated implement as follow-on work", () => {
+		for (const task of [
+			"Review only and fix any real issues",
+			"Review only. Check the update handler.",
+			"Review only. Inspect the create function.",
+			"Review-only: flag issues and suggest how to fix them",
+			"Read-only review of the add user endpoint",
+			"Review only. Determine whether they add tests.",
+			"Review only. Do not implement anything.",
+			"Review only; do not implement the approved fix.",
+		]) {
+			assert.equal(classifyTaskMutationIntent("delegate", task).kind, "read-only", task);
+			assert.equal(classifyTaskMutationIntent("worker", task).kind, "read-only", task);
+		}
+		assert.equal(classifyTaskMutationIntent("reviewer", "Review only and fix any real issues").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("reviewer", "Review this and fix any real issues").kind, "read-only");
+	});
+
 	it("stops the prohibition object before a following implementation clause", () => {
 		for (const task of [
 			"Do not modify tests but implement the fix",

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -35,6 +35,20 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("delegate", "Review only; update the report").kind, "read-only");
 	});
 
+	it("keeps advisory infinitives read-only without hiding later imperatives", () => {
+		for (const task of [
+			"Review only; explain how to update the parser.",
+			"Read-only audit; recommend how to fix the parser.",
+			"Review only; describe how to implement the approved fix.",
+		]) {
+			assert.equal(classifyTaskMutationIntent("delegate", task).kind, "read-only", task);
+		}
+		assert.equal(
+			classifyTaskMutationIntent("delegate", "Review only; explain how to update the parser, then implement the approved fix.").kind,
+			"implementation",
+		);
+	});
+
 	it("stops the prohibition object before a following implementation clause", () => {
 		for (const task of [
 			"Do not modify tests but implement the fix",

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -57,10 +57,8 @@ describe("classifyTaskMutationIntent", () => {
 			"Review only; do not implement the approved fix.",
 		]) {
 			assert.equal(classifyTaskMutationIntent("delegate", task).kind, "read-only", task);
-			assert.equal(classifyTaskMutationIntent("worker", task).kind, "read-only", task);
 		}
 		assert.equal(classifyTaskMutationIntent("reviewer", "Review only and fix any real issues").kind, "read-only");
-		assert.equal(classifyTaskMutationIntent("reviewer", "Review this and fix any real issues").kind, "read-only");
 	});
 
 	it("stops the prohibition object before a following implementation clause", () => {

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -25,6 +25,16 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Do not modify files\nin src; implement the fix").kind, "implementation");
 	});
 
+	it("does not let read-only markers swallow generic implementation imperatives", () => {
+		for (const task of [
+			"Without edits, update the parser",
+			"Review only; add the missing test",
+		]) {
+			assert.equal(classifyTaskMutationIntent("delegate", task).kind, "implementation", task);
+		}
+		assert.equal(classifyTaskMutationIntent("delegate", "Review only; update the report").kind, "read-only");
+	});
+
 	it("stops the prohibition object before a following implementation clause", () => {
 		for (const task of [
 			"Do not modify tests but implement the fix",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces #2060 with a maintainer branch based on current `main` (`dc2df2ba`, after #2061 and #2064).

This preserves the contribution reviewed at exact original head `0358d28adfee65d1b5df53f15a81cc1ae5111fb1`: explicitly read-only review and audit tasks can proceed after host capability clamping removes requested mutation tools, while implementation intent, writer intent, and unknown wording remain conservative. Later real implementation imperatives still win, and reviewer-named agents do not inherit a writer acceptance role from read-only wording.

Advisory infinitives stay read-only. Follow-on matching is clause-initial and agent-aware, so review nouns such as “update handler” or “fix any real issues” do not invert a review-only task. Negated implement after a review-only marker stays read-only.

A resumed async workflow child that fails before proceed now releases the parent workflow capacity slot the same way a runner pre-startup failure does. The user-visible release contract is locked by the integration lease-failure test; the retain-without-proof unit test stays.

Thanks to [@stekman08](https://github.com/stekman08) for the original contribution in #2060. Linked issue: #2058.

## Verification

- `test/unit/active-async-capacity.test.ts` and `test/integration/intercom-result-delivery.test.ts` — including `marks a resumed workflow child async when its runner starts and fails before proceed` and `retains terminal workflows while a resumed async child lacks observed proof`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b6b4b87-9077-48c4-909d-e67485c7584e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b6b4b87-9077-48c4-909d-e67485c7584e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

