### PR TITLE
fix: ignore filename verbs in task-intent classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Ignore verbs inside filenames and path-like tokens when classifying implementation intent, so artifact names such as `daily-update.mp3` do not create an implementation obligation. Thanks to [@SiebertLanhove](https://github.com/SiebertLanhove) for #2039.
 - Accept the boolean `fast` field on async recovery descriptors so a setting the writer persists can round-trip through follow-up. Thanks to [@isty2e](https://github.com/isty2e) for #2045.
 - Override `PI_PACKAGE_DIR` in detached runners with the detected npm Pi package root so npm runtime assets resolve from that package instead of an inherited host path. Thanks to [@alvarosevilla95](https://github.com/alvarosevilla95) for #2050.
 - Preserve explicit read-only task intent after host capability clamping, while still blocking implementation tasks that lack mutation tools. Thanks to [@stekman08](https://github.com/stekman08) for #2060.

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -97,11 +97,6 @@ function stripSeverityCompounds(task: string): string {
 }
 export { stripSeverityCompounds };
 
-// Hyphens and slashes are word boundaries, so a token like daily-update.mp3
-// or src/add.ts would otherwise look like the verbs update/add. Neutralize
-// only tokens that contain those verbs; leave objects such as package.json
-// so "Fix package.json" stays an implementation obligation. Acceptance still
-// uses the raw write-verb vocabulary.
 const PATH_LIKE_TOKEN_PATTERN = /[^\s]+[/\\][^\s]+|[^\s/\\]+\.[A-Za-z][A-Za-z0-9]{0,9}\b/g;
 const PATH_INTERNAL_IMPLEMENTATION_VERB = /\b(?:implement|edit|modify|refactor|delete|update|add|remove|replace|create)\b/i;
 

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -7,6 +7,7 @@
  * - `classifyTaskMutationIntent` / `expectsImplementationMutation`: does the
  *   task REQUIRE file changes? Consumed by the completion mutation guard,
  *   which blocks completion, so its vocabulary is deliberately narrow.
+ *   Verbs inside filenames and path-like tokens do not count.
  * - `taskMayMutate`: COULD the task plausibly change files? Consumed by
  *   acceptance level inference, which only raises evidence gates, so its
  *   vocabulary is deliberately broad (any bare write verb).
@@ -95,6 +96,16 @@ function stripSeverityCompounds(task: string): string {
 	return task.replace(SEVERITY_COMPOUND_PATTERN, " ");
 }
 export { stripSeverityCompounds };
+
+// Hyphens and slashes are word boundaries, so a token like daily-update.mp3
+// or src/add.ts would otherwise look like the verbs update/add. Strip those
+// tokens before implementation matching only; acceptance still uses the raw
+// write-verb vocabulary.
+const PATH_LIKE_TOKEN_PATTERN = /[^\s]+[/\\][^\s]+|[^\s/\\]+\.[A-Za-z][A-Za-z0-9]{0,9}\b/g;
+
+function stripPathLikeTokens(task: string): string {
+	return task.replace(PATH_LIKE_TOKEN_PATTERN, " ");
+}
 
 const FIX_OR_PATCH_IMPLEMENTATION_PATTERN = /\b(?:fix|patch)\s+(?:(?:it|this|that|them|each|any|all|these|those)\b|(?:(?:a|an|the|any|all)\s+)?(?:(?:failing|failed|broken|flaky|red|cold|start|current|existing|reported|approved|known|regression|unit|integration|e2e|source|typescript|type-?script|ts|type-?check|compiler)\s+)*(?:bug|defect|issues?|problems?|failures?|regressions?|tests?|errors?|items?|typos?|code|source|implementation|component|function|module|class|method|logic|file|files|readme|docs?|changelog|package\.json|config|manifest|extension|prompt|command|lint(?:ing)?|build|ci|type-?check|type\s+checking)\b)/i;
 
@@ -190,7 +201,7 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
 		if (prohibitions.blanket) return { kind: "read-only" };
-		const remaining = prohibitions.strippedText;
+		const remaining = stripPathLikeTokens(prohibitions.strippedText);
 		if (isReviewerStyleAgent(agent)) {
 			return hasImplementationIntent(agent, remaining) ? { kind: "implementation" } : { kind: "read-only" };
 		}
@@ -201,7 +212,7 @@ export function classifyTaskMutationIntent(agent: string, task: string): TaskMut
 	}
 
 	if (RESEARCH_AGENT_PATTERNS.some((pattern) => pattern.test(agent))) return { kind: "read-only" };
-	if (hasImplementationIntent(agent, taskText)) return { kind: "implementation" };
+	if (hasImplementationIntent(agent, stripPathLikeTokens(taskText))) return { kind: "implementation" };
 	if (isReviewerStyleAgent(agent)) return { kind: "read-only" };
 	return taskHasReadOnlyDeliverable(taskTextWithoutScopedConstraints) ? { kind: "read-only" } : { kind: "unknown" };
 }

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -98,13 +98,15 @@ function stripSeverityCompounds(task: string): string {
 export { stripSeverityCompounds };
 
 // Hyphens and slashes are word boundaries, so a token like daily-update.mp3
-// or src/add.ts would otherwise look like the verbs update/add. Strip those
-// tokens before implementation matching only; acceptance still uses the raw
-// write-verb vocabulary.
+// or src/add.ts would otherwise look like the verbs update/add. Neutralize
+// only tokens that contain those verbs; leave objects such as package.json
+// so "Fix package.json" stays an implementation obligation. Acceptance still
+// uses the raw write-verb vocabulary.
 const PATH_LIKE_TOKEN_PATTERN = /[^\s]+[/\\][^\s]+|[^\s/\\]+\.[A-Za-z][A-Za-z0-9]{0,9}\b/g;
+const PATH_INTERNAL_IMPLEMENTATION_VERB = /\b(?:implement|edit|modify|refactor|delete|update|add|remove|replace|create)\b/i;
 
 function stripPathLikeTokens(task: string): string {
-	return task.replace(PATH_LIKE_TOKEN_PATTERN, " ");
+	return task.replace(PATH_LIKE_TOKEN_PATTERN, (token) => (PATH_INTERNAL_IMPLEMENTATION_VERB.test(token) ? " " : token));
 }
 
 const FIX_OR_PATCH_IMPLEMENTATION_PATTERN = /\b(?:fix|patch)\s+(?:(?:it|this|that|them|each|any|all|these|those)\b|(?:(?:a|an|the|any|all)\s+)?(?:(?:failing|failed|broken|flaky|red|cold|start|current|existing|reported|approved|known|regression|unit|integration|e2e|source|typescript|type-?script|ts|type-?check|compiler)\s+)*(?:bug|defect|issues?|problems?|failures?|regressions?|tests?|errors?|items?|typos?|code|source|implementation|component|function|module|class|method|logic|file|files|readme|docs?|changelog|package\.json|config|manifest|extension|prompt|command|lint(?:ing)?|build|ci|type-?check|type\s+checking)\b)/i;

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -192,6 +192,13 @@ describe("classifyTaskMutationIntent", () => {
 		);
 		assert.equal(classifyTaskMutationIntent("worker", "Update the source file").kind, "implementation");
 		assert.equal(classifyTaskMutationIntent("worker", "Update src/auth.ts").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Update daily-update.mp3").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Fix the bug in src/foo.ts").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Fix package.json").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Patch package.json").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Fix README.md").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("delegate", "Update package.json").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Review only; fix the package.json").kind, "implementation");
 		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests; render to artifacts/daily-update.mp3").kind, "read-only");
 		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests; render to artifacts/daily-update.mp3. Then implement the fix.").kind, "implementation");
 	});

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -167,6 +167,34 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(expectsImplementationMutation("worker", "Do not modify tests; implement the fix"), true);
 		assert.equal(expectsImplementationMutation("worker", "Review the diff and suggest fixes only. Do not edit files."), false);
 	});
+
+	it("does not read verbs inside filenames or path-like tokens as implementation", () => {
+		const brief = "Render an audio briefing with the existing renderer to artifacts/daily-briefing.mp3.";
+		const renamed = "Render an audio briefing with the existing renderer to artifacts/daily-update.mp3.";
+		assert.equal(classifyTaskMutationIntent("worker", brief).kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", renamed).kind, "unknown");
+		assert.equal(classifyTaskMutationIntent("worker", brief).kind, classifyTaskMutationIntent("worker", renamed).kind);
+		assert.equal(expectsImplementationMutation("worker", renamed), false);
+
+		for (const task of [
+			"Render an audio briefing to daily-update.mp3.",
+			"Inspect artifacts/create-user.patch and report findings.",
+			"Read src/add-user.ts and describe the flow.",
+			"Summarize the contents of remove-old-cache.js.",
+			"Review the notes in replace-token.md.",
+		]) {
+			assert.notEqual(classifyTaskMutationIntent("worker", task).kind, "implementation", task);
+		}
+
+		assert.equal(
+			classifyTaskMutationIntent("worker", "Render an audio briefing to artifacts/daily-update.mp3. Then update the source file.").kind,
+			"implementation",
+		);
+		assert.equal(classifyTaskMutationIntent("worker", "Update the source file").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Update src/auth.ts").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests; render to artifacts/daily-update.mp3").kind, "read-only");
+		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests; render to artifacts/daily-update.mp3. Then implement the fix.").kind, "implementation");
+	});
 });
 
 describe("taskMayMutate", () => {

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -168,39 +168,25 @@ describe("classifyTaskMutationIntent", () => {
 		assert.equal(expectsImplementationMutation("worker", "Review the diff and suggest fixes only. Do not edit files."), false);
 	});
 
-	it("does not read verbs inside filenames or path-like tokens as implementation", () => {
+	it("does not treat verbs inside artifact filenames as implementation", () => {
 		const brief = "Render an audio briefing with the existing renderer to artifacts/daily-briefing.mp3.";
 		const renamed = "Render an audio briefing with the existing renderer to artifacts/daily-update.mp3.";
 		assert.equal(classifyTaskMutationIntent("worker", brief).kind, "unknown");
 		assert.equal(classifyTaskMutationIntent("worker", renamed).kind, "unknown");
-		assert.equal(classifyTaskMutationIntent("worker", brief).kind, classifyTaskMutationIntent("worker", renamed).kind);
-		assert.equal(expectsImplementationMutation("worker", renamed), false);
+	});
 
-		for (const task of [
-			"Render an audio briefing to daily-update.mp3.",
-			"Inspect artifacts/create-user.patch and report findings.",
-			"Read src/add-user.ts and describe the flow.",
-			"Summarize the contents of remove-old-cache.js.",
-			"Review the notes in replace-token.md.",
-		]) {
-			assert.notEqual(classifyTaskMutationIntent("worker", task).kind, "implementation", task);
-		}
-
+	it("keeps a later real imperative after a filename token", () => {
 		assert.equal(
 			classifyTaskMutationIntent("worker", "Render an audio briefing to artifacts/daily-update.mp3. Then update the source file.").kind,
 			"implementation",
 		);
-		assert.equal(classifyTaskMutationIntent("worker", "Update the source file").kind, "implementation");
-		assert.equal(classifyTaskMutationIntent("worker", "Update src/auth.ts").kind, "implementation");
-		assert.equal(classifyTaskMutationIntent("worker", "Update daily-update.mp3").kind, "implementation");
-		assert.equal(classifyTaskMutationIntent("worker", "Fix the bug in src/foo.ts").kind, "implementation");
+	});
+
+	it("keeps a real verb whose object is a filename", () => {
 		assert.equal(classifyTaskMutationIntent("worker", "Fix package.json").kind, "implementation");
-		assert.equal(classifyTaskMutationIntent("worker", "Patch package.json").kind, "implementation");
-		assert.equal(classifyTaskMutationIntent("worker", "Fix README.md").kind, "implementation");
+		assert.equal(classifyTaskMutationIntent("worker", "Update daily-update.mp3").kind, "implementation");
 		assert.equal(classifyTaskMutationIntent("delegate", "Update package.json").kind, "implementation");
 		assert.equal(classifyTaskMutationIntent("worker", "Review only; fix the package.json").kind, "implementation");
-		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests; render to artifacts/daily-update.mp3").kind, "read-only");
-		assert.equal(classifyTaskMutationIntent("worker", "Do not modify tests; render to artifacts/daily-update.mp3. Then implement the fix.").kind, "implementation");
 	});
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2039. The worker implementation matcher treated verbs inside artifact filenames (for example `daily-update.mp3`) as implementation requests because hyphens and slashes are word boundaries.

Path-like tokens are neutralized before implementation matching only when they contain an implementation verb. That keeps `Render … daily-update.mp3` from becoming implementation, while a real imperative whose object is a filename (`Fix package.json`, `Update package.json`) still wins. `taskMayMutate` / read-only acceptance is unchanged.

Rebased onto current `main` (includes #2073). Source and tests for this fix are unchanged from approved heads `b13ff1545b5d1e020b2916199e93768736f8211d` and `ef9e340b8fff626793c4300bd59b945dee09d0a3`.

Thanks to [@SiebertLanhove](https://github.com/SiebertLanhove) for #2039.

## Test plan

- [x] #2039 pair: `daily-briefing.mp3` and `daily-update.mp3` both classify as `unknown`
- [x] Later imperative after a filename still classifies as implementation
- [x] Filename-as-object cases: `Fix package.json`, `Update daily-update.mp3`, delegate `Update package.json`, `Review only; fix the package.json`
- [x] Changelog keeps current main Fixed lines (including #2073 / #2045) plus the #2039 entry once
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a36bd68e-cee5-4a82-988e-f6a2f9c4d341?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a36bd68e-cee5-4a82-988e-f6a2f9c4d341&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

