### PR TITLE
fix: fail closed when detached process-tree descendants remain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Do not report owned process-tree cleanup as `observed` when a detached descendant remains active after the owned process group exits. Thanks to [@rtbe](https://github.com/rtbe) for #2053.
 - Ignore verbs inside filenames and path-like tokens when classifying implementation intent, so artifact names such as `daily-update.mp3` do not create an implementation obligation. Thanks to [@SiebertLanhove](https://github.com/SiebertLanhove) for #2039.
 - Accept the boolean `fast` field on async recovery descriptors so a setting the writer persists can round-trip through follow-up. Thanks to [@isty2e](https://github.com/isty2e) for #2045.
 - Override `PI_PACKAGE_DIR` in detached runners with the detected npm Pi package root so npm runtime assets resolve from that package instead of an inherited host path. Thanks to [@alvarosevilla95](https://github.com/alvarosevilla95) for #2050.

--- a/src/runs/background/owned-process-tree.ts
+++ b/src/runs/background/owned-process-tree.ts
@@ -6,7 +6,6 @@ const DEFAULT_KILL_VERIFY_MS = 1000;
 const VERIFY_INTERVAL_MS = 25;
 
 type SignalResult = "sent" | "absent" | { diagnostic: string };
-type ProcessRow = { pid: number; ppid: number; pgid: number; stat: string };
 
 function diagnostic(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -22,89 +21,59 @@ function signalProcess(id: number, signal: NodeJS.Signals): SignalResult {
 	}
 }
 
-function readProcessTable(): ProcessRow[] | { diagnostic: string } {
-	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,stat="], { encoding: "utf-8" });
+function activeProcessGroupMembers(processGroupId: number): number[] | { diagnostic: string } {
+	const result = spawnSync("ps", ["-axo", "pid=,pgid=,stat="], { encoding: "utf-8" });
 	if (result.error || result.status !== 0) {
 		return { diagnostic: result.error ? diagnostic(result.error) : (result.stderr.trim() || `ps exited with ${result.status}`) };
 	}
-	const rows: ProcessRow[] = [];
-	for (const line of result.stdout.split("\n")) {
-		const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)/.exec(line);
-		if (!match) continue;
-		rows.push({ pid: Number(match[1]), ppid: Number(match[2]), pgid: Number(match[3]), stat: match[4]! });
-	}
-	return rows;
-}
-
-function childrenByParent(rows: ProcessRow[]): Map<number, ProcessRow[]> {
-	const children = new Map<number, ProcessRow[]>();
-	for (const row of rows) {
-		if (row.stat.startsWith("Z")) continue;
-		const siblings = children.get(row.ppid);
-		if (siblings) siblings.push(row);
-		else children.set(row.ppid, [row]);
-	}
-	return children;
-}
-
-function walkDescendants(rootPid: number, children: Map<number, ProcessRow[]>): ProcessRow[] {
-	const descendants: ProcessRow[] = [];
-	const seen = new Set<number>([rootPid]);
-	const queue = [rootPid];
-	for (let index = 0; index < queue.length; index++) {
-		for (const child of children.get(queue[index]!) ?? []) {
-			if (seen.has(child.pid)) continue;
-			seen.add(child.pid);
-			descendants.push(child);
-			queue.push(child.pid);
-		}
-	}
-	return descendants;
-}
-
-function activeProcessGroupMembers(rows: ProcessRow[], processGroupId: number): number[] {
 	const members: number[] = [];
-	for (const row of rows) {
-		if (row.pgid !== processGroupId || row.stat.startsWith("Z")) continue;
-		members.push(row.pid);
+	for (const line of result.stdout.split("\n")) {
+		const match = /^\s*(\d+)\s+(\d+)\s+(\S+)/.exec(line);
+		if (!match || Number(match[2]) !== processGroupId || match[3]!.startsWith("Z")) continue;
+		members.push(Number(match[1]));
 	}
 	return members;
 }
 
-function recordDetachedDescendants(rows: ProcessRow[], rootPid: number, processGroupId: number, detached: Set<number>): void {
-	const children = childrenByParent(rows);
-	for (const origin of [rootPid, ...detached]) {
-		for (const descendant of walkDescendants(origin, children)) {
-			if (descendant.pgid !== processGroupId) detached.add(descendant.pid);
-		}
+function processIsActive(pid: number): boolean {
+	const result = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf-8" });
+	return result.status === 0 && Boolean(result.stdout.trim()) && !result.stdout.trim().startsWith("Z");
+}
+
+function knownDetachedDescendants(processGroupId: number): number[] {
+	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,stat="], { encoding: "utf-8" });
+	if (result.error || result.status !== 0) return [];
+	const owned = new Set<number>();
+	const rows: { pid: number; ppid: number; pgid: number }[] = [];
+	for (const line of result.stdout.split("\n")) {
+		const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)/.exec(line);
+		if (!match || match[4]!.startsWith("Z")) continue;
+		const pid = Number(match[1]);
+		const ppid = Number(match[2]);
+		const pgid = Number(match[3]);
+		if (pgid === processGroupId) owned.add(pid);
+		rows.push({ pid, ppid, pgid });
 	}
-	const active = new Set(rows.filter((row) => !row.stat.startsWith("Z")).map((row) => row.pid));
-	for (const pid of [...detached]) {
-		if (!active.has(pid)) detached.delete(pid);
+	const detached: number[] = [];
+	for (const row of rows) {
+		if (owned.has(row.ppid) && row.pgid !== processGroupId) detached.push(row.pid);
 	}
+	return detached;
 }
 
 async function waitUntilGroupTerminal(
 	processGroupId: number,
 	timeoutMs: number,
-	observe: (rows: ProcessRow[]) => void,
 ): Promise<false | { state: "enumeration-failed" | "still-active"; diagnostic: string }> {
 	const deadline = Date.now() + timeoutMs;
 	while (true) {
-		const rows = readProcessTable();
-		if (Array.isArray(rows)) {
-			observe(rows);
-			const members = activeProcessGroupMembers(rows, processGroupId);
-			if (members.length === 0) return false;
-			const remaining = deadline - Date.now();
-			if (remaining <= 0) {
-				return { state: "still-active", diagnostic: `Process group ${processGroupId} still has active members: ${members.join(", ")}.` };
-			}
-			await new Promise<void>((resolve) => setTimeout(resolve, Math.min(VERIFY_INTERVAL_MS, remaining)));
-			continue;
-		}
+		const members = activeProcessGroupMembers(processGroupId);
+		if (Array.isArray(members) && members.length === 0) return false;
 		const remaining = deadline - Date.now();
-		if (remaining <= 0) return { state: "enumeration-failed", diagnostic: rows.diagnostic };
+		if (remaining <= 0) {
+			if (!Array.isArray(members)) return { state: "enumeration-failed", diagnostic: members.diagnostic };
+			return { state: "still-active", diagnostic: `Process group ${processGroupId} still has active members: ${members.join(", ")}.` };
+		}
 		await new Promise<void>((resolve) => setTimeout(resolve, Math.min(VERIFY_INTERVAL_MS, remaining)));
 	}
 }
@@ -113,14 +82,11 @@ function observed(processGroupId: number): ProcessTreeTerminal {
 	return { state: "observed", mechanism: "posix-process-group", processGroupId, verifiedAt: Date.now() };
 }
 
-function proveObserved(processGroupId: number, rootPid: number, detached: Set<number>): ProcessTreeTerminal {
-	const rows = readProcessTable();
-	if (Array.isArray(rows)) recordDetachedDescendants(rows, rootPid, processGroupId, detached);
-	const live = [...detached];
-	if (live.length > 0) {
-		return { state: "unknown", reason: "verification-failed", diagnostic: `Owned detached descendant(s) still active: ${live.join(", ")}.` };
-	}
-	return observed(processGroupId);
+function observedIfDetachedGone(processGroupId: number, detached: number[]): ProcessTreeTerminal {
+	if (detached.length === 0) return observed(processGroupId);
+	const live = detached.filter(processIsActive);
+	if (live.length === 0) return observed(processGroupId);
+	return { state: "unknown", reason: "verification-failed", diagnostic: `Owned detached descendant(s) still active: ${live.join(", ")}.` };
 }
 
 /** Owns one writer process group and arbitrates its cleanup exactly once. */
@@ -144,30 +110,26 @@ export function createOwnedProcessTreeController(
 				signalProcess(target, "SIGTERM");
 				return { state: "unknown", reason: "unsupported-platform" };
 			}
-			const detached = new Set<number>();
-			const observe = (rows: ProcessRow[]) => recordDetachedDescendants(rows, pid, pid, detached);
-			const snapshot = readProcessTable();
-			if (Array.isArray(snapshot)) observe(snapshot);
+			const detached = knownDetachedDescendants(pid);
 			const term = signalProcess(target, "SIGTERM");
 			if (term !== "sent" && term !== "absent") {
 				return { state: "unknown", reason: "signal-failed", diagnostic: term.diagnostic };
 			}
-			const termExit = await waitUntilGroupTerminal(pid, options.termGraceMs ?? DEFAULT_TERM_GRACE_MS, observe);
-			if (termExit === false) return proveObserved(pid, pid, detached);
+			const termExit = await waitUntilGroupTerminal(pid, options.termGraceMs ?? DEFAULT_TERM_GRACE_MS);
+			if (termExit === false) return observedIfDetachedGone(pid, detached);
 
 			const kill = signalProcess(target, "SIGKILL");
 			if (kill !== "sent" && kill !== "absent") {
-				const rows = readProcessTable();
-				if (!Array.isArray(rows) || activeProcessGroupMembers(rows, pid).length > 0) {
+				const members = activeProcessGroupMembers(pid);
+				if (!Array.isArray(members) || members.length > 0) {
 					return { state: "unknown", reason: "signal-failed", diagnostic: kill.diagnostic };
 				}
-				observe(rows);
 			}
-			const killExit = await waitUntilGroupTerminal(pid, options.killVerifyMs ?? DEFAULT_KILL_VERIFY_MS, observe);
+			const killExit = await waitUntilGroupTerminal(pid, options.killVerifyMs ?? DEFAULT_KILL_VERIFY_MS);
 			if (killExit !== false) {
 				return { state: "unknown", reason: "verification-failed", diagnostic: killExit.diagnostic };
 			}
-			return proveObserved(pid, pid, detached);
+			return observedIfDetachedGone(pid, detached);
 		})();
 		return termination;
 	};

--- a/src/runs/background/owned-process-tree.ts
+++ b/src/runs/background/owned-process-tree.ts
@@ -35,16 +35,11 @@ function activeProcessGroupMembers(processGroupId: number): number[] | { diagnos
 	return members;
 }
 
-function processIsActive(pid: number): boolean {
-	const result = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf-8" });
-	return result.status === 0 && Boolean(result.stdout.trim()) && !result.stdout.trim().startsWith("Z");
-}
-
 function knownDetachedDescendants(processGroupId: number): number[] {
 	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,stat="], { encoding: "utf-8" });
 	if (result.error || result.status !== 0) return [];
 	const owned = new Set<number>();
-	const rows: { pid: number; ppid: number; pgid: number }[] = [];
+	const outside: { pid: number; ppid: number }[] = [];
 	for (const line of result.stdout.split("\n")) {
 		const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)/.exec(line);
 		if (!match || match[4]!.startsWith("Z")) continue;
@@ -52,13 +47,9 @@ function knownDetachedDescendants(processGroupId: number): number[] {
 		const ppid = Number(match[2]);
 		const pgid = Number(match[3]);
 		if (pgid === processGroupId) owned.add(pid);
-		rows.push({ pid, ppid, pgid });
+		else outside.push({ pid, ppid });
 	}
-	const detached: number[] = [];
-	for (const row of rows) {
-		if (owned.has(row.ppid) && row.pgid !== processGroupId) detached.push(row.pid);
-	}
-	return detached;
+	return outside.filter((row) => owned.has(row.ppid)).map((row) => row.pid);
 }
 
 async function waitUntilGroupTerminal(
@@ -82,9 +73,11 @@ function observed(processGroupId: number): ProcessTreeTerminal {
 	return { state: "observed", mechanism: "posix-process-group", processGroupId, verifiedAt: Date.now() };
 }
 
-function observedIfDetachedGone(processGroupId: number, detached: number[]): ProcessTreeTerminal {
-	if (detached.length === 0) return observed(processGroupId);
-	const live = detached.filter(processIsActive);
+function observedUnlessLiveDetached(processGroupId: number, detached: readonly number[]): ProcessTreeTerminal {
+	const live = detached.filter((pid) => {
+		const result = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf-8" });
+		return result.status === 0 && Boolean(result.stdout.trim()) && !result.stdout.trim().startsWith("Z");
+	});
 	if (live.length === 0) return observed(processGroupId);
 	return { state: "unknown", reason: "verification-failed", diagnostic: `Owned detached descendant(s) still active: ${live.join(", ")}.` };
 }
@@ -116,7 +109,7 @@ export function createOwnedProcessTreeController(
 				return { state: "unknown", reason: "signal-failed", diagnostic: term.diagnostic };
 			}
 			const termExit = await waitUntilGroupTerminal(pid, options.termGraceMs ?? DEFAULT_TERM_GRACE_MS);
-			if (termExit === false) return observedIfDetachedGone(pid, detached);
+			if (termExit === false) return observedUnlessLiveDetached(pid, detached);
 
 			const kill = signalProcess(target, "SIGKILL");
 			if (kill !== "sent" && kill !== "absent") {
@@ -129,7 +122,7 @@ export function createOwnedProcessTreeController(
 			if (killExit !== false) {
 				return { state: "unknown", reason: "verification-failed", diagnostic: killExit.diagnostic };
 			}
-			return observedIfDetachedGone(pid, detached);
+			return observedUnlessLiveDetached(pid, detached);
 		})();
 		return termination;
 	};

--- a/src/runs/background/owned-process-tree.ts
+++ b/src/runs/background/owned-process-tree.ts
@@ -6,6 +6,7 @@ const DEFAULT_KILL_VERIFY_MS = 1000;
 const VERIFY_INTERVAL_MS = 25;
 
 type SignalResult = "sent" | "absent" | { diagnostic: string };
+type ProcessRow = { pid: number; ppid: number; pgid: number; stat: string };
 
 function diagnostic(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -21,39 +22,105 @@ function signalProcess(id: number, signal: NodeJS.Signals): SignalResult {
 	}
 }
 
-function activeProcessGroupMembers(processGroupId: number): number[] | { diagnostic: string } {
-	const result = spawnSync("ps", ["-axo", "pid=,pgid=,stat="], { encoding: "utf-8" });
+function readProcessTable(): ProcessRow[] | { diagnostic: string } {
+	const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,stat="], { encoding: "utf-8" });
 	if (result.error || result.status !== 0) {
 		return { diagnostic: result.error ? diagnostic(result.error) : (result.stderr.trim() || `ps exited with ${result.status}`) };
 	}
-	const members: number[] = [];
+	const rows: ProcessRow[] = [];
 	for (const line of result.stdout.split("\n")) {
-		const match = /^\s*(\d+)\s+(\d+)\s+(\S+)/.exec(line);
-		if (!match || Number(match[2]) !== processGroupId || match[3]!.startsWith("Z")) continue;
-		members.push(Number(match[1]));
+		const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)/.exec(line);
+		if (!match) continue;
+		rows.push({ pid: Number(match[1]), ppid: Number(match[2]), pgid: Number(match[3]), stat: match[4]! });
+	}
+	return rows;
+}
+
+function childrenByParent(rows: ProcessRow[]): Map<number, ProcessRow[]> {
+	const children = new Map<number, ProcessRow[]>();
+	for (const row of rows) {
+		if (row.stat.startsWith("Z")) continue;
+		const siblings = children.get(row.ppid);
+		if (siblings) siblings.push(row);
+		else children.set(row.ppid, [row]);
+	}
+	return children;
+}
+
+function walkDescendants(rootPid: number, children: Map<number, ProcessRow[]>): ProcessRow[] {
+	const descendants: ProcessRow[] = [];
+	const seen = new Set<number>([rootPid]);
+	const queue = [rootPid];
+	for (let index = 0; index < queue.length; index++) {
+		for (const child of children.get(queue[index]!) ?? []) {
+			if (seen.has(child.pid)) continue;
+			seen.add(child.pid);
+			descendants.push(child);
+			queue.push(child.pid);
+		}
+	}
+	return descendants;
+}
+
+function activeProcessGroupMembers(rows: ProcessRow[], processGroupId: number): number[] {
+	const members: number[] = [];
+	for (const row of rows) {
+		if (row.pgid !== processGroupId || row.stat.startsWith("Z")) continue;
+		members.push(row.pid);
 	}
 	return members;
+}
+
+function recordDetachedDescendants(rows: ProcessRow[], rootPid: number, processGroupId: number, detached: Set<number>): void {
+	const children = childrenByParent(rows);
+	for (const origin of [rootPid, ...detached]) {
+		for (const descendant of walkDescendants(origin, children)) {
+			if (descendant.pgid !== processGroupId) detached.add(descendant.pid);
+		}
+	}
+	const active = new Set(rows.filter((row) => !row.stat.startsWith("Z")).map((row) => row.pid));
+	for (const pid of [...detached]) {
+		if (!active.has(pid)) detached.delete(pid);
+	}
 }
 
 async function waitUntilGroupTerminal(
 	processGroupId: number,
 	timeoutMs: number,
+	observe: (rows: ProcessRow[]) => void,
 ): Promise<false | { state: "enumeration-failed" | "still-active"; diagnostic: string }> {
 	const deadline = Date.now() + timeoutMs;
 	while (true) {
-		const members = activeProcessGroupMembers(processGroupId);
-		if (Array.isArray(members) && members.length === 0) return false;
-		const remaining = deadline - Date.now();
-		if (remaining <= 0) {
-			if (!Array.isArray(members)) return { state: "enumeration-failed", diagnostic: members.diagnostic };
-			return { state: "still-active", diagnostic: `Process group ${processGroupId} still has active members: ${members.join(", ")}.` };
+		const rows = readProcessTable();
+		if (Array.isArray(rows)) {
+			observe(rows);
+			const members = activeProcessGroupMembers(rows, processGroupId);
+			if (members.length === 0) return false;
+			const remaining = deadline - Date.now();
+			if (remaining <= 0) {
+				return { state: "still-active", diagnostic: `Process group ${processGroupId} still has active members: ${members.join(", ")}.` };
+			}
+			await new Promise<void>((resolve) => setTimeout(resolve, Math.min(VERIFY_INTERVAL_MS, remaining)));
+			continue;
 		}
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) return { state: "enumeration-failed", diagnostic: rows.diagnostic };
 		await new Promise<void>((resolve) => setTimeout(resolve, Math.min(VERIFY_INTERVAL_MS, remaining)));
 	}
 }
 
 function observed(processGroupId: number): ProcessTreeTerminal {
 	return { state: "observed", mechanism: "posix-process-group", processGroupId, verifiedAt: Date.now() };
+}
+
+function proveObserved(processGroupId: number, rootPid: number, detached: Set<number>): ProcessTreeTerminal {
+	const rows = readProcessTable();
+	if (Array.isArray(rows)) recordDetachedDescendants(rows, rootPid, processGroupId, detached);
+	const live = [...detached];
+	if (live.length > 0) {
+		return { state: "unknown", reason: "verification-failed", diagnostic: `Owned detached descendant(s) still active: ${live.join(", ")}.` };
+	}
+	return observed(processGroupId);
 }
 
 /** Owns one writer process group and arbitrates its cleanup exactly once. */
@@ -77,25 +144,30 @@ export function createOwnedProcessTreeController(
 				signalProcess(target, "SIGTERM");
 				return { state: "unknown", reason: "unsupported-platform" };
 			}
+			const detached = new Set<number>();
+			const observe = (rows: ProcessRow[]) => recordDetachedDescendants(rows, pid, pid, detached);
+			const snapshot = readProcessTable();
+			if (Array.isArray(snapshot)) observe(snapshot);
 			const term = signalProcess(target, "SIGTERM");
 			if (term !== "sent" && term !== "absent") {
 				return { state: "unknown", reason: "signal-failed", diagnostic: term.diagnostic };
 			}
-			const termExit = await waitUntilGroupTerminal(pid, options.termGraceMs ?? DEFAULT_TERM_GRACE_MS);
-			if (termExit === false) return observed(pid);
+			const termExit = await waitUntilGroupTerminal(pid, options.termGraceMs ?? DEFAULT_TERM_GRACE_MS, observe);
+			if (termExit === false) return proveObserved(pid, pid, detached);
 
 			const kill = signalProcess(target, "SIGKILL");
 			if (kill !== "sent" && kill !== "absent") {
-				const members = activeProcessGroupMembers(pid);
-				if (!Array.isArray(members) || members.length > 0) {
+				const rows = readProcessTable();
+				if (!Array.isArray(rows) || activeProcessGroupMembers(rows, pid).length > 0) {
 					return { state: "unknown", reason: "signal-failed", diagnostic: kill.diagnostic };
 				}
+				observe(rows);
 			}
-			const killExit = await waitUntilGroupTerminal(pid, options.killVerifyMs ?? DEFAULT_KILL_VERIFY_MS);
+			const killExit = await waitUntilGroupTerminal(pid, options.killVerifyMs ?? DEFAULT_KILL_VERIFY_MS, observe);
 			if (killExit !== false) {
 				return { state: "unknown", reason: "verification-failed", diagnostic: killExit.diagnostic };
 			}
-			return observed(pid);
+			return proveObserved(pid, pid, detached);
 		})();
 		return termination;
 	};

--- a/src/runs/shared/external-cli-runner.ts
+++ b/src/runs/shared/external-cli-runner.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { finished } from "node:stream/promises";
-import type { ExternalProcessStatus } from "../../shared/types.ts";
+import type { ExternalProcessStatus, ProcessTreeTerminal } from "../../shared/types.ts";
 import { createOwnedProcessTreeController, type OwnedProcessTreeController } from "../background/owned-process-tree.ts";
 import { omitExtensionBindingsEnv } from "./extension-bindings.ts";
 import {
@@ -141,7 +141,7 @@ function classifyInvalidation(error: string): "auth" | "permission" | "launch" {
 	return "launch";
 }
 
-function terminateExternalProcessTree(pid: number, controller: OwnedProcessTreeController): Promise<unknown> {
+function terminateExternalProcessTree(pid: number, controller: OwnedProcessTreeController): Promise<ProcessTreeTerminal> {
 	if (process.platform !== "win32") return controller.terminate();
 	return new Promise((resolve) => {
 		const cleanup = spawn("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
@@ -239,7 +239,7 @@ export function runExternalCli(input: {
 		let settled = false;
 		let processTree: OwnedProcessTreeController | undefined;
 		let processPid: number | undefined;
-		let termination: Promise<unknown> | undefined;
+		let termination: Promise<ProcessTreeTerminal> | undefined;
 		const flushProgress = () => {
 			if (!latestProgress) return;
 			input.onParserProgress?.(latestProgress);
@@ -381,8 +381,7 @@ export function runExternalCli(input: {
 			input.registerTimeout?.(undefined);
 			input.registerStop?.(undefined);
 			void (async () => {
-				if (termination) await termination;
-				else if (processTree) await processTree.finishAfterWriterClose();
+				const treeProof = termination ? await termination : processTree ? await processTree.finishAfterWriterClose() : undefined;
 				const endedAt = Date.now();
 				const externalProcess: ExternalProcessStatus = {
 					...initialProcess,
@@ -398,15 +397,18 @@ export function runExternalCli(input: {
 				input.onProcess?.(externalProcess);
 				const stderr = stderrTail.text().trim();
 				const parserFailure = parserError?.message ?? (parserTerminal?.state === "failed" ? parserTerminal.error ?? "External CLI parser reported terminal failure." : undefined);
+				const treeFailure = process.platform !== "win32" && treeProof?.state === "unknown"
+					? `Process-tree cleanup failed: ${treeProof.reason}.`
+					: undefined;
 				const error = stopped
 					? input.stopMessage ?? "Subagent stopped by user."
 					: timedOut
 						? input.timeoutMessage ?? "Subagent timed out."
-						: spawnError?.message ?? parserFailure ?? (exitCode === 0 ? undefined : stderr || `External CLI exited with code ${exitCode}.`);
+						: spawnError?.message ?? parserFailure ?? treeFailure ?? (exitCode === 0 ? undefined : stderr || `External CLI exited with code ${exitCode}.`);
 				if (error && input.preflight && !parserError) invalidateExternalCliPreflight(input.command, input.preflight, classifyInvalidation(error));
 				const result: ExternalCliRunResult = {
 					output: (!parserError && parserTerminal?.state === "completed" ? parserTerminal.output ?? "" : stdoutTail.text()).trim(),
-					exitCode: timedOut || stopped || spawnError || parserFailure ? 1 : exitCode,
+					exitCode: timedOut || stopped || spawnError || parserFailure || treeFailure ? 1 : exitCode,
 					...(error ? { error } : {}),
 					...(timedOut ? { timedOut: true } : {}),
 					...(stopped ? { stopped: true } : {}),

--- a/test/unit/owned-process-tree.test.ts
+++ b/test/unit/owned-process-tree.test.ts
@@ -78,7 +78,6 @@ test("owned process tree kills descendants and verifies a TERM-resistant POSIX g
 });
 
 test("owned process tree does not claim observed while a detached descendant remains", { skip: process.platform === "win32" }, async () => {
-	const unrelated = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore" });
 	const writer = spawn(process.execPath, ["-e", `
 		const { spawn } = require("node:child_process");
 		const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore" });
@@ -86,27 +85,21 @@ test("owned process tree does not claim observed while a detached descendant rem
 		setInterval(() => {}, 1000);
 	`], { detached: true, stdio: ["ignore", "pipe", "ignore"] });
 	assert.ok(writer.pid);
-	assert.ok(unrelated.pid);
 	const grandchildPid = await new Promise<number>((resolve, reject) => {
 		writer.once("error", reject);
 		writer.stdout!.once("data", (chunk) => resolve(Number(String(chunk).trim())));
 	});
 	try {
-		for (let attempt = 0; attempt < 50 && !processIsActive(grandchildPid); attempt += 1) {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-		}
-		assert.equal(processIsActive(grandchildPid), true);
 		const proof = await createOwnedProcessTreeController(writer.pid, { termGraceMs: 50, killVerifyMs: 1000 }).terminate();
-		assert.equal(proof.state, "unknown", JSON.stringify(proof));
-		if (proof.state !== "unknown") throw new Error("expected unverified process-tree proof");
-		assert.equal(proof.reason, "verification-failed");
-		assert.match(proof.diagnostic ?? "", /detached descendant/);
+		assert.deepEqual(
+			{ state: proof.state, reason: proof.state === "unknown" ? proof.reason : undefined },
+			{ state: "unknown", reason: "verification-failed" },
+			JSON.stringify(proof),
+		);
 		assert.equal(processIsActive(writer.pid), false);
 		assert.equal(processIsActive(grandchildPid), true);
-		assert.equal(processIsActive(unrelated.pid), true);
 	} finally {
 		killProcessGroup(grandchildPid);
-		killProcessGroup(unrelated.pid);
 		killProcessGroup(writer.pid);
 	}
 });

--- a/test/unit/owned-process-tree.test.ts
+++ b/test/unit/owned-process-tree.test.ts
@@ -11,6 +11,15 @@ function processIsActive(pid: number): boolean {
 	return result.status === 0 && Boolean(result.stdout.trim()) && !result.stdout.trim().startsWith("Z");
 }
 
+function killProcessGroup(pid: number | undefined): void {
+	if (!pid) return;
+	try {
+		process.kill(-pid, "SIGKILL");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+	}
+}
+
 test("owned process tree fails closed when process-group ownership is unsupported", { skip: process.platform !== "win32" }, async () => {
 	const proof = await createOwnedProcessTreeController(999_999).terminate();
 	assert.deepEqual(proof, { state: "unknown", reason: "unsupported-platform" });
@@ -65,5 +74,39 @@ test("owned process tree kills descendants and verifies a TERM-resistant POSIX g
 		delete process.env.PI_TEST_PS_MARKER;
 		delete process.env.PI_TEST_REAL_PS;
 		fs.rmSync(fixtureDir, { recursive: true, force: true });
+	}
+});
+
+test("owned process tree does not claim observed while a detached descendant remains", { skip: process.platform === "win32" }, async () => {
+	const unrelated = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore" });
+	const writer = spawn(process.execPath, ["-e", `
+		const { spawn } = require("node:child_process");
+		const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore" });
+		process.stdout.write(String(child.pid) + "\\n");
+		setInterval(() => {}, 1000);
+	`], { detached: true, stdio: ["ignore", "pipe", "ignore"] });
+	assert.ok(writer.pid);
+	assert.ok(unrelated.pid);
+	const grandchildPid = await new Promise<number>((resolve, reject) => {
+		writer.once("error", reject);
+		writer.stdout!.once("data", (chunk) => resolve(Number(String(chunk).trim())));
+	});
+	try {
+		for (let attempt = 0; attempt < 50 && !processIsActive(grandchildPid); attempt += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+		assert.equal(processIsActive(grandchildPid), true);
+		const proof = await createOwnedProcessTreeController(writer.pid, { termGraceMs: 50, killVerifyMs: 1000 }).terminate();
+		assert.equal(proof.state, "unknown", JSON.stringify(proof));
+		if (proof.state !== "unknown") throw new Error("expected unverified process-tree proof");
+		assert.equal(proof.reason, "verification-failed");
+		assert.match(proof.diagnostic ?? "", /detached descendant/);
+		assert.equal(processIsActive(writer.pid), false);
+		assert.equal(processIsActive(grandchildPid), true);
+		assert.equal(processIsActive(unrelated.pid), true);
+	} finally {
+		killProcessGroup(grandchildPid);
+		killProcessGroup(unrelated.pid);
+		killProcessGroup(writer.pid);
 	}
 });

--- a/test/unit/owned-process-tree.test.ts
+++ b/test/unit/owned-process-tree.test.ts
@@ -11,15 +11,6 @@ function processIsActive(pid: number): boolean {
 	return result.status === 0 && Boolean(result.stdout.trim()) && !result.stdout.trim().startsWith("Z");
 }
 
-function killProcessGroup(pid: number | undefined): void {
-	if (!pid) return;
-	try {
-		process.kill(-pid, "SIGKILL");
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
-	}
-}
-
 test("owned process tree fails closed when process-group ownership is unsupported", { skip: process.platform !== "win32" }, async () => {
 	const proof = await createOwnedProcessTreeController(999_999).terminate();
 	assert.deepEqual(proof, { state: "unknown", reason: "unsupported-platform" });
@@ -91,15 +82,14 @@ test("owned process tree does not claim observed while a detached descendant rem
 	});
 	try {
 		const proof = await createOwnedProcessTreeController(writer.pid, { termGraceMs: 50, killVerifyMs: 1000 }).terminate();
-		assert.deepEqual(
-			{ state: proof.state, reason: proof.state === "unknown" ? proof.reason : undefined },
-			{ state: "unknown", reason: "verification-failed" },
-			JSON.stringify(proof),
-		);
+		assert.equal(proof.state, "unknown", JSON.stringify(proof));
 		assert.equal(processIsActive(writer.pid), false);
 		assert.equal(processIsActive(grandchildPid), true);
 	} finally {
-		killProcessGroup(grandchildPid);
-		killProcessGroup(writer.pid);
+		for (const pid of [grandchildPid, writer.pid]) {
+			try { process.kill(-pid, "SIGKILL"); } catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+			}
+		}
 	}
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Maintainer PR for #2053 on current `main`. Credit [@rtbe](https://github.com/rtbe) for the report and reproduction.

## Vision

From VISION.md:

> Completion needs evidence: concrete outputs, changed files where change was expected, validation results, or an explicit blocked state.
> When behavior cannot be proven, the system fails closed instead of reporting optimistic success.

Unproven process-tree cleanup must fail closed instead of reporting optimistic `observed` success.

## Problem

`createOwnedProcessTreeController().terminate()` signaled and verified one POSIX process group, then returned `state: "observed"` even when a descendant launched with `detached: true` was still alive. That descendant is a different process group, so group-only verification does not cover it. Callers could treat `observed` as complete subprocess cleanup.

## Contract

- Owned detached descendants must not survive while the result claims `observed` cleanup.
- Either verify their termination, or report that their termination is unverified. Do not treat `observed` as proof that all owned subprocesses stopped.
- Do not signal unrelated process groups.
- Cover the detached-descendant case next to the existing same-group regression. One distinct behavior per test.

## Change

- Same-group cleanup stays on the original group wait path. No second supervisor, and no process-tree walker during group polls.
- One lookup, before signaling, records children of the owned group that already have a different PGID.
- After the owned group is empty, return `observed` when none were recorded or they have exited. Return `unknown` / `verification-failed` only when a known detached descendant is still active.
- Signal only the owned process group (`-pid`). Detached groups are not signaled.
- External CLI no longer reports success when process-tree proof is `unknown`. Host commands and worktree setup already fail closed on `unknown`; they are unchanged.
- Nested-agent settlement is untouched. This does not widen default-deny nested subagent grants or redesign the process supervisor.

## Validation

- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/owned-process-tree.test.ts test/unit/host-command.test.ts test/unit/external-cli-runner.test.ts test/unit/process-terminal.test.ts`
- `npx tsc --noEmit`
- Issue reproduction: same-group descendant → `observed`; detached descendant → `unknown` while the descendant remains alive

Closes #2053.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f94f99d-f808-41ec-8ff4-4e3c493faf3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f94f99d-f808-41ec-8ff4-4e3c493faf3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

