### PR TITLE
feat(watchdog): support bounded model fallback chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add opt-in watchdog `fallbackModels` for main, children, and per-agent overrides, retrying provider failures only before tool work within the existing review deadline. Thanks to [@dwizzle204](https://github.com/dwizzle204) for #2075.
 - Add portable Inspect commands and a terminal-neutral plugin seam, including open-only Ghostty 1.3+ right splits on macOS. Thanks to [@tiratatp](https://github.com/tiratatp) for #2046.
 - Add an opt-in `quiet: true` flag for recurring `schedule.create`. A quiet schedule's successful automatic runs and successful workflow children keep their completion notices but no longer trigger a parent turn; failed, stopped, or paused outcomes still wake the session. One-shot `at` schedules and `schedule.run` stay noisy unless that launch passes `quiet: true`. Default behavior is unchanged. Thanks to [@pablontiv](https://github.com/pablontiv) for #2055.
 - Add opt-in `orcaProgressTabs.autoCloseDelaySec` to close Orca observer tabs after a successful run. Thanks to [@G0-0000](https://github.com/G0-0000) for #2063.

--- a/docs/watchdog.md
+++ b/docs/watchdog.md
@@ -106,6 +106,10 @@ The recommendation is Opus 4.8 or GPT 5.5 at thinking high, whichever your main 
 
 Omit `main.model` to inherit the session model and thinking level. A `main.model` without a thinking suffix or `main.thinking` runs with thinking off, so prefer `:high` for the strong pairing.
 
+Set `fallbackModels` in JSON settings on `main`, `children`, or `children.overrides.<agent>` to opt into an ordered fallback chain, for example `"fallbackModels": ["openai-codex/gpt-5.5:high"]`. Child overrides win over `children.fallbackModels`; neither inherits the main watchdog's chain. Arrays replace across user → project → session settings, and `[]` clears an inherited chain. Status shows configured chains.
+
+Unavailable configured candidates are skipped and resolved duplicates are tried once. Each attempt uses a fresh reviewer with its own model auth, provider stream, and thinking; an inherited primary keeps the actual session model/thinking, while fallbacks use explicit-model thinking rules. Fallback follows normal subagent provider-failure semantics (including rate limits, quota, auth, unavailability, and provider timeouts), **only before any tool work**, including read-only inspection. Clean/normal completion, length limits, findings, clarification, cancellation, and the overall watchdog deadline never trigger fallback. All attempts share the original deadline; exhaustion remains a failed review. With no fallback chain, existing single-model behavior is unchanged.
+
 Agents can call `subagent({ action: "watchdog.recommend-model" })` and `subagent({ action: "watchdog.configure", model: "recommended", scope: "session" | "user" | "project" })`. They should use `scope: "session"` unless you ask for a lasting default.
 
 ## Optional main-session clarification
@@ -134,7 +138,7 @@ Reviews retain the existing `agentEndTimeoutMs`. Questions and evidence are capp
 
 ## Child watchdogs
 
-Opt in under `subagents.watchdog.children`. `model` and `thinking` set the default child watchdog; `overrides.<agent>` can set `model`, `thinking`, `enabled`, or `cadence` per role.
+Opt in under `subagents.watchdog.children`. `model`, `fallbackModels`, and `thinking` set the default child watchdog; `overrides.<agent>` can set `model`, `fallbackModels`, `thinking`, `enabled`, or `cadence` per role.
 
 ## Launch rules
 

--- a/src/watchdog/child-status.ts
+++ b/src/watchdog/child-status.ts
@@ -16,6 +16,7 @@ export interface ChildWatchdogConfig {
 	agentEndTimeoutMs: number;
 	maxWarnings: number | null;
 	model?: string;
+	fallbackModels?: string[];
 	thinking?: string | false;
 	lsp: WatchdogLspConfig;
 	stalemateRepeats: number;
@@ -47,6 +48,7 @@ export function resolveChildWatchdogConfig(input: {
 	const enabled = input.config.enabled && (override?.enabled ?? input.config.children.enabled);
 	if (!enabled) return undefined;
 	const model = override?.model ?? input.config.children.model;
+	const fallbackModels = override?.fallbackModels ?? input.config.children.fallbackModels;
 	const thinking = override?.thinking ?? input.config.children.thinking;
 	const cadence = override?.cadence ?? input.config.children.cadence ?? input.config.cadence;
 	return {
@@ -57,6 +59,7 @@ export function resolveChildWatchdogConfig(input: {
 		agentEndTimeoutMs: input.config.agentEndTimeoutMs,
 		maxWarnings: input.config.maxWarnings,
 		...(model ? { model } : {}),
+		...(fallbackModels !== undefined ? { fallbackModels: [...fallbackModels] } : {}),
 		...(thinking !== undefined ? { thinking } : {}),
 		lsp: { ...input.config.lsp },
 		stalemateRepeats: input.config.stalemateRepeats,
@@ -137,6 +140,10 @@ export function decodeChildWatchdogConfig(raw: string | undefined): ChildWatchdo
 	const agent = childConfigOptionalString(parsed, "agent");
 	const childIndex = childConfigOptionalIndex(parsed, "childIndex");
 	const model = childConfigOptionalString(parsed, "model");
+	const fallbackModels = parsed.fallbackModels;
+	if (fallbackModels !== undefined && (!Array.isArray(fallbackModels) || fallbackModels.some((value) => typeof value !== "string" || !value.trim()))) {
+		throw new Error("Invalid child watchdog config: fallbackModels must be an array of non-empty strings.");
+	}
 	return {
 		...(runId ? { runId } : {}),
 		...(agent ? { agent } : {}),
@@ -145,6 +152,7 @@ export function decodeChildWatchdogConfig(raw: string | undefined): ChildWatchdo
 		agentEndTimeoutMs: childConfigPositiveInteger(parsed, "agentEndTimeoutMs"),
 		maxWarnings: childConfigNullableNonNegativeInteger(parsed, "maxWarnings"),
 		...(model ? { model } : {}),
+		...(fallbackModels !== undefined ? { fallbackModels: (fallbackModels as string[]).map((value) => value.trim()) } : {}),
 		...(thinking !== undefined ? { thinking: thinking as string | false } : {}),
 		lsp: childConfigLsp(parsed.lsp),
 		stalemateRepeats: childConfigPositiveInteger(parsed, "stalemateRepeats"),

--- a/src/watchdog/register-child.ts
+++ b/src/watchdog/register-child.ts
@@ -21,6 +21,7 @@ export function childResolvedConfig(config: ChildWatchdogConfig): ResolvedWatchd
 		main: {
 			enabled: true,
 			...(config.model ? { model: config.model } : {}),
+			...(config.fallbackModels !== undefined ? { fallbackModels: [...config.fallbackModels] } : {}),
 			...(config.thinking !== undefined ? { thinking: config.thinking } : {}),
 		},
 		stalemateRepeats: config.stalemateRepeats,

--- a/src/watchdog/register-main.ts
+++ b/src/watchdog/register-main.ts
@@ -63,11 +63,16 @@ function mainThinkingLine(snapshot: ReturnType<MainWatchdogRuntime["getSnapshot"
 }
 
 function mainModelLine(snapshot: ReturnType<MainWatchdogRuntime["getSnapshot"]>, ctx: ExtensionContext): string {
+	const fallbacks = fallbackLine(snapshot.config.main.fallbackModels);
 	if (snapshot.config.main.model) {
 		const source = snapshot.sessionModelOverride?.model ? "session override" : "configured";
-		return `Main model: ${splitKnownThinkingSuffix(snapshot.config.main.model).baseModel} (${source})`;
+		return `Main model: ${splitKnownThinkingSuffix(snapshot.config.main.model).baseModel} (${source})${fallbacks}`;
 	}
-	return `Main model: ${currentSessionModelLine(ctx)}`;
+	return `Main model: ${currentSessionModelLine(ctx)}${fallbacks}`;
+}
+
+function fallbackLine(models: string[] | undefined): string {
+	return models === undefined ? "" : ` · fallbacks ${models.length ? models.join(" → ") : "none"}`;
 }
 
 function childrenLine(snapshot: ReturnType<MainWatchdogRuntime["getSnapshot"]>): string {
@@ -80,11 +85,12 @@ function childrenLine(snapshot: ReturnType<MainWatchdogRuntime["getSnapshot"]>):
 			const bits = [agent];
 			if (override.enabled !== undefined) bits.push(boolLabel(override.enabled));
 			if (override.model) bits.push(splitKnownThinkingSuffix(override.model).baseModel);
+			if (override.fallbackModels !== undefined) bits.push(fallbackLine(override.fallbackModels));
 			if (override.thinking !== undefined) bits.push(`thinking ${override.thinking === false ? "off" : override.thinking}`);
 			return bits.join(" ");
 		}).join("; ")}`
 		: "";
-	return `Children: ${boolLabel(snapshot.config.enabled && children.enabled)} · model ${model} · thinking ${thinking}${overrideText}`;
+	return `Children: ${boolLabel(snapshot.config.enabled && children.enabled)} · model ${model}${fallbackLine(children.fallbackModels)} · thinking ${thinking}${overrideText}`;
 }
 
 function recommendationLine(ctx: ExtensionContext): string {

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -3,7 +3,7 @@ import { createReadOnlyTools, convertToLlm, type ExtensionContext } from "@earen
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { Model, ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
-import { buildModelCandidates, isRetryableModelFailureAttempt, resolveModelCandidate } from "../runs/shared/model-fallback.ts";
+import { buildModelCandidates, isContextOverflow, isRetryableModelFailureAttempt, resolveModelCandidate } from "../runs/shared/model-fallback.ts";
 import { agentStreamOptions } from "../shared/agent-stream-options.ts";
 import { opencodeSessionHeaders } from "../shared/opencode-session-headers.ts";
 import { resolveEffectiveThinking, splitKnownThinkingSuffix, THINKING_LEVELS, toModelInfo } from "../shared/model-info.ts";
@@ -272,7 +272,7 @@ export function createMainWatchdogReview(provider: WatchdogContextProvider, opti
 			} catch (error) {
 				if (aborted()) return { stopReason: "aborted" };
 				if (!(error instanceof WatchdogAuthError)) throw error;
-				if (!isRetryableModelFailureAttempt({ error: error.message }) || index === candidates.length - 1) throw error.cause ?? error;
+				if (isContextOverflow(error.message) || !isRetryableModelFailureAttempt({ error: error.message }) || index === candidates.length - 1) throw error.cause ?? error;
 			}
 		}
 		throw new Error("No usable watchdog model candidates.");
@@ -374,6 +374,6 @@ async function runWatchdogAttempt(ctx: ExtensionContext, request: WatchdogReview
 	const error = terminal && "errorMessage" in terminal && typeof terminal.errorMessage === "string" ? terminal.errorMessage : undefined;
 	return {
 		result: clarification ? { clarification } : { stopReason },
-		retryable: !clarification && stopReason === "error" && isRetryableModelFailureAttempt({ error, messages: agent.state.messages, toolCount }),
+		retryable: !clarification && stopReason === "error" && !isContextOverflow(error) && isRetryableModelFailureAttempt({ error, messages: agent.state.messages, toolCount }),
 	};
 }

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -3,7 +3,7 @@ import { createReadOnlyTools, convertToLlm, type ExtensionContext } from "@earen
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import type { Model, ProviderHeaders } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
-import { resolveModelCandidate } from "../runs/shared/model-fallback.ts";
+import { buildModelCandidates, isRetryableModelFailureAttempt, resolveModelCandidate } from "../runs/shared/model-fallback.ts";
 import { agentStreamOptions } from "../shared/agent-stream-options.ts";
 import { opencodeSessionHeaders } from "../shared/opencode-session-headers.ts";
 import { resolveEffectiveThinking, splitKnownThinkingSuffix, THINKING_LEVELS, toModelInfo } from "../shared/model-info.ts";
@@ -117,9 +117,16 @@ function resolveConfiguredModel(ctx: ExtensionContext, rawModel: string): { mode
 	return { model, modelString: resolved };
 }
 
+class WatchdogAuthError extends Error {}
+
 async function resolveReviewAuth(ctx: ExtensionContext, model: RegistryModel): Promise<WatchdogReviewAuth> {
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-	if (auth.ok === false) throw new Error(`Watchdog model auth failed for ${fullModelId(model)}: ${auth.error}`);
+	let auth;
+	try {
+		auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	} catch (error) {
+		throw new WatchdogAuthError(`Watchdog model auth failed for ${fullModelId(model)}: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+	}
+	if (auth.ok === false) throw new WatchdogAuthError(`Watchdog model auth failed for ${fullModelId(model)}: ${auth.error}`);
 	return {
 		...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
 		...(auth.headers ? { headers: auth.headers } : {}),
@@ -239,18 +246,6 @@ function buildReviewPrompt(request: WatchdogReviewRequest, selection: WatchdogRe
 	].join("\n\n");
 }
 
-function finalStopReason(agent: Agent): "stop" | "error" | "aborted" | "length" {
-	for (let index = agent.state.messages.length - 1; index >= 0; index--) {
-		const message = agent.state.messages[index];
-		if (message && typeof message === "object" && (message as { role?: unknown }).role === "assistant") {
-			const stopReason = (message as { stopReason?: unknown }).stopReason;
-			if (stopReason === "error" || stopReason === "aborted" || stopReason === "length") return stopReason;
-			return "stop";
-		}
-	}
-	return "stop";
-}
-
 function resolveContext(provider: WatchdogContextProvider): ExtensionContext | undefined {
 	return typeof provider === "function" ? provider() : provider;
 }
@@ -259,89 +254,126 @@ export function createMainWatchdogReview(provider: WatchdogContextProvider, opti
 	return async (request) => {
 		const ctx = resolveContext(provider);
 		if (!ctx) throw new Error("Main watchdog review cannot run without an active Pi extension context.");
-		if (ctx.signal?.aborted || request.signal?.aborted) return { stopReason: "aborted" };
-		const selection = await resolveWatchdogReviewModel(ctx, request.config, {
-			currentThinkingLevel: options.getThinkingLevel?.(),
-		});
-		if (ctx.signal?.aborted || request.signal?.aborted) return { stopReason: "aborted" };
-		const auth = selection.auth;
-		const registeredProvider = (ctx.modelRegistry as {
-			getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
-		}).getRegisteredProviderConfig?.(selection.model.provider);
-		const baseStreamFn = options.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === selection.model.api
-			? registeredProvider.streamSimple
-			: streamSimple);
-		const sessionId = ctx.sessionManager.getSessionId();
-		const streamFn: StreamFn = (model, context, streamOptions) => {
-			// Agent may enter one final loop iteration after an aborted mixed tool batch.
-			// Never send that iteration to the provider after an intentional yield.
-			if (clarification) throw new Error("Watchdog review yielded for clarification.");
-			return baseStreamFn(model, context, {
-				...streamOptions,
-				...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
-				env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
-				headers: { ...opencodeSessionHeaders(model, sessionId), ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
-			});
-		};
-		const diffBaseline = options.diffBaseline?.();
-		let clarification: { question: string; evidence: string } | undefined;
-		let warned = false;
-		const warnRequest = request.allowClarification ? { ...request, emitWarning: (warning: WatchdogWarning) => {
-			if (clarification) return false;
-			const accepted = request.emitWarning(warning);
-			warned ||= accepted;
-			return accepted;
-		} } : request;
-		const tools = [
-			...(options.createReadOnlyTools ?? createReadOnlyTools)(ctx.cwd).filter((tool) => WATCHDOG_ALLOWED_TOOL_NAMES.has(tool.name) && tool.name !== "watchdog_warn"),
-			createWatchdogWarnTool(warnRequest),
-			...(diffBaseline ? [createWatchdogDiffTool(diffBaseline)] : []),
-		];
-		if (request.allowClarification) tools.push({
-			name: "watchdog_ask",
-			label: "Watchdog clarification",
-			description: "Send one focused question when missing task status, intent or other orchestrator context prevents a concrete review judgment. Yields and ends this review so the orchestrator can handle the message and continue; no answer or follow-up review is required. Never ask for approval or permission, or after recording a warning. Question and evidence are capped at 1000 and 2000 characters.",
-			parameters: WatchdogAskParams,
-			executionMode: "sequential",
-			async execute(_id, rawParams) {
-				const params = rawParams as Static<typeof WatchdogAskParams>;
-				if (warned || clarification || ctx.signal?.aborted || request.signal?.aborted) throw new Error("Clarification unavailable after warning, yield, or cancellation.");
-				if (!params.question.trim() || !params.evidence.trim()) throw new Error("A focused question and concrete evidence are required.");
-				clarification = { question: boundWatchdogReviewText(params.question.trim(), 1_000), evidence: boundWatchdogReviewText(params.evidence.trim(), 2_000) };
-				agent.abort(); // Intentional yield also stops mixed tool batches; terminate alone does not.
-				return { content: [{ type: "text", text: "Review yielded for clarification." }], details: {} };
-			},
-		});
-		const agent = new Agent({
-			initialState: {
-				systemPrompt: buildWatchdogSystemPrompt(ctx, {
-					hasScope: request.hasScope,
-					guidance: loadWatchdogGuidance(ctx.cwd, request.config.guidance.watchdogMd),
-					hasDiff: diffBaseline !== undefined,
-				}),
-				model: selection.model,
-				thinkingLevel: selection.thinkingLevel,
-				tools,
-			},
-			convertToLlm,
-			...agentStreamOptions(streamFn),
-			getApiKey: (providerName) => providerName === selection.model.provider ? auth.apiKey : undefined,
-			beforeToolCall: async ({ toolCall }) => !clarification && (WATCHDOG_ALLOWED_TOOL_NAMES.has(toolCall.name) || (request.allowClarification && toolCall.name === "watchdog_ask"))
-				? undefined
-				: { block: true, reason: `Watchdog reviews are read-only; tool '${toolCall.name}' is not allowed.` },
-			toolExecution: "sequential",
-		});
-		const abort = () => agent.abort();
-		ctx.signal?.addEventListener("abort", abort, { once: true });
-		request.signal?.addEventListener("abort", abort, { once: true });
-		try {
-			if (ctx.signal?.aborted || request.signal?.aborted) return { stopReason: "aborted" };
-			await agent.prompt(buildReviewPrompt(request, selection));
-		} finally {
-			ctx.signal?.removeEventListener("abort", abort);
-			request.signal?.removeEventListener("abort", abort);
+		const aborted = () => ctx.signal?.aborted || request.signal?.aborted;
+		if (aborted()) return { stopReason: "aborted" };
+		const inherited = !request.config.main.model && ctx.model ? fullModelId(ctx.model) : undefined;
+		const candidates = request.config.main.fallbackModels?.length
+			? buildModelCandidates(request.config.main.model ?? inherited, request.config.main.fallbackModels,
+				ctx.modelRegistry.getAvailable().map(toModelInfo), ctx.model?.provider, { primaryModelFromParent: Boolean(inherited) })
+			: [request.config.main.model];
+		for (let index = 0; index < candidates.length; index++) {
+			if (aborted()) return { stopReason: "aborted" };
+			const candidate = candidates[index];
+			const config = { ...request.config, main: { ...request.config.main, model: candidate === inherited ? undefined : candidate } };
+			try {
+				const attempt = await runWatchdogAttempt(ctx, { ...request, config }, options);
+				if (aborted()) return { stopReason: "aborted" };
+				if (!attempt.retryable || index === candidates.length - 1) return attempt.result;
+			} catch (error) {
+				if (aborted()) return { stopReason: "aborted" };
+				if (!(error instanceof WatchdogAuthError)) throw error;
+				if (!isRetryableModelFailureAttempt({ error: error.message }) || index === candidates.length - 1) throw error.cause ?? error;
+			}
 		}
-		if (ctx.signal?.aborted || request.signal?.aborted) return { stopReason: "aborted" };
-		return clarification ? { clarification } : { stopReason: finalStopReason(agent) };
+		throw new Error("No usable watchdog model candidates.");
+	};
+}
+
+async function runWatchdogAttempt(ctx: ExtensionContext, request: WatchdogReviewRequest, options: CreateMainWatchdogReviewOptions): Promise<{
+	result: Awaited<ReturnType<WatchdogReviewFunction>>;
+	retryable?: boolean;
+}> {
+	const selection = await resolveWatchdogReviewModel(ctx, request.config, {
+		currentThinkingLevel: options.getThinkingLevel?.(),
+	});
+	if (ctx.signal?.aborted || request.signal?.aborted) return { result: { stopReason: "aborted" } };
+	const auth = selection.auth;
+	const registeredProvider = (ctx.modelRegistry as {
+		getRegisteredProviderConfig?: (provider: string) => { api?: string; streamSimple?: StreamFn } | undefined;
+	}).getRegisteredProviderConfig?.(selection.model.provider);
+	const baseStreamFn = options.streamFn ?? (registeredProvider?.streamSimple && registeredProvider.api === selection.model.api
+		? registeredProvider.streamSimple
+		: streamSimple);
+	const sessionId = ctx.sessionManager.getSessionId();
+	const streamFn: StreamFn = (model, context, streamOptions) => {
+		// Agent may enter one final loop iteration after an aborted mixed tool batch.
+		// Never send that iteration to the provider after an intentional yield.
+		if (clarification) throw new Error("Watchdog review yielded for clarification.");
+		return baseStreamFn(model, context, {
+			...streamOptions,
+			...(auth.apiKey ? { apiKey: auth.apiKey } : {}),
+			env: auth.env || streamOptions?.env ? { ...(auth.env ?? {}), ...(streamOptions?.env ?? {}) } : undefined,
+			headers: { ...opencodeSessionHeaders(model, sessionId), ...(streamOptions?.headers ?? {}), ...(auth.headers ?? {}) },
+		});
+	};
+	const diffBaseline = options.diffBaseline?.();
+	let clarification: { question: string; evidence: string } | undefined;
+	let warned = false;
+	let toolCount = 0;
+	const warnRequest = request.allowClarification ? { ...request, emitWarning: (warning: WatchdogWarning) => {
+		if (clarification) return false;
+		const accepted = request.emitWarning(warning);
+		warned ||= accepted;
+		return accepted;
+	} } : request;
+	const tools = [
+		...(options.createReadOnlyTools ?? createReadOnlyTools)(ctx.cwd).filter((tool) => WATCHDOG_ALLOWED_TOOL_NAMES.has(tool.name) && tool.name !== "watchdog_warn"),
+		createWatchdogWarnTool(warnRequest),
+		...(diffBaseline ? [createWatchdogDiffTool(diffBaseline)] : []),
+	];
+	if (request.allowClarification) tools.push({
+		name: "watchdog_ask",
+		label: "Watchdog clarification",
+		description: "Send one focused question when missing task status, intent or other orchestrator context prevents a concrete review judgment. Yields and ends this review so the orchestrator can handle the message and continue; no answer or follow-up review is required. Never ask for approval or permission, or after recording a warning. Question and evidence are capped at 1000 and 2000 characters.",
+		parameters: WatchdogAskParams,
+		executionMode: "sequential",
+		async execute(_id, rawParams) {
+			const params = rawParams as Static<typeof WatchdogAskParams>;
+			if (warned || clarification || ctx.signal?.aborted || request.signal?.aborted) throw new Error("Clarification unavailable after warning, yield, or cancellation.");
+			if (!params.question.trim() || !params.evidence.trim()) throw new Error("A focused question and concrete evidence are required.");
+			clarification = { question: boundWatchdogReviewText(params.question.trim(), 1_000), evidence: boundWatchdogReviewText(params.evidence.trim(), 2_000) };
+			agent.abort(); // Intentional yield also stops mixed tool batches; terminate alone does not.
+			return { content: [{ type: "text", text: "Review yielded for clarification." }], details: {} };
+		},
+	});
+	const agent = new Agent({
+		initialState: {
+			systemPrompt: buildWatchdogSystemPrompt(ctx, {
+				hasScope: request.hasScope,
+				guidance: loadWatchdogGuidance(ctx.cwd, request.config.guidance.watchdogMd),
+				hasDiff: diffBaseline !== undefined,
+			}),
+			model: selection.model,
+			thinkingLevel: selection.thinkingLevel,
+			tools,
+		},
+		convertToLlm,
+		...agentStreamOptions(streamFn),
+		getApiKey: (providerName) => providerName === selection.model.provider ? auth.apiKey : undefined,
+		beforeToolCall: async ({ toolCall }) => !clarification && (WATCHDOG_ALLOWED_TOOL_NAMES.has(toolCall.name) || (request.allowClarification && toolCall.name === "watchdog_ask"))
+			? undefined
+			: { block: true, reason: `Watchdog reviews are read-only; tool '${toolCall.name}' is not allowed.` },
+		toolExecution: "sequential",
+	});
+	// Include rejected/invalid calls as well as read-only work and findings.
+	agent.subscribe((event) => { if (event.type === "tool_execution_start") toolCount++; });
+	const abort = () => agent.abort();
+	ctx.signal?.addEventListener("abort", abort, { once: true });
+	request.signal?.addEventListener("abort", abort, { once: true });
+	try {
+		if (ctx.signal?.aborted || request.signal?.aborted) return { result: { stopReason: "aborted" } };
+		await agent.prompt(buildReviewPrompt(request, selection));
+	} finally {
+		ctx.signal?.removeEventListener("abort", abort);
+		request.signal?.removeEventListener("abort", abort);
+	}
+	if (ctx.signal?.aborted || request.signal?.aborted) return { result: { stopReason: "aborted" } };
+	const terminal = agent.state.messages.findLast((message) => message.role === "assistant");
+	const reason = terminal && "stopReason" in terminal ? terminal.stopReason : undefined;
+	const stopReason = reason === "error" || reason === "aborted" || reason === "length" ? reason : "stop";
+	const error = terminal && "errorMessage" in terminal && typeof terminal.errorMessage === "string" ? terminal.errorMessage : undefined;
+	return {
+		result: clarification ? { clarification } : { stopReason },
+		retryable: !clarification && stopReason === "error" && isRetryableModelFailureAttempt({ error, messages: agent.state.messages, toolCount }),
 	};
 }

--- a/src/watchdog/settings.ts
+++ b/src/watchdog/settings.ts
@@ -111,9 +111,9 @@ const ROLE_MODEL_RULE_FIELDS = new Set(["allow", "deny", "note"]);
 const GUIDANCE_FIELDS = new Set(["watchdogMd"]);
 const SCOPE_FIELDS = new Set(["enabled"]);
 const CADENCE_FIELDS = new Set(["everyNTools"]);
-const ENDPOINT_FIELDS = new Set(["enabled", "model", "thinking"]);
-const CHILDREN_FIELDS = new Set(["enabled", "model", "thinking", "watchdogTailTimeoutMs", "cadence", "overrides"]);
-const CHILD_OVERRIDE_FIELDS = new Set(["enabled", "model", "thinking", "cadence"]);
+const ENDPOINT_FIELDS = new Set(["enabled", "model", "fallbackModels", "thinking"]);
+const CHILDREN_FIELDS = new Set(["enabled", "model", "fallbackModels", "thinking", "watchdogTailTimeoutMs", "cadence", "overrides"]);
+const CHILD_OVERRIDE_FIELDS = new Set(["enabled", "model", "fallbackModels", "thinking", "cadence"]);
 const LSP_FIELDS = new Set(["enabled", "timeoutMs", "maxFiles", "maxDiagnostics"]);
 
 function cloneDefaultConfig(): ResolvedWatchdogConfig {
@@ -221,6 +221,7 @@ function parseEndpointPatch(value: unknown, field: string, meta: ParseMeta): Wat
 	const input = parseObject(value, field, meta);
 	assertKnownFields(input, ENDPOINT_FIELDS, field, meta);
 	const patch: WatchdogEndpointPatch = {};
+	if ("fallbackModels" in input) patch.fallbackModels = parseStringList(input.fallbackModels, `${field}.fallbackModels`, meta);
 	if ("enabled" in input) patch.enabled = parseBoolean(input.enabled, `${field}.enabled`, meta);
 	if ("model" in input) patch.model = parseNonEmptyString(input.model, `${field}.model`, meta);
 	if ("thinking" in input) patch.thinking = parseThinking(input.thinking, `${field}.thinking`, meta);
@@ -231,6 +232,7 @@ function parseChildOverridePatch(value: unknown, field: string, meta: ParseMeta)
 	const input = parseObject(value, field, meta);
 	assertKnownFields(input, CHILD_OVERRIDE_FIELDS, field, meta);
 	const patch: WatchdogChildOverridePatch = {};
+	if ("fallbackModels" in input) patch.fallbackModels = parseStringList(input.fallbackModels, `${field}.fallbackModels`, meta);
 	if ("enabled" in input) patch.enabled = parseBoolean(input.enabled, `${field}.enabled`, meta);
 	if ("model" in input) patch.model = parseNonEmptyString(input.model, `${field}.model`, meta);
 	if ("thinking" in input) patch.thinking = parseThinking(input.thinking, `${field}.thinking`, meta);
@@ -242,6 +244,7 @@ function parseChildrenPatch(value: unknown, field: string, meta: ParseMeta): Wat
 	const input = parseObject(value, field, meta);
 	assertKnownFields(input, CHILDREN_FIELDS, field, meta);
 	const patch: WatchdogChildrenPatch = {};
+	if ("fallbackModels" in input) patch.fallbackModels = parseStringList(input.fallbackModels, `${field}.fallbackModels`, meta);
 	if ("enabled" in input) patch.enabled = parseBoolean(input.enabled, `${field}.enabled`, meta);
 	if ("model" in input) patch.model = parseNonEmptyString(input.model, `${field}.model`, meta);
 	if ("thinking" in input) patch.thinking = parseThinking(input.thinking, `${field}.thinking`, meta);

--- a/src/watchdog/types.ts
+++ b/src/watchdog/types.ts
@@ -87,12 +87,14 @@ export interface WatchdogCadenceConfig {
 export interface WatchdogEndpointConfig {
 	enabled: boolean;
 	model?: string;
+	fallbackModels?: string[];
 	thinking?: string | false;
 }
 
 export interface WatchdogChildOverrideConfig {
 	enabled?: boolean;
 	model?: string;
+	fallbackModels?: string[];
 	thinking?: string | false;
 	cadence?: Partial<WatchdogCadenceConfig>;
 }

--- a/test/unit/watchdog-child-status.test.ts
+++ b/test/unit/watchdog-child-status.test.ts
@@ -12,6 +12,7 @@ import {
 	unresolvedChildWatchdogBlockers,
 } from "../../src/watchdog/child-status.ts";
 import { DEFAULT_WATCHDOG_CONFIG } from "../../src/watchdog/settings.ts";
+import { childResolvedConfig } from "../../src/watchdog/register-child.ts";
 import { events } from "../support/helpers.ts";
 
 function warningMessage(overrides: Record<string, unknown> = {}) {
@@ -66,6 +67,17 @@ describe("child watchdog warning envelope", () => {
 });
 
 describe("child watchdog status helpers", () => {
+	it("passes child fallback precedence through the launch decoder and reviewer config", () => {
+		const base = { ...DEFAULT_WATCHDOG_CONFIG, enabled: true, main: { enabled: true, fallbackModels: ["main/a"] }, children: { ...DEFAULT_WATCHDOG_CONFIG.children, enabled: true, overrides: {} } };
+		assert.equal(resolveChildWatchdogConfig({ config: base })?.fallbackModels, undefined);
+		const config = { ...base, children: { ...base.children, fallbackModels: ["child/a"], overrides: { worker: { fallbackModels: [] }, reviewer: { fallbackModels: ["override/a"] } } } };
+		for (const [agent, expected] of [["other", ["child/a"]], ["worker", []], ["reviewer", ["override/a"]]] as const) {
+			const payload = resolveChildWatchdogConfig({ config, agent })!;
+			const decoded = decodeChildWatchdogConfig(JSON.stringify(payload))!;
+			assert.deepEqual(childResolvedConfig(decoded).main.fallbackModels, expected);
+			assert.throws(() => decodeChildWatchdogConfig(JSON.stringify({ ...payload, fallbackModels: [null] })), /fallbackModels/);
+		}
+	});
 	it("resolves child cadence from override, then children, then the top-level cadence", () => {
 		const base = { ...DEFAULT_WATCHDOG_CONFIG, enabled: true, children: { ...DEFAULT_WATCHDOG_CONFIG.children, enabled: true, overrides: {} } };
 		assert.deepEqual(resolveChildWatchdogConfig({ config: base, agent: "worker" })?.cadence, { everyNTools: null });

--- a/test/unit/watchdog-review.test.ts
+++ b/test/unit/watchdog-review.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
 import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { Type } from "typebox";
 import { WATCHDOG_GUIDANCE_MAX_CHARS } from "../../src/watchdog/guidance.ts";
 import {
 	createAssistantMessageEventStream,
@@ -16,7 +17,8 @@ import {
 } from "@earendil-works/pi-ai";
 import { DEFAULT_WATCHDOG_CONFIG } from "../../src/watchdog/settings.ts";
 import { createMainWatchdogReview, resolveWatchdogReviewModel } from "../../src/watchdog/review.ts";
-import type { WatchdogReviewRequest } from "../../src/watchdog/runtime.ts";
+import { MainWatchdogRuntime, type WatchdogReviewRequest } from "../../src/watchdog/runtime.ts";
+import { buildWatchdogStatus } from "../../src/watchdog/register-main.ts";
 import type { ResolvedWatchdogConfig, WatchdogWarning } from "../../src/watchdog/types.ts";
 
 function model(provider: string, id: string, overrides: Partial<Model<any>> = {}): Model<any> {
@@ -118,6 +120,135 @@ function request(config: ResolvedWatchdogConfig, warnings: WatchdogWarning[]): W
 }
 
 describe("main watchdog review adapter", () => {
+	it("keeps the runtime deadline authoritative during fallback setup and displays configured chains", async () => {
+		const a = model("mock", "a");
+		const b = model("mock", "b");
+		const ctx = createCtx({ current: a, models: [a, b] });
+		let release!: () => void;
+		const pending = new Promise<void>((resolve) => { release = resolve; });
+		const registry = (ctx as any).modelRegistry;
+		const getAuth = registry.getApiKeyAndHeaders;
+		registry.getApiKeyAndHeaders = async (entry: Model<any>) => {
+			if (entry.id === "b") await pending;
+			return getAuth(entry);
+		};
+		const { streamFn, calls } = createStreamFn([fauxAssistantMessage("", { stopReason: "error", errorMessage: "rate limit" })]);
+		const config = enabledConfig({ fallbackModels: ["mock/b"] });
+		config.agentEndTimeoutMs = 10;
+		config.lsp.enabled = false;
+		config.children.fallbackModels = ["mock/a"];
+		config.children.overrides.worker = { fallbackModels: [] };
+		const review = createMainWatchdogReview(ctx, { streamFn });
+		let reviewDone: ReturnType<typeof review>;
+		const runtime = new MainWatchdogRuntime({ resolveConfig: () => ({ ok: true, config, errors: [], sources: [] }), review: (req) => reviewDone = review(req) });
+		try {
+			runtime.enqueueDelta("Assistant changed a file");
+			await runtime.handleAgentEnd({}, ctx);
+			assert.equal(runtime.getSnapshot().status, "stale");
+			release();
+			assert.equal((await reviewDone!)?.stopReason, "aborted");
+			assert.deepEqual(calls.map((call) => call.model.id), ["a"]);
+			const status = buildWatchdogStatus(runtime.getSnapshot(), ctx);
+			assert.match(status, /Main model: .*fallbacks mock\/b/);
+			assert.match(status, /Children: .*fallbacks mock\/a.*worker.*fallbacks none/);
+		} finally {
+			release();
+			runtime.reset("cleanup");
+		}
+	});
+
+	it("retries ordered provider failures with fresh model-specific context and deduplicated candidates", async () => {
+		const primary = model("first", "a");
+		const fallback = model("second", "b");
+		const calls: Array<{ model: Model<any>; context: Context; options?: SimpleStreamOptions }> = [];
+		const streamFn: StreamFn = (nextModel, context, options) => {
+			calls.push({ model: nextModel, context: { ...context, messages: [...context.messages] }, options });
+			return responseStream(fauxAssistantMessage("", { stopReason: "error", errorMessage: "429 quota exceeded" }));
+		};
+		const ctx = createCtx({ current: primary, models: [fallback], authenticated: ["first/a", "second/b"], thinkingLevel: "high" });
+		// Both provider registrations are resolved separately; no generic stream override.
+		const providers: string[] = [];
+		(ctx as any).modelRegistry.getRegisteredProviderConfig = (provider: string) => ({ api: "faux", streamSimple: (...args: Parameters<StreamFn>) => {
+			providers.push(provider);
+			return streamFn(...args);
+		} });
+		const result = await createMainWatchdogReview(ctx)(request(enabledConfig({ fallbackModels: ["first/a", "second/b:low", "second/b:low"] }), []));
+		assert.equal(result?.stopReason, "error", "exhaustion must not become clean success");
+		assert.deepEqual(calls.map((call) => call.model), [primary, fallback]);
+		assert.deepEqual(providers, ["first", "second"]);
+		assert.equal(calls[0].model, primary, "inherited primary retains session model identity");
+		assert.deepEqual(calls.map((call) => call.options?.reasoning), ["high", "low"]);
+		assert.deepEqual(calls.map((call) => call.options?.apiKey), ["key-first-a", "key-second-b"]);
+		assert.deepEqual(calls.map((call) => call.options?.headers?.["x-model"]), ["a", "b"]);
+		assert.deepEqual(calls.map((call) => call.options?.env?.WATCHDOG_PROVIDER), ["first", "second"]);
+		assert.deepEqual(calls.map((call) => call.context.messages.length), [1, 1]);
+	});
+
+	it("skips an unavailable configured primary and retries a provider timeout", async () => {
+		const a = model("mock", "a");
+		const b = model("mock", "b");
+		const { streamFn, calls } = createStreamFn([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "provider timeout" }),
+			fauxAssistantMessage("", { stopReason: "stop" }),
+		]);
+		const result = await createMainWatchdogReview(createCtx({ current: a, models: [a, b] }), { streamFn })(request(enabledConfig({ model: "missing/model", fallbackModels: ["mock/a", "mock/b"] }), []));
+		assert.equal(result?.stopReason, "stop");
+		assert.deepEqual(calls.map((call) => call.model.id), ["a", "b"]);
+	});
+
+	it("does not retry normal, length, aborted, or unclassified error outcomes", async () => {
+		const a = model("mock", "a");
+		const b = model("mock", "b");
+		for (const stopReason of ["stop", "length", "aborted", "error"] as const) {
+			const { streamFn, calls } = createStreamFn([fauxAssistantMessage("", { stopReason, errorMessage: stopReason === "error" ? "invalid request" : "provider timeout" })]);
+			const result = await createMainWatchdogReview(createCtx({ current: a, models: [a, b] }), { streamFn })(request(enabledConfig({ fallbackModels: ["mock/b"] }), []));
+			assert.equal(result?.stopReason, stopReason);
+			assert.equal(calls.length, 1);
+		}
+	});
+
+	it("does not retry provider errors after inspection or warnings, even rejected warnings", async () => {
+		const a = model("mock", "a");
+		const b = model("mock", "b");
+		for (const toolCall of [fauxToolCall("ls", { path: "." }), fauxToolCall("watchdog_warn", { severity: "concern", summary: "Concern", evidence: "Evidence", recommendedAction: "Fix" })]) {
+			let inspections = 0;
+			const { streamFn, calls } = createStreamFn([
+				fauxAssistantMessage(toolCall, { stopReason: "toolUse" }),
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: "provider unavailable" }),
+			]);
+			const result = await createMainWatchdogReview(createCtx({ current: a, models: [a, b] }), {
+				streamFn,
+				createReadOnlyTools: () => [{ name: "ls", label: "ls", description: "List files", parameters: Type.Object({ path: Type.String() }), execute: async () => {
+					inspections++;
+					return { content: [{ type: "text", text: "file.ts" }], details: {} };
+				} }],
+			})({ ...request(enabledConfig({ fallbackModels: ["mock/b"] }), []), emitWarning: () => false });
+			assert.equal(result?.stopReason, "error");
+			assert.deepEqual(calls.map((call) => call.model.id), ["a", "a"]);
+			assert.equal(inspections, toolCall.name === "ls" ? 1 : 0);
+		}
+	});
+
+	it("retries pre-stream auth failure but never advances after request cancellation during setup", async () => {
+		const a = model("mock", "a");
+		const b = model("mock", "b");
+		for (const cancel of [false, true]) {
+			const controller = new AbortController();
+			const ctx = createCtx({ current: a, models: [a, b] });
+			const registry = (ctx as any).modelRegistry;
+			const getAuth = registry.getApiKeyAndHeaders;
+			registry.getApiKeyAndHeaders = async (entry: Model<any>) => {
+				if (entry.id !== "a") return getAuth(entry);
+				if (cancel) controller.abort();
+				return { ok: false, error: "token expired" };
+			};
+			const { streamFn, calls } = createStreamFn([]);
+			const result = await createMainWatchdogReview(ctx, { streamFn })({ ...request(enabledConfig({ fallbackModels: ["mock/b"] }), []), signal: controller.signal });
+			assert.equal(result?.stopReason, cancel ? "aborted" : "stop");
+			assert.deepEqual(calls.map((call) => call.model.id), cancel ? [] : ["b"]);
+		}
+	});
+
 	it("yields an ask from a mixed batch without another model call or warning", async () => {
 		const { streamFn, calls } = createStreamFn([fauxAssistantMessage([
 			fauxToolCall("watchdog_ask", { question: "Which constraint applies?", evidence: "Two scope statements differ." }),
@@ -125,8 +256,9 @@ describe("main watchdog review adapter", () => {
 			fauxToolCall("ls", { path: "." }),
 		], { stopReason: "toolUse" })]);
 		const warnings: WatchdogWarning[] = [];
-		const review = createMainWatchdogReview(createCtx({ current: model("mock", "review") }), { streamFn });
-		const result = await review({ ...request(enabledConfig(), warnings), allowClarification: true });
+		const current = model("mock", "review");
+		const review = createMainWatchdogReview(createCtx({ current, models: [current, model("mock", "fallback")] }), { streamFn });
+		const result = await review({ ...request(enabledConfig({ fallbackModels: ["mock/fallback"] }), warnings), allowClarification: true });
 		assert.deepEqual(result, { clarification: { question: "Which constraint applies?", evidence: "Two scope statements differ." } });
 		assert.equal(calls.length, 1);
 		assert.deepEqual(warnings, []);

--- a/test/unit/watchdog-review.test.ts
+++ b/test/unit/watchdog-review.test.ts
@@ -196,6 +196,17 @@ describe("main watchdog review adapter", () => {
 		assert.deepEqual(calls.map((call) => call.model.id), ["a", "b"]);
 	});
 
+	it("does not retry context overflow even when the provider error also says upstream", async () => {
+		const a = model("mock", "a");
+		const b = model("mock", "b");
+		const { streamFn, calls } = createStreamFn([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "upstream: maximum context length exceeded" }),
+		]);
+		const result = await createMainWatchdogReview(createCtx({ current: a, models: [a, b] }), { streamFn })(request(enabledConfig({ fallbackModels: ["mock/b"] }), []));
+		assert.deepEqual(calls.map((call) => call.model.id), ["a"]);
+		assert.equal(result?.stopReason, "error");
+	});
+
 	it("does not retry normal, length, aborted, or unclassified error outcomes", async () => {
 		const a = model("mock", "a");
 		const b = model("mock", "b");

--- a/test/unit/watchdog-settings.test.ts
+++ b/test/unit/watchdog-settings.test.ts
@@ -67,6 +67,21 @@ describe("watchdog settings", () => {
 		assert.equal(resolveWatchdogConfig(tempProject, { session: { children: { clarification: true } } }).ok, false);
 	});
 
+	it("validates fallback arrays and replaces or clears layered chains", () => {
+		writeJson(userSettingsPath(), { subagents: { watchdog: { main: { fallbackModels: ["user/a"] }, children: { fallbackModels: ["user/b"], overrides: { worker: { fallbackModels: ["user/c"] } } } } } });
+		writeJson(projectSettingsPath(), { subagents: { watchdog: { main: { fallbackModels: [" project/a "] }, children: { overrides: { worker: { fallbackModels: [] } } } } } });
+		const config = resolveWatchdogConfig(tempProject).config;
+		assert.deepEqual(config.main.fallbackModels, ["project/a"]);
+		assert.deepEqual(config.children.fallbackModels, ["user/b"]);
+		assert.deepEqual(config.children.overrides.worker.fallbackModels, []);
+		assert.deepEqual(resolveWatchdogConfig(tempProject, { session: { main: { fallbackModels: [] } } }).config.main.fallbackModels, []);
+		for (const fallbackModels of ["model/a", null, [""], [12]]) {
+			for (const session of [{ main: { fallbackModels } }, { children: { fallbackModels } }, { children: { overrides: { worker: { fallbackModels } } } }]) {
+				assert.equal(resolveWatchdogConfig(tempProject, { session }).ok, false);
+			}
+		}
+	});
+
 	it("lets root enabled opt the main watchdog in while children stay default-off", () => {
 		writeJson(userSettingsPath(), {
 			subagents: {


### PR DESCRIPTION
## Summary

Adds opt-in `fallbackModels` for main/child watchdogs and per-agent overrides. Reuses normal subagent candidate selection and failure classification; each attempt resolves its own model, auth, provider stream and thinking. Arrays replace, and `[]` clears inherited chains.

Retries only qualifying provider failures before any tool work. Findings, normal completion, clarification, cancellation and the overall review deadline do not trigger retries. Attempts share the existing deadline. No-chain behavior is preserved.

Thanks to [@dwizzle204](https://github.com/dwizzle204) for the request. Closes #2075.

## Validation

- 243 affected watchdog/model-fallback tests passed; one existing native-SDK-gated smoke skipped.
- After simplification, 60 affected reviewer/runtime tests passed.
- Typecheck and diff hygiene passed.
- Scope challenge, simplification/deslop, fresh independent review and parent source verification completed.
- No live-provider or interactive-host smoke; CI and Greptile pending on this published head.