### PR TITLE
fix(workflow): validate worktree sources before child admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Reject materialized workflow launch groups with invalid worktree repositories or dirty sources before dispatching children or claiming fan-out/output ownership. Allocation still rechecks; workflow-key failure traces may remain. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2076.
 - Wait for remembered detached foreground descendants before parent settlement, without aborting a result-bearing child on the runner grace window. Thanks to [@shaharmor](https://github.com/shaharmor) for #2051.
 - Do not report owned process-tree cleanup as `observed` when a detached descendant remains active after the owned process group exits. Thanks to [@rtbe](https://github.com/rtbe) for #2053.
 - Ignore verbs inside filenames and path-like tokens when classifying implementation intent, so artifact names such as `daily-update.mp3` do not create an implementation obligation. Thanks to [@SiebertLanhove](https://github.com/SiebertLanhove) for #2039.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -380,6 +380,8 @@ Each child uses the existing worktree lifecycle: it branches from clean HEAD, jo
 
 A top-level `{ workflowScript, worktree: true }` makes isolation the default for every workflow child. An individual child can override that default with `worktree: false`. Keep one writer when parallel writes are not intentionally isolated.
 
+Before a materialized `runs.run` or `runs.all` group dispatches fresh children, isolated sources must be Git repositories with clean working trees (excluding `.pi/subagents/` runtime state). A rejected group dispatches no children and spends no fan-out slots or child output claims; key-level failure traces can remain. Checks are shared only within that group, are cancellable, and run again at allocation because sources can change. Retained resumes keep their stored contracts. Select the correct cwd or arrange an operator-approved commit/stash; isolation is never dropped automatically.
+
 Use `baseRef` to branch managed worktrees from `HEAD` or a supported named ref such as `refs/heads/release`, `refs/tags/v1`, or `origin/main`. Full 40/64-character commit IDs and revision expressions such as `HEAD~1` are unsupported. For example, `{ workflowScript, worktree: true, baseRef: "refs/heads/release" }` applies the release ref to children unless a child supplies its own `baseRef`. If omitted, the default `HEAD` is resolved at worktree allocation, not when the script is validated or a schedule is created. The source checkout must still be clean, and the ref must resolve to a commit before any worktree is allocated.
 
 Configure the worktree provider, native path layout, base directory, and setup hook in [configuration.md](configuration.md).

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -139,6 +139,7 @@ import { resolveWorkflowResource } from "../../workflows/workflow-resources.ts";
 import {
 	cleanupWorktrees,
 	createWorktrees,
+	preflightWorktreeSource,
 	withWorktreeTransaction,
 	type WorktreeSetupProgress,
 	diffWorktrees,
@@ -4537,6 +4538,35 @@ export async function steerWorkflowChildByKey(input: {
 	}
 }
 
+export async function preflightWorkflowWorktrees(input: {
+	workflowDefaults: SubagentParamsLike;
+	defaultWorktree?: boolean;
+	calls: Array<{ key: string; params: Record<string, unknown> }>;
+	ctxCwd: string;
+	signal: AbortSignal;
+	deadlineAt?: number;
+}): Promise<void> {
+	const sources = new Map<string, string[]>();
+	for (const { key, params } of input.calls) {
+		// The workflow validates retained IDs/receipt references before admission; resolution follows it.
+		if (params.resume !== undefined) continue;
+		const effective = prepareWorkflowLaunchParams(input.workflowDefaults, params, "preflight", key);
+		if ((effective.worktree ?? input.defaultWorktree) !== true) continue;
+		// Match recursive execute's resolution, including relative default/child cwd.
+		const cwd = resolveRequestedCwd(input.ctxCwd, effective.cwd);
+		const keys = sources.get(cwd) ?? [];
+		keys.push(key);
+		sources.set(cwd, keys);
+	}
+	for (const [cwd, keys] of sources) {
+		try { await preflightWorktreeSource(cwd, { signal: input.signal, deadlineAt: input.deadlineAt }); }
+		catch (error) {
+			throw new Error(`Worktree admission failed for ${keys.map((key) => `'${key}'`).join(", ")} at ${cwd}: ${error instanceof Error ? error.message : String(error)} Select the correct cwd or arrange an operator-approved commit/stash.`, { cause: error });
+		}
+	}
+	input.signal.throwIfAborted();
+}
+
 export function prepareWorkflowLaunchParams(
 	workflowDefaults: SubagentParamsLike,
 	childParams: Record<string, unknown>,
@@ -5554,7 +5584,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									persist({ tolerateStatusWriteFailure: true });
 								} });
 							},
-							admit: (calls) => {
+							admit: async (calls, admissionSignal) => {
+								await preflightWorkflowWorktrees({ workflowDefaults: workflowChildDefaults, defaultWorktree: deps.config.worktree, calls, ctxCwd: parentCwd, signal: admissionSignal, deadlineAt: workflowDeadlineAt });
 								const outputClaims = workflowChildOutputClaims({ ctxCwd: parentCwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, state: deps.state, claimedOutputPaths, entries: calls });
 								if (outputClaims.error) throw new Error(outputClaims.error);
 								status.runFanoutBudget = claimRunFanoutBatch(workflowFanoutBudget, calls.map(({ key }) => `workflow[${key}]`));
@@ -5820,7 +5851,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						}
 						sendWorkflowProgress();
 					},
-					admit: (calls) => {
+					admit: async (calls, admissionSignal) => {
+						await preflightWorkflowWorktrees({ workflowDefaults: workflowChildDefaults, defaultWorktree: deps.config.worktree, calls, ctxCwd: ctx.cwd, signal: admissionSignal, deadlineAt: workflowDeadlineAt });
 						const outputClaims = workflowChildOutputClaims({ ctxCwd: ctx.cwd, workflowCwd, artifactsDir: workflowArtifactsDir, workflowRunId: foregroundWorkflowRunId, aggregateOutputPath: workflowAggregateOutputPath, configuredOutputBaseDir, discoverAgents: discoverWorkflowAgents, agents: workflowAgents, workflowAgentScope: workflowChildDefaults.agentScope, state: deps.state, claimedOutputPaths, entries: calls });
 						if (outputClaims.error) throw new Error(outputClaims.error);
 						claimRunFanoutBatch(workflowFanoutBudget, calls.map(({ key }) => `workflow[${key}]`));

--- a/src/runs/shared/worktree.ts
+++ b/src/runs/shared/worktree.ts
@@ -341,11 +341,9 @@ export function validateWorktreePatchRepresentsCurrentWorktree(worktreePath: str
 	return undefined;
 }
 
-async function resolveRepoState(tx: SetupTransaction, cwd: string, requestedBaseRef: string | undefined): Promise<RepoState> {
+async function probeWorktreeSource(tx: Pick<SetupTransaction, "git" | "gitChecked">, cwd: string): Promise<string> {
 	const repoCheck = await tx.git(cwd, ["rev-parse", "--is-inside-work-tree"], [0, 128]);
 	if (repoCheck.status !== 0 || repoCheck.stdout.trim() !== "true") throw new Error("worktree isolation requires a git repository");
-	const rawPrefix = (await tx.gitChecked(cwd, ["rev-parse", "--show-prefix"])).trim();
-	const cwdRelative = rawPrefix ? path.normalize(rawPrefix.replace(/[\\/]+$/, "")) : "";
 	const toplevel = (await tx.gitChecked(cwd, ["rev-parse", "--show-toplevel"])).trim();
 
 	// pi-subagents writes durable runtime state under .pi/subagents/ by default;
@@ -354,6 +352,26 @@ async function resolveRepoState(tx: SetupTransaction, cwd: string, requestedBase
 	if (status.trim().length > 0) {
 		throw new Error("worktree isolation requires a clean git working tree. Commit or stash changes first.");
 	}
+	return toplevel;
+}
+
+/** Read-only admission check; allocation repeats it because source state can change. */
+export async function preflightWorktreeSource(cwd: string, options: Pick<SetupCommandOptions, "signal" | "deadlineAt"> = {}): Promise<void> {
+	const git = async (cwd: string, args: string[], acceptedExitCodes: readonly number[] = [0]): Promise<SetupCommandResult> => {
+		const result = await runSetupCommand("git", ["-C", cwd, ...args], { ...options, acceptedExitCodes });
+		if (result.error) throw result.error;
+		if (result.outputIncomplete || result.status === null || !acceptedExitCodes.includes(result.status)) {
+			throw new Error(result.stderr.trim().slice(0, 2000) || "Worktree source probe failed");
+		}
+		return result;
+	};
+	await probeWorktreeSource({ git, gitChecked: async (cwd, args) => (await git(cwd, args)).stdout }, cwd);
+}
+
+async function resolveRepoState(tx: SetupTransaction, cwd: string, requestedBaseRef: string | undefined): Promise<RepoState> {
+	const toplevel = await probeWorktreeSource(tx, cwd);
+	const rawPrefix = (await tx.gitChecked(cwd, ["rev-parse", "--show-prefix"])).trim();
+	const cwdRelative = rawPrefix ? path.normalize(rawPrefix.replace(/[\\/]+$/, "")) : "";
 
 	const baseRef = normalizeWorktreeBaseRef(requestedBaseRef) ?? DEFAULT_WORKTREE_BASE_REF;
 	let baseCommit: string;

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -2288,6 +2288,10 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				} finally {
 					launchSemaphore.release();
 				}
+			}, (error: unknown) => {
+				if (!childController.signal.aborted) throw error;
+				const reason = childController.signal.reason;
+				return stoppedChildResult(key, reason instanceof Error ? reason.message : typeof reason === "string" ? reason : "Workflow script aborted.");
 			}).then((result) => {
 				let normalized = !result.ok && !result.error ? { ...result, error: result.output } : result;
 				if (resolvedResumeLineage?.length && normalized.runId) {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -1123,7 +1123,7 @@ export interface RunWorkflowScriptOptions {
 	continueAfterAbortWhenChildrenSettled?: (abortError: Error) => boolean;
 	/** Maximum children executing concurrently within this workflow. Defaults to 20. */
 	globalConcurrencyLimit?: number;
-	admit?: (calls: Array<{ key: string; params: Record<string, unknown> }>) => void | Promise<void>;
+	admit?: (calls: Array<{ key: string; params: Record<string, unknown> }>, signal: AbortSignal) => void | Promise<void>;
 	launch: (key: string, params: Record<string, unknown>, signal: AbortSignal, admission: { admitted: boolean; batch: boolean }) => Promise<WorkflowScriptChildResult>;
 	resolveResume?: (reference: WorkflowReceiptResumeReference | string, signal: AbortSignal, index?: number) => string | WorkflowResolvedResumeReference | Promise<string | WorkflowResolvedResumeReference>;
 	status: (keyOrRunId: string, signal: AbortSignal) => Promise<WorkflowScriptChildResult>;
@@ -2231,7 +2231,7 @@ export async function runWorkflowScript(options: RunWorkflowScriptOptions): Prom
 				admission = Promise.resolve().then(() => {
 					if (settled || finishing) return;
 					for (const call of calls) assertRecoveryBarrierAllowsRun(call.key, call.params);
-					return options.admit?.(calls);
+					return options.admit?.(calls, childController.signal);
 				});
 				if (batch) batchAdmissions.set(batch.id, admission);
 			}

--- a/test/integration/workflow-worktree-admission.test.ts
+++ b/test/integration/workflow-worktree-admission.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { createEventBus, makeAgent, makeMinimalCtx } from "../support/helpers.ts";
+import { installAsyncExecutionHooks, available, createSubagentExecutor, mockPi, tempDir, createRepo, readAsyncPayload, ASYNC_DIR } from "../support/async-execution-fixture.ts";
+
+function makeAdmissionExecutor(config: Record<string, unknown> = {}) {
+	return createSubagentExecutor!({
+		pi: { events: createEventBus(), getSessionName: () => undefined, sendMessage() {} },
+		state: { baseCwd: tempDir, currentSessionId: null, asyncJobs: new Map(), foregroundControls: new Map(), lastForegroundControlId: null },
+		config,
+		asyncByDefault: false,
+		tempArtifactsDir: tempDir,
+		getSubagentSessionRoot: () => tempDir,
+		expandTilde: (p: string) => p,
+		discoverAgents: () => ({ agents: [makeAgent("worker")] }),
+	});
+}
+
+function callCount(): number {
+	return fs.readdirSync(mockPi.dir).filter((name) => name.startsWith("call-") && name.endsWith(".json")).length;
+}
+
+describe("public workflow worktree admission", { skip: !available }, () => {
+	installAsyncExecutionHooks();
+	for (const async of [false, true]) {
+		for (const source of ["nonrepo", "dirty"] as const) {
+			it(`rejects a mixed ${source} group before child dispatch or budget claims (async=${async})`, async () => {
+				const repo = createRepo("pi-admission-valid-");
+				const invalid = source === "dirty" ? createRepo("pi-admission-dirty-") : tempDir;
+				if (source === "dirty") fs.writeFileSync(path.join(invalid, "untracked.txt"), "dirty");
+				try {
+					const executor = makeAdmissionExecutor(source === "dirty" ? { worktree: true } : {});
+					const output = path.join(tempDir, "child-output.md");
+					const script = `const results = await runs.all([${JSON.stringify(repo)}, ${JSON.stringify(invalid)}].map((cwd, i) => ({ key: 'child-' + i, agent: 'worker', task: 'Inspect', cwd, output: i === 0 ? ${JSON.stringify(output)} : false }))); if (results.some(r => !r.ok)) throw new Error(results.map(r => r.error).join('; ')); return results;`;
+					const result = await executor.executePublic(`admission-${source}-${async}`, { workflowScript: script, async, ...(source === "nonrepo" ? { isolation: "worktree" } : {}), maxSubagentSpawnsPerRun: 2, output: false }, new AbortController().signal, undefined, makeMinimalCtx(tempDir));
+					let budget: unknown;
+					if (async) {
+						assert.ok(result.details?.asyncId);
+						const payload = await readAsyncPayload(result.details.asyncId);
+						assert.equal(payload.success, false);
+						assert.match(payload.error ?? "", /Worktree admission failed.*child-1/);
+						const status = JSON.parse(fs.readFileSync(path.join(ASYNC_DIR, result.details.asyncId, "status.json"), "utf8"));
+						budget = status.runFanoutBudget;
+						assert.ok(status.steps.every((step: { runId?: string }) => !step.runId));
+					} else {
+						assert.equal(result.isError, true);
+						assert.match(result.content.map((item) => item.text).join("\n"), /Worktree admission failed.*child-1/);
+						budget = (result.details as { runFanoutBudget?: unknown }).runFanoutBudget;
+					}
+					assert.deepEqual(budget, { used: 0, limit: 2, remaining: 2 });
+					assert.equal(callCount(), 0);
+					assert.equal(fs.existsSync(output), false);
+				} finally {
+					fs.rmSync(repo, { recursive: true, force: true });
+					if (invalid !== tempDir) fs.rmSync(invalid, { recursive: true, force: true });
+				}
+			});
+		}
+	}
+	it("launches a valid isolated child and preserves explicit false on a non-repository sibling", async () => {
+		const repo = createRepo("pi-admission-clean-");
+		mockPi.onCall({ output: "Inspected" });
+		mockPi.onCall({ output: "Shared cwd inspected" });
+		try {
+			const executor = makeAdmissionExecutor({ worktreeProvider: "native", worktree: true });
+			const result = await executor.executePublic("admission-clean", {
+				workflowScript: `const results = await runs.all([{ key: 'isolated', agent: 'worker', task: 'Inspect', cwd: ${JSON.stringify(repo)}, async: false }, { key: 'shared', agent: 'worker', task: 'Inspect shared', worktree: false, async: false }]); return results.map(r => r.ok);`,
+				async: false, worktree: true, output: false,
+			}, new AbortController().signal, undefined, makeMinimalCtx(tempDir));
+			assert.notEqual(result.isError, true, JSON.stringify(result));
+			assert.equal(callCount(), 2);
+			assert.deepEqual((result.details as { workflow?: { value?: unknown } }).workflow?.value, [true, true]);
+		} finally {
+			fs.rmSync(repo, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import { Worker } from "node:worker_threads";
 import { formatWorkflowJsonPreview, previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError } from "../../src/workflows/scripted-workflow.ts";
+import { preflightWorkflowWorktrees } from "../../src/runs/foreground/subagent-executor.ts";
 
 describe("scripted workflow runtime", () => {
 	it("uses ordinary statement-body return semantics", async () => {
@@ -385,11 +386,14 @@ describe("scripted workflow runtime", () => {
 		assert.deepEqual(launchParams?.intercomBridge, { mode: "off" });
 	});
 
-	it("resolves a keyed workflow receipt before launching a retained child", async () => {
+	it("resolves a keyed workflow receipt despite an invalid current worktree source", async (t) => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-receipt-resume-"));
+		t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
 		let launchParams: Record<string, unknown> | undefined;
 		let resolvedReference: unknown;
 		const result = await runWorkflowScript({
 			script: `return runs.run("cross-review", { resume: { workflowRunId: "workflow-1", key: "advisor", latest: true }, task: "Continue" });`,
+			admit: (calls, signal) => preflightWorkflowWorktrees({ workflowDefaults: { worktree: true }, calls, ctxCwd: cwd, signal }),
 			resolveResume(reference) {
 				resolvedReference = reference;
 				return { runId: "retained-run", runIds: ["ancestor-run", "retained-run"] };
@@ -416,6 +420,7 @@ describe("scripted workflow runtime", () => {
 			await assert.rejects(
 				runWorkflowScript({
 					script: `return runs.run("cross-review", { resume: ${resume}, task: "Continue" });`,
+					admit() { assert.fail("Invalid receipt reached admission"); },
 					async launch(key) { return { key, ok: true, output: "unexpected", artifactPaths: [] }; },
 					async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
 				}),
@@ -2580,12 +2585,14 @@ describe("scripted workflow runtime", () => {
 		let launchCount = 0;
 		let resolveAdmission!: () => void;
 		let markAdmissionStarted!: () => void;
+		let admissionSignal: AbortSignal | undefined;
 		const admissionStarted = new Promise<void>((resolve) => { markAdmissionStarted = resolve; });
 
 		const workflow = runWorkflowScript({
 			script: `await runs.run("slow", { agent: "worker", task: "wait" });`,
 			signal: controller.signal,
-			admit() {
+			admit(_calls, signal) {
+				admissionSignal = signal;
 				markAdmissionStarted();
 				return new Promise<void>((resolve) => { resolveAdmission = resolve; });
 			},
@@ -2598,6 +2605,7 @@ describe("scripted workflow runtime", () => {
 
 		await admissionStarted;
 		controller.abort(new Error("Workflow stopped by user."));
+		assert.equal(admissionSignal?.aborted, true);
 		await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError
 			&& error.message === "Workflow stopped by user."
 			&& error.partial.trace.some((entry) => entry.operation === "run" && entry.key === "slow" && entry.state === "stopped")

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -6,6 +6,8 @@ import { describe, it } from "node:test";
 import { Worker } from "node:worker_threads";
 import { formatWorkflowJsonPreview, previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError } from "../../src/workflows/scripted-workflow.ts";
 import { preflightWorkflowWorktrees } from "../../src/runs/foreground/subagent-executor.ts";
+import { runSetupCommand } from "../../src/runs/shared/worktree-setup-command.ts";
+import { claimRunFanoutBatch, createRunFanoutBudget, getRunFanoutBudgetSnapshot } from "../../src/runs/shared/run-fanout-budget.ts";
 
 describe("scripted workflow runtime", () => {
 	it("uses ordinary statement-body return semantics", async () => {
@@ -2613,6 +2615,40 @@ describe("scripted workflow runtime", () => {
 		resolveAdmission();
 		await new Promise((resolve) => queueMicrotask(resolve));
 		assert.equal(launchCount, 0);
+	});
+
+	it("classifies admission subprocess cancellation on workflow timeout as stopped", { timeout: 5_000 }, async (t) => {
+		const budget = createRunFanoutBudget("admission-timeout", 1);
+		t.after(() => fs.rmSync(budget.directory, { recursive: true, force: true }));
+		let spawned = false;
+		let launches = 0;
+		let childSettled!: (result: { outcome: string; error?: string }) => void;
+		const child = new Promise<{ outcome: string; error?: string }>((resolve) => { childSettled = resolve; });
+		const workflow = runWorkflowScript({
+			script: `await runs.run("slow", { agent: "worker", task: "wait" });`,
+			workflowRunId: "admission-timeout",
+			timeoutMs: 1_000,
+			async admit(calls, signal) {
+				const result = await runSetupCommand(process.execPath, ["-e", "setTimeout(() => {}, 10000)"], {
+					signal, onSpawn() { spawned = true; },
+				});
+				if (result.error) throw result.error;
+				claimRunFanoutBatch(budget, calls.map(({ key }) => key));
+			},
+			onChildSettled: childSettled,
+			async launch(key) {
+				launches++;
+				return { key, ok: true, output: "unexpected", artifactPaths: [] };
+			},
+			async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+		});
+		await assert.rejects(workflow, (error: unknown) => error instanceof WorkflowScriptError && error.errorKind === "timeout");
+		assert.equal(spawned, true);
+		const result = await child;
+		assert.equal(result.outcome, "stopped");
+		assert.match(result.error ?? "", /timed out/);
+		assert.equal(launches, 0);
+		assert.deepEqual(getRunFanoutBudgetSnapshot(budget), { used: 0, limit: 1, remaining: 1 });
 	});
 
 	it("drops a child response that settles after the workflow aborts", async () => {

--- a/test/unit/workflow-worktree-admission.test.ts
+++ b/test/unit/workflow-worktree-admission.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { it } from "node:test";
+import { preflightWorkflowWorktrees } from "../../src/runs/foreground/subagent-executor.ts";
+
+it("rechecks effective relative sources after changes without applying fresh defaults to retained resumes", async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-admission-"));
+	const repo = path.join(root, "repo");
+	fs.mkdirSync(repo);
+	assert.equal(spawnSync("git", ["init", repo]).status, 0);
+	// Admission deliberately does not resolve HEAD: base refs remain allocation-time checks.
+	fs.mkdirSync(path.join(repo, ".pi", "subagents"), { recursive: true });
+	fs.writeFileSync(path.join(repo, ".pi", "subagents", "runtime.json"), "{}");
+	const signal = new AbortController().signal;
+	const calls = [{ key: "a", params: { agent: "worker", task: "Inspect" } }, { key: "b", params: { agent: "worker", task: "Inspect", cwd: "./repo" } }];
+	try {
+		await preflightWorkflowWorktrees({ ctxCwd: root, workflowDefaults: { cwd: "repo", worktree: true }, calls, signal });
+		fs.writeFileSync(path.join(repo, "untracked.txt"), "dirty");
+		await assert.rejects(preflightWorkflowWorktrees({ ctxCwd: root, workflowDefaults: { cwd: "repo", worktree: true }, calls, signal }), /a.*b.*clean git working tree/);
+		await preflightWorkflowWorktrees({ ctxCwd: root, workflowDefaults: { worktree: true }, calls: [
+			{ key: "retained", params: { resume: "original-run", task: "Continue" } },
+		], signal });
+	} finally {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

Validate Git repository/cleanliness preconditions for each materialized fresh-launch workflow group before child dispatch, fan-out slots, or output claims. Reuse the existing cancellable Git setup primitives and keep allocation-time checks. Retained IDs and keyed receipt references retain their stored contracts; explicit worktree:false and existing cwd/default semantics are preserved.

This does not statically evaluate a whole script or remove existing key-level failure traces. The separate launch-status marker proposal is deferred.

Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2076. Closes #2076.

## Validation

- 118 affected unit tests and 5 public executor integration tests passed; typecheck passed.
- Independent review caught keyed retained-receipt handling; fixed with a red/green public workflow regression and invalid-reference guard coverage.
- Scope challenge, simplification/deslop, independent review, and parent verification completed. Current-main integration changes only changelog composition; candidate source/tests remain identical.
- Local incremental preflight median ~19ms per clean source/group (1 or16 same-cwd siblings); no Git probes for nonisolated groups. Large/network repository performance is unmeasured. No live-model smoke.
- Exact-head CI/Greptile pending.