### PR TITLE
fix(fallback): recognize status-prefixed provider 401 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Recognize OpenRouter's status-prefixed 401 errors for configured model fallback before tool work, including watchdog reviews. Thanks to [@freezscholte](https://github.com/freezscholte) for #2077.
 - A manual `schedule.run` that attaches a run satisfies the next natural fire, so manually-run schedules no longer double-fire (#2052). Thanks to [@brandonmwest](https://github.com/brandonmwest) for #2052.
 - Wait for remembered detached foreground descendants before parent settlement, without aborting a result-bearing child on the runner grace window. Thanks to [@shaharmor](https://github.com/shaharmor) for #2051.
 - Do not report owned process-tree cleanup as `observed` when a detached descendant remains active after the owned process group exits. Thanks to [@rtbe](https://github.com/rtbe) for #2053.

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -543,6 +543,8 @@ const RETRYABLE_MODEL_FAILURE_PATTERNS = [
 	/quota/i,
 	/billing/i,
 	/credit/i,
+	// OpenRouter can return only a status-prefixed body, without auth-related prose.
+	/^\s*401\s*:/,
 	/auth(?:entication)?/i,
 	/unauthori[sz]ed/i,
 	/forbidden/i,

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -505,6 +505,18 @@ describe("model fallback helpers", () => {
 		assert.equal(isRetryableModelFailure("500"), true);
 	});
 
+	it("retries OpenRouter's status-prefixed 401 only before tool activity", () => {
+		const error = '401: {"message":"User not found.","code":401}';
+		const messages = [{ role: "assistant", errorMessage: error }];
+		assert.equal(isRetryableModelFailureAttempt({ error, messages, toolCount: 0 }), true);
+		assert.equal(isRetryableModelFailureAttempt({ error, messages: [], toolCount: 0 }), true);
+		assert.equal(isRetryableModelFailureAttempt({ error, messages, toolCount: 1 }), false);
+		assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ role: "assistant" }], toolCount: 0 }), false);
+		for (const taskError of ["User not found.", "User 401 not found.", `Lookup failed: ${error}`, `bash failed (exit 1): ${error}`]) {
+			assert.equal(isRetryableModelFailure(taskError), false, taskError);
+		}
+	});
+
 	it("does not treat ordinary task/tool failures as retryable model failures", () => {
 		assert.equal(isRetryableModelFailure("bash failed (exit 1): command not found"), false);
 		assert.equal(isRetryableModelFailure("read failed (exit 1): no such file or directory"), false);

--- a/test/unit/watchdog-review.test.ts
+++ b/test/unit/watchdog-review.test.ts
@@ -196,6 +196,18 @@ describe("main watchdog review adapter", () => {
 		assert.deepEqual(calls.map((call) => call.model.id), ["a", "b"]);
 	});
 
+	it("retries OpenRouter's 401 on the configured cross-provider fallback", async () => {
+		const a = model("openrouter", "a");
+		const b = model("second", "b");
+		const { streamFn, calls } = createStreamFn([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: '401: {"message":"User not found.","code":401}' }),
+			fauxAssistantMessage("", { stopReason: "stop" }),
+		]);
+		const result = await createMainWatchdogReview(createCtx({ current: a, models: [a, b] }), { streamFn })(request(enabledConfig({ fallbackModels: ["second/b"] }), []));
+		assert.equal(result?.stopReason, "stop");
+		assert.deepEqual(calls.map((call) => call.model), [a, b]);
+	});
+
 	it("does not retry context overflow even when the provider error also says upstream", async () => {
 		const a = model("mock", "a");
 		const b = model("mock", "b");


### PR DESCRIPTION
## Summary

Recognize the reported OpenRouter `401: {"message":"User not found.","code":401}` provider failure for configured fallback. Matching is limited to leading status-prefixed 401 syntax; naked user-not-found messages, arbitrary embedded numbers and tool failures are not newly matched. Existing tool-activity, message-provenance and context-overflow guards remain intact.

Thanks to [@freezscholte](https://github.com/freezscholte) for #2077. Closes #2077.

## Validation

- Both new public contract regressions failed before the two-line production change; all128 affected tests pass afterward.
- Typecheck and diff hygiene pass.
- Fresh independent review and parent source verification passed.
- Tests use reported error text and provider stream fixtures; no live revoked-key call or full process-launch matrix was run.
- Exact-head CI/Greptile pending.