### PR TITLE
fix(intent): recognize quoted review finding categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Allow read-only reviewers to classify findings as quoted "must fix before" categories without treating the labels as implementation instructions; actual required fixes still require mutation tools. Thanks to [@freezscholte](https://github.com/freezscholte) for #2079.
 - A manual `schedule.run` that attaches a run satisfies the next natural fire, so manually-run schedules no longer double-fire (#2052). Thanks to [@brandonmwest](https://github.com/brandonmwest) for #2052.
 - Wait for remembered detached foreground descendants before parent settlement, without aborting a result-bearing child on the runner grace window. Thanks to [@shaharmor](https://github.com/shaharmor) for #2051.
 - Do not report owned process-tree cleanup as `observed` when a detached descendant remains active after the owned process group exits. Thanks to [@rtbe](https://github.com/rtbe) for #2053.

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -97,6 +97,11 @@ function stripSeverityCompounds(task: string): string {
 }
 export { stripSeverityCompounds };
 
+// Quoted categories in a finding-classification request describe fixes, not
+// instructions to perform them. Strip only that request, leaving sibling
+// imperatives (including another "must fix") subject to the normal guards.
+const FINDING_CLASSIFICATION_PATTERN = /\b(?:classify|categorize|weigh)\s+(?:(?:the|remaining)\s+)*(?:findings?|items?|issues?)\s+as\s+["“]must\s+fix\s+before\s+[^"”\n.;!?]+["”]\s+(?:vs\.?|versus)\s+["“]must\s+fix\s+before\s+[^"”\n.;!?]+["”]/gi;
+
 const PATH_LIKE_TOKEN_PATTERN = /[^\s]+[/\\][^\s]+|[^\s/\\]+\.[A-Za-z][A-Za-z0-9]{0,9}\b/g;
 const PATH_INTERNAL_IMPLEMENTATION_VERB = /\b(?:implement|edit|modify|refactor|delete|update|add|remove|replace|create)\b/i;
 
@@ -193,7 +198,7 @@ function hasImplementationIntent(agent: string, taskText: string): boolean {
 }
 
 export function classifyTaskMutationIntent(agent: string, task: string): TaskMutationIntent {
-	const taskText = stripSeverityCompounds(stripFrameworkInstructions(task));
+	const taskText = stripPatterns(stripSeverityCompounds(stripFrameworkInstructions(task)), [FINDING_CLASSIFICATION_PATTERN]);
 	const taskTextWithoutScopedConstraints = stripPatterns(taskText, SCOPED_NO_EDIT_CONSTRAINT_PATTERNS);
 	const prohibitions = analyzeNoEditProhibitions(taskTextWithoutScopedConstraints);
 	if (prohibitions.present) {
@@ -232,7 +237,7 @@ const MAY_MUTATE_VERB_PATTERN = /\b(?:fix|implement|update|write|edit|modify|mig
  * does.
  */
 export function taskMayMutate(task: string): boolean {
-	const taskText = stripPatterns(stripSeverityCompounds(stripFrameworkInstructions(task)), SCOPED_NO_EDIT_CONSTRAINT_PATTERNS);
+	const taskText = stripPatterns(stripSeverityCompounds(stripFrameworkInstructions(task)), [FINDING_CLASSIFICATION_PATTERN, ...SCOPED_NO_EDIT_CONSTRAINT_PATTERNS]);
 	const prohibitions = analyzeNoEditProhibitions(taskText);
 	if (prohibitions.blanket) return false;
 	return MAY_MUTATE_VERB_PATTERN.test(stripPatterns(prohibitions.strippedText, READ_ONLY_DELIVERABLE_PATTERNS));

--- a/src/runs/shared/task-intent.ts
+++ b/src/runs/shared/task-intent.ts
@@ -100,7 +100,7 @@ export { stripSeverityCompounds };
 // Quoted categories in a finding-classification request describe fixes, not
 // instructions to perform them. Strip only that request, leaving sibling
 // imperatives (including another "must fix") subject to the normal guards.
-const FINDING_CLASSIFICATION_PATTERN = /\b(?:classify|categorize|weigh)\s+(?:(?:the|remaining)\s+)*(?:findings?|items?|issues?)\s+as\s+["“]must\s+fix\s+before\s+[^"”\n.;!?]+["”]\s+(?:vs\.?|versus)\s+["“]must\s+fix\s+before\s+[^"”\n.;!?]+["”]/gi;
+const FINDING_CLASSIFICATION_PATTERN = /\b(?:classify|categorize|weigh)\s+(?:(?:the|remaining)\s+)*(?:findings?|items?|issues?)\s+as\s+["“]must\s+fix\s+before\s+[^"”\n]+["”]\s+(?:vs\.?|versus)\s+["“]must\s+fix\s+before\s+[^"”\n]+["”]/gi;
 
 const PATH_LIKE_TOKEN_PATTERN = /[^\s]+[/\\][^\s]+|[^\s/\\]+\.[A-Za-z][A-Za-z0-9]{0,9}\b/g;
 const PATH_INTERNAL_IMPLEMENTATION_VERB = /\b(?:implement|edit|modify|refactor|delete|update|add|remove|replace|create)\b/i;

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -409,6 +409,30 @@ test("read-only audit tasks survive host-clamped declared mutation tools", () =>
 	}
 });
 
+test("review finding classifications are not implementation launch obligations", () => {
+	const task = 'Review the disabled code and weigh remaining items as "must fix before ENABLING" vs "must fix before MERGING disabled code".';
+	const tools = ["read", "grep", "find", "ls"];
+	assert.equal(validateImplementationToolContract({ agent: "reviewer", task, tools }), undefined);
+	assert.equal(evaluateCompletionMutationGuard({
+		agent: "reviewer", task, tools: [...tools, "edit"], messages: [assistantText("Findings classified.")],
+	}).triggered, false);
+});
+
+test("review classification wording does not hide actual required fixes", () => {
+	const classification = 'Classify findings as "must fix before ENABLING" vs "must fix before MERGING disabled code"';
+	for (const task of [
+		"You must fix the bug before enabling the feature.",
+		`${classification}; you must fix the bug before enabling the feature.`,
+	]) {
+		assert.match(validateImplementationToolContract({
+			agent: "reviewer", task, tools: ["read", "grep", "find", "ls"],
+		}) ?? "", /no mutation-capable tools/, task);
+		assert.equal(evaluateCompletionMutationGuard({
+			agent: "reviewer", task, tools: ["read", "edit"], messages: [assistantText("Findings classified.")],
+		}).triggered, true, task);
+	}
+});
+
 test("oracle review tasks with bash available do not require mutation", () => {
 	const task = "Review prep findings and determine what to implement with playbooks instead of before.";
 	const result = evaluateCompletionMutationGuard({

--- a/test/unit/completion-guard.test.ts
+++ b/test/unit/completion-guard.test.ts
@@ -418,6 +418,15 @@ test("review finding classifications are not implementation launch obligations",
 	}).triggered, false);
 });
 
+test("quoted review categories allow version punctuation without hiding trailing fixes", () => {
+	const task = 'Classify findings as "must fix before v1.0" vs "must fix before v2.0".';
+	const tools = ["read", "grep", "find", "ls"];
+	assert.equal(validateImplementationToolContract({ agent: "reviewer", task, tools }), undefined);
+	assert.match(validateImplementationToolContract({
+		agent: "reviewer", task: `${task} You must fix the bug before enabling the feature.`, tools,
+	}) ?? "", /no mutation-capable tools/);
+});
+
 test("review classification wording does not hide actual required fixes", () => {
 	const classification = 'Classify findings as "must fix before ENABLING" vs "must fix before MERGING disabled code"';
 	for (const task of [

--- a/test/unit/task-intent.test.ts
+++ b/test/unit/task-intent.test.ts
@@ -203,6 +203,13 @@ describe("taskMayMutate", () => {
 		assert.equal(taskMayMutate("Summarize the build output"), false);
 	});
 
+	it("distinguishes quoted finding categories from sibling fix instructions", () => {
+		const task = 'Classify findings as "must fix before ENABLING" vs "must fix before MERGING disabled code"';
+		assert.equal(taskMayMutate(task), false);
+		assert.equal(taskMayMutate(`${task}; you must fix the bug.`), true);
+		assert.equal(taskMayMutate('You "must fix before ENABLING" the feature.'), true);
+	});
+
 	it("keeps verbs that survive outside a scoped prohibition", () => {
 		assert.equal(taskMayMutate("Do not modify tests but implement the fix"), true);
 		assert.equal(taskMayMutate("Do not modify tests; update the parser"), true);


### PR DESCRIPTION
## Summary

Allow read-only review requests to classify findings using quoted comparative must-fix-before categories without treating those labels as instructions to edit. The bounded normalization leaves neighboring actual fix instructions subject to the existing hard mutation-capability guard. It is not a general natural-language parser or a warning-only guard.

Thanks to [@freezscholte](https://github.com/freezscholte) for #2079. Closes #2079.

## Validation

- Reported prompt reproduced a failing public launch-contract regression before the fix.
- 134 affected unit tests and3 public implementation-launch refusal tests passed; typecheck/diff hygiene passed.
- Fresh independent reviewer reran3 focused regressions and found no blockers; parent verified the narrow source boundary.
- No full-suite or live-model smoke. Exact-head CI/Greptile pending.