### PR TITLE
fix(watchdog): keep configured model recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Keep the configured main watchdog model and thinking in recommendations instead of suggesting a hardcoded replacement, and clarify user-scope model saves. Thanks to [@freezscholte](https://github.com/freezscholte) for #2078.
 - A manual `schedule.run` that attaches a run satisfies the next natural fire, so manually-run schedules no longer double-fire (#2052). Thanks to [@brandonmwest](https://github.com/brandonmwest) for #2052.
 - Wait for remembered detached foreground descendants before parent settlement, without aborting a result-bearing child on the runner grace window. Thanks to [@shaharmor](https://github.com/shaharmor) for #2051.
 - Do not report owned process-tree cleanup as `observed` when a detached descendant remains active after the owned process group exits. Thanks to [@rtbe](https://github.com/rtbe) for #2053.

--- a/docs/watchdog.md
+++ b/docs/watchdog.md
@@ -88,7 +88,9 @@ One model setting serves both boundary and cadence reviews per endpoint. Use a s
 /subagents-watchdog on
 ```
 
-The recommendation is Opus 4.8 or GPT 5.5 at thinking high, whichever your main session is not using and is authenticated. Saving a model does not enable the watchdog; use `on` separately.
+When a main watchdog model is configured (including a session override), recommendations keep that model and its effective thinking level rather than judging its strength or independence. An unavailable or unauthenticated configured model is reported, not replaced. Without a configured main model, the recommendation remains Opus 4.8 or GPT 5.5 at thinking high, whichever your main session is not using and is authenticated.
+
+`session model recommended` changes only this session. `model recommended` explicitly saves the recommendation to **user settings**, affecting other projects without overrides; it does not change project settings. Project and session overrides still take precedence. Use an explicit model to replace a configured choice. Saving a model does not enable the watchdog; use `on` separately.
 
 ```json
 {

--- a/src/watchdog/model-selection.ts
+++ b/src/watchdog/model-selection.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { normalizeModelSegment, resolveModelCandidate } from "../runs/shared/model-fallback.ts";
+import type { WatchdogEndpointConfig } from "./types.ts";
 import {
 	getSupportedThinkingLevels,
 	splitKnownThinkingSuffix,
@@ -43,6 +44,7 @@ export interface ResolvedWatchdogModelInput {
 }
 
 export interface WatchdogModelRecommendation {
+	source: "configured" | "suggested";
 	model: string;
 	thinking: ThinkingLevel;
 	label: string;
@@ -147,6 +149,7 @@ function resolveStrongCandidate(ctx: ExtensionContext, family: StrongWatchdogFam
 		if (!getSupportedThinkingLevels(modelInfo).includes(STRONG_WATCHDOG_THINKING)) continue;
 		const current = ctx.model ? fullModelId(toModelInfo(ctx.model)) : "no current session model";
 		return {
+			source: "suggested",
 			model: resolved.model,
 			thinking: STRONG_WATCHDOG_THINKING,
 			label: preference.label,
@@ -164,4 +167,21 @@ export function recommendStrongWatchdogModel(ctx: ExtensionContext): WatchdogMod
 	}
 	const current = ctx.model ? fullModelId(toModelInfo(ctx.model)) : "the current session";
 	throw new Error(`No authenticated strong complementary watchdog model was found for ${current}. Configure access to Opus 4.8 or GPT 5.5, then run the recommendation again.`);
+}
+
+export function recommendWatchdogModel(ctx: ExtensionContext, configured: WatchdogEndpointConfig): WatchdogModelRecommendation {
+	if (!configured.model) return recommendStrongWatchdogModel(ctx);
+	const resolved = resolveWatchdogModelInput(ctx, configured.model);
+	const thinking = resolved.thinking ?? parseWatchdogThinkingInput(configured.thinking) ?? "off";
+	return {
+		...resolved,
+		source: "configured",
+		thinking: thinking === false ? "off" : thinking,
+		label: "configured watchdog",
+		reason: "Keep the configured watchdog model and thinking; no replacement recommendation is needed. This is not a strength or independence assessment.",
+	};
+}
+
+export function formatWatchdogRecommendation(recommendation: WatchdogModelRecommendation): string {
+	return `${recommendation.source === "configured" ? "Keep configured watchdog" : "Recommended strong watchdog"}: ${recommendation.model}:${recommendation.thinking}`;
 }

--- a/src/watchdog/register-main.ts
+++ b/src/watchdog/register-main.ts
@@ -3,7 +3,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { resolveEffectiveThinking, splitKnownThinkingSuffix, THINKING_LEVELS, type ThinkingLevel } from "../shared/model-info.ts";
 import { SLASH_TEXT_RESULT_TYPE } from "../shared/types.ts";
 import { captureWatchdogDiffBaseline, type WatchdogDiffBaseline } from "./diff-tool.ts";
-import { recommendStrongWatchdogModel, resolveWatchdogModelInput, parseWatchdogThinkingInput } from "./model-selection.ts";
+import { formatWatchdogRecommendation, recommendWatchdogModel, resolveWatchdogModelInput, parseWatchdogThinkingInput } from "./model-selection.ts";
 import { renderWatchdogWarning } from "./render.ts";
 import { createMainWatchdogReview } from "./review.ts";
 import { MainWatchdogRuntime, type WatchdogReviewFunction } from "./runtime.ts";
@@ -93,12 +93,11 @@ function childrenLine(snapshot: ReturnType<MainWatchdogRuntime["getSnapshot"]>):
 	return `Children: ${boolLabel(snapshot.config.enabled && children.enabled)} · model ${model}${fallbackLine(children.fallbackModels)} · thinking ${thinking}${overrideText}`;
 }
 
-function recommendationLine(ctx: ExtensionContext): string {
+function recommendationLine(snapshot: ReturnType<MainWatchdogRuntime["getSnapshot"]>, ctx: ExtensionContext): string {
 	try {
-		const recommendation = recommendStrongWatchdogModel(ctx);
-		return `Recommended strong watchdog: ${recommendation.model}:${recommendation.thinking} (${recommendation.label}, complementary reviewer)`;
+		return formatWatchdogRecommendation(recommendWatchdogModel(ctx, snapshot.config.main));
 	} catch (error) {
-		return `Recommended strong watchdog: unavailable (${messageFromError(error)})`;
+		return `Watchdog recommendation unavailable (${messageFromError(error)})`;
 	}
 }
 
@@ -126,7 +125,7 @@ export function buildWatchdogStatus(snapshot: ReturnType<MainWatchdogRuntime["ge
 		mainModelLine(snapshot, ctx),
 		`Main thinking: ${mainThinkingLine(snapshot, ctx)}`,
 		childrenLine(snapshot),
-		recommendationLine(ctx),
+		recommendationLine(snapshot, ctx),
 		`Agent-end timeout: ${snapshot.config.agentEndTimeoutMs}ms`,
 		`Stalemate: ${snapshot.boundaryRepeats}/${snapshot.config.stalemateRepeats}${snapshot.stalemate ? " · stopped" : ""}`,
 		`Rules: ${snapshot.config.rules ? `${Object.keys(snapshot.config.rules.roleModels).length} role models · ${snapshot.config.rules.action}` : "none"}`,
@@ -152,7 +151,7 @@ export function buildWatchdogStatus(snapshot: ReturnType<MainWatchdogRuntime["ge
 		"",
 		"Model commands:",
 		"- /subagents-watchdog recommend-model",
-		"- /subagents-watchdog model recommended",
+		"- /subagents-watchdog model recommended (saves to user settings, not project settings)",
 		"- /subagents-watchdog model <provider/model[:thinking]>",
 		"- /subagents-watchdog model inherit",
 		"- /subagents-watchdog session model recommended",
@@ -178,12 +177,12 @@ function parseThinkingCommand(raw: string): ThinkingLevel | false | null {
 	return parseWatchdogThinkingInput(value, "/subagents-watchdog thinking") ?? null;
 }
 
-function resolveModelCommandValue(ctx: ExtensionCommandContext, raw: string): { model: string | null; thinking: ThinkingLevel | false | null; description: string } {
+function resolveModelCommandValue(runtime: MainWatchdogRuntime, ctx: ExtensionCommandContext, raw: string): { model: string | null; thinking: ThinkingLevel | false | null; description: string } {
 	const value = raw.trim();
 	if (!value) throw new Error("Expected a model, 'recommended', or 'inherit'.");
 	if (value === "inherit") return { model: null, thinking: null, description: "current session model and thinking" };
 	if (value === "recommended") {
-		const recommendation = recommendStrongWatchdogModel(ctx as ExtensionContext);
+		const recommendation = recommendWatchdogModel(ctx, runtime.getSnapshot(ctx.cwd).config.main);
 		return {
 			model: recommendation.model,
 			thinking: recommendation.thinking,
@@ -198,18 +197,18 @@ function resolveModelCommandValue(ctx: ExtensionCommandContext, raw: string): { 
 	};
 }
 
-function buildRecommendationText(ctx: ExtensionCommandContext): string {
-	const recommendation = recommendStrongWatchdogModel(ctx as ExtensionContext);
+function buildRecommendationText(runtime: MainWatchdogRuntime, ctx: ExtensionCommandContext): string {
+	const recommendation = recommendWatchdogModel(ctx, runtime.getSnapshot(ctx.cwd).config.main);
 	return [
 		"Subagent watchdog recommended model",
 		`Current session: ${currentSessionModelLine(ctx as ExtensionContext)}`,
-		`Recommended: ${recommendation.model}:${recommendation.thinking}`,
+		recommendation.source === "configured" ? formatWatchdogRecommendation(recommendation) : `Recommended: ${recommendation.model}:${recommendation.thinking}`,
 		`Reason: ${recommendation.reason}`,
 		"",
 		"Apply for this session:",
 		"/subagents-watchdog session model recommended",
 		"",
-		"Save as your user default:",
+		"Save as your user default (affects other projects without overrides; does not change project settings):",
 		"/subagents-watchdog model recommended",
 	].join("\n");
 }
@@ -228,12 +227,7 @@ function buildCheckText(runtime: MainWatchdogRuntime, ctx: ExtensionCommandConte
 	}
 	lines.push(`Main thinking: ${mainThinkingLine(snapshot, ctx as ExtensionContext)}`);
 	lines.push(lspLine(snapshot));
-	try {
-		const recommendation = recommendStrongWatchdogModel(ctx as ExtensionContext);
-		lines.push(`Recommended strong watchdog: ${recommendation.model}:${recommendation.thinking}`);
-	} catch (error) {
-		lines.push(`Recommended strong watchdog: unavailable (${messageFromError(error)})`);
-	}
+	lines.push(recommendationLine(snapshot, ctx));
 	return lines.join("\n");
 }
 
@@ -265,7 +259,7 @@ async function handleWatchdogCommand(
 	}
 	if (input === "recommend-model") {
 		try {
-			sendSlashText(pi, buildRecommendationText(ctx));
+			sendSlashText(pi, buildRecommendationText(runtime, ctx));
 		} catch (error) {
 			sendSlashText(pi, `Subagent watchdog recommended model\n\n${messageFromError(error)}`);
 		}
@@ -308,7 +302,7 @@ async function handleWatchdogCommand(
 	if (input.startsWith("session model ")) {
 		const rawModel = input.slice("session model ".length);
 		try {
-			const value = resolveModelCommandValue(ctx, rawModel);
+			const value = resolveModelCommandValue(runtime, ctx, rawModel);
 			const snapshot = value.model === null
 				? runtime.clearSessionModel(ctx.cwd)
 				: runtime.setSessionModel({ model: value.model, thinking: value.thinking ?? null }, ctx.cwd);
@@ -326,7 +320,7 @@ async function handleWatchdogCommand(
 	if (input.startsWith("model ")) {
 		const rawModel = input.slice("model ".length);
 		try {
-			const value = resolveModelCommandValue(ctx, rawModel);
+			const value = resolveModelCommandValue(runtime, ctx, rawModel);
 			const settingsPath = writeWatchdogModelSettings({
 				scope: "user",
 				target: { kind: "main" },
@@ -336,7 +330,7 @@ async function handleWatchdogCommand(
 			runtime.refreshConfig(ctx.cwd);
 			const snapshot = runtime.getSnapshot(ctx.cwd);
 			sendSlashText(pi, [
-				`Subagent watchdog model saved: ${value.description}.`,
+				`Subagent watchdog model saved to user settings: ${value.description}. Project and session overrides still take precedence.`,
 				`Updated: ${settingsPath}`,
 				`Main now: ${boolLabel(snapshot.enabled)}`,
 				value.model === null ? "The watchdog now inherits the current session model and thinking." : "Run /subagents-watchdog on if the watchdog is still off.",

--- a/src/watchdog/tool-actions.ts
+++ b/src/watchdog/tool-actions.ts
@@ -4,8 +4,8 @@ import { THINKING_LEVELS, type ThinkingLevel } from "../shared/model-info.ts";
 import type { Details } from "../shared/types.ts";
 import { buildWatchdogStatus } from "./register-main.ts";
 import type { MainWatchdogRuntime } from "./runtime.ts";
-import { parseWatchdogThinkingInput, recommendStrongWatchdogModel, resolveWatchdogModelInput } from "./model-selection.ts";
-import { writeWatchdogModelSettings, type WatchdogModelSettingsTarget, type WatchdogSettingsWriteScope } from "./settings.ts";
+import { formatWatchdogRecommendation, parseWatchdogThinkingInput, recommendStrongWatchdogModel, recommendWatchdogModel, resolveWatchdogModelInput } from "./model-selection.ts";
+import { resolveWatchdogConfig, writeWatchdogModelSettings, type WatchdogModelSettingsTarget, type WatchdogSettingsWriteScope } from "./settings.ts";
 
 interface WatchdogToolParams {
 	action?: string;
@@ -52,7 +52,7 @@ function parseThinking(raw: string | false | undefined): ThinkingLevel | false |
 	return parseWatchdogThinkingInput(raw, "watchdog.configure thinking") ?? undefined;
 }
 
-function resolveConfiguredValue(ctx: ExtensionContext, params: WatchdogToolParams): { model?: string | null; thinking?: ThinkingLevel | false | null; description: string } {
+function resolveConfiguredValue(ctx: ExtensionContext, params: WatchdogToolParams, runtime?: MainWatchdogRuntime): { model?: string | null; thinking?: ThinkingLevel | false | null; description: string } {
 	const thinking = parseThinking(params.thinking);
 	const rawModel = params.model?.trim();
 	if (!rawModel) {
@@ -61,7 +61,9 @@ function resolveConfiguredValue(ctx: ExtensionContext, params: WatchdogToolParam
 	}
 	if (rawModel === "inherit") return { model: null, thinking: thinking ?? null, description: "inherit" };
 	if (rawModel === "recommended") {
-		const recommendation = recommendStrongWatchdogModel(ctx);
+		const recommendation = (params.target ?? "main") === "main"
+			? recommendWatchdogModel(ctx, (runtime?.getSnapshot(ctx.cwd).config ?? resolveWatchdogConfig(ctx.cwd).config).main)
+			: recommendStrongWatchdogModel(ctx);
 		return {
 			model: recommendation.model,
 			thinking: recommendation.thinking,
@@ -76,11 +78,11 @@ function resolveConfiguredValue(ctx: ExtensionContext, params: WatchdogToolParam
 	};
 }
 
-function buildRecommendationText(ctx: ExtensionContext): string {
-	const recommendation = recommendStrongWatchdogModel(ctx);
+function buildRecommendationText(ctx: ExtensionContext, runtime?: MainWatchdogRuntime): string {
+	const recommendation = recommendWatchdogModel(ctx, (runtime?.getSnapshot(ctx.cwd).config ?? resolveWatchdogConfig(ctx.cwd).config).main);
 	return [
 		"Subagent watchdog recommended model",
-		`Recommended: ${recommendation.model}:${recommendation.thinking}`,
+		recommendation.source === "configured" ? formatWatchdogRecommendation(recommendation) : `Recommended: ${recommendation.model}:${recommendation.thinking}`,
 		`Reason: ${recommendation.reason}`,
 		"Apply temporarily with subagent({ action: \"watchdog.configure\", scope: \"session\", model: \"recommended\" }).",
 		"Persist with scope: \"project\" or scope: \"user\" only when the user asks for that scope.",
@@ -100,10 +102,9 @@ function buildCheckText(runtime: MainWatchdogRuntime | undefined, ctx: Extension
 	}
 	lines.push(`LSP diagnostics: ${snapshot.lsp.enabled ? "on" : "off"} · ${snapshot.lsp.status}`);
 	try {
-		const recommendation = recommendStrongWatchdogModel(ctx);
-		lines.push(`Recommended strong watchdog: ${recommendation.model}:${recommendation.thinking}`);
+		lines.push(formatWatchdogRecommendation(recommendWatchdogModel(ctx, snapshot.config.main)));
 	} catch (error) {
-		lines.push(`Recommended strong watchdog unavailable: ${messageFromError(error)}`);
+		lines.push(`Watchdog recommendation unavailable: ${messageFromError(error)}`);
 	}
 	return lines.join("\n");
 }
@@ -114,13 +115,13 @@ export function handleWatchdogToolAction(action: string, params: WatchdogToolPar
 			if (!runtime) return result("Subagent watchdog runtime is unavailable.", true);
 			return result(buildWatchdogStatus(runtime.getSnapshot(ctx.cwd), ctx));
 		}
-		if (action === "watchdog.recommend-model") return result(buildRecommendationText(ctx));
+		if (action === "watchdog.recommend-model") return result(buildRecommendationText(ctx, runtime));
 		if (action === "watchdog.check") return result(buildCheckText(runtime, ctx));
 		if (action !== "watchdog.configure") return result(`Unknown watchdog action: ${action}`, true);
 
 		const scope = parseScope(params.scope);
 		const target = parseTarget(params);
-		const value = resolveConfiguredValue(ctx, params);
+		const value = resolveConfiguredValue(ctx, params, runtime);
 		if (scope === "session") {
 			if (!runtime) return result("Subagent watchdog runtime is unavailable.", true);
 			if (target.kind !== "main") return result("Session-scoped watchdog.configure currently supports target='main' only.", true);

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -327,6 +327,40 @@ describe("subagents watchdog slash command", { skip: !available ? "watchdog comm
 		});
 	});
 
+	it("keeps a configured project watchdog in recommendations and explicit user-scope saves", async () => {
+		await withIsolatedHome(async () => {
+			await withTempProject("pi-watchdog-configured-", async (root) => {
+				const configured = { provider: "github-copilot", id: "gpt-6-astra", reasoning: true };
+				const gpt = { provider: "openai-codex", id: "gpt-5.5", reasoning: true };
+				const models = [configured, gpt];
+				const projectPath = path.join(root, ".pi", "settings.json");
+				fs.mkdirSync(path.dirname(projectPath), { recursive: true });
+				const projectSettings = JSON.stringify({ subagents: { watchdog: { main: { model: "github-copilot/gpt-6-astra", thinking: "high" } } } });
+				fs.writeFileSync(projectPath, projectSettings);
+				const ctx = createCommandContext({ cwd: root, model: configured, modelRegistry: {
+					getAvailable: () => models,
+					find: (provider: string, id: string) => models.find((entry) => entry.provider === provider && entry.id === id),
+					hasConfiguredAuth: () => true,
+				} });
+				const { commands, sent } = createWatchdogHarness();
+				for (const command of ["status", "recommend-model", "check"]) {
+					await commands.get("subagents-watchdog")!.handler(command, ctx);
+					const content = String((sent.at(-1) as { content?: unknown }).content ?? "");
+					assert.match(content, /Keep configured watchdog: github-copilot\/gpt-6-astra:high/);
+					assert.doesNotMatch(content, /Recommended strong watchdog|strong independent watchdog/);
+				}
+				const userPath = path.join(process.env.HOME!, ".pi", "agent", "settings.json");
+				assert.equal(fs.existsSync(userPath), false);
+				await commands.get("subagents-watchdog")!.handler("model recommended", ctx);
+				assert.deepEqual(JSON.parse(fs.readFileSync(userPath, "utf-8")).subagents.watchdog.main, {
+					model: "github-copilot/gpt-6-astra", thinking: "high",
+				});
+				assert.match(String((sent.at(-1) as { content?: unknown }).content), /saved to user settings/);
+				assert.equal(fs.readFileSync(projectPath, "utf-8"), projectSettings);
+			});
+		});
+	});
+
 	it("supports session-scoped recommended watchdog models without writing settings", async () => {
 		await withIsolatedHome(async () => {
 			await withTempProject("pi-watchdog-session-model-", async (root) => {

--- a/test/unit/watchdog-tool-actions.test.ts
+++ b/test/unit/watchdog-tool-actions.test.ts
@@ -67,6 +67,36 @@ describe("watchdog tool actions", () => {
 		assert.equal(runtime.getSnapshot(tempProject).config.main.thinking, "high");
 	});
 
+	it("keeps session model overrides and their thinking in recommendations", () => {
+		const runtime = new MainWatchdogRuntime({ cwd: tempProject });
+		const ctx = createCtx({ provider: "openai-codex", id: "gpt-5.5" });
+		runtime.setSessionModel({ model: "openai-codex/gpt-5.5", thinking: false }, tempProject);
+		const recommendation = handleWatchdogToolAction("watchdog.recommend-model", {}, ctx, runtime);
+		assert.equal(recommendation.isError, undefined);
+		assert.match(text(recommendation), /Keep configured watchdog: openai-codex\/gpt-5.5:off/);
+		assert.doesNotMatch(text(recommendation), /strong independent watchdog/);
+		const applied = handleWatchdogToolAction("watchdog.configure", { model: "recommended" }, ctx, runtime);
+		assert.equal(applied.isError, undefined);
+		assert.equal(runtime.getSnapshot(tempProject).config.main.model, "openai-codex/gpt-5.5");
+		assert.equal(runtime.getSnapshot(tempProject).config.main.thinking, "off");
+		runtime.setSessionModel({ model: "openai-codex/gpt-5.5:low", thinking: false }, tempProject);
+		const suffixed = handleWatchdogToolAction("watchdog.configure", { model: "recommended" }, ctx, runtime);
+		assert.equal(suffixed.isError, undefined);
+		assert.equal(runtime.getSnapshot(tempProject).config.main.thinking, "low");
+		assert.equal(fs.existsSync(path.join(tempHome, ".pi", "agent", "settings.json")), false);
+	});
+
+	it("does not replace an unavailable configured model with a strong recommendation", () => {
+		const runtime = new MainWatchdogRuntime({ cwd: tempProject });
+		const ctx = createCtx({ provider: "openai-codex", id: "gpt-5.5" });
+		runtime.setSessionModel({ model: "custom/unavailable", thinking: "low" }, tempProject);
+		const result = handleWatchdogToolAction("watchdog.configure", { model: "recommended", scope: "user" }, ctx, runtime);
+		assert.equal(result.isError, true);
+		assert.match(text(result), /was not found/);
+		assert.equal(runtime.getSnapshot(tempProject).config.main.model, "custom/unavailable");
+		assert.equal(fs.existsSync(path.join(tempHome, ".pi", "agent", "settings.json")), false);
+	});
+
 	it("preserves omitted session model fields when configuring thinking", () => {
 		const runtime = new MainWatchdogRuntime({ cwd: tempProject });
 		const ctx = createCtx({ provider: "openai-codex", id: "gpt-5.5" });


### PR DESCRIPTION
## Summary

Keep the effective configured main-watchdog model and thinking when displaying or applying recommendations, including session overrides. Configured unavailable/unauthenticated choices report an error rather than silently selecting a different model. Unconfigured and child-target recommendations remain unchanged.

Clarify that the existing model recommended slash command writes user settings while session model recommended is temporary. No persistence-scope or confirmation-policy change; configured choices are not labeled as independently assessed for model strength.

Thanks to [@freezscholte](https://github.com/freezscholte) for #2078. Closes #2078.

## Validation

- Public slash regression failed before the fix and passes after.
- 40 slash integration tests,141 watchdog tests and1 executor routing test passed; one existing native-SDK smoke skipped.
- Typecheck/diff hygiene, fresh independent review and parent source verification passed.
- No live-provider or interactive smoke; exact-head CI/Greptile pending.