### PR TITLE
test: capture bounded Windows async result timeout evidence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,9 @@ jobs:
         if: failure()
         with:
           name: shared-cwd-terminal-${{ matrix.os }}
-          path: ${{ runner.temp }}/1906-terminal-evidence/shared-cwd-terminal.json
+          path: |
+            ${{ runner.temp }}/1906-terminal-evidence/shared-cwd-terminal.json
+            ${{ runner.temp }}/1906-terminal-evidence/async-result-*.json
           if-no-files-found: ignore
 
   bun-workflow-script:

--- a/test/integration/acceptance-file-report.test.ts
+++ b/test/integration/acceptance-file-report.test.ts
@@ -13,6 +13,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { readProcessTerminal } from "../../src/runs/background/process-terminal.ts";
+import { captureAsyncResultTimeout } from "../support/async-result-diagnostic.ts";
 import { childSessionFactoryModule, setChildSessionFactoryModule } from "../../src/runs/shared/child-session.ts";
 import type { MockPi } from "../support/helpers.ts";
 import { createEventBus, createMockPi, createTempDir, events, makeAgent, makeAgentConfigs, makeMinimalCtx, tryImport } from "../support/helpers.ts";
@@ -120,8 +121,13 @@ async function waitForAsyncResult(id: string, timeoutMs = 15_000): Promise<Async
 	if (marks) marks.resultWaitStartedAt = Date.now();
 	const resultPath = path.join(RESULTS_DIR!, `${id}.json`);
 	const deadline = Date.now() + timeoutMs;
+	if (marks) marks.resultDeadline = deadline;
 	while (!fs.existsSync(resultPath)) {
-		if (Date.now() > deadline) assert.fail(`Timed out waiting for async result file: ${resultPath}`);
+		if (Date.now() > deadline) {
+			if (marks) marks.resultTimeoutAt = Date.now();
+			ownedRunners.get(id)?.captureResultTimeout("timeout");
+			assert.fail(`Timed out waiting for async result file: ${resultPath}`);
+		}
 		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
 	const payload = JSON.parse(fs.readFileSync(resultPath, "utf-8")) as AsyncResultPayload;
@@ -330,6 +336,17 @@ public static class AcceptanceIdentity {
 			identity ??= queryIdentity(matched.length === 1 ? matched[0]!.proc : undefined);
 			return { ...snapshot, identity };
 		},
+		captureResultTimeout(phase: "timeout" | "teardown") {
+			// Reuse existing object-correlated observations; do not query processes or add a wait.
+			const matched = processes.filter(({ proc }) => pid !== undefined && proc.pid === pid);
+			const phases = this.readEvidence(path.join(ASYNC_DIR!, id, "runner.stderr.log"), "phases");
+			const evidence = captureAsyncResultTimeout({
+				id, asyncDir: path.join(ASYNC_DIR!, id), resultsDir: RESULTS_DIR!, phase,
+				waitStartedAt: marks.resultWaitStartedAt!, deadline: marks.resultDeadline!,
+				observer: { pid, marks, events: matched.length === 1 ? matched[0]!.events : [], phases: "entries" in phases && Array.isArray(phases.entries) ? phases.entries : [] },
+			});
+			console.log("#async-result-timeout " + JSON.stringify(evidence));
+		},
 		measureControl(proof: unknown) {
 			if (!disableCompileCache) return;
 			try {
@@ -361,12 +378,14 @@ describe("acceptance file reports", { skip: !runSync ? "pi packages not availabl
 			// The reader validates identity/shape and treats absent or partial I/O as unproven.
 			proof = readProcessTerminal(asyncDir, { runId: id });
 			if (proof?.state === "observed") {
+				if (diagnostic.marks.resultTimeoutAt) diagnostic.captureResultTimeout("teardown");
 				diagnostic.measureControl(proof);
 				diagnostic.dispose();
 				return;
 			}
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		} while (Date.now() <= deadline);
+		if (diagnostic.marks.resultTimeoutAt) diagnostic.captureResultTimeout("teardown");
 		let evidence: unknown;
 		try { evidence = diagnostic.snapshot(proof); }
 		catch { evidence = { snapshot: "unavailable" }; }

--- a/test/integration/async-execution.part-1.test.ts
+++ b/test/integration/async-execution.part-1.test.ts
@@ -14,6 +14,7 @@ import * as fs from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
 import * as path from "node:path";
 import { events, makeAgent, makeMinimalCtx, resolveMockPiCallArgs } from "../support/helpers.ts";
+import { captureAsyncResultTimeout } from "../support/async-result-diagnostic.ts";
 import { registerSubagentCapabilityCeiling } from "../../src/api/capability-ceiling.ts";
 import { registerWorkflowResource } from "../../src/api/workflow-resources.ts";
 import type { WorkflowReceipt } from "../../src/workflows/workflow-receipt.ts";
@@ -157,35 +158,55 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		}
 	});
 
-	it("summarizes result-wait evidence without exposing artifact contents", async () => {
+	it("captures bounded result-wait evidence without exposing artifact contents", async () => {
 		const id = `async-wait-diagnostic-${Date.now().toString(36)}`;
 		const asyncDir = path.join(ASYNC_DIR, id);
 		fs.mkdirSync(asyncDir, { recursive: true });
+		const previous = process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+		process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR = path.join(tempDir, "diagnostics");
 		try {
-			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ state: "running", steps: [{ status: "pending" }], task: "secret-prompt" }));
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ runId: id, sessionId: "session-1", state: "running", startedAt: 123, processTerminal: { runnerProcessInstanceId: "secret-instance" }, steps: [{ status: "pending" }], task: "secret-prompt" }));
+			fs.writeFileSync(path.join(asyncDir, "process-terminal.json"), JSON.stringify({ runId: id, state: "pending", runnerProcessInstanceId: "secret-instance" }));
 			fs.writeFileSync(path.join(asyncDir, "runner.stdout.log"), "");
 			fs.mkdirSync(path.join(asyncDir, "runner.stderr.log"));
 			fs.writeFileSync(path.join(asyncDir, "runner-startup-proceed.json"), JSON.stringify({ token: "secret-token" }));
-			fs.writeFileSync(path.join(asyncDir, "events.jsonl"), "secret-event-output\n");
-			const checkTimeout = async (stepState: string, callCount: number) => {
-				await assert.rejects(waitForAsyncResultFile(id, -1), (error: unknown) => {
-					assert.ok(error instanceof Error);
-					assert.match(error.message, new RegExp(`"steps":\\["${stepState}"\\]`));
-					assert.ok(error.message.includes(`mock queue: readable, prompt call records=${callCount}`));
-					assert.match(error.message, /runner.stdout.log: empty/);
-					assert.match(error.message, /runner.stderr.log: unreadable \(EISDIR\)/);
-					assert.match(error.message, /process-terminal.json: absent/);
-					assert.match(error.message, /runner-startup-proceed.json: readable, \d+ bytes \(contents withheld\)/);
-					assert.match(error.message, /events.jsonl: readable/);
-					assert.doesNotMatch(error.message, /secret-/);
-					return true;
+			fs.writeFileSync(path.join(asyncDir, "events.jsonl"), JSON.stringify({ type: "subagent.run.started", runId: id, ts: 124, task: "secret-event-output" }) + "\n");
+			const pendingDir = path.join(RESULTS_DIR, "result-pending", "session-1");
+			fs.mkdirSync(pendingDir, { recursive: true });
+			const pendingPath = path.join(pendingDir, `${id}.json`);
+			fs.writeFileSync(pendingPath, JSON.stringify({ id: "secret-other-run", state: "complete", output: "secret-output" }));
+			try {
+				await assert.rejects(waitForAsyncResultFile(id, -1), /Timed out waiting for async result file/);
+				const files = fs.readdirSync(process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR).filter((name) => name.startsWith("async-result-"));
+				assert.equal(files.length, 1);
+				const text = fs.readFileSync(path.join(process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR, files[0]!), "utf-8");
+				assert.ok(Buffer.byteLength(text) <= 32_768);
+				assert.doesNotMatch(text, /secret-/);
+				const evidence = JSON.parse(text);
+				assert.equal(evidence.files.status.runMatches, true);
+				assert.equal(evidence.files.status.startedAt, 123);
+				assert.equal(evidence.files.pending.runMatches, false);
+				assert.equal(evidence.files.proof.state, "pending");
+				assert.equal(evidence.files.proof.runnerMatches, true);
+				assert.equal(evidence.files.public.io, "absent");
+				assert.equal(typeof evidence.files.pending.mtimeMs, "number");
+				assert.equal(evidence.files.stderr.io, "not-file");
+				assert.equal(evidence.files.events.entries[0].ts, 124);
+				assert.equal(fs.existsSync(pendingPath), true, "capture must not promote pending results");
+				fs.writeFileSync(path.join(asyncDir, "status.json"), "secret-oversized".repeat(10_000));
+				// Capture failures must not replace the original test assertion.
+				process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR = path.join(asyncDir, "status.json", "unwritable");
+				const oversized = captureAsyncResultTimeout({ id, asyncDir, resultsDir: RESULTS_DIR, waitStartedAt: 1, deadline: 2,
+					observer: { pid: 7, marks: { resultTimeoutAt: 3 }, events: [{ type: "close", at: 4, code: 0, error: "secret-error" }], phases: [{ phase: "exit-request", ts: 3, pid: 7, output: "secret-output" }] },
 				});
-			};
-			await checkTimeout("pending", 0);
-			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ state: "running", steps: [{ status: "running" }] }));
-			fs.writeFileSync(path.join(mockPi.dir, "call-diagnostic.json"), JSON.stringify({ task: "secret-mock-prompt" }));
-			await checkTimeout("running", 1);
+				assert.equal(oversized.files.status.io, "oversized");
+				assert.equal(oversized.observer?.events[0]?.at, 4);
+				assert.equal(oversized.observer?.phases[0]?.pidMatches, true);
+				assert.doesNotMatch(JSON.stringify(oversized), /secret-/);
+			} finally { fs.rmSync(pendingPath, { force: true }); }
 		} finally {
+			if (previous === undefined) delete process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+			else process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR = previous;
 			fs.rmSync(asyncDir, { recursive: true, force: true });
 		}
 	});

--- a/test/support/async-execution-fixture.ts
+++ b/test/support/async-execution-fixture.ts
@@ -16,6 +16,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { createEventBus, createMockPi, createTempDir, makeAgent, removeTempDir, resolveMockPiCallArgs, tryImport } from "./helpers.ts";
 import type { MockPi } from "./helpers.ts";
+import { captureAsyncResultTimeout } from "./async-result-diagnostic.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
 
@@ -334,30 +335,12 @@ function readIfExists(filePath: string): string | undefined {
 
 async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<string> {
 	const resultPath = path.join(RESULTS_DIR, `${id}.json`);
-	const deadline = Date.now() + timeoutMs;
+	const waitStartedAt = Date.now();
+	const deadline = waitStartedAt + timeoutMs;
 	while (!fs.existsSync(resultPath)) {
 		if (Date.now() > deadline) {
 			const asyncDir = path.join(ASYNC_DIR, id);
-			// Summarize before teardown; never print free-form output, prompts or tokens.
-			const evidence = ["status.json", "runner-startup-proceed.json", "process-terminal.json", "events.jsonl", "runner.stdout.log", "runner.stderr.log"].map((name) => {
-				let text: string;
-				try {
-					text = fs.readFileSync(path.join(asyncDir, name), "utf-8");
-				} catch (error) {
-					const code = (error as NodeJS.ErrnoException).code;
-					return `${name}: ${code === "ENOENT" ? "absent" : `unreadable (${code ?? "unknown"})`}`;
-				}
-				if (!text.length) return `${name}: empty`;
-				const size = `${Buffer.byteLength(text)} bytes (contents withheld)`;
-				if (name !== "status.json") return `${name}: readable, ${size}`;
-				try {
-					const status = JSON.parse(text) as AsyncStatusPayload;
-					const knownState = (value: unknown) => ["pending", "running", "complete", "failed", "cancelled"].includes(String(value)) ? value : "other/absent";
-					return `${name}: ${JSON.stringify({ state: knownState(status.state), steps: status.steps?.map((step) => knownState(step.status)), endedAtPresent: typeof status.endedAt === "number" })}`;
-				} catch {
-					return `${name}: invalid status JSON, ${size}`;
-				}
-			});
+			const evidence = captureAsyncResultTimeout({ id, asyncDir, resultsDir: RESULTS_DIR, waitStartedAt, deadline });
 			// The current fixture queue proves prompt entry, not per-run identity or settlement.
 			const queueDir = process.env.MOCK_PI_QUEUE_DIR;
 			let mockEvidence = "mock queue: not configured";
@@ -373,7 +356,7 @@ async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<s
 			assert.fail([
 				`Timed out waiting for async result file: ${resultPath}`,
 				mockEvidence,
-				...evidence,
+				JSON.stringify(evidence),
 			].join("\n"));
 		}
 		await new Promise((resolve) => setTimeout(resolve, 100));

--- a/test/support/async-result-diagnostic.ts
+++ b/test/support/async-result-diagnostic.ts
@@ -1,0 +1,121 @@
+/** Failure-only, read-only projections. Never use these observations as cleanup authority. */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { encodeIndexSegment } from "../../src/runs/background/index-segment.ts";
+
+const record = (value: unknown): Record<string, unknown> => value !== null && typeof value === "object" ? value as Record<string, unknown> : {};
+const number = (value: unknown) => typeof value === "number" && Number.isFinite(value) ? value : undefined;
+const known = (value: unknown, values: string[]) => typeof value === "string" && values.includes(value) ? value : undefined;
+const state = (value: unknown) => known(value, ["pending", "running", "complete", "failed", "cancelled", "stopped", "paused", "partial", "observed", "unknown", "not-started"]);
+const errorCode = (error: unknown) => known(record(error).code, ["ENOENT", "EACCES", "EPERM", "EBUSY", "EIO", "EMFILE", "ENFILE", "ENOSPC", "ENOTDIR"]) ?? "other";
+
+export function captureAsyncResultTimeout(options: {
+	id: string; asyncDir: string; resultsDir: string; waitStartedAt: number; deadline: number;
+	phase?: "timeout" | "teardown";
+	observer?: { pid?: number; marks: Record<string, number>; events: unknown[]; phases: unknown[] };
+}) {
+	const { id, asyncDir, resultsDir } = options;
+	let runnerInstance: unknown;
+	const project = (value: unknown) => {
+		const raw = record(value);
+		const instance = raw.runnerProcessInstanceId ?? record(raw.processTerminal).runnerProcessInstanceId;
+		return {
+			runMatches: (raw.runId ?? raw.id) === id,
+			runnerMatches: runnerInstance === undefined || typeof instance !== "string" ? undefined : instance === runnerInstance,
+			state: state(raw.state ?? raw.status), startedAt: number(raw.startedAt), endedAt: number(raw.endedAt),
+			reason: known(raw.reason, ["runner-candidate-missing", "runner-instance-mismatch", "writer-close-unverified", "process-tree-unverified", "canonical-session-unavailable", "canonical-session-lease-active", "canonical-session-release-unverified", "proof-write-failed"]),
+			lastUpdate: number(raw.lastUpdate), observedAt: number(raw.observedAt), pid: number(raw.pid),
+			steps: Array.isArray(raw.steps) ? raw.steps.slice(0, 16).map((step) => state(record(step).status)) : undefined,
+		};
+	};
+	const read = (file: string, kind: "json" | "events" | "metadata" = "json") => {
+		const summary: Record<string, unknown> = { readAt: Date.now() };
+		let data: Record<string, unknown> = {};
+		try {
+			// Opening a directory differs across Windows/POSIX; do not attempt a content read.
+			const initial = fs.statSync(file);
+			if (!initial.isFile()) return { summary: { ...summary, io: "not-file", size: initial.size, mtimeMs: initial.mtimeMs }, data };
+			const fd = fs.openSync(file, "r");
+			try {
+				const stat = fs.fstatSync(fd);
+				Object.assign(summary, { size: stat.size, mtimeMs: stat.mtimeMs });
+				if (!stat.isFile()) summary.io = "not-file";
+				else if (kind === "metadata") summary.io = "present";
+				else if (kind === "json" && stat.size > 65_536) summary.io = "oversized";
+				else {
+					const limit = kind === "events" ? 8192 : 65_536;
+					const offset = Math.max(0, stat.size - limit);
+					const buffer = Buffer.alloc(Math.min(stat.size, limit));
+					const bytes = fs.readSync(fd, buffer, 0, buffer.length, offset);
+					const text = buffer.toString("utf8", 0, bytes);
+					Object.assign(summary, { io: "readable", bytes, truncated: offset > 0 });
+					if (kind === "json") {
+						data = record(JSON.parse(text));
+						Object.assign(summary, project(data));
+					} else {
+						const entries: unknown[] = [];
+						for (const line of text.split("\n").slice(offset > 0 ? 1 : 0)) {
+							try {
+								const event = record(JSON.parse(line));
+								const type = known(event.type, ["subagent.run.started", "subagent.run.completed", "subagent.run.process_terminal"]);
+								if (type) entries.push({ type, ts: number(event.ts), ...project(event) });
+							} catch { /* Partial or non-JSON lines carry no diagnostic authority. */ }
+						}
+						summary.entries = entries.slice(-16);
+					}
+				}
+			} finally { fs.closeSync(fd); }
+		} catch (error) {
+			summary.io = error instanceof SyntaxError ? "invalid-json" : errorCode(error) === "ENOENT" ? "absent" : errorCode(error);
+		}
+		return { summary, data };
+	};
+	const status = read(path.join(asyncDir, "status.json"));
+	if (status.data.runId === id && typeof record(status.data.processTerminal).runnerProcessInstanceId === "string") {
+		runnerInstance = record(status.data.processTerminal).runnerProcessInstanceId;
+	}
+	const sessionId = status.data.runId === id && typeof status.data.sessionId === "string" ? status.data.sessionId : undefined;
+	const key = `${encodeIndexSegment(id, 250)}.json`;
+	const files: Record<string, Record<string, unknown>> = {
+		status: status.summary,
+		public: read(path.join(resultsDir, `${id}.json`)).summary,
+		pending: sessionId ? read(path.join(resultsDir, "result-pending", encodeIndexSegment(sessionId), key)).summary : { io: "session-unavailable" },
+		sessionIndex: sessionId ? read(path.join(resultsDir, "result-index", "sessions", encodeIndexSegment(sessionId), key)).summary : { io: "session-unavailable" },
+		runIndex: read(path.join(resultsDir, "result-index", "runs", key)).summary,
+		proceed: read(path.join(asyncDir, "runner-startup-proceed.json"), "metadata").summary,
+		candidate: read(path.join(asyncDir, "process-terminal-candidate.json")).summary,
+		proof: read(path.join(asyncDir, "process-terminal.json")).summary,
+		events: read(path.join(asyncDir, "events.jsonl"), "events").summary,
+		stdout: read(path.join(asyncDir, "runner.stdout.log"), "metadata").summary,
+		stderr: read(path.join(asyncDir, "runner.stderr.log"), "metadata").summary,
+	};
+	const observer = options.observer;
+	const snapshot = {
+		version: 1, phase: options.phase ?? "timeout", runKey: createHash("sha256").update(id).digest("hex"),
+		snapshotAt: Date.now(), waitStartedAt: number(options.waitStartedAt), deadline: number(options.deadline),
+		files,
+		observer: observer ? {
+			pid: number(observer.pid),
+			marks: Object.fromEntries(["bodyStartedAt", "launchStartedAt", "launchFinishedAt", "resultWaitStartedAt", "resultDeadline", "resultTimeoutAt", "resultReadAt", "teardownStartedAt"].map((key) => [key, number(observer.marks[key])])),
+			events: observer.events.slice(-8).map((value) => {
+				const raw = record(value);
+				return { type: known(raw.type, ["spawn", "error", "exit", "close"]), at: number(raw.at), code: number(raw.code), signal: known(raw.signal, ["SIGTERM", "SIGKILL", "SIGINT", "SIGABRT", "SIGSEGV"]) };
+			}),
+			phases: observer.phases.slice(-16).map((value) => {
+				const raw = record(value);
+				return { phase: known(raw.phase, ["dispose-entry", "dispose-return", "dispose-rejection", "exit", "exit-request", "exit-dispatch-return", "exit-dispatch-throw", "native-trace-exit"]), ts: number(raw.ts), pidMatches: raw.pid === observer.pid, invocation: number(raw.invocation), code: number(raw.code) };
+			}),
+		} : undefined,
+	};
+	// Artifact destination is outside isolated cleanup roots in CI. No unprojected fields leave this helper.
+	try {
+		const dir = process.env.PI_SUBAGENTS_TERMINAL_EVIDENCE_DIR;
+		const text = JSON.stringify(snapshot);
+		if (dir && Buffer.byteLength(text) <= 32_768) {
+			fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(path.join(dir, `async-result-${snapshot.runKey}-${snapshot.phase}.json`), text, { mode: 0o600 });
+		}
+	} catch { /* Diagnostic I/O must not replace the existing assertion or teardown result. */ }
+	return snapshot;
+}


### PR DESCRIPTION
## Diagnostic capture only — not a production fix

Prepare one Windows CI capture for recurring async-result assertion timeouts on main (34332022749), also observed before the worktree-admission change. An exact failed acceptance runner exited normally after15.921s against a15s result deadline; disposal itself was fast. The missing evidence is where time was spent and whether a public or pending result appeared before teardown.

Adds bounded, allowlisted timeout/teardown snapshots and failure-artifact upload. No production code, functional assertions, deadlines, polling intervals, concurrency settings or retries change. Captures are observations, not cleanup authority. No raw prompts, output/error content, credentials, paths or run/session identifiers are uploaded.

## Validation

- 53 affected integration-suite tests and5 final focused diagnostic/behavior tests passed locally.
- Production and diagnostic-helper typechecks, YAML upload checks and diff hygiene passed.
- Fresh independent privacy/diagnostic-validity review and parent source verification passed.

The diagnostic CI result will guide the next action. This PR does not claim that main is fixed and will not be merged merely because its tests pass.