### PR TITLE
fix: let nested coordinators reply to their children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Let fanout-authorized child coordinators answer their own children's supervisor requests with explicitly selected `subagent_supervisor`, preserving immediate-parent session ownership and tool restrictions. Keep explicitly requested native coordination tools through host-builtin filtering, and poll only live descendant channels.
 - Keep the configured main watchdog model and thinking in recommendations instead of suggesting a hardcoded replacement, and clarify user-scope model saves. Thanks to [@freezscholte](https://github.com/freezscholte) for #2078.
 - Recognize OpenRouter's status-prefixed 401 errors for configured model fallback before tool work, including watchdog reviews. Thanks to [@freezscholte](https://github.com/freezscholte) for #2077.
 - A manual `schedule.run` that attaches a run satisfies the next natural fire, so manually-run schedules no longer double-fire (#2052). Thanks to [@brandonmwest](https://github.com/brandonmwest) for #2052.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
-- Let fanout-authorized child coordinators answer their own children's supervisor requests with explicitly selected `subagent_supervisor`, preserving immediate-parent session ownership and tool restrictions. Keep explicitly requested native coordination tools through host-builtin filtering, and poll only live descendant channels.
+- Let fanout-authorized child coordinators answer their own children's supervisor requests with explicitly selected `subagent_supervisor`, preserving immediate-parent session ownership and tool restrictions. Keep explicitly requested native coordination tools through host-builtin filtering, and poll only live descendant channels. Thanks to [@shaharmor](https://github.com/shaharmor) for #2087.
 - Allow read-only reviewers to classify findings as quoted "must fix before" categories without treating the labels as implementation instructions; actual required fixes still require mutation tools. Thanks to [@freezscholte](https://github.com/freezscholte) for #2079.
 - Reject materialized workflow launch groups with invalid worktree repositories or dirty sources before dispatching children or claiming fan-out/output ownership. Allocation still rechecks; workflow-key failure traces may remain. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2076.
 - Keep the configured main watchdog model and thinking in recommendations instead of suggesting a hardcoded replacement, and clarify user-scope model saves. Thanks to [@freezscholte](https://github.com/freezscholte) for #2078.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -439,6 +439,14 @@ Children should not ask for clarification when the only conflict is review-only/
 
 The parent replies with `subagent_supervisor({ action: "reply", replyTo, message })` or checks pending requests with `subagent_supervisor({ action: "pending" })`. Supervisor messages are scoped to the exact Pi session id that spawned the child. A second Pi session in the same repository does not receive those requests.
 
+A nested coordinator needs both directions of coordination. If its agent declares an explicit `tools` allowlist, include `subagent_supervisor` to answer its own children, alongside `subagent` for delegation and `contact_supervisor` for asking its parent:
+
+```yaml
+tools: read, subagent, contact_supervisor, subagent_supervisor
+```
+
+For A → B → C, C's request belongs to B, not A. B can escalate a separate question to A with `contact_supervisor`, then answer C using C's original `replyTo` request id. A's reply to B does not resolve C's request, and steering is not a substitute for replying. Only fanout-authorized children get the downward supervisor provider; explicit tool exclusions and capability ceilings still apply, and ordinary leaves do not gain delegation or reply tools. Requesting `subagent_supervisor` without fanout authorization fails at launch with an actionable error. A coordinator that excludes the reply tool does not start downward supervision or receive prompts to use it. Explicitly selected native coordination tools survive host-builtin filtering because their providers are child runtime hooks, not host builtins.
+
 Child-side routine completion handoffs are not expected. If a child appears stalled, needs-attention notices show up in the parent session with useful next actions, such as checking `subagent({ action: "status" })`, interrupting the run, or nudging the child.
 
 If a `workflowScript` child detaches through `contact_supervisor`, the enclosing async workflow stays `paused` until that child exits. Then the extension reconciles it to `complete` or `failed`. Wait on the child until that happens.

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -160,6 +160,7 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 	const waitToolConfig = resolveWaitToolConfig(config.waitTool);
 	const state = childConfig.runtimeState ?? createChildSafeState();
 	const asyncChildren = new Map<string, { dir: string; agents: string[] }>();
+	const foregroundChannels = new Set<string>();
 	const supervisorChannel = createNativeSupervisorChannel(pi, state, {
 		getChannelDirs: () => {
 			const dirs = new Set<string>();
@@ -171,15 +172,22 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 					if (child.status === "detached") dirs.add(resolveSupervisorChannelDir(run.runId, child.agent, child.index));
 				}
 			}
+			const retiringForeground = [...foregroundChannels].filter(dir => !dirs.has(dir));
+			for (const dir of dirs) foregroundChannels.add(dir);
+			for (const dir of retiringForeground) dirs.add(dir);
+			const retiringAsync: string[] = [];
 			for (const [id, child] of asyncChildren) {
 				const status = readStatus(child.dir);
-				if (status && status.state !== "queued" && status.state !== "running") {
-					asyncChildren.delete(id);
-					continue;
-				}
+				if (status && status.state !== "queued" && status.state !== "running") retiringAsync.push(id);
 				for (const [index, agent] of child.agents.entries()) dirs.add(resolveSupervisorChannelDir(id, agent, index));
 			}
-			return [...dirs];
+			return {
+				dirs: [...dirs],
+				retire: () => {
+					for (const dir of retiringForeground) foregroundChannels.delete(dir);
+					for (const id of retiringAsync) asyncChildren.delete(id);
+				},
+			};
 		},
 	});
 	const executor = createSubagentExecutor({
@@ -235,6 +243,7 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 	pi.on("session_shutdown", () => {
 		unsubscribeAsyncStarted?.();
 		asyncChildren.clear();
+		foregroundChannels.clear();
 		supervisorChannel.dispose();
 		state.supervisorOwnerSessionId = null;
 	});

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -9,11 +9,13 @@ import { resolveWaitToolConfig } from "../runs/background/wait-config.ts";
 import type { ChildRuntimeConfig } from "../runs/shared/child-runtime-config.ts";
 import { readNestedControlRequests, resolveInheritedNestedRoute, type NestedRoute, writeNestedControlResult } from "../runs/shared/nested-events.ts";
 import { deliverSubagentIntercomMessageEvent } from "../intercom/result-intercom.ts";
+import { createNativeSupervisorChannel, NATIVE_SUPERVISOR_TOOL_NAME, resolveSupervisorChannelDir } from "../intercom/native-supervisor-channel.ts";
+import { readStatus } from "../shared/utils.ts";
 import { resolveSubagentIntercomTarget } from "../intercom/intercom-bridge.ts";
 import { createSubagentParamsSchema } from "./schemas.ts";
 import { finalizeToolResult } from "./tool-result.ts";
 import { loadConfig, resolveAsyncByDefault } from "./config.ts";
-import { type Details, type SubagentState } from "../shared/types.ts";
+import { SUBAGENT_ASYNC_STARTED_EVENT, type AsyncStartedEvent, type Details, type SubagentState } from "../shared/types.ts";
 
 function getSubagentSessionRoot(parentSessionFile: string | null): string {
 	if (parentSessionFile) {
@@ -141,7 +143,7 @@ function startNestedControlInboxListener(pi: ExtensionAPI, state: SubagentState,
 	return () => clearInterval(timer);
 }
 
-/** Register the child-side `subagent` tool for fanout-authorized children. */
+/** Register delegation and supervisor replies for fanout-authorized children. */
 export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, childConfig: ChildRuntimeConfig): void {
 	if (!childConfig.fanoutChild) return;
 
@@ -157,6 +159,29 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 	const config = loadConfig();
 	const waitToolConfig = resolveWaitToolConfig(config.waitTool);
 	const state = childConfig.runtimeState ?? createChildSafeState();
+	const asyncChildren = new Map<string, { dir: string; agents: string[] }>();
+	const supervisorChannel = createNativeSupervisorChannel(pi, state, {
+		getChannelDirs: () => {
+			const dirs = new Set<string>();
+			for (const run of state.foregroundControls.values()) {
+				for (const child of run.activeChildren?.values() ?? []) dirs.add(resolveSupervisorChannelDir(run.runId, child.agent, child.index));
+			}
+			for (const run of state.foregroundRuns?.values() ?? []) {
+				for (const child of run.children) {
+					if (child.status === "detached") dirs.add(resolveSupervisorChannelDir(run.runId, child.agent, child.index));
+				}
+			}
+			for (const [id, child] of asyncChildren) {
+				const status = readStatus(child.dir);
+				if (status && status.state !== "queued" && status.state !== "running") {
+					asyncChildren.delete(id);
+					continue;
+				}
+				for (const [index, agent] of child.agents.entries()) dirs.add(resolveSupervisorChannelDir(id, agent, index));
+			}
+			return [...dirs];
+		},
+	});
 	const executor = createSubagentExecutor({
 		pi,
 		state,
@@ -170,6 +195,8 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 		discoverAgents,
 		allowMutatingManagementActions: false,
 		childRuntime: childConfig,
+		activateSupervisorTransport: supervisorChannel.activateTransport,
+		findPendingAsks: supervisorChannel.findPendingAsks,
 	});
 
 	const params = createSubagentParamsSchema();
@@ -188,6 +215,29 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 	};
 
 	pi.registerTool(tool);
+	let unsubscribeAsyncStarted: (() => void) | undefined;
+	pi.on("session_start", (_event, ctx) => {
+		supervisorChannel.registerTools();
+		// The host applies the explicit allowlist to dynamic registration too.
+		if (!pi.getAllTools().some(tool => tool.name === NATIVE_SUPERVISOR_TOOL_NAME)) return;
+		// Downward asks belong to this coordinator, not its parent or persisted session file.
+		state.supervisorOwnerSessionId = ctx.sessionManager.getSessionId() || null;
+		unsubscribeAsyncStarted = pi.events.on(SUBAGENT_ASYNC_STARTED_EVENT, (payload: unknown) => {
+			const info = payload as AsyncStartedEvent;
+			if (!info.id || !info.asyncDir || info.sessionId !== state.currentSessionId) return;
+			const agents = info.agents ?? (info.agent ? [info.agent] : []);
+			asyncChildren.set(info.id, { dir: info.asyncDir, agents });
+			supervisorChannel.activateTransport();
+		});
+		supervisorChannel.start();
+		supervisorChannel.activateTransport();
+	});
+	pi.on("session_shutdown", () => {
+		unsubscribeAsyncStarted?.();
+		asyncChildren.clear();
+		supervisorChannel.dispose();
+		state.supervisorOwnerSessionId = null;
+	});
 	const route = resolveNestedControlRoute(childConfig);
 	if (!route) return;
 	const listenerCleanupKey = "__piSubagentFanoutChildNestedControlInboxCleanups";

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -83,8 +83,8 @@ interface IntercomParams {
 type SupervisorWatch = (filename: fs.PathLike, listener: fs.WatchListener<string>) => fs.FSWatcher;
 
 interface NativeSupervisorChannelDeps {
-	/** Child coordinators poll only their live descendants; the root retains global discovery. */
-	getChannelDirs?: () => string[];
+	/** Owned live/final-drain mailboxes. Only a completed poll retires the snapshot, never a demand probe. */
+	getChannelDirs?: () => { dirs: string[]; retire?: () => void };
 	/** Retained scheduled states for the current runtime owner, never foreign owners. */
 	getCurrentOwnerStates?: () => Iterable<SubagentState>;
 	platform?: NodeJS.Platform;
@@ -688,7 +688,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	const hasTransportDemand = () => {
 		if (pending.size > 0) return true;
 		if (state.foregroundControls.size > 0) return true;
-		if (deps.getChannelDirs?.().length) return true;
+		if (deps.getChannelDirs?.().dirs.length) return true;
 		if ([...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running")) return true;
 		for (const ownerState of deps.getCurrentOwnerStates?.() ?? []) {
 			for (const job of ownerState.asyncJobs.values()) {
@@ -719,7 +719,8 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		// Only display notifications require a live UI context, not request registration.
 		refreshPendingRequests(pending, state, observeRequestLifecycle, runState);
 		const now = Date.now();
-		for (const { channelDir, file } of listRequestFiles(deps.getChannelDirs?.())) {
+		const channels = deps.getChannelDirs?.();
+		for (const { channelDir, file } of listRequestFiles(channels?.dirs)) {
 			if (seenFiles.has(file)) continue;
 			const request = parseRequestFile(file, channelDir);
 			if (!request || !requestMatchesOwner(request, state)) continue;
@@ -774,6 +775,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 				if (pending.has(request.id)) markForegroundSupervisorAttention(request, state);
 			}
 		}
+		channels?.retire?.();
 	};
 
 	const startPolling = (): void => {

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -83,6 +83,8 @@ interface IntercomParams {
 type SupervisorWatch = (filename: fs.PathLike, listener: fs.WatchListener<string>) => fs.FSWatcher;
 
 interface NativeSupervisorChannelDeps {
+	/** Child coordinators poll only their live descendants; the root retains global discovery. */
+	getChannelDirs?: () => string[];
 	/** Retained scheduled states for the current runtime owner, never foreign owners. */
 	getCurrentOwnerStates?: () => Iterable<SubagentState>;
 	platform?: NodeJS.Platform;
@@ -286,18 +288,18 @@ function parseRequestFile(file: string, channelDir: string): PendingSupervisorRe
 	}
 }
 
-function listRequestFiles(): Array<{ channelDir: string; file: string }> {
-	let channelEntries: fs.Dirent[];
-	try {
-		channelEntries = fs.readdirSync(SUPERVISOR_CHANNEL_ROOT, { withFileTypes: true });
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-		throw error;
+function listRequestFiles(channelDirs?: string[]): Array<{ channelDir: string; file: string }> {
+	if (!channelDirs) {
+		try {
+			channelDirs = fs.readdirSync(SUPERVISOR_CHANNEL_ROOT, { withFileTypes: true })
+				.filter(entry => entry.isDirectory()).map(entry => path.join(SUPERVISOR_CHANNEL_ROOT, entry.name));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+			throw error;
+		}
 	}
 	const files: Array<{ channelDir: string; file: string }> = [];
-	for (const entry of channelEntries) {
-		if (!entry.isDirectory()) continue;
-		const channelDir = path.join(SUPERVISOR_CHANNEL_ROOT, entry.name);
+	for (const channelDir of channelDirs) {
 		const requestsDir = path.join(channelDir, REQUESTS_DIR);
 		let requestEntries: fs.Dirent[];
 		try {
@@ -606,6 +608,7 @@ function buildParentSupervisorTool(pi: ExtensionAPI, pending: Map<string, Pendin
 }
 
 export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentState, deps: NativeSupervisorChannelDeps = {}): {
+	registerTools: () => void;
 	start: () => void;
 	activateTransport: () => void;
 	findPendingAsks: (target: { runId: string; agent: string; childIndex: number }) => string[];
@@ -681,10 +684,11 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	let started = false;
 	let lastStaleCleanupAt = 0;
 	const platform = deps.platform ?? process.platform;
-	const useNativeWatcher = () => shouldUseNativeFsWatch("supervisor-channel", platform) && platform !== "win32";
+	const useNativeWatcher = () => !deps.getChannelDirs && shouldUseNativeFsWatch("supervisor-channel", platform) && platform !== "win32";
 	const hasTransportDemand = () => {
 		if (pending.size > 0) return true;
 		if (state.foregroundControls.size > 0) return true;
+		if (deps.getChannelDirs?.().length) return true;
 		if ([...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running")) return true;
 		for (const ownerState of deps.getCurrentOwnerStates?.() ?? []) {
 			for (const job of ownerState.asyncJobs.values()) {
@@ -699,6 +703,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 
 	const cleanupStaleChannelsIfDue = (): void => {
+		if (deps.getChannelDirs) return; // The root owns global retention cleanup.
 		const nowMs = Date.now();
 		if (nowMs - lastStaleCleanupAt < STALE_EMPTY_CHANNEL_CLEANUP_INTERVAL_MS) return;
 		lastStaleCleanupAt = nowMs;
@@ -714,7 +719,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		// Only display notifications require a live UI context, not request registration.
 		refreshPendingRequests(pending, state, observeRequestLifecycle, runState);
 		const now = Date.now();
-		for (const { channelDir, file } of listRequestFiles()) {
+		for (const { channelDir, file } of listRequestFiles(deps.getChannelDirs?.())) {
 			if (seenFiles.has(file)) continue;
 			const request = parseRequestFile(file, channelDir);
 			if (!request || !requestMatchesOwner(request, state)) continue;
@@ -775,7 +780,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 		if (poller) return;
 		poller = timers.setInterval(() => {
 			poll();
-			if (!useNativeWatcher() && platform === "darwin" && !hasTransportDemand()) {
+			if (!useNativeWatcher() && (platform === "darwin" || deps.getChannelDirs) && !hasTransportDemand()) {
 				if (poller) timers.clearInterval(poller);
 				poller = undefined;
 			}
@@ -830,6 +835,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	};
 
 	return {
+		registerTools: registerParentTools,
 		activateTransport: () => {
 			if (!started) return;
 			poll();
@@ -857,6 +863,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 			started = true;
 			registerParentTools();
 			poll();
+			if (deps.getChannelDirs) return; // Child polling starts only after a descendant launch.
 			try {
 				fs.mkdirSync(SUPERVISOR_CHANNEL_ROOT, { recursive: true });
 				if (!useNativeWatcher()) {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -3870,6 +3870,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 				}
 			},
 		}));
+		// Capture the owned mailbox before a child can start and finish between polling ticks.
+		if (deps.childRuntime?.fanoutChild) deps.activateSupervisorTransport?.();
 	}
 
 	const modelResponseAliases = deps.config.modelResponseAliases === undefined ? undefined : structuredClone(deps.config.modelResponseAliases);

--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -62,6 +62,8 @@ const FAST_MODE_ALLOWED_MODELS = new Set([
 ]);
 const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
 const PI_BUILTIN_TOOL_NAMES = new Set(["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"]);
+// These providers come from child hooks, not the host's builtin tool registry.
+const NATIVE_COORDINATION_TOOL_NAMES = new Set(["subagent", "contact_supervisor", "subagent_supervisor"]);
 
 export function deriveForkPromptCacheKey(parentSessionId: string | undefined): string | undefined {
 	const parent = parentSessionId?.trim();
@@ -369,10 +371,10 @@ export function resolvePiLaunchToolPlan(
 					: requestedBuiltinTools
 				).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
 	const declaredBuiltinTools = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => hostAvailableSet.has(tool))
+		? ceilingFilteredBuiltinTools.filter((tool) => hostAvailableSet.has(tool) || NATIVE_COORDINATION_TOOL_NAMES.has(tool))
 		: ceilingFilteredBuiltinTools;
 	const unavailableHostBuiltins = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => !hostAvailableSet.has(tool))
+		? ceilingFilteredBuiltinTools.filter((tool) => !hostAvailableSet.has(tool) && !NATIVE_COORDINATION_TOOL_NAMES.has(tool))
 		: [];
 	const excludeTools = [...new Set((input.excludeTools ?? []).map((tool) => tool.trim()).filter(Boolean))];
 	const excludedToolSet = new Set(excludeTools);
@@ -382,6 +384,9 @@ export function resolvePiLaunchToolPlan(
 		!excludedToolSet.has("subagent") &&
 		(!allowedToolSet || allowedToolSet.has("subagent"))
 	);
+	if (effectiveDeclaredBuiltinTools.includes("subagent_supervisor") && !fanoutAuthorized) {
+		throw new Error("Tool 'subagent_supervisor' requires fanout authorization: include 'subagent' in the effective tools allowlist or enable allowNestedSubagents.");
+	}
 	const toolExtensionPaths: string[] = capabilityCeiling?.denyExtensions
 		? []
 		: (input.tools ?? []).filter(
@@ -422,8 +427,8 @@ export function resolvePiLaunchToolPlan(
 			...internalTools,
 		]),
 	];
-	// Supervisor-coordination names stay in the --tools allowlist but are never
-	// strict requirements: children register contact_supervisor at runtime through
+	// Upward contact stays in the --tools allowlist but is not a strict
+	// requirement: children register contact_supervisor at runtime through
 	// the native supervisor channel (or pi-intercom). The pre-0.50 bridge always
 	// appended intercom alongside contact_supervisor, so that exact pairing is
 	// legacy plumbing, not a user demand for an external intercom provider;

--- a/test/smoke/pi085-child.ts
+++ b/test/smoke/pi085-child.ts
@@ -39,7 +39,7 @@ try {
 		const launch = buildInProcessChildLaunch({
 			host: "runner", cwd: process.cwd(), childAgentName: "coordinator-smoke", childIndex: 0,
 			sessionEnabled: false, model: "pi085-smoke/local", tools, hostAvailableBuiltins: ["read"],
-			runId: `coordination-${tools.length}`, parentSessionId: "root-A",
+			runId: `coordination-${tools.length}`, parentSessionId: "root-A", orchestratorIntercomTarget: "root-A",
 			extensions: [`${process.cwd()}/pi085-extension.ts`],
 			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
 		});

--- a/test/smoke/pi085-child.ts
+++ b/test/smoke/pi085-child.ts
@@ -30,4 +30,28 @@ try {
 	assert.deepEqual([started, stopped, state.started, state.stopped], [1, 1, 1, 1]);
 	assert.deepEqual(errors, []);
 	console.log("PASS public SDK/default child factory: local prompt, API identity, startup/shutdown");
+	const { buildInProcessChildLaunch } = await import(pathToFileURL(`${process.env.SMOKE_EXTENSION}/src/runs/shared/child-launch.ts`).href);
+	for (const tools of [
+		["read", "subagent", "contact_supervisor", "subagent_supervisor"],
+		["read", "subagent", "contact_supervisor"],
+		["read", "contact_supervisor"],
+	]) {
+		const launch = buildInProcessChildLaunch({
+			host: "runner", cwd: process.cwd(), childAgentName: "coordinator-smoke", childIndex: 0,
+			sessionEnabled: false, model: "pi085-smoke/local", tools, hostAvailableBuiltins: ["read"],
+			runId: `coordination-${tools.length}`, parentSessionId: "root-A",
+			extensions: [`${process.cwd()}/pi085-extension.ts`],
+			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+		});
+		let snapshot;
+		launch.session.hooks.push({ name: "coordination-tools", factory(pi) {
+			pi.on("session_start", () => { snapshot = { registered: pi.getAllTools().map(tool => tool.name), active: pi.getActiveTools() }; });
+		} });
+		const coordinated = await factory.create(launch.session);
+		try {
+			assert.deepEqual(new Set(snapshot.registered), new Set(tools));
+			assert.deepEqual(new Set(snapshot.active), new Set(tools));
+		} finally { await coordinated.dispose(); }
+	}
+	console.log("PASS native coordinator/leaf tools: real SDK registration and explicit allowlists");
 } finally { await factory.dispose(); }

--- a/test/unit/child-runtime-config.test.ts
+++ b/test/unit/child-runtime-config.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { createChildHooks } from "../../src/runs/shared/child-hooks.ts";
+import { buildInProcessChildLaunch } from "../../src/runs/shared/child-launch.ts";
 import { childSupervisorMetadata, evaluateChildToolDiagnostic, type ChildRuntimeConfig } from "../../src/runs/shared/child-runtime-config.ts";
 
 function baseConfig(overrides: Partial<ChildRuntimeConfig> = {}): ChildRuntimeConfig {
@@ -34,6 +35,29 @@ describe("child runtime config", () => {
 		assert.deepEqual(createChildHooks(baseConfig()).map((hook) => hook.name), ["pi-subagents:prompt-runtime"]);
 		assert.deepEqual(createChildHooks(baseConfig({ fast: true })).map((hook) => hook.name), ["pi-subagents:prompt-runtime", "pi-subagents:fast-mode"]);
 		assert.deepEqual(createChildHooks(baseConfig({ fanoutChild: true })).map((hook) => hook.name), ["pi-subagents:prompt-runtime", "pi-subagents:fanout-child"]);
+	});
+
+	it("provides the coordinator reply tool before agent_start without granting it to leaves", async () => {
+		for (const tools of [["subagent", "contact_supervisor", "subagent_supervisor"], ["subagent", "contact_supervisor"], ["contact_supervisor"]]) {
+			const launch = buildInProcessChildLaunch({
+				host: "parent", cwd: process.cwd(), childAgentName: "coordinator", childIndex: 0,
+				sessionEnabled: false, tools, runId: "registration", parentSessionId: "root-A",
+				inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+			});
+			const pi = fakePi([]);
+			for (const hook of launch.session.hooks) hook.factory(pi.api as never);
+			const ctx = { sessionManager: { getSessionId: () => "coordinator-B", getSessionFile: () => "/sessions/B.jsonl" } };
+			try {
+				for (const handler of pi.handlers.get("session_start") ?? []) await handler({}, ctx);
+				assert.equal(pi.tools.some(tool => tool.name === "subagent_supervisor"), tools.includes("subagent"));
+				for (const handler of pi.handlers.get("agent_start") ?? []) await handler({}, ctx);
+				const selected = pi.tools.map(tool => tool.name).filter(name => launch.session.tools?.includes(name));
+				assert.equal(selected.includes("subagent_supervisor"), tools.includes("subagent_supervisor"));
+				assert.deepEqual(launch.session.tools, tools, "registration must not expand explicit tools");
+			} finally {
+				for (const handler of pi.handlers.get("session_shutdown") ?? []) await handler({}, ctx);
+			}
+		}
 	});
 
 	it("hooks read the config object", async () => {

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -44,6 +44,37 @@ describe("child tool plan host builtin intersection", () => {
 		assert.deepEqual(plan.effectiveToolAllowlist, ["bash"]);
 	});
 
+	it("keeps requested native coordination tools through host builtin filtering, but not ceilings or exclusions", () => {
+		const tools = ["read", "subagent", "contact_supervisor", "subagent_supervisor"];
+		const input = { tools, hostAvailableBuiltins: ["read"] };
+		const plan = resolvePiLaunchToolPlan(input);
+		assert.deepEqual(plan.effectiveToolAllowlist, tools);
+		assert.deepEqual(plan.requiredChildTools, ["read", "subagent", "subagent_supervisor"]);
+		assert.equal(plan.fanoutAuthorized, true);
+		assert.deepEqual(plan.unavailableHostBuiltins, []);
+		for (const restriction of [
+			{ excludeTools: ["subagent_supervisor"] },
+			{ capabilityCeiling: { version: 1 as const, allowedTools: ["read", "subagent", "contact_supervisor"], denyExtensions: true, sources: ["test"] } },
+		]) {
+			const restricted = resolvePiLaunchToolPlan({ ...input, ...restriction });
+			assert.equal(restricted.fanoutAuthorized, true);
+			assert.equal(restricted.effectiveToolAllowlist.includes("subagent_supervisor"), false);
+		}
+		const leaf = resolvePiLaunchToolPlan({ ...input, tools: ["read", "contact_supervisor"] });
+		assert.equal(leaf.fanoutAuthorized, false);
+		assert.equal(leaf.effectiveToolAllowlist.includes("subagent_supervisor"), false);
+	});
+
+	it("rejects an explicitly requested reply tool when fanout authorization is absent or removed", () => {
+		for (const input of [
+			{ tools: ["read", "subagent_supervisor"] },
+			{ tools: ["read", "subagent", "subagent_supervisor"], excludeTools: ["subagent"] },
+			{ tools: ["read", "subagent", "subagent_supervisor"], capabilityCeiling: { version: 1 as const, allowedTools: ["read", "subagent_supervisor"], sources: ["test"] } },
+		]) {
+			assert.throws(() => resolvePiLaunchToolPlan({ ...input, hostAvailableBuiltins: ["read"] }), /subagent_supervisor.*requires fanout authorization/);
+		}
+	});
+
 	it("keeps all tools when host provides them", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "bash"],

--- a/test/unit/index-child-registration.test.ts
+++ b/test/unit/index-child-registration.test.ts
@@ -1285,6 +1285,7 @@ describe("subagent extension child mode", () => {
 			const registrations = [];
 			function makePi(source) {
 				return {
+					on() {},
 					events: { on() { return () => {}; }, emit() {} },
 					registerTool(tool) {
 						if (registeredNames.has(tool.name)) {
@@ -1324,6 +1325,7 @@ describe("subagent extension child mode", () => {
 			import registerFanoutChildSubagentExtension from "./src/extension/fanout-child.ts";
 			let registeredTool;
 			const fakePi = {
+				on() {},
 				events: { on() { return () => {}; }, emit() {} },
 				registerTool(tool) { registeredTool = tool; },
 				getSessionName() { return undefined; },

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -96,6 +97,66 @@ afterEach(() => {
 });
 
 describe("native supervisor channel", () => {
+	for (const platform of ["darwin", "win32", "linux"] as const) {
+		it(`bounds coordinator polling to owned channels and stops when idle (${platform})`, async () => {
+			const owner = randomUUID();
+			const runId = randomUUID();
+			const requestId = writeRequest({ sessionId: owner, runId });
+			const ownDir = resolveSupervisorChannelDir(runId, "worker", 0);
+			// Even a request with the same owner is not scanned unless its run is registered.
+			for (let i = 0; i < 100; i++) writeRequest({ sessionId: owner, runId: randomUUID() });
+			let dirs: string[] = [];
+			let tick: (() => void) | undefined;
+			const tools = new Map<string, { execute(id: string, params: unknown): Promise<unknown> }>();
+			const notices: unknown[] = [];
+			const ctx = { sessionManager: { getSessionId: () => owner } };
+			const channel = createNativeSupervisorChannel({
+				getAllTools: () => [...tools.keys()].map(name => ({ name })),
+				registerTool: (tool: { name: string; execute: (id: string, params: unknown) => Promise<unknown> }) => tools.set(tool.name, tool),
+				sendMessage: (message: unknown) => notices.push(message),
+			} as never, makeState(owner, ctx), {
+				platform, getChannelDirs: () => dirs,
+				watch: (() => { throw new Error("scoped coordinator must not watch the global root"); }) as never,
+				timers: {
+					setInterval: ((handler: () => void) => { tick = handler; return { unref() {} } as NodeJS.Timeout; }) as typeof setInterval,
+					clearInterval: (() => { tick = undefined; }) as typeof clearInterval,
+					setImmediate, clearImmediate,
+				},
+			});
+			const readdir = fsDefault.readdirSync;
+			let scans = 0;
+			fsDefault.readdirSync = ((dir: fs.PathLike, options: unknown) => {
+				assert.equal(String(dir), path.join(ownDir, "requests"), "coordinators must not scan unrelated retained channels");
+				scans++;
+				return (readdir as (dir: fs.PathLike, options: unknown) => unknown)(dir, options);
+			}) as typeof fsDefault.readdirSync;
+			syncBuiltinESMExports();
+			try {
+				channel.registerTools();
+				assert.ok(tools.has(NATIVE_SUPERVISOR_TOOL_NAME));
+				assert.equal(scans, 0, "tool registration does not start transport");
+				channel.start();
+				assert.equal(tick, undefined, "idle coordinator has no polling timer");
+				assert.equal(scans, 0);
+				dirs = [ownDir];
+				channel.activateTransport();
+				assert.equal(scans, 1, "one owned mailbox read regardless of 100 retained foreign channels");
+				assert.equal(notices.length, 1);
+				assert.equal(typeof tick, "function");
+				await tools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", { action: "reply", replyTo: requestId, message: "Proceed" });
+				dirs = [];
+				const scansBeforeIdle = scans;
+				tick!();
+				assert.equal(tick, undefined, "finished descendants stop polling on every platform");
+				assert.equal(scans, scansBeforeIdle);
+			} finally {
+				channel.dispose();
+				fsDefault.readdirSync = readdir;
+				syncBuiltinESMExports();
+			}
+		});
+	}
+
 	it("delivers requests only to the exact current session id and wakes the parent", () => {
 		const currentSessionId = `session-${randomUUID()}`;
 		const otherSessionId = `session-${randomUUID()}`;

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -115,7 +115,7 @@ describe("native supervisor channel", () => {
 				registerTool: (tool: { name: string; execute: (id: string, params: unknown) => Promise<unknown> }) => tools.set(tool.name, tool),
 				sendMessage: (message: unknown) => notices.push(message),
 			} as never, makeState(owner, ctx), {
-				platform, getChannelDirs: () => dirs,
+				platform, getChannelDirs: () => ({ dirs }),
 				watch: (() => { throw new Error("scoped coordinator must not watch the global root"); }) as never,
 				timers: {
 					setInterval: ((handler: () => void) => { tick = handler; return { unref() {} } as NodeJS.Timeout; }) as typeof setInterval,
@@ -156,6 +156,49 @@ describe("native supervisor channel", () => {
 			}
 		});
 	}
+
+	it("retires only polled mailbox snapshots, never demand probes", () => {
+		const owner = randomUUID();
+		const runId = randomUUID();
+		const dir = resolveSupervisorChannelDir(runId, "worker", 0);
+		const state = makeState(owner, { sessionManager: { getSessionId: () => owner } });
+		let live = false;
+		let retiring = false;
+		let drained = 0;
+		let tick: (() => void) | undefined;
+		const notices: unknown[] = [];
+		const channel = createNativeSupervisorChannel({
+			getAllTools: () => [], registerTool() {},
+			sendMessage(message: unknown) { notices.push(message); live = false; retiring = true; },
+		} as never, state, {
+			platform: "darwin",
+			getChannelDirs: () => ({
+				dirs: live || retiring ? [dir] : [],
+				...(retiring ? { retire: () => {
+					assert.equal(notices.length, 1, "delivery precedes retirement");
+					drained++;
+					retiring = false;
+				} } : {}),
+			}),
+			timers: {
+				setInterval: ((handler: () => void) => { tick = handler; return { unref() {} } as NodeJS.Timeout; }) as typeof setInterval,
+				clearInterval: (() => { tick = undefined; }) as typeof clearInterval,
+				setImmediate, clearImmediate,
+			},
+		});
+		try {
+			channel.start();
+			live = true;
+			writeRequest({ sessionId: owner, runId, reason: "progress_update" });
+			channel.activateTransport();
+			assert.equal(drained, 0, "demand observes completion without retiring its unpolled snapshot");
+			assert.equal(notices.length, 1);
+			assert.equal(typeof tick, "function", "demand keeps the final drain scheduled");
+			tick!();
+			assert.equal(tick, undefined);
+			assert.equal(drained, 1);
+		} finally { channel.dispose(); }
+	});
 
 	it("delivers requests only to the exact current session id and wakes the parent", () => {
 		const currentSessionId = `session-${randomUUID()}`;

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -499,6 +499,7 @@ describe("nested control routing", () => {
 		routeRoots.push(path.dirname(route.eventSink));
 		const childRuntime = fanoutChildRuntime(route, "root-poll-error");
 		const pi = {
+			on() {},
 			events: { emit() {}, on() { return () => {}; } },
 			registerTool() {},
 			getSessionName() { return "child"; },
@@ -535,6 +536,7 @@ describe("nested control routing", () => {
 		routeRoots.push(path.dirname(route.eventSink));
 		const childRuntime = fanoutChildRuntime(route, "root-result-write-fails");
 		const pi = {
+			on() {},
 			events: { emit() {}, on() { return () => {}; } },
 			registerTool() {},
 			getSessionName() { return "child"; },
@@ -585,6 +587,7 @@ describe("nested control routing", () => {
 		}) as typeof clearInterval;
 		try {
 			const makePi = () => ({
+				on() {},
 				events: { emit() {}, on() { return () => {}; } },
 				registerTool() { registrations.push("subagent"); },
 				getSessionName() { return "child"; },
@@ -626,6 +629,7 @@ describe("nested control routing", () => {
 		routeRoots.push(path.dirname(route.eventSink));
 		const childRuntime = fanoutChildRuntime(route, "root-ownerless");
 		const pi = {
+			on() {},
 			events: { emit() {}, on() { return () => {}; } },
 			registerTool() {},
 			getSessionName() { return "child"; },

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { afterEach, describe, it } from "node:test";
+import { afterEach, describe, it, type TestContext } from "node:test";
 import {
 	NATIVE_SUPERVISOR_TOOL_NAME,
 	createNativeSupervisorChannel,
@@ -117,7 +118,7 @@ function hookRuntime(launch: ChildSessionLaunch, platform: NodeJS.Platform, sign
 	const registered = new Map<string, Tool>();
 	const handlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown>>();
 	const subscribers = new Set<(event: ChildSessionEvent) => void>();
-	const notices: unknown[] = [];
+	const notices: Array<{ customType?: string; details?: { requestId?: string } }> = [];
 	const active = () => [...registered.keys()].filter(name => (!launch.tools || launch.tools.includes(name)) && !launch.excludeTools?.includes(name));
 	let closed = false;
 	const pi = {
@@ -127,7 +128,7 @@ function hookRuntime(launch: ChildSessionLaunch, platform: NodeJS.Platform, sign
 		getAllTools: () => active().map(name => ({ name, sourceInfo: { source: name === "read" ? "builtin" : "extension" } })),
 		getSessionName: () => "shared-name",
 		setSessionName() {},
-		sendMessage(message: { customType?: string }) { if (message.customType === "subagent_supervisor_request") notices.push(message); },
+		sendMessage(message: typeof notices[number]) { if (message.customType === "subagent_supervisor_request") notices.push(message); },
 	};
 	registered.set("read", { execute: async () => { throw new Error("fixture has no model-authored read calls"); } });
 	// Capture each native channel's platform without changing unrelated executor filesystem behavior.
@@ -153,7 +154,185 @@ function hookRuntime(launch: ChildSessionLaunch, platform: NodeJS.Platform, sign
 	};
 }
 
+function captureSupervisorPolling(t: TestContext, allowedDirs: Set<string>) {
+	const intervals = new Map<object, () => void>();
+	const scans: string[] = [];
+	const watches: string[] = [];
+	let starts = 0;
+	const set = globalThis.setInterval;
+	const clear = globalThis.clearInterval;
+	t.mock.method(globalThis, "setInterval", ((handler: () => void, delay: number, ...args: unknown[]) => {
+		if (delay !== 250) return set(handler, delay, ...args);
+		starts++;
+		const token = { unref() {} };
+		intervals.set(token, handler);
+		return token;
+	}) as typeof setInterval);
+	t.mock.method(globalThis, "clearInterval", ((token: ReturnType<typeof setInterval>) => {
+		if (!intervals.delete(token)) clear(token);
+	}) as typeof clearInterval);
+	const channelRoot = path.dirname(resolveSupervisorChannelDir("fixture", "worker", 0));
+	const readdir = fsDefault.readdirSync;
+	const watch = fsDefault.watch;
+	t.mock.method(fsDefault, "readdirSync", ((dir: fs.PathLike, options: unknown) => {
+		if (String(dir).startsWith(channelRoot)) scans.push(String(dir));
+		return (readdir as (dir: fs.PathLike, options: unknown) => unknown)(dir, options);
+	}) as typeof fsDefault.readdirSync);
+	t.mock.method(fsDefault, "watch", ((dir: fs.PathLike, ...args: unknown[]) => {
+		if (String(dir).startsWith(channelRoot)) watches.push(String(dir));
+		return (watch as (dir: fs.PathLike, ...args: unknown[]) => fs.FSWatcher)(dir, ...args);
+	}) as typeof fsDefault.watch);
+	syncBuiltinESMExports();
+	return {
+		intervals, scans, get starts() { return starts; },
+		tick() { for (const handler of [...intervals.values()]) handler(); },
+		assertScoped() {
+			assert.deepEqual(watches, [], "coordinator must not watch supervisor channels");
+			for (const dir of scans) assert.ok(allowedDirs.has(dir), `Unexpected supervisor scan: ${dir}`);
+		},
+		restore() { t.mock.restoreAll(); syncBuiltinESMExports(); },
+	};
+}
+
 describe("supervisor ask registration", () => {
+	for (const platform of ["darwin", "win32", "linux"] as const) {
+		it(`drains foreground and workflow progress completed between ticks exactly once (${platform})`, async (t) => {
+			clearExclusions();
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "nested-final-progress-"));
+			const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+			process.env.PI_CODING_AGENT_DIR = root;
+			fs.mkdirSync(path.join(root, "agents"), { recursive: true });
+			fs.writeFileSync(path.join(root, "agents", "leaf.md"), "---\nname: leaf\ndescription: Read-only leaf\ntools: read, contact_supervisor\nmodel: mock/test-model\n---\nInspect only.\n");
+			const launch = buildInProcessChildLaunch({
+				host: "parent", cwd: root, childAgentName: "coordinator", childIndex: 0,
+				sessionEnabled: false, tools: ["subagent", "subagent_supervisor"],
+				inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+			});
+			const abort = new AbortController();
+			const runtime = hookRuntime(launch.session, platform, abort.signal);
+			const allowed = new Set<string>();
+			const polling = captureSupervisorPolling(t, allowed);
+			const updates: string[] = [];
+			const leaves: ReturnType<typeof hookRuntime>[] = [];
+			setChildSessionFactory({
+				async create(childLaunch) {
+					const leaf = hookRuntime(childLaunch, platform, abort.signal);
+					leaves.push(leaf);
+					const dir = childLaunch.runtime.supervisorChannelDir!;
+					createdChannels.push(dir);
+					allowed.add(path.join(dir, "requests"));
+					assert.equal(childLaunch.runtime.orchestratorSessionId, runtime.owner);
+					await leaf.emit("session_start");
+					return {
+						sessionId: leaf.owner, sessionFile: leaf.sessionFile, modelId: "mock/test-model", messages: [],
+						subscribe: leaf.subscribe, steer: async () => {}, followUp: async () => {},
+						abort: async () => { abort.abort(); }, dispose: () => leaf.emit("session_shutdown"),
+						async prompt() {
+							await leaf.emit("agent_start");
+							const progress = await leaf.call("contact_supervisor", { reason: "progress_update", message: "Inspection complete." });
+							updates.push(progress.details.requestId!);
+							await leaf.emit("message_end", { message: { role: "assistant", content: [{ type: "text", text: "Inspection complete." }], model: "mock/test-model", stopReason: "stop", usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } } } });
+							await leaf.emit("agent_end");
+							await leaf.emit("agent_settled");
+						},
+					};
+				},
+				async dispose() {},
+			});
+			try {
+				for (let i = 0; i < 100; i++) writeRequest({ sessionId: runtime.owner, runId: randomUUID(), reason: "progress_update" });
+				await runtime.emit("session_start");
+				assert.equal(polling.intervals.size, 0);
+				assert.equal(polling.scans.length, 0);
+				for (const mode of ["foreground", "workflow"] as const) {
+					const params = mode === "foreground"
+						? { agent: "leaf", task: "Inspect read-only and report progress.", async: false, output: false }
+						: { workflowScript: "return runs.run('inspect', { agent: 'leaf', task: 'Inspect read-only and report progress.', async: false, output: false });", async: false };
+					const result = await runtime.call("subagent", params);
+					assert.notEqual(result.isError, true, text(result));
+					assert.equal(leaves.at(-1)!.closed, true, "child starts and completes without a timer tick");
+					assert.equal(polling.intervals.size, 1, "final mailbox drain remains scheduled");
+					const scansBeforeDrain = polling.scans.length;
+					polling.tick();
+					assert.equal(polling.scans.length, scansBeforeDrain + 1, "terminal child gets exactly one final mailbox scan");
+					assert.deepEqual(runtime.notices.map(notice => notice.details?.requestId), updates);
+					polling.assertScoped();
+					assert.equal(polling.intervals.size, 0, "last drain retires the poller");
+					const scans = polling.scans.length;
+					polling.tick();
+					await runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "pending" });
+					assert.equal(polling.scans.length, scans, "retired mailboxes are not scanned by idle queries");
+					assert.equal(runtime.notices.length, updates.length, "no duplicate notifications");
+				}
+				assert.equal(polling.starts, 2, "next launch rearms polling");
+			} finally {
+				abort.abort();
+				setChildSessionFactory(undefined);
+				for (const leaf of leaves) await leaf.emit("session_shutdown");
+				await runtime.emit("session_shutdown");
+				polling.restore();
+				if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+				else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		});
+
+		it(`drains direct-async progress completed between ticks and retires only owned mailboxes (${platform})`, async (t) => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "nested-async-final-progress-"));
+			const launch = buildInProcessChildLaunch({
+				host: "parent", cwd: root, childAgentName: "coordinator", childIndex: 0,
+				sessionEnabled: false, tools: ["subagent", "subagent_supervisor"],
+				inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+			});
+			const runtime = hookRuntime(launch.session, platform, new AbortController().signal);
+			const allowed = new Set<string>();
+			const polling = captureSupervisorPolling(t, allowed);
+			try {
+				await runtime.emit("session_start");
+				assert.equal(polling.intervals.size, 0);
+				for (let cycle = 0; cycle < 2; cycle++) {
+					const runId = randomUUID();
+					const dir = resolveSupervisorChannelDir(runId, "leaf", 0);
+					allowed.add(path.join(dir, "requests"));
+					const unrelatedRun = randomUUID();
+					writeRequest({ sessionId: runtime.owner, runId: unrelatedRun, reason: "progress_update" });
+					runtime.events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: unrelatedRun, asyncDir: root, agent: "worker", sessionId: "foreign-session" });
+					fs.writeFileSync(path.join(root, "status.json"), JSON.stringify({ runId, state: "running" }));
+					runtime.events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: runId, asyncDir: root, agent: "leaf", sessionId: runtime.sessionFile });
+					assert.equal(polling.intervals.size, 1);
+					const progress = writeRequest({ sessionId: runtime.owner, runId, agent: "leaf", reason: "progress_update" });
+					const foreign = writeRequest({ sessionId: "foreign-owner", runId, agent: "leaf", reason: "progress_update" });
+					fs.writeFileSync(path.join(root, "status.json"), JSON.stringify({ runId, state: "complete" }));
+					const scans = polling.scans.length;
+					polling.tick();
+					assert.equal(runtime.notices.at(-1)?.details?.requestId, progress);
+					polling.assertScoped();
+					assert.equal(runtime.notices.length, cycle + 1);
+					assert.equal(polling.scans.length, scans + 1, "terminal mailbox gets exactly one final scan");
+					assert.equal(fs.existsSync(path.join(dir, "requests", `${progress}.json`)), false);
+					assert.equal(fs.existsSync(path.join(dir, "requests", `${foreign}.json`)), true, "foreign requests are never accepted or deleted");
+					assert.equal(polling.intervals.size, 0);
+					await runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "pending" });
+					polling.tick();
+					assert.equal(polling.scans.length, scans + 1);
+					assert.equal(runtime.notices.length, cycle + 1);
+				}
+				assert.equal(polling.starts, 2);
+				const live = randomUUID();
+				allowed.add(path.join(resolveSupervisorChannelDir(live, "leaf", 0), "requests"));
+				fs.writeFileSync(path.join(root, "status.json"), JSON.stringify({ runId: live, state: "running" }));
+				runtime.events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: live, asyncDir: root, agent: "leaf", sessionId: runtime.sessionFile });
+				assert.equal(polling.intervals.size, 1);
+				await runtime.emit("session_shutdown");
+				assert.equal(polling.intervals.size, 0, "shutdown closes live polling too");
+			} finally {
+				await runtime.emit("session_shutdown");
+				polling.restore();
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		});
+	}
+
 	for (const platform of ["darwin", "win32"] as const) {
 		it(`answers nested A → B → C asks through the child hooks and executor (${platform})`, { timeout: 15_000 }, async () => {
 			clearExclusions();

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -15,7 +15,12 @@ import {
 import { steerWorkflowForegroundTarget } from "../../src/runs/foreground/workflow-foreground-steering.ts";
 import { createSubagentExecutor } from "../../src/runs/foreground/subagent-executor.ts";
 import type { ForegroundRunControl, ForegroundSteerInput, SubagentState } from "../../src/shared/types.ts";
-import { DIRS } from "../../src/shared/types.ts";
+import { DIRS, SUBAGENT_ASYNC_STARTED_EVENT } from "../../src/shared/types.ts";
+import { runSync } from "../../src/runs/foreground/execution.ts";
+import { setChildSessionFactory, type ChildSessionFactory, type ChildSessionLaunch, type ChildSessionEvent } from "../../src/runs/shared/child-session.ts";
+import { createEventBus, makeAgent } from "../support/helpers.ts";
+import { clearExclusions } from "../../src/runs/shared/model-exclusions.ts";
+import { buildInProcessChildLaunch } from "../../src/runs/shared/child-launch.ts";
 
 const createdChannels: string[] = [];
 
@@ -100,7 +105,265 @@ afterEach(() => {
 	for (const channel of createdChannels.splice(0)) fs.rmSync(channel, { recursive: true, force: true });
 });
 
+/** Deterministic session/model seam: real launch hooks and tools, with the host's tool allowlist. */
+function hookRuntime(launch: ChildSessionLaunch, platform: NodeJS.Platform, signal: AbortSignal) {
+	type Tool = { execute(id: string, params: Record<string, unknown>, signal: AbortSignal, update: undefined, ctx: unknown): Promise<{
+		content: Array<{ type: string; text?: string }>; isError?: boolean;
+		details: { asyncDir: string; pending: Array<{ id: string; agent: string }>; requestId?: string; replyTo?: string };
+	}> };
+	const owner = randomUUID();
+	const sessionFile = path.join(launch.cwd, `${owner}.jsonl`);
+	const ctx = { ...makeCtx(owner, sessionFile), cwd: launch.cwd, ui: {}, modelRegistry: { getAvailable: () => [] } };
+	const registered = new Map<string, Tool>();
+	const handlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown>>();
+	const subscribers = new Set<(event: ChildSessionEvent) => void>();
+	const notices: unknown[] = [];
+	const active = () => [...registered.keys()].filter(name => (!launch.tools || launch.tools.includes(name)) && !launch.excludeTools?.includes(name));
+	let closed = false;
+	const pi = {
+		events: createEventBus(),
+		on(name: string, handler: (event: unknown, ctx: unknown) => unknown) { handlers.set(name, [...(handlers.get(name) ?? []), handler]); },
+		registerTool(tool: Tool & { name: string }) { registered.set(tool.name, tool); },
+		getAllTools: () => active().map(name => ({ name, sourceInfo: { source: name === "read" ? "builtin" : "extension" } })),
+		getSessionName: () => "shared-name",
+		setSessionName() {},
+		sendMessage(message: { customType?: string }) { if (message.customType === "subagent_supervisor_request") notices.push(message); },
+	};
+	registered.set("read", { execute: async () => { throw new Error("fixture has no model-authored read calls"); } });
+	// Capture each native channel's platform without changing unrelated executor filesystem behavior.
+	const descriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+	try {
+		Object.defineProperty(process, "platform", { ...descriptor, value: platform });
+		for (const hook of launch.hooks) hook.factory(pi as never);
+	} finally { Object.defineProperty(process, "platform", descriptor); }
+	return {
+		owner, sessionFile, registered, active, notices, events: pi.events,
+		get closed() { return closed; },
+		subscribe(listener: (event: ChildSessionEvent) => void) { subscribers.add(listener); return () => { subscribers.delete(listener); }; },
+		async emit(type: string, fields = {}) {
+			if (type === "session_shutdown") { if (closed) return; closed = true; }
+			const event = { type, ...fields };
+			for (const handler of handlers.get(type) ?? []) await handler(event, ctx);
+			for (const listener of subscribers) listener(event);
+		},
+		async call(name: string, params: Record<string, unknown>) {
+			assert.ok(active().includes(name), `Tool '${name}' is not active in ${launch.runtime.agent}`);
+			return registered.get(name)!.execute(randomUUID(), params, signal, undefined, ctx);
+		},
+	};
+}
+
 describe("supervisor ask registration", () => {
+	for (const platform of ["darwin", "win32"] as const) {
+		it(`answers nested A → B → C asks through the child hooks and executor (${platform})`, { timeout: 15_000 }, async () => {
+			clearExclusions();
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "nested-supervisor-"));
+			const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+			process.env.PI_CODING_AGENT_DIR = root;
+			const agentsDir = path.join(root, "agents");
+			fs.mkdirSync(agentsDir, { recursive: true });
+			fs.writeFileSync(path.join(agentsDir, "leaf.md"), "---\nname: leaf\ndescription: Read-only leaf\ntools: read, contact_supervisor\nmodel: mock/test-model\n---\nInspect only.\n");
+			const a = randomUUID();
+			const parentTools = new Map<string, SupervisorTool>();
+			const parent = createNativeSupervisorChannel(makePi({ tools: parentTools }) as never, makeState(a, makeCtx(a)), { platform });
+			const runtimes: ReturnType<typeof hookRuntime>[] = [];
+			const workflows: string[] = [];
+			let cRequest: string | undefined;
+			let cReturned = false;
+			let bReturned = false;
+			const abort = new AbortController();
+			const factory: ChildSessionFactory = {
+				async create(launch) {
+					const runtime = hookRuntime(launch, platform, abort.signal);
+					runtimes.push(runtime);
+					if (launch.runtime.supervisorChannelDir) createdChannels.push(launch.runtime.supervisorChannelDir);
+					await runtime.emit("session_start");
+					return {
+						sessionId: runtime.owner, sessionFile: runtime.sessionFile, modelId: "mock/test-model", messages: [],
+						subscribe: runtime.subscribe,
+						steer: async () => { throw new Error("steering is not a supervisor reply"); },
+						followUp: async () => { throw new Error("follow-up is not a supervisor reply"); },
+						abort: async () => { abort.abort(); },
+						dispose: () => runtime.emit("session_shutdown"),
+						async prompt() {
+							await runtime.emit("agent_start");
+							if (launch.runtime.agent === "coordinator") {
+								assert.ok(runtime.registered.has(NATIVE_SUPERVISOR_TOOL_NAME), "B needs a native downward provider");
+								assert.ok(runtime.active().includes(NATIVE_SUPERVISOR_TOOL_NAME), "B's requested supervisor tool must be callable");
+								const receipt = await runtime.call("subagent", {
+									workflowScript: "return runs.run('inspect', { agent: 'leaf', task: 'Inspect the repository read-only and ask which option to report.', async: false });",
+									async: true,
+								});
+								assert.notEqual(receipt.isError, true, text(receipt));
+								workflows.push(receipt.details.asyncDir);
+								// No explicit pending scan: executor activation must discover C's delayed ask.
+								await waitForCondition(() => runtime.notices.length > 0, "B to discover C's ask without a manual scan");
+								const pending = await runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "pending" });
+								const [ask] = pending.details.pending;
+								cRequest = ask.id;
+								assert.equal(ask.agent, "leaf");
+								assert.equal(cReturned, false);
+								await assert.rejects(parentTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("foreign", { action: "reply", replyTo: cRequest, message: "A cannot answer C" }), /No pending supervisor request found/);
+								await assert.rejects(runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "reply", replyTo: "wrong-request-id", message: "Wrong" }), /No pending supervisor request found/);
+								const escalation = await runtime.call("contact_supervisor", { reason: "need_decision", message: "C needs a choice; may I approve option A?" });
+								assert.match(text(escalation), /Approve option A/);
+								assert.equal(cReturned, false, "A's answer to B must not unblock C");
+								const reply = await runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "reply", replyTo: cRequest, message: "Use option A" });
+								assert.equal(reply.details.replyTo, cRequest);
+								bReturned = true;
+							} else {
+								assert.equal(launch.runtime.agent, "leaf");
+								assert.equal(launch.runtime.orchestratorSessionId, runtimes[0]!.owner, "C belongs to B's exact runtime id, not A or B's file");
+								assert.equal(runtime.registered.has(NATIVE_SUPERVISOR_TOOL_NAME), false, "leaf must not get downward authority");
+								await new Promise(resolve => setTimeout(resolve, 25));
+								const reply = await runtime.call("contact_supervisor", { reason: "need_decision", message: "Which option?" });
+								assert.equal(reply.details.requestId, cRequest);
+								assert.match(text(reply), /Use option A/);
+								cReturned = true;
+							}
+							await runtime.emit("message_end", { message: { role: "assistant", content: [{ type: "text", text: "Inspection complete." }], model: "mock/test-model", stopReason: "stop", usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } } } });
+							await runtime.emit("agent_end");
+							await runtime.emit("agent_settled");
+						},
+					};
+				},
+				async dispose() {},
+			};
+			try {
+				parent.start();
+				setChildSessionFactory(factory);
+				const run = runSync(root, [makeAgent("coordinator", { model: "mock/test-model", tools: ["read", "subagent", "contact_supervisor", "subagent_supervisor"] })], "coordinator", "Inspect read-only with the assigned leaf.", {
+					runId: randomUUID(), parentSessionId: a, orchestratorIntercomTarget: "shared-name", signal: abort.signal,
+				});
+				await waitForCondition(() => runtimes.length > 0, "coordinator startup");
+				// Surface diagnostic failures immediately rather than hiding them behind an ask timeout.
+				const result = await Promise.race([
+					run.then(result => { assert.equal(result.exitCode, 0, result.error); return result; }),
+					(async () => {
+						await waitForCondition(() => {
+							// A may be idle; its explicit query is authoritative.
+							void parentTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("pending", { action: "pending" });
+							return parent.pending.size > 0;
+						}, "B's escalation to A");
+						const [ask] = parent.pending.values();
+						assert.equal(ask!.agent, "coordinator");
+						assert.notEqual(ask!.id, cRequest);
+						await parentTools.get(NATIVE_SUPERVISOR_TOOL_NAME)!.execute("reply", { action: "reply", replyTo: ask!.id, message: "Approve option A" });
+						return await run;
+					})(),
+				]);
+				assert.equal(result.exitCode, 0, result.error);
+				assert.equal(bReturned, true);
+				assert.equal(cReturned, true, "B's final drain must await C's real blocked contact call and workflow completion");
+				for (const dir of workflows) {
+					const status = JSON.parse(fs.readFileSync(path.join(dir, "status.json"), "utf8"));
+					assert.equal(status.state, "complete", JSON.stringify(status));
+				}
+				for (const runtime of runtimes) assert.equal(runtime.closed, true);
+				const stale = writeRequest({ sessionId: runtimes[0]!.owner, runId: randomUUID() });
+				await assert.rejects(runtimes[0]!.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "reply", replyTo: stale, message: "No authority after shutdown" }), /No pending supervisor request found/);
+			} finally {
+				abort.abort();
+				setChildSessionFactory(undefined);
+				for (const runtime of runtimes) await runtime.emit("session_shutdown");
+				parent.dispose();
+				if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+				else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+				for (const dir of workflows) fs.rmSync(dir, { recursive: true, force: true });
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		});
+	}
+
+	it("discovers a direct async child's ask without polling pending on Darwin", { timeout: 5000 }, async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "nested-async-supervisor-"));
+		const launch = buildInProcessChildLaunch({
+			host: "parent", cwd: root, childAgentName: "coordinator", childIndex: 0,
+			sessionEnabled: false, tools: ["subagent", "subagent_supervisor"],
+			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+		});
+		const abort = new AbortController();
+		const runtime = hookRuntime(launch.session, "darwin", abort.signal);
+		const runId = randomUUID();
+		const channelDir = resolveSupervisorChannelDir(runId, "leaf", 0);
+		createdChannels.push(channelDir);
+		const childTools = new Map<string, SupervisorTool>();
+		registerNativeSupervisorClient(makePi({ tools: childTools }) as never, { channelDir, runId, agent: "leaf", childIndex: 0, orchestratorSessionId: runtime.owner });
+		let request: Promise<{ content: Array<{ type: string; text?: string }> }> | undefined;
+		const contact = childTools.get("contact_supervisor") as unknown as {
+			execute(id: string, params: { reason: string; message: string }, signal: AbortSignal): NonNullable<typeof request>;
+		};
+		try {
+			await runtime.emit("session_start");
+			fs.writeFileSync(path.join(root, "status.json"), JSON.stringify({ runId, state: "running" }));
+			runtime.events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: runId, asyncDir: root, agent: "leaf", sessionId: runtime.sessionFile });
+			request = contact.execute("ask", { reason: "need_decision", message: "Which option?" }, abort.signal);
+			// Attach rejection handling before any assertion can abort the child.
+			void request!.catch(() => {});
+			await waitForCondition(() => runtime.notices.length > 0, "direct async ask notification");
+			const pending = await runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "pending" });
+			await runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "reply", replyTo: pending.details.pending[0]!.id, message: "Use option A" });
+			assert.match(text(await request), /Use option A/);
+		} finally {
+			abort.abort();
+			await request?.catch(() => {});
+			await runtime.emit("session_shutdown");
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("does not activate supervision when the coordinator excludes the reply tool", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "nested-no-supervisor-"));
+		const launch = buildInProcessChildLaunch({
+			host: "parent", cwd: root, childAgentName: "coordinator", childIndex: 0,
+			sessionEnabled: false, tools: ["subagent"],
+			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+		});
+		const runtime = hookRuntime(launch.session, "win32", new AbortController().signal);
+		const runId = randomUUID();
+		try {
+			writeRequest({ sessionId: runtime.owner, runId });
+			await runtime.emit("session_start");
+			runtime.events.emit(SUBAGENT_ASYNC_STARTED_EVENT, { id: runId, asyncDir: root, agent: "worker", sessionId: runtime.sessionFile });
+			await new Promise(resolve => setTimeout(resolve, 600));
+			assert.equal(runtime.notices.length, 0, "no instructions to call an excluded reply tool");
+			await assert.rejects(runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "pending" }), /not active/);
+			await assert.rejects(runtime.call("subagent", { action: "schedule.run", id: "not-authorized" }), /not available/);
+		} finally {
+			await runtime.emit("session_shutdown");
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("wires fresh pending-ask lookup into the child-safe steering executor", async () => {
+		fs.mkdirSync(DIRS.async, { recursive: true });
+		const root = fs.mkdtempSync(path.join(DIRS.async, "child-blocked-steer-"));
+		const launch = buildInProcessChildLaunch({
+			host: "parent", cwd: root, childAgentName: "coordinator", childIndex: 0,
+			sessionEnabled: false, tools: ["subagent", "subagent_supervisor"],
+			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+		});
+		const runtime = hookRuntime(launch.session, "darwin", new AbortController().signal);
+		try {
+			await runtime.emit("session_start");
+			const runId = randomUUID();
+			const requestId = writeRequest({ sessionId: runtime.owner, runId });
+			const status = JSON.stringify({ runId, sessionId: runtime.sessionFile, state: "running", mode: "single", pid: process.pid, startedAt: Date.now(), steps: [{ agent: "worker", status: "running" }] });
+			fs.writeFileSync(path.join(root, "status.json"), status);
+			await assert.rejects(runtime.call("subagent", { action: "steer", dir: root, message: "After the decision, inspect docs." }), (error: Error) => {
+				assert.ok(error.message.includes(`"replyTo":"${requestId}"`), error.message);
+				assert.match(error.message, /not delivered or queued/);
+				return true;
+			});
+			assert.equal(runtime.notices.length, 0, "receipt lookup must not register or notify");
+			assert.equal(fs.readFileSync(path.join(root, "status.json"), "utf8"), status);
+			assert.deepEqual(fs.readdirSync(path.join(resolveSupervisorChannelDir(runId, "worker", 0), "replies")), []);
+		} finally {
+			await runtime.emit("session_shutdown");
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
 	it("public single async steering reports exact pending asks without reply, queue or recovery", async () => {
 		const owner = randomUUID();
 		fs.mkdirSync(DIRS.async, { recursive: true });


### PR DESCRIPTION
## Summary

Nested coordinators can now answer their own children's blocking supervisor requests. Previously, in A → B → C, both B and C could call `contact_supervisor`, but B's child runtime never registered the `subagent_supervisor` tool needed to answer C.

The fix reuses the existing native request/reply channel and shared child runtime state. B's downward authority comes from B's exact runtime session ID, not A's ID or B's session-file path. A cannot answer C directly, and answering B's escalation does not resolve C's original request.

- Keep explicitly requested native coordination tools through host-builtin filtering without bypassing capability ceilings or exclusions.
- Discover both foreground/workflow and direct async child asks; only explicit, request-ID-correlated replies unblock the child.
- Poll only the coordinator's live descendant mailboxes, with no global watcher/scanner and no idle polling. An excluded reply tool does not start downward supervision.
- Reject a requested reply tool without fanout authorization at launch with a specific diagnostic.

Agent profiles with explicit allowlists still need both roles:
```yaml
tools: read, subagent, contact_supervisor, subagent_supervisor
```

Related: #2069

## Validation

- **166 focused tests passed**, including A → B → C: C asks, B escalates to A, A answers B, B replies using C's original request ID, C's blocked call returns, and the workflow completes. Real launch hooks, executor, filesystem channel, and workflow engine are exercised with a deterministic session/model fixture.
- Reproduced the direct-async Darwin notification gap before the follow-up fix; the new regression now passes without querying `pending` to trigger discovery.
- Scoped transport tests cover Darwin, Windows, and Linux branches: one owned-mailbox scan despite 100 unrelated retained channels; no global watcher or idle timer.
- **1,006 integration tests passed**, 6 skipped. An initial result-publication barrier timeout passed in isolation and in the full rerun.
- `npm run typecheck` and `git diff --check` passed.
- An installed Pi 0.84.4 SDK probe confirmed actual registered and active tools for explicit coordinators, coordinators omitting the reply tool, and leaves. The existing Pi 0.85 clean-install smoke now carries these assertions too.

## Validation limits

The full local unit run had **3,053 passes, 13 skips, and 3 environment failures**: missing `oxlint`, missing `@earendil-works/pi-server`, and `kill EPERM` in the detached-process fixture. Full dependency installation was blocked by registry E404/ETARGET errors; package manifests and the lockfile are unchanged.

Windows transport selection is covered on macOS, but native Windows filesystem/process behavior and the Pi 0.85 clean-install smoke await CI. No live external-model end-to-end run was performed.
