### PR TITLE
fix(tui): advance workflow timing and nest live child cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Advance live workflow and lane elapsed times from their starts, and nest loaded workflow children in the async widget instead of repeating lane rows and sibling cards. Partial fix for #2085; thanks to [@expoli](https://github.com/expoli).
 - Reject materialized workflow launch groups with invalid worktree repositories or dirty sources before dispatching children or claiming fan-out/output ownership. Allocation still rechecks; workflow-key failure traces may remain. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2076.
 - Keep the configured main watchdog model and thinking in recommendations instead of suggesting a hardcoded replacement, and clarify user-scope model saves. Thanks to [@freezscholte](https://github.com/freezscholte) for #2078.
 - Recognize OpenRouter's status-prefixed 401 errors for configured model fallback before tool work, including watchdog reviews. Thanks to [@freezscholte](https://github.com/freezscholte) for #2077.

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -353,6 +353,7 @@ function projectPaneEntries(state: SubagentState): FleetStatusEntry[] {
 }
 
 export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntry[] {
+	const now = Date.now();
 	const entries: FleetStatusEntry[] = [];
 	const activeWorkflowKeys = new Set([...state.asyncJobs.values()]
 		.filter((job) => job.mode === "workflow" && isActiveState(job.status))
@@ -413,7 +414,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 
 	for (const job of state.asyncJobs.values()) {
 		if (!isActiveState(job.status)) continue;
-		const startedAt = job.startedAt ?? job.updatedAt ?? Date.now();
+		const startedAt = job.startedAt ?? job.updatedAt ?? now;
 		const linkedParentKey = linkedWorkflowParentKey(job.parentWorkflowRunId, activeWorkflowKeys);
 		if (job.mode === "workflow") {
 			const latestEmit = job.workflow?.emits?.length ? formatWorkflowJsonPreview(job.workflow.emits.at(-1), 120) : undefined;
@@ -425,7 +426,7 @@ export function collectFleetStatusEntries(state: SubagentState): FleetStatusEntr
 				hostSteps: job.hostSteps,
 				preflight: job.preflight,
 				trace: job.workflow?.trace,
-				now: job.updatedAt ?? Date.now(),
+				now,
 			});
 			entries.push({
 				key: `async:${job.asyncId}`,

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -45,6 +45,9 @@ import { formatWorkflowChecklistBottleneck, formatWorkflowChecklistPhase, format
 type Theme = ExtensionContext["ui"]["theme"];
 
 interface WorkflowWidgetProjection {
+	now: number;
+	children?: AsyncJobState[];
+	materializedKeys?: Set<string>;
 	stages: WorkflowGraphNode[];
 	steps: AsyncJobStep[];
 	stageProgress?: { total: number; current?: number };
@@ -443,11 +446,14 @@ function workflowStageProgress(job: AsyncJobState, stages = job.mode === "workfl
 	return { total: stages.length };
 }
 
-function buildWorkflowWidgetProjection(job: AsyncJobState): WorkflowWidgetProjection {
+function buildWorkflowWidgetProjection(job: AsyncJobState, now = Date.now()): WorkflowWidgetProjection {
 	const stages = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph) : [];
 	const stageProgress = workflowStageProgress(job, stages);
-	const steps = workflowWidgetSteps(job, stages);
-	const projection: WorkflowWidgetProjection = { stages, steps };
+	const clock = job.status === "running" ? now : job.updatedAt;
+	const loadedSteps = workflowWidgetSteps(job, stages);
+	const steps = job.mode === "workflow" ? loadedSteps.map((step) => step.status === "running" && step.startedAt !== undefined && clock !== undefined
+		? { ...step, durationMs: Math.max(0, clock - step.startedAt) } : step) : loadedSteps;
+	const projection: WorkflowWidgetProjection = { stages, steps, now };
 	if (stageProgress) projection.stageProgress = stageProgress;
 	if (stages.length) projection.plannedKeys = new Set(stages.map((node) => node.id));
 	if (job.mode === "workflow") {
@@ -457,19 +463,27 @@ function buildWorkflowWidgetProjection(job: AsyncJobState): WorkflowWidgetProjec
 			hostSteps: job.hostSteps,
 			preflight: job.preflight,
 			trace: job.workflow?.trace,
-			now: job.updatedAt ?? Date.now(),
+			now: clock,
 		});
 		if (checklist.total > 0) projection.checklist = checklist;
 	}
 	return projection;
 }
 
-function workflowWidgetProjectionLookup(): WorkflowWidgetProjectionLookup {
+function workflowWidgetProjectionLookup(now = Date.now(), childrenByParent = new Map<string, AsyncJobState[]>()): WorkflowWidgetProjectionLookup {
 	const projections = new WeakMap<AsyncJobState, WorkflowWidgetProjection>();
 	return (job: AsyncJobState) => {
 		const cached = projections.get(job);
 		if (cached) return cached;
-		const projection = buildWorkflowWidgetProjection(job);
+		const projection = buildWorkflowWidgetProjection(job, now);
+		const children = childrenByParent.get(job.asyncId);
+		if (children?.length) {
+			projection.children = children;
+			projection.materializedKeys = new Set(children.flatMap((child) => [child.asyncId, ...(child.workflowKey ? [child.workflowKey] : [])]));
+			for (const step of projection.steps) {
+				if (step.runId && projection.materializedKeys.has(step.runId) && step.workflowKey) projection.materializedKeys.add(step.workflowKey);
+			}
+		}
 		projections.set(job, projection);
 		return projection;
 	};
@@ -1051,9 +1065,11 @@ function hostStepRenderKey(row: AsyncStatusWorkflowRow): unknown[] {
 }
 
 export function widgetRenderKey(job: AsyncJobState, expanded = false): string {
-	const projection = buildWorkflowWidgetProjection(job);
+	const projection = buildWorkflowWidgetProjection(job, job.updatedAt ?? 0);
 	return JSON.stringify({
 		asyncDir: job.asyncDir,
+		parentWorkflowRunId: job.parentWorkflowRunId,
+		workflowKey: job.workflowKey,
 		status: job.status,
 		description: job.mode === "workflow" ? job.description : undefined,
 		activityState: job.activityState,
@@ -1501,9 +1517,10 @@ function compactWorkflowStats(job: AsyncJobState, rows: readonly CompactWorkflow
 	const rowToolUses = rows.map((row) => row.toolUses).filter((value): value is number => value !== undefined);
 	const toolUses = job.toolCount ?? (rowToolUses.length ? rowToolUses.reduce((sum, value) => sum + value, 0) : undefined);
 	const rowDuration = rows.map((row) => row.durationMs).filter((value): value is number => value !== undefined);
-	const durationMs = job.startedAt !== undefined && job.updatedAt !== undefined
-		? Math.max(0, job.updatedAt - job.startedAt)
-		: rowDuration.length ? Math.max(...rowDuration) : undefined;
+	const end = job.status === "running" ? projection.now : job.updatedAt;
+	const durationMs = job.status !== "queued" && job.startedAt !== undefined && end !== undefined
+		? Math.max(0, end - job.startedAt)
+		: job.status !== "queued" && rowDuration.length ? Math.max(...rowDuration) : undefined;
 	return statJoin(theme, [
 		`id: ${compactWorkflowShortId(job)}`,
 		...progress,
@@ -1541,7 +1558,9 @@ function compactWorkflowWidgetBodyLines(job: AsyncJobState, theme: Theme, frame:
 	const rows = compactWorkflowLaneRows(job, projection.checklist);
 	const lines = [`  ${compactWorkflowStats(job, rows, theme, projection)}`];
 	if (rows.length) {
-		for (const row of rows) lines.push(compactWorkflowLaneLine(row, theme, "  ", frame));
+		for (const row of rows) {
+			if (!projection.materializedKeys?.has(row.key)) lines.push(compactWorkflowLaneLine(row, theme, "  ", frame));
+		}
 	} else {
 		lines.push(`  ${theme.fg("dim", "◦ waiting for workflow lanes")}`);
 	}
@@ -2085,7 +2104,8 @@ function widgetStats(job: AsyncJobState, theme: Theme, projection = buildWorkflo
 	if (projection.checklist && !checklistPrimary) parts.push(formatWorkflowChecklistSummary(projection.checklist));
 	if (job.toolCount !== undefined) parts.push(formatToolUseStat(job.toolCount));
 	if (job.totalTokens?.total) parts.push(formatTokenUsage(job.totalTokens, "token"));
-	if (job.startedAt !== undefined && job.updatedAt !== undefined) parts.push(formatDuration(Math.max(0, job.updatedAt - job.startedAt)));
+	const end = job.status === "running" && (job.mode === "workflow" || job.parentWorkflowRunId) ? projection.now : job.updatedAt;
+	if (job.status !== "queued" && job.startedAt !== undefined && end !== undefined) parts.push(formatDuration(Math.max(0, end - job.startedAt)));
 	return statJoin(theme, parts);
 }
 
@@ -2364,7 +2384,8 @@ function hostStepWidgetLines(job: AsyncJobState, theme: Theme, indent: string): 
 }
 
 function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded: boolean, width: number, frame?: number, projection = buildWorkflowWidgetProjection(job)): string[] {
-	const { steps } = projection;
+	const steps = projection.steps.filter((step) => !projection.materializedKeys?.has(step.workflowKey ?? "") && !projection.materializedKeys?.has(step.runId ?? ""));
+	const checklist = widgetChecklistWithoutMaterializedChildren(projection);
 	if (!expanded && job.mode === "workflow") {
 		return compactWorkflowWidgetBodyLines(job, theme, frame, projection);
 	}
@@ -2372,7 +2393,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 		const lane = projectAsyncLane(job, laneStepForJob(job, steps));
 		return [
 			...(expanded ? workflowPreflightLines(job) : []),
-			...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame),
+			...workflowChecklistWidgetLines(checklist, theme, "  ", expanded, frame),
 			...(lane ? formatLaneProjectionLines(lane, theme, "  ") : []),
 			...hostStepWidgetLines(job, theme, "  "),
 			`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
@@ -2382,7 +2403,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 	if (job.mode === "chain" && !job.activeParallelGroup && job.parallelGroups?.length) return widgetChainDetails(job, theme, expanded, width, frame);
 	const lines: string[] = [
 		...(expanded ? workflowPreflightLines(job) : []),
-		...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame, { includeItemErrors: !expanded }),
+		...workflowChecklistWidgetLines(checklist, theme, "  ", expanded, frame, { includeItemErrors: !expanded }),
 	];
 	const group = activeParallelWidgetGroup(job);
 	if (group) {
@@ -2724,6 +2745,48 @@ function fitAdaptiveWidgetLines(jobs: AsyncJobState[], buildLines: () => string[
 
 const asyncWidgetUpdates = new WeakMap<ExtensionContext["ui"], (jobs: AsyncJobState[]) => void>();
 
+/** Attach only to loaded workflow parents; orphan jobs remain top-level. */
+function widgetJobTree(jobs: AsyncJobState[], now: number): { roots: AsyncJobState[]; projectionFor: WorkflowWidgetProjectionLookup } {
+	const parents = new Map(jobs.filter((job) => job.mode === "workflow").map((job) => [job.asyncId, job]));
+	const childrenByParent = new Map<string, AsyncJobState[]>();
+	const roots: AsyncJobState[] = [];
+	for (const job of jobs) {
+		const parent = job.parentWorkflowRunId ? parents.get(job.parentWorkflowRunId) : undefined;
+		// Root-only adaptive summaries cannot advertise live work under a non-running parent.
+		const keepLiveRoot = isProgressiveActiveJob(job) && parent?.status !== "running";
+		if (parent && parent.asyncId !== job.asyncId && !keepLiveRoot) {
+			const children = childrenByParent.get(parent.asyncId) ?? [];
+			children.push(job);
+			childrenByParent.set(parent.asyncId, children);
+		} else roots.push(job);
+	}
+	return { roots, projectionFor: workflowWidgetProjectionLookup(now, childrenByParent) };
+}
+
+function widgetChecklistWithoutMaterializedChildren(projection: WorkflowWidgetProjection): WorkflowChecklistProjection | undefined {
+	const { checklist, materializedKeys } = projection;
+	if (!checklist || !materializedKeys) return checklist;
+	return { ...checklist, phases: checklist.phases.map((phase) => ({ ...phase, items: phase.items.filter((item) => !materializedKeys.has(item.key)) })) };
+}
+
+function materializedWidgetChildLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, frame: number | undefined, projectionFor: WorkflowWidgetProjectionLookup): string[] {
+	const children = projectionFor(job).children;
+	if (!children?.length) return [];
+	const lines: string[] = [];
+	const shown = orderedWidgetJobs(children).slice(0, MAX_WIDGET_JOBS);
+	for (const [index, child] of shown.entries()) {
+		const projection = projectionFor(child);
+		const last = index === children.length - 1;
+		const identity = child.workflowKey ?? child.asyncId;
+		const stats = widgetStats(child, theme, projection, !expanded);
+		lines.push(`  ${last ? "└─" : "├─"} ${theme.bold(identity)} ${widgetStatusGlyph(child, theme, frame)} ${themeBold(theme, widgetJobName(child))}${contextModeBadge(theme, child.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`);
+		for (const detail of foregroundStyleWidgetDetails(child, theme, expanded, Math.max(0, width - 6), frame, projection)) lines.push(`  ${last ? "  " : "│ "}${detail}`);
+		for (const detail of materializedWidgetChildLines(child, theme, Math.max(0, width - 4), expanded, frame, projectionFor)) lines.push(`    ${detail}`);
+	}
+	if (shown.length < children.length) lines.push(`  +${children.length - shown.length} more workflow children`);
+	return lines;
+}
+
 function buildWidgetComponent(jobs: AsyncJobState[], ui: ExtensionContext["ui"]): (tui: { requestRender(): void }, theme: Theme) => Component {
 	return (tui, theme) => {
 		const container = new Container();
@@ -2743,20 +2806,21 @@ function buildWidgetComponent(jobs: AsyncJobState[], ui: ExtensionContext["ui"])
 			},
 		});
 		container.render = (renderWidth: number): string[] => {
-			const frame = Math.floor(Date.now() / WIDGET_ANIMATION_INTERVAL_MS);
+			const now = Date.now();
+			const frame = Math.floor(now / WIDGET_ANIMATION_INTERVAL_MS);
 			const expanded = ui.getToolsExpanded?.() ?? false;
 			if (cachedLines && cachedRenderWidth === renderWidth && cachedFrame === frame && cachedExpanded === expanded) return cachedLines;
 			const width = Math.max(0, renderWidth - 2);
-			const projectionFor = workflowWidgetProjectionLookup();
+			const { roots, projectionFor } = widgetJobTree(jobs, now);
 			const buildLines = (): string[] => expanded
-				? buildWidgetLinesWithProjection(jobs, theme, width, true, frame, projectionFor)
-				: jobs.length === 1
-					? compactSingleWidgetLines(jobs[0]!, theme, width, frame, projectionFor(jobs[0]!))
-					: buildWidgetLinesWithProjection(jobs, theme, width, false, frame, projectionFor);
+				? buildWidgetLinesWithProjection(roots, theme, width, true, frame, projectionFor)
+				: roots.length === 1 && !projectionFor(roots[0]!).children?.length
+					? compactSingleWidgetLines(roots[0]!, theme, width, frame, projectionFor(roots[0]!))
+					: buildWidgetLinesWithProjection(roots, theme, width, false, frame, projectionFor);
 			cachedRenderWidth = renderWidth;
 			cachedFrame = frame;
 			cachedExpanded = expanded;
-			cachedLines = fitAdaptiveWidgetLines(jobs, buildLines, theme, width, expanded, frame, projectionFor).map((line) => paddedWidgetLine(line, renderWidth));
+			cachedLines = fitAdaptiveWidgetLines(roots, buildLines, theme, width, expanded, frame, projectionFor).map((line) => paddedWidgetLine(line, renderWidth));
 			return cachedLines;
 		};
 		return component;
@@ -2765,7 +2829,10 @@ function buildWidgetComponent(jobs: AsyncJobState[], ui: ExtensionContext["ui"])
 
 function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, width = getTermWidth(), expanded = false, frame?: number, projectionFor: WorkflowWidgetProjectionLookup = workflowWidgetProjectionLookup()): string[] {
 	if (jobs.length === 0) return [];
-	if (jobs.length === 1) return buildSingleWidgetLines(jobs[0]!, theme, width, expanded, frame, projectionFor(jobs[0]!));
+	if (jobs.length === 1) return [
+		...buildSingleWidgetLines(jobs[0]!, theme, width, expanded, frame, projectionFor(jobs[0]!)),
+		...materializedWidgetChildLines(jobs[0]!, theme, width, expanded, frame, projectionFor).map((line) => truncLine(line, width)),
+	];
 	const running = jobs.filter((job) => job.status === "running");
 	const queued = jobs.filter((job) => job.status === "queued");
 	const finished = jobs.filter((job) => job.status !== "running" && job.status !== "queued");
@@ -2791,7 +2858,7 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 			: [
 				`  ${theme.fg("dim", `⎿  ${widgetActivity(job)}`)}`,
 				...widgetLaneDetailLines(job, theme, projection),
-				...workflowChecklistWidgetLines(projection.checklist, theme, "  ", expanded, frame, { includeItemErrors: !expanded || !job.steps?.length }),
+				...workflowChecklistWidgetLines(widgetChecklistWithoutMaterializedChildren(projection), theme, "  ", expanded, frame, { includeItemErrors: !expanded || !job.steps?.length }),
 				...widgetParallelAgentDetails(job, theme, expanded, width, frame),
 			];
 		items.push([
@@ -2799,6 +2866,7 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 				? compactWorkflowHeaderLine(job, theme, width)
 				: `${widgetStatusGlyph(job, theme, frame)} ${themeBold(theme, widgetJobName(job))}${contextModeBadge(theme, job.context)}${stats ? ` ${theme.fg("dim", "·")} ${stats}` : ""}`,
 			...details,
+			...materializedWidgetChildLines(job, theme, width, expanded, frame, projectionFor),
 		]);
 	};
 
@@ -2845,7 +2913,8 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 }
 
 export function buildWidgetLines(jobs: AsyncJobState[], theme: Theme, width = getTermWidth(), expanded = false, frame?: number): string[] {
-	return buildWidgetLinesWithProjection(jobs, theme, width, expanded, frame);
+	const { roots, projectionFor } = widgetJobTree(jobs, Date.now());
+	return buildWidgetLinesWithProjection(roots, theme, width, expanded, frame, projectionFor);
 }
 
 /**

--- a/src/workflows/workflow-checklist.ts
+++ b/src/workflows/workflow-checklist.ts
@@ -186,7 +186,7 @@ function duration(step: Pick<WorkflowChecklistStep, "durationMs" | "startedAt" |
 	const startedAt = finite(step.startedAt);
 	if (explicit !== undefined) return Math.max(0, explicit);
 	if (startedAt === undefined) return undefined;
-	const end = state === "running" ? now : finite(step.endedAt) ?? now;
+	const end = state === "running" ? now : finite(step.endedAt);
 	return end === undefined ? undefined : Math.max(0, end - startedAt);
 }
 
@@ -296,7 +296,7 @@ function priority(item: WorkflowChecklistItem): number {
 }
 
 function applyNow(item: WorkflowChecklistItem, now: number | undefined): WorkflowChecklistItem {
-	return item.durationMs === undefined && item.startedAt !== undefined && now !== undefined ? { ...item, durationMs: Math.max(0, now - item.startedAt) } : item;
+	return item.state === "running" && item.startedAt !== undefined && now !== undefined ? { ...item, durationMs: Math.max(0, now - item.startedAt) } : item;
 }
 
 function finalize(phase: WorkflowChecklistPhase): void {

--- a/test/integration/render-widget.test.ts
+++ b/test/integration/render-widget.test.ts
@@ -91,6 +91,95 @@ function resetWidgetLayout(): void {
 }
 
 describe("subagent async widget rendering", () => {
+	it("advances quiet workflow clocks without advancing a terminal sibling", () => {
+		const originalNow = Date.now;
+		const job = {
+			asyncId: "quiet-workflow", asyncDir: "/tmp/quiet", mode: "workflow", status: "running", startedAt: 1_000, updatedAt: 1_083,
+			steps: [
+				{ index: 0, workflowKey: "live", agent: "worker", status: "running", startedAt: 1_000, durationMs: 0 },
+				{ index: 1, workflowKey: "done", agent: "reviewer", status: "complete", startedAt: 1_000, endedAt: 3_000, durationMs: 2_000 },
+			],
+		};
+		try {
+			Date.now = () => 415_000;
+			assert.match(buildWidgetLines([job], theme, 180).join("\n"), /6m54s/);
+			const first = buildWidgetLines([job], theme, 180, true).join("\n");
+			assert.match(first, /worker.*6m54s/);
+			assert.match(first, /reviewer.*2\.0s/);
+			Date.now = () => 425_000;
+			const second = buildWidgetLines([job], theme, 180, true).join("\n");
+			assert.match(second, /worker.*7m4s/);
+			assert.match(second, /reviewer.*2\.0s/);
+			assert.match(buildWidgetLines([{ ...job, status: "complete", updatedAt: 3_000 }], theme, 180).join("\n"), /2\.0s/);
+			assert.equal(job.steps[0]!.durationMs, 0, "rendering must not persist clocks");
+		} finally { Date.now = originalNow; }
+	});
+
+	it("nests two same-agent workflow children once and collapses the group adaptively", () => {
+		const children = ["t7", "t9"].map((key) => ({
+			asyncId: `child-${key}`, asyncDir: `/tmp/${key}`, parentWorkflowRunId: "parent", workflowKey: key,
+			mode: "single", agents: ["chorus-worker"], status: "running", startedAt: 1_000, updatedAt: 1_083,
+		}));
+		const parent = { asyncId: "parent", asyncDir: "/tmp/parent", mode: "workflow", status: "running", startedAt: 1_000, updatedAt: 1_083,
+			steps: children.map((child, index) => ({ index, workflowKey: child.workflowKey, runId: child.asyncId, agent: "chorus-worker", status: "running" })) };
+		for (const expanded of [false, true]) {
+			const lines = buildWidgetLines([children[0]!, parent, children[1]!], theme, 180, expanded);
+			const text = lines.join("\n");
+			for (const key of ["t7", "t9"]) {
+				assert.equal(text.match(new RegExp(`[├└]─ ${key} `, "g"))?.length, 1, text);
+				assert.match(text, new RegExp(`  [├└]─ ${key} .*chorus-worker`));
+				assert.doesNotMatch(text, new RegExp(`${runningGlyphPattern} ${key} · chorus-worker`), "no mirrored lane row");
+			}
+			assert.doesNotMatch(text, new RegExp(`[├└]─ ${runningGlyphPattern} chorus-worker`), "children must not also be sibling cards");
+			assert.ok(lines.every((line) => visibleWidth(line) <= 180));
+		}
+		assert.equal(buildWidgetLines(children, theme, 180).join("\n").match(new RegExp(`[├└]─ ${runningGlyphPattern} chorus-worker`, "g"))?.length, 2, "orphans stay visible");
+		for (const rows of [12, 30, 80]) withStdoutSize(rows, 100, () => {
+			resetWidgetLayout();
+			const { ctx, widgets } = createUiContext();
+			renderWidget(ctx, [parent, ...children]);
+			const lines = renderWidgetLines(widgets[0], 100);
+			const text = lines.join("\n");
+			for (const key of ["t7", "t9"]) {
+				const count = text.match(new RegExp(`[├└]─ ${key} `, "g"))?.length ?? 0;
+				assert.ok(count <= 1, text);
+				if (rows === 80) assert.equal(count, 1, "roomy adaptive layout keeps both child rows");
+			}
+			assert.ok(lines.every((line) => visibleWidth(line) <= 100));
+			assert.ok(lines.length <= 14);
+			resetWidgetLayout();
+		});
+	});
+	it("keeps live children visible when their workflow parent is not running", () => {
+		for (const status of ["complete", "queued"]) {
+			const parent = { asyncId: "parent", asyncDir: "/tmp/parent", mode: "workflow", status, startedAt: 1_000, updatedAt: 2_000 };
+			const child = { asyncId: "live-child", asyncDir: "/tmp/live-child", mode: "single", status: "running", agents: ["live-worker"], parentWorkflowRunId: "parent", workflowKey: "live" };
+			const jobs = status === "queued"
+				? [parent, child, { asyncId: "other", asyncDir: "/tmp/other", status: "running", agents: ["other-worker"] }]
+				: [parent, child];
+			const full = buildWidgetLines(jobs, theme, 180).join("\n");
+			assert.equal(full.match(new RegExp(`[├└]─ (?:live )?${runningGlyphPattern} live-worker`, "g"))?.length, 1, full);
+			assert.match(full, status === "queued" ? /1 queued/ : /id: parent · 1\.0s/);
+			for (const rows of [12, 23]) withStdoutSize(rows, 100, () => {
+				resetWidgetLayout();
+				const { ctx, widgets } = createUiContext();
+				try {
+					renderWidget(ctx, jobs);
+					const lines = renderWidgetLines(widgets[0], 100);
+					const text = lines.join("\n");
+					if (rows === 12) {
+						assert.match(text, status === "queued" ? /2\/3 running, 1 queued/ : /1\/2 running/);
+						assert.equal(lines.length, 1);
+					} else {
+						assert.equal(text.match(new RegExp(`${runningGlyphPattern} live-worker`, "g"))?.length, 1, text);
+						assert.ok(lines.length <= 4);
+					}
+					assert.ok(lines.every((line) => visibleWidth(line) <= 100));
+				} finally { resetWidgetLayout(); }
+			});
+		}
+	});
+
 	it("updates the mounted async widget without changing host insertion order", () => {
 		type Widget = { render(width: number): string[]; dispose?(): void };
 		const widgets = new Map<string, Widget>();
@@ -172,7 +261,7 @@ describe("subagent async widget rendering", () => {
 		};
 		const compact = buildWidgetLines([job], theme, 180).join("\n");
 		assert.match(compact, /async workflow: Review workflow ─ background/);
-		assert.match(compact, /id: a6b9aa6b · 1\/2 done · 1 active · 5 tool uses · 2\.5s/);
+		assert.match(compact, /id: a6b9aa6b · 1\/2 done · 1 active · 5 tool uses/);
 		assert.match(compact, /write · worker\/mutation · apply the smallest fix · src\/tui · fix\.md/);
 		assert.match(compact, /review · reviewer\/review · active · check the compact surface · src\/tui · review\.md/);
 		assert.doesNotMatch(compact, /Plan:|Plan note:|preflight mismatch|Preflight advisory/);

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -46,6 +46,30 @@ const theme = {
 };
 
 describe("below-editor subagent FleetView", () => {
+	it("advances quiet workflow bottlenecks while terminal durations stay frozen", () => {
+		const state = stateForTest();
+		state.asyncJobs.set("quiet", {
+			asyncId: "quiet", asyncDir: "/tmp/quiet", mode: "workflow", status: "running", startedAt: 1_000, updatedAt: 1_083,
+			steps: [
+				{ index: 0, workflowKey: "live", agent: "worker", status: "running", startedAt: 2_000, durationMs: 0 },
+				{ index: 1, workflowKey: "done", agent: "worker", status: "complete", startedAt: 1_000, durationMs: 2_000 },
+				{ index: 2, workflowKey: "queued", agent: "worker", status: "pending", startedAt: 1_000 },
+				{ index: 3, workflowKey: "unknown", agent: "worker", status: "running" },
+			],
+		});
+		const originalNow = Date.now;
+		try {
+			for (const now of [415_000, 425_000]) {
+				Date.now = () => now;
+				const entry = collectFleetStatusEntries(state)[0]!;
+				const items = entry.workflowChecklist!.phases.flatMap((phase) => phase.items);
+				assert.equal(items.find((item) => item.key === "live")?.durationMs, now - 2_000);
+				assert.equal(items.find((item) => item.key === "done")?.durationMs, 2_000);
+				assert.equal(items.find((item) => item.key === "queued")?.durationMs, undefined);
+				assert.equal(items.find((item) => item.key === "unknown")?.durationMs, undefined);
+			}
+		} finally { Date.now = originalNow; }
+	});
 	it("formats elapsed time and token counts like the Claude Code fleet", () => {
 		assert.equal(formatFleetElapsed(10_600), "11s");
 		assert.equal(formatFleetTokens(999), "↓ 999 tokens");


### PR DESCRIPTION
## Partial coverage — related to #2085

Advance running workflow/checklist durations from their start times rather than stale update timestamps or zero duration snapshots. Keep terminal durations frozen and unknown/queued durations honest.

Nest materialized children under running workflow parents without repeating their lane rows and sibling cards. Live children of non-running parents remain standalone, preserving visibility and genuine parent lifecycle labels. Orphans, adaptive limits and existing cache/cadence remain intact.

Token aggregation, cross-surface layout policy and legacy inspector timing are deliberately deferred. Keep #2085 open. Thanks to [@expoli](https://github.com/expoli) for the report.

## Validation

-195 affected tests and typecheck pass, including public before/after live timing and hidden-child regression.
- Scope/simplification/deslop and fresh independent review completed; reviewer visibility finding fixed with focused red/green regression and parent verification.
- Existing projection/cache observations unchanged; synthetic local render median overhead around0.5 microseconds, not a whole-session performance claim.
- Current-main integration changed only changelog composition; candidate source/tests unchanged.
- Exact-head CI and Greptile passed before merge. No live interactive smoke.