### PR TITLE
test: consume setup input before signaling fixture readiness

### DIFF
--- a/test/integration/async-execution.part-4.test.ts
+++ b/test/integration/async-execution.part-4.test.ts
@@ -178,9 +178,21 @@ const args = process.argv.slice(2);
 if (args.includes('--version')) { console.log('wt v0.75.0'); process.exit(0); }
 if (args.includes('--help')) { console.log('--create --base --no-cd --no-hooks --format'); process.exit(0); }
 if (${allocatorFailure}) require('node:child_process').execFileSync('git', ['branch', args[args.indexOf('--create') + 1]], { cwd: ${JSON.stringify(repo)} });
-const socket = require('node:net').connect(${port}, '127.0.0.1', () => socket.write('ready'));
-socket.on('data', data => {
- if (data.toString() === 'release') { socket.end(); if (${allocatorFailure}) process.exitCode = 1; else console.log('{}'); }
+// Complete the setup stdin contract before exposing the independent release gate.
+// Otherwise the hook can exit before the runner writes input and cause EPIPE.
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+ if (!${allocatorFailure}) {
+  const setup = JSON.parse(input);
+  require('node:assert/strict').equal(setup.runId, ${JSON.stringify(`${id}-s0`)});
+  require('node:assert/strict').equal(setup.repoRoot, ${JSON.stringify(fs.realpathSync(repo))});
+ }
+ const socket = require('node:net').connect(${port}, '127.0.0.1', () => socket.write('ready'));
+ socket.on('data', data => {
+  if (data.toString() === 'release') { socket.end(); if (${allocatorFailure}) process.exitCode = 1; else console.log('{}'); }
+ });
 });
 setTimeout(() => process.exit(90), 15000).unref();
 `, { mode: 0o755 });


### PR DESCRIPTION
## Main-health fix
Fixes #2094.

The background setup fixture could announce TCP readiness and exit after release without consuming JSON stdin. CI34361701308 recorded prelaunch EPIPE / hook failed; a real subprocess probe using production runSetupCommand and its synchronous onSpawn seam reproduced EPIPE despite valid stdout/exit0. Reading stdin before readiness removes that race.

This one-file fixture fix requires EOF and validates setup JSON before exposing the existing release gate. Allocator-failure mode drains its empty input without parsing it. All existing success/stop/pause/deadline/cleanup/ownership assertions and time budgets remain unchanged. No production behavior or error normalization.

## Evidence
- Five affected lifecycle cases pass; typecheck and diff hygiene pass.
- Fresh independent review: fix-forward justified; no concrete failures or required simplification.
- The defect predates footprint2090; relevant fixture/runtime files were unchanged by that PR.
- Exact CI scheduling interleaving was not captured; causal mechanism reproduced locally on macOS/Node25. Actual Ubuntu/Node24 proof remains required CI.
- No unchanged-main retry or deadline increase was used.

This restores main health before further feature merges. Required exact-head CI/Greptile and post-merge main CI remain mandatory. Test-only change; no release/tag.