### PR TITLE
fix(tui): freeze terminal detail elapsed times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Freeze terminal FleetView detail elapsed from recorded duration or end time, omitting unknown durations while running rows keep advancing. Related to #2085 (partial); thanks to [@expoli](https://github.com/expoli).
 - Advance live workflow and lane elapsed times from their starts, and nest loaded workflow children in the async widget instead of repeating lane rows and sibling cards. Partial fix for #2085; thanks to [@expoli](https://github.com/expoli).
 - Let fanout-authorized child coordinators answer their own children's supervisor requests with explicitly selected `subagent_supervisor`, preserving immediate-parent session ownership and tool restrictions. Keep explicitly requested native coordination tools through host-builtin filtering, and poll only live descendant channels. Thanks to [@shaharmor](https://github.com/shaharmor) for #2087.
 - Allow read-only reviewers to classify findings as quoted "must fix before" categories without treating the labels as implementation instructions; actual required fixes still require mutation tools. Thanks to [@freezscholte](https://github.com/freezscholte) for #2079.

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -108,6 +108,8 @@ export interface AsyncStatusWorkflowRow {
 	modelThinking?: string;
 	activity?: string;
 	startedAt?: number;
+	endedAt?: number;
+	durationMs?: number;
 	tokens?: number;
 	window?: number;
 	overflow?: number;
@@ -536,6 +538,8 @@ function projectLoadedWorkflowRow(step: AsyncJobStep, index: number, preflight?:
 		...(modelThinking ? { modelThinking } : {}),
 		...(activity ? { activity } : {}),
 		...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
+		...(step.endedAt !== undefined ? { endedAt: step.endedAt } : {}),
+		...(step.durationMs !== undefined ? { durationMs: step.durationMs } : {}),
 		...(step.tokens?.total !== undefined ? { tokens: step.tokens.total } : {}),
 		...(step.tokens?.window !== undefined ? { window: step.tokens.window } : {}),
 		...(preflight ? { preflight } : {}),

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -76,6 +76,7 @@ type FleetNestedRow = {
 	modelThinking?: string;
 	activity?: string;
 	startedAt?: number;
+	endedAt?: number;
 	depth: number;
 	overflow?: number;
 };
@@ -99,6 +100,13 @@ export function resolveFleetViewPlacement(value: unknown): FleetViewPlacement {
 
 export function formatFleetElapsed(ms: number): string {
 	return `${Math.max(0, Math.round(ms / 1000))}s`;
+}
+
+function detailElapsed(row: Pick<AsyncStatusWorkflowRow, "startedAt" | "endedAt" | "durationMs"> & { state: string }): string | undefined {
+	const duration = row.state === "running" && row.startedAt !== undefined
+		? Date.now() - row.startedAt
+		: row.durationMs ?? (row.startedAt !== undefined && row.endedAt !== undefined ? row.endedAt - row.startedAt : undefined);
+	return duration !== undefined ? formatFleetElapsed(duration) : undefined;
 }
 
 export function formatFleetTokens(count: number, window?: number): string {
@@ -221,6 +229,7 @@ function nestedFleetRows(children: NestedRunSummary[] | undefined, visibleLimit:
 						...(modelThinking ? { modelThinking } : {}),
 						...(activity ? { activity } : {}),
 						...(step.startedAt !== undefined ? { startedAt: step.startedAt } : {}),
+						...(step.endedAt !== undefined ? { endedAt: step.endedAt } : {}),
 					});
 					if (!appendRuns(step.children, depth + 1)) {
 						omitted += nestedStepDisplayCount(steps, stepIndex + 1);
@@ -244,6 +253,7 @@ function nestedFleetRows(children: NestedRunSummary[] | undefined, visibleLimit:
 					...(modelThinking ? { modelThinking } : {}),
 					...(activity ? { activity } : {}),
 					...(child.startedAt !== undefined ? { startedAt: child.startedAt } : {}),
+					...(child.endedAt !== undefined ? { endedAt: child.endedAt } : {}),
 				});
 			}
 			if (!appendRuns(child.children, depth + 1)) {
@@ -779,8 +789,8 @@ export class SubagentFleetStatus {
 		const modelThinking = row.modelThinking ? ` (${row.modelThinking})` : "";
 		const activity = row.activity ? ` · ${row.activity}` : "";
 		const left = `${indent}${marker} ${nestedStatusGlyph(row.state, theme)} ${theme.fg(fleetAgentIdentityColor(row.agentIdentity ?? row.name), `${row.name}${modelThinking}`)} · ${row.state}${activity}`;
-		const elapsed = row.startedAt !== undefined ? ` · ${formatFleetElapsed(Date.now() - row.startedAt)}` : "";
-		return truncateToWidth(`${left}${theme.fg("dim", elapsed)}`, width);
+		const elapsed = detailElapsed(row);
+		return truncateToWidth(`${left}${elapsed !== undefined ? theme.fg("dim", ` · ${elapsed}`) : ""}`, width);
 	}
 
 	private workflowRowGlyph(row: AsyncStatusWorkflowRow, theme: Theme): string {
@@ -833,7 +843,7 @@ export class SubagentFleetStatus {
 		].filter((value): value is string => Boolean(value)).join(" · ") : "";
 		const left = `${indent}${marker} ${this.workflowRowGlyph(row, theme)} ${theme.fg("muted", `${kind}${row.name}${context ? ` ${context}` : ""}${modelThinking}`)} · ${this.workflowRowStateLabel(row, theme)}${activity}${hints ? ` · ${hints}` : ""}`;
 		const details = [
-			row.startedAt !== undefined ? formatFleetElapsed(Date.now() - row.startedAt) : undefined,
+			detailElapsed(row),
 			row.tokens !== undefined ? formatFleetTokens(row.tokens, row.window) : undefined,
 			row.provider ? `provider:${row.provider}` : undefined,
 			row.role ? `role:${row.role}` : undefined,
@@ -913,6 +923,8 @@ export class SubagentFleetStatus {
 						row.modelThinking,
 						row.activity,
 						row.startedAt,
+						row.endedAt,
+						row.durationMs,
 						row.tokens,
 						row.provider,
 						row.role,
@@ -931,6 +943,7 @@ export class SubagentFleetStatus {
 						row.modelThinking,
 						row.activity,
 						row.startedAt,
+						row.endedAt,
 						row.depth,
 						row.overflow,
 					]),

--- a/test/unit/fleet-status.test.ts
+++ b/test/unit/fleet-status.test.ts
@@ -46,6 +46,60 @@ const theme = {
 };
 
 describe("below-editor subagent FleetView", () => {
+	for (const source of ["workflow", "nested-run", "nested-step"] as const) {
+		it(`advances only running ${source} detail elapsed and freezes terminal evidence`, () => {
+			const cases = [
+				{ status: "running", startedAt: 1_000, durationMs: 0, expected: ["9s", "19s"] },
+				{ status: "complete", startedAt: 1_000, endedAt: 4_000, expected: ["3s", "3s"] },
+				{ status: "failed", startedAt: 1_000, endedAt: 4_000, expected: ["3s", "3s"] },
+				{ status: "stopped", startedAt: 1_000, endedAt: 4_000, expected: ["3s", "3s"] },
+				{ status: "paused", startedAt: 1_000, expected: [undefined, undefined] },
+				{ status: "complete", startedAt: 1_000, expected: [undefined, undefined] },
+				{ status: "pending", startedAt: 1_000, expected: [undefined, undefined] },
+				{ status: "running", expected: [undefined, undefined] },
+				...(source === "workflow" ? [
+					{ status: "complete", durationMs: 2_000, startedAt: 1_000, endedAt: 4_000, expected: ["2s", "2s"] },
+					{ status: "complete", durationMs: 0, expected: ["0s", "0s"] },
+				] as const : []),
+			] as const;
+			const originalNow = Date.now;
+			try {
+				for (const { expected, ...facts } of cases) {
+					Date.now = () => 10_000;
+					const state = stateForTest();
+					const step = { index: 0, agent: "timed-leaf", ...facts };
+					state.asyncJobs.set("owner", {
+						asyncId: "owner", asyncDir: "/tmp/owner", status: "running", startedAt: 1_000,
+						mode: source === "workflow" ? "workflow" : "single",
+						steps: source === "workflow" ? [step] : [{ index: 0, agent: "owner", status: "running" }],
+						...(source !== "workflow" ? { nestedChildren: [{
+							id: "nested", parentRunId: "owner", parentStepIndex: 0, depth: 1, path: [{ runId: "owner", stepIndex: 0 }],
+							...(source === "nested-step" ? { state: "running" as const, mode: "parallel" as const, steps: [step] }
+								: { ...facts, state: facts.status === "pending" ? "queued" as const : facts.status, agent: "timed-leaf" }),
+						}] } : {}),
+					});
+					let widgetFactory: ((tui: unknown, theme: typeof theme) => { render(width: number): string[] }) | undefined;
+					const ctx = { hasUI: true, ui: {
+						setWidget(_key: string, content: typeof widgetFactory) { if (content) widgetFactory = content; },
+						onTerminalInput() { return () => {}; }, getEditorText() { return ""; },
+						requestRender() {}, notify() {}, theme,
+					} } as unknown as ExtensionContext;
+					const fleet = new SubagentFleetStatus(state, () => {}, { refreshMs: 60_000 });
+					try {
+						fleet.setContext(ctx);
+						const component = widgetFactory!({ requestRender() {}, focusedComponent: Object.create(Editor.prototype) as Editor }, theme);
+						fleet.handleKey("\x1b[B");
+						for (const [index, now] of [10_000, 20_000].entries()) {
+							Date.now = () => now;
+							const line = component.render(240).find((line) => line.includes("timed-leaf") && /[├└]─/.test(line));
+							assert.ok(line, `${source} ${facts.status} must remain visible`);
+							assert.equal(line.match(/ · (\d+s)(?: ·|$)/)?.[1], expected[index], `${source} ${facts.status} at ${now}`);
+						}
+					} finally { fleet.dispose(); }
+				}
+			} finally { Date.now = originalNow; }
+		});
+	}
 	it("advances quiet workflow bottlenecks while terminal durations stay frozen", () => {
 		const state = stateForTest();
 		state.asyncJobs.set("quiet", {


### PR DESCRIPTION
## Summary
Freeze completed FleetView nested/workflow detail rows using recorded duration or end time; omit unknown durations rather than keep growing them from the current clock. Running rows continue advancing. Forward existing timing facts through projections and rendering cache keys without adding lifecycle state or scans.

Related to #2085 (partial). Thanks to [@expoli](https://github.com/expoli) for the report; changelog credit included. Preserve the timing/nesting changes already landed in #2088, the separately reviewed usage labels in #2093 and theme changes in #2091. Cross-surface duplicate expansion remains separate; keep #2085 open.

## Validation
- Three public-render tests fail on original code and pass after the fix: loaded workflow steps, nested runs, nested steps; running advancement and terminal stability, zero/precedence/unknown evidence.
- 71 focused tests, typecheck and diff hygiene pass.
- Fresh independent review found no concrete failure or required simplification.
- Mechanical merge of the main-health fixture fix changes no candidate behavior; final tree matches clean merge-tree.

No interactive terminal smoke/full CI claim. Required exact-head CI/Greptile and post-merge main CI remain gates. No release/tag.