### PR TITLE
fix(tui): avoid duplicate fully covered workflow details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - Advance live workflow and lane elapsed times from their starts, and nest loaded workflow children in the async widget instead of repeating lane rows and sibling cards. Partial fix for #2085; thanks to [@expoli](https://github.com/expoli).
+- Collapse duplicate async workflow details only when the same inline Fleet roster fully renders the group; retain detail for nested, attached, truncated, or uncertain coverage. Related to #2085; thanks to [@expoli](https://github.com/expoli).
 - Let fanout-authorized child coordinators answer their own children's supervisor requests with explicitly selected `subagent_supervisor`, preserving immediate-parent session ownership and tool restrictions. Keep explicitly requested native coordination tools through host-builtin filtering, and poll only live descendant channels. Thanks to [@shaharmor](https://github.com/shaharmor) for #2087.
 - Allow read-only reviewers to classify findings as quoted "must fix before" categories without treating the labels as implementation instructions; actual required fixes still require mutation tools. Thanks to [@freezscholte](https://github.com/freezscholte) for #2079.
 - Reject materialized workflow launch groups with invalid worktree repositories or dirty sources before dispatching children or claiming fan-out/output ownership. Allocation still rechecks; workflow-key failure traces may remain. Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2076.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -30,7 +30,7 @@ import { getAgentDir } from "../shared/utils.ts";
 import { isStaleExtensionContextError, withCachedUiContext } from "../shared/extension-context.ts";
 import { currentCompletionOwnerId } from "../shared/completion-owner.ts";
 import { cleanupOldChainDirs } from "../shared/settings.ts";
-import { clearLegacyResultAnimationTimer, renderSubagentResult, renderSubagentSummary } from "../tui/render.ts";
+import { clearLegacyResultAnimationTimer, renderSubagentResult, renderSubagentSummary, setInlineWorkflowCoverage } from "../tui/render.ts";
 import { openSubagentFleet } from "../tui/fleet.ts";
 import { createBuiltinInspectorPlugins } from "../inspectors/plugins.ts";
 import { SubagentFleetStatus, resolveFleetViewPlacement } from "../tui/fleet-status.ts";
@@ -512,7 +512,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 				}
 				throw error;
 			}
-		}, { placement: fleetViewPlacement })
+		}, { placement: fleetViewPlacement, onWorkflowCoverageChange: setInlineWorkflowCoverage })
 		: undefined;
 	let executorScheduled: ((id: string, params: SubagentParamsLike, signal: AbortSignal, ctx: ExtensionContext) => Promise<AgentToolResult<Details>>) | undefined;
 	let goalTurnId = 0;

--- a/src/tui/fleet-status.ts
+++ b/src/tui/fleet-status.ts
@@ -8,6 +8,7 @@ import { contextModeLabel } from "../runs/shared/context-mode.ts";
 import { formatWorkflowJsonPreview } from "../workflows/scripted-workflow.ts";
 import { hostStepReportName, hostStepVerdictLabel } from "../runs/shared/host-step-status.ts";
 import { isStaleExtensionContextError } from "../shared/extension-context.ts";
+import { widgetRenderKey } from "./render.ts";
 import { formatWorkflowChecklistBottleneck, formatWorkflowChecklistPhase, formatWorkflowChecklistSummary, projectWorkflowChecklist, type WorkflowChecklistPhase, type WorkflowChecklistProjection } from "../workflows/workflow-checklist.ts";
 
 export const FLEET_STATUS_WIDGET_KEY = "subagent-fleet-status";
@@ -91,6 +92,7 @@ export interface FleetStatusOptions {
 	refreshMs?: number;
 	maxAgentRows?: number;
 	placement?: FleetViewPlacement;
+	onWorkflowCoverageChange?: (ui: ExtensionContext["ui"], coverage: ReadonlyMap<string, string>) => void;
 }
 
 export function resolveFleetViewPlacement(value: unknown): FleetViewPlacement {
@@ -527,6 +529,8 @@ export class SubagentFleetStatus {
 	private inspectorOpen = false;
 	private lastRenderKey = "";
 	private entries: FleetStatusEntry[] = [];
+	private workflowSnapshots = new Map<string, string>();
+	private readonly onWorkflowCoverageChange: FleetStatusOptions["onWorkflowCoverageChange"];
 	private readonly state: SubagentState;
 	private readonly openInspector: (itemKey: string) => Promise<void> | void;
 	private readonly refreshMs: number;
@@ -543,10 +547,14 @@ export class SubagentFleetStatus {
 		this.refreshMs = options.refreshMs ?? REFRESH_MS;
 		this.maxAgentRows = options.maxAgentRows ?? MAX_AGENT_ROWS;
 		this.placement = options.placement ?? "belowEditor";
+		this.onWorkflowCoverageChange = options.onWorkflowCoverageChange;
 	}
 
 	setContext(ctx: ExtensionContext): void {
-		if (!ctx.hasUI) return;
+		if (!ctx.hasUI) {
+			this.clearUiRegistration();
+			return;
+		}
 		const ui = ctx.ui;
 		if (this.ui === ui) {
 			this.ctx = ctx;
@@ -583,6 +591,19 @@ export class SubagentFleetStatus {
 			return;
 		}
 		this.entries = collectFleetStatusEntries(this.state);
+		this.workflowSnapshots.clear();
+		if (this.active && this.onWorkflowCoverageChange) {
+			const parents = new Set([...this.state.asyncJobs.values()].map((job) => job.parentWorkflowRunId));
+			const attachedOwners = new Set(this.entries.map((entry) => entry.parentKey));
+			for (const job of this.state.asyncJobs.values()) {
+				// Fleet does not expand attached workflow wrappers or step descendants.
+				// Unknown/unsupported coverage deliberately retains the async tree.
+				if (job.mode !== "workflow" || !isActiveState(job.status) || job.parentWorkflowRunId || parents.has(job.asyncId)
+					|| job.nestedChildren?.length || job.steps?.some((step) => step.children?.length)
+					|| attachedOwners.has(`async:${job.asyncId}`)) continue;
+				this.workflowSnapshots.set(`async:${job.asyncId}`, widgetRenderKey(job));
+			}
+		}
 		this.clampSelection();
 		if (this.inspectorOpen || this.state.fleetInspectorOpen) {
 			this.lastRenderKey = "";
@@ -598,6 +619,7 @@ export class SubagentFleetStatus {
 		}
 
 		const renderKey = this.getRenderKey();
+		if (!this.active || renderKey !== this.lastRenderKey) this.clearWorkflowCoverage();
 		if (!this.widgetRegistered) {
 			ctx.ui.setWidget(FLEET_STATUS_WIDGET_KEY, (tui, theme) => {
 				this.tui = tui;
@@ -608,6 +630,7 @@ export class SubagentFleetStatus {
 					},
 					dispose: () => {
 						if (this.tui !== tui) return;
+						this.clearWorkflowCoverage();
 						this.widgetRegistered = false;
 						this.tui = undefined;
 					},
@@ -689,8 +712,12 @@ export class SubagentFleetStatus {
 	}
 
 	render(width: number, theme: Theme): string[] {
-		if (!this.hasInlineSurface()) return [];
+		if (!this.hasInlineSurface() || this.state.widgetsSuspended || this.inspectorOpen || this.state.fleetInspectorOpen) {
+			this.clearWorkflowCoverage();
+			return [];
+		}
 		if (!this.active) {
+			this.clearWorkflowCoverage();
 			const workEntries = this.entries.filter((entry) => !entry.surface);
 			const projectEntries = this.entries.filter((entry) => entry.surface === "project-pane");
 			const tokens = workEntries.reduce((total, entry) => total + entry.tokens, 0);
@@ -741,6 +768,23 @@ export class SubagentFleetStatus {
 			}
 		}
 		if (hiddenBelow > 0) lines.push(rightAlign("", theme.fg("dim", `↓ ${hiddenBelow} more`), width));
+		if (this.ui && this.widgetRegistered && this.onWorkflowCoverageChange) {
+			const coverage = new Map<string, string>();
+			for (const [key, snapshot] of this.workflowSnapshots) {
+				const ownerIndex = tree.findIndex((row) => row.kind === "owner" && row.entry.key === key);
+				const owner = tree[ownerIndex];
+				if (owner?.kind !== "owner" || ownerIndex < start) continue;
+				const count = (owner.entry.workflowRows?.length ?? 0) + (owner.entry.workflowChecklist?.phases.length ?? 0);
+				if (!count || ownerIndex + count >= start + visibleCount) continue;
+				const descendants = tree.slice(ownerIndex + 1, ownerIndex + count + 1);
+				if (!descendants.every((row) => (row.kind === "workflow" && row.ownerKey === key && !row.row.overflow
+					&& visibleWidth(this.renderWorkflowRow(row.row, row.last, Infinity, theme)) <= width)
+					|| (row.kind === "workflow-phase" && row.ownerKey === key
+						&& visibleWidth(this.renderWorkflowPhaseRow(row.phase, row.last, Infinity, theme)) <= width))) continue;
+				coverage.set(key.slice("async:".length), snapshot);
+			}
+			this.onWorkflowCoverageChange(this.ui, coverage);
+		}
 		this.renderProjectPaneSection(lines, selectedIndex, width, theme, rosterIndexByKey);
 		return lines;
 	}
@@ -956,6 +1000,7 @@ export class SubagentFleetStatus {
 	}
 
 	private clearWidget(): void {
+		this.clearWorkflowCoverage();
 		if (!this.widgetRegistered) return;
 		try {
 			this.ui?.setWidget(FLEET_STATUS_WIDGET_KEY, undefined);
@@ -969,6 +1014,7 @@ export class SubagentFleetStatus {
 	}
 
 	private clearUiRegistration(): void {
+		this.clearWorkflowCoverage();
 		if (this.timer) clearInterval(this.timer);
 		this.timer = undefined;
 
@@ -998,5 +1044,9 @@ export class SubagentFleetStatus {
 		if (cleanupErrors.length > 1) {
 			throw new AggregateError(cleanupErrors, "Failed to clean up FleetView UI registration");
 		}
+	}
+
+	private clearWorkflowCoverage(): void {
+		if (this.ui) this.onWorkflowCoverageChange?.(this.ui, new Map());
 	}
 }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -46,6 +46,7 @@ type Theme = ExtensionContext["ui"]["theme"];
 
 interface WorkflowWidgetProjection {
 	now: number;
+	inlineFleetCovered?: boolean;
 	children?: AsyncJobState[];
 	materializedKeys?: Set<string>;
 	stages: WorkflowGraphNode[];
@@ -1557,6 +1558,7 @@ function compactWorkflowHeaderLine(job: AsyncJobState, theme: Theme, width?: num
 function compactWorkflowWidgetBodyLines(job: AsyncJobState, theme: Theme, frame: number | undefined, projection: WorkflowWidgetProjection): string[] {
 	const rows = compactWorkflowLaneRows(job, projection.checklist);
 	const lines = [`  ${compactWorkflowStats(job, rows, theme, projection)}`];
+	if (projection.inlineFleetCovered) return [...lines, `  ${theme.fg("dim", "Workflow children shown in Fleet roster")}`];
 	if (rows.length) {
 		for (const row of rows) {
 			if (!projection.materializedKeys?.has(row.key)) lines.push(compactWorkflowLaneLine(row, theme, "  ", frame));
@@ -2436,7 +2438,7 @@ function foregroundStyleWidgetDetails(job: AsyncJobState, theme: Theme, expanded
 }
 
 function buildSingleWidgetLines(job: AsyncJobState, theme: Theme, width: number, expanded: boolean, frame?: number, projection = buildWorkflowWidgetProjection(job)): string[] {
-	if (!expanded && job.mode === "workflow") return [compactWorkflowHeaderLine(job, theme, width), ...compactWorkflowWidgetBodyLines(job, theme, frame, projection)].map((line) => truncLine(line, width));
+	if ((!expanded || projection.inlineFleetCovered) && job.mode === "workflow") return [compactWorkflowHeaderLine(job, theme, width), ...compactWorkflowWidgetBodyLines(job, theme, frame, projection)].map((line) => truncLine(line, width));
 	const stats = widgetStats(job, theme, projection, !expanded);
 	const count = job.mode === "workflow"
 		? projection.checklist?.total ?? projection.stageProgress?.total ?? job.stepsTotal ?? job.agents?.length ?? job.steps?.length
@@ -2744,6 +2746,17 @@ function fitAdaptiveWidgetLines(jobs: AsyncJobState[], buildLines: () => string[
 }
 
 const asyncWidgetUpdates = new WeakMap<ExtensionContext["ui"], (jobs: AsyncJobState[]) => void>();
+const inlineWorkflowCoverage = new WeakMap<ExtensionContext["ui"], ReadonlyMap<string, string>>();
+const asyncWidgetInvalidations = new WeakMap<ExtensionContext["ui"], () => void>();
+
+/** Presentation-only coverage from the mounted inline Fleet roster, never configuration. */
+export function setInlineWorkflowCoverage(ui: ExtensionContext["ui"], coverage: ReadonlyMap<string, string>): void {
+	const previous = inlineWorkflowCoverage.get(ui);
+	if ((previous?.size ?? 0) === coverage.size && [...coverage].every(([id, key]) => previous?.get(id) === key)) return;
+	if (coverage.size) inlineWorkflowCoverage.set(ui, coverage);
+	else inlineWorkflowCoverage.delete(ui);
+	asyncWidgetInvalidations.get(ui)?.();
+}
 
 /** Attach only to loaded workflow parents; orphan jobs remain top-level. */
 function widgetJobTree(jobs: AsyncJobState[], now: number): { roots: AsyncJobState[]; projectionFor: WorkflowWidgetProjectionLookup } {
@@ -2794,6 +2807,13 @@ function buildWidgetComponent(jobs: AsyncJobState[], ui: ExtensionContext["ui"])
 		let cachedFrame: number | undefined;
 		let cachedExpanded: boolean | undefined;
 		let cachedLines: string[] | undefined;
+		let cachedCoverage = "[]";
+		const invalidate = (): void => {
+			cachedLines = undefined;
+			resetWidgetLayoutSession();
+			tui.requestRender();
+		};
+		asyncWidgetInvalidations.set(ui, invalidate);
 		const update = (nextJobs: AsyncJobState[]): void => {
 			jobs = nextJobs;
 			cachedLines = undefined;
@@ -2803,15 +2823,24 @@ function buildWidgetComponent(jobs: AsyncJobState[], ui: ExtensionContext["ui"])
 		const component = Object.assign(container, {
 			dispose(): void {
 				if (asyncWidgetUpdates.get(ui) === update) asyncWidgetUpdates.delete(ui);
+				if (asyncWidgetInvalidations.get(ui) === invalidate) asyncWidgetInvalidations.delete(ui);
 			},
 		});
 		container.render = (renderWidth: number): string[] => {
 			const now = Date.now();
 			const frame = Math.floor(now / WIDGET_ANIMATION_INTERVAL_MS);
 			const expanded = ui.getToolsExpanded?.() ?? false;
-			if (cachedLines && cachedRenderWidth === renderWidth && cachedFrame === frame && cachedExpanded === expanded) return cachedLines;
+			const coverage = inlineWorkflowCoverage.get(ui);
+			const covered = new Set(jobs.filter((job) => coverage?.has(job.asyncId)
+				&& !jobs.some((child) => child.parentWorkflowRunId === job.asyncId)
+				&& coverage.get(job.asyncId) === widgetRenderKey(job)).map((job) => job.asyncId));
+			const coverageKey = JSON.stringify([...covered]);
+			if (cachedLines && cachedRenderWidth === renderWidth && cachedFrame === frame && cachedExpanded === expanded && cachedCoverage === coverageKey) return cachedLines;
+			if (cachedCoverage !== coverageKey) resetWidgetLayoutSession();
+			cachedCoverage = coverageKey;
 			const width = Math.max(0, renderWidth - 2);
 			const { roots, projectionFor } = widgetJobTree(jobs, now);
+			for (const job of roots) projectionFor(job).inlineFleetCovered = covered.has(job.asyncId);
 			const buildLines = (): string[] => expanded
 				? buildWidgetLinesWithProjection(roots, theme, width, true, frame, projectionFor)
 				: roots.length === 1 && !projectionFor(roots[0]!).children?.length
@@ -2849,7 +2878,7 @@ function buildWidgetLinesWithProjection(jobs: AsyncJobState[], theme: Theme, wid
 	let slots = MAX_WIDGET_JOBS;
 	const appendJob = (job: AsyncJobState): void => {
 		const projection = projectionFor(job);
-		const compactWorkflow = !expanded && job.mode === "workflow";
+		const compactWorkflow = (!expanded || projection.inlineFleetCovered) && job.mode === "workflow";
 		const stats = compactWorkflow ? "" : widgetStats(job, theme, projection, !expanded);
 		const details = compactWorkflow
 			? [

--- a/test/integration/inline-workflow-visibility.test.ts
+++ b/test/integration/inline-workflow-visibility.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import { Editor } from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AsyncJobState, SubagentState } from "../../src/shared/types.ts";
+import { WIDGET_KEY } from "../../src/shared/types.ts";
+import { FLEET_STATUS_WIDGET_KEY, SubagentFleetStatus } from "../../src/tui/fleet-status.ts";
+import { renderWidget, setInlineWorkflowCoverage } from "../../src/tui/render.ts";
+
+const theme = { fg: (_name: string, text: string) => text, bg: (_name: string, text: string) => text, bold: (text: string) => text };
+type Mounted = { render(width: number): string[]; dispose?(): void };
+function harness(maxAgentRows = 6, inspector: () => Promise<void> = async () => {}) {
+	const job: AsyncJobState = { asyncId: "workflow", asyncDir: "/tmp/workflow", mode: "workflow", status: "running", startedAt: 1_000,
+		steps: [{ workflowKey: "lane-a", agent: "unique-worker", status: "running" }] };
+	const state = { asyncJobs: new Map([[job.asyncId, job]]), foregroundControls: new Map() } as unknown as SubagentState;
+	const mounted = new Map<string, Mounted>();
+	let requests = 0;
+	let expanded = false;
+	const tui = { requestRender() { requests++; }, focusedComponent: Object.create(Editor.prototype) };
+	const ctx = { hasUI: true, ui: { theme, getToolsExpanded: () => expanded, getEditorText: () => "", onTerminalInput: () => () => {}, notify() {},
+		setWidget(key: string, factory: ((tui: unknown, theme: unknown) => Mounted) | undefined) {
+			mounted.get(key)?.dispose?.(); mounted.delete(key);
+			if (factory) mounted.set(key, factory(tui, theme));
+		} } } as unknown as ExtensionContext;
+	const fleet = new SubagentFleetStatus(state, inspector, { refreshMs: 60_000, maxAgentRows, onWorkflowCoverageChange: setInlineWorkflowCoverage });
+	fleet.setContext(ctx);
+	renderWidget(ctx, [job]);
+	return { job, state, ctx, fleet, mounted, get requests() { return requests; }, setExpanded(value: boolean) { expanded = value; },
+		asyncText: () => mounted.get(WIDGET_KEY)!.render(240).join("\n"),
+		roster: (width = 240) => mounted.get(FLEET_STATUS_WIDGET_KEY)!.render(width).join("\n"),
+		activate() { fleet.handleKey("\x1b[B"); },
+		close() { fleet.dispose(); mounted.get(WIDGET_KEY)?.dispose?.(); renderWidget(ctx, []); },
+	};
+}
+
+it("collapses only after the actual same-UI roster renders, and restores on deactivation/disposal", () => {
+	const h = harness();
+	try {
+		assert.match(h.asyncText(), /unique-worker/);
+		h.activate();
+		assert.match(h.asyncText(), /unique-worker/, "activation alone is not rendered coverage");
+		assert.match(h.roster(), /unique-worker/);
+		const before = h.requests;
+		assert.match(h.asyncText(), /Workflow children shown in Fleet roster/);
+		assert.doesNotMatch(h.asyncText(), /unique-worker/);
+		h.setExpanded(true);
+		assert.doesNotMatch(h.asyncText(), /unique-worker/);
+		h.fleet.handleKey("\x1b");
+		assert.ok(h.requests > before, "coverage changes invalidate the existing widget");
+		assert.match(h.asyncText(), /unique-worker/);
+		h.activate(); h.roster();
+		h.mounted.get(FLEET_STATUS_WIDGET_KEY)!.dispose?.();
+		assert.match(h.asyncText(), /unique-worker/);
+	} finally { h.close(); }
+});
+
+it("retains detail for row overflow, horizontal truncation, nested and attached children", () => {
+	for (const kind of ["budget", "width", "nested", "attached", "overflow"] as const) {
+		const h = harness(kind === "budget" ? 1 : 20);
+		try {
+			if (kind === "nested") h.job.steps![0]!.children = [{ id: "nested", state: "running", agent: "nested-worker" }];
+			if (kind === "attached") h.state.asyncJobs.set("child", { asyncId: "child", asyncDir: "/tmp/child", mode: "single", status: "running", parentWorkflowRunId: h.job.asyncId, agents: ["attached-worker"] });
+			if (kind === "overflow") for (let i = 0; i < 6; i++) h.job.steps!.push({ agent: `worker-${i}`, status: "running" });
+			renderWidget(h.ctx, [...h.state.asyncJobs.values()]);
+			h.activate(); h.roster(kind === "width" ? 20 : 240);
+			assert.doesNotMatch(h.asyncText(), /Workflow children shown in Fleet roster/, kind);
+			assert.match(h.asyncText(), /unique-worker/, kind);
+		} finally { h.close(); }
+	}
+});
+
+it("revokes coverage when navigation scrolls a workflow out of the roster, or its context becomes stale", () => {
+	const h = harness(3);
+	try {
+		h.state.asyncJobs.set("later", { asyncId: "later", asyncDir: "/tmp/later", mode: "single", status: "running", startedAt: 2_000, agents: ["later-worker"] });
+		h.activate(); h.roster();
+		assert.match(h.asyncText(), /Workflow children shown in Fleet roster/);
+		h.fleet.handleKey("\x1b[B"); h.fleet.handleKey("\x1b[B"); h.roster();
+		assert.match(h.asyncText(), /unique-worker/);
+		h.fleet.handleKey("\x1b[A"); h.roster();
+		assert.match(h.asyncText(), /Workflow children shown in Fleet roster/);
+		Object.defineProperty(h.ctx, "hasUI", { get() { throw new Error("This extension ctx is stale after session replacement or reload."); }, configurable: true });
+		h.fleet.refresh();
+		assert.match(h.asyncText(), /unique-worker/);
+	} finally {
+		Object.defineProperty(h.ctx, "hasUI", { value: true, configurable: true });
+		h.close();
+	}
+});
+
+it("new step identities and materialized children revoke stale coverage within the same frame", () => {
+	const h = harness();
+	try {
+		h.activate(); h.roster();
+		assert.doesNotMatch(h.asyncText(), /unique-worker/);
+		h.job.steps!.push({ workflowKey: "lane-b", agent: "new-worker", status: "running" });
+		assert.match(h.asyncText(), /new-worker/, "in-place arrival cannot use cached covered lines");
+		h.fleet.refresh(); h.roster();
+		assert.match(h.asyncText(), /Workflow children shown in Fleet roster/);
+		const child: AsyncJobState = { asyncId: "child", asyncDir: "/tmp/child", mode: "single", status: "running", parentWorkflowRunId: h.job.asyncId, agents: ["attached-worker"] };
+		renderWidget(h.ctx, [h.job, child]);
+		assert.match(h.asyncText(), /attached-worker/);
+		assert.doesNotMatch(h.asyncText(), /Workflow children shown in Fleet roster/);
+	} finally { h.close(); }
+});
+
+it("restores detail for suspension, inspector transitions, UI replacement, and headless replacement", async () => {
+	let finish!: () => void;
+	const h = harness(6, () => new Promise<void>((resolve) => { finish = resolve; }));
+	try {
+		h.activate(); h.roster();
+		h.state.widgetsSuspended = true; h.fleet.refresh();
+		assert.match(h.asyncText(), /unique-worker/);
+		h.state.widgetsSuspended = false; h.fleet.refresh(); h.roster();
+		assert.doesNotMatch(h.asyncText(), /unique-worker/);
+		h.fleet.handleKey("\x1b[B"); h.fleet.handleKey("\r");
+		assert.match(h.asyncText(), /unique-worker/);
+		await Promise.resolve(); finish();
+		await new Promise((resolve) => setImmediate(resolve));
+		h.roster();
+		assert.doesNotMatch(h.asyncText(), /unique-worker/);
+		h.state.fleetInspectorOpen = true; h.fleet.refresh();
+		assert.match(h.asyncText(), /unique-worker/);
+		h.state.fleetInspectorOpen = false; h.fleet.refresh(); h.roster();
+		const oldText = h.asyncText;
+		const other = harness();
+		try {
+			assert.match(other.asyncText(), /unique-worker/, "coverage cannot leak to a second UI");
+			h.fleet.setContext(other.ctx);
+			assert.match(oldText(), /unique-worker/, "old UI regains detail immediately");
+			h.fleet.setContext({ hasUI: false } as ExtensionContext);
+			assert.match(other.asyncText(), /unique-worker/);
+		} finally { other.close(); }
+	} finally { h.close(); }
+});


### PR DESCRIPTION
## Summary
For fully rendered simple workflow groups in the same inline Fleet roster, retain the async card summary and replace duplicate details with an explicit Fleet pointer. Coverage comes from actual roster rendering, not enabled configuration or registration. Restore detail when coverage changes or is cleared.

Related to #2085 (partial). Thanks to [@expoli](https://github.com/expoli) for the report; changelog credit included. Conservative limitation: materialized/attached children, nested groups, truncated or budgeted rows, inactive Fleet and uncertain coverage retain async detail. This does not establish full #2085 resolution or a terminal-wide viewport visibility model.

## Evidence
- Five public mounted-UI tests pass, covering before/after activation and actual rendering, same-frame arrivals, context/disposal/suspension/inspector transitions, width/row budgets and unsupported coverage.
- 78 integration cases, 35 Fleet tests and typecheck pass; diff hygiene clean.
- Fresh independent initial review found no concrete blocker or warranted simplification. Only subsequent local edit adds the requested credit line.
- Mechanical main integration tree03fee07f1ba8fbe7626ad389a2ad22fad4f792aa equals clean merge-tree; existing theme/diagnostic changes preserved.
- Uses existing projections, render fingerprints and in-memory UI callbacks; no new watchers, filesystem scans, persistent/config state or runner lifecycle.

## Measured cost and limits
Warm local four-workflow micro-profile: callback disabled0.113ms/cycle, coverage enabled0.152ms/cycle, +0.039ms (~35% relative). This is not performance-neutral, nor a real-terminal or large-fleet benchmark. No interactive terminal smoke/full-suite claim.

Required exact-head CI/Greptile and post-merge main CI remain gates. No release/tag.