### PR TITLE
fix(workflow): reject static fanout budget mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement.
 - Restore background SDK sessions for the official Pi 0.85.1 Linux x64 standalone release, without a separate SDK install; npm runners keep their package-root and lifecycle behavior. Thanks to [@xz-dev](https://github.com/xz-dev) for #2049.
 - Preserve the parent's active theme when foreground children start, while initializing themes in detached runners and refreshing slash-result rendering. Thanks to [@kubahasek](https://github.com/kubahasek) for #2089.
 - Advance live workflow and lane elapsed times from their starts, and nest loaded workflow children in the async widget instead of repeating lane rows and sibling cards. Partial fix for #2085; thanks to [@expoli](https://github.com/expoli).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
-- Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement.
+- Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement. Thanks to [@ton77v](https://github.com/ton77v) for #2101.
 - Label workflow usage as belonging to child rows instead of showing a misleading zero or overlapping wrapper totals in FleetView; preserve unrelated standalone usage in mixed summaries and distinguish summed concurrent windows from a single context window. Related to #2085; thanks to [@expoli](https://github.com/expoli).
 - Restore background SDK sessions for the official Pi 0.85.1 Linux x64 standalone release, without a separate SDK install; npm runners keep their package-root and lifecycle behavior. Thanks to [@xz-dev](https://github.com/xz-dev) for #2049.
 - Preserve the parent's active theme when foreground children start, while initializing themes in detached runners and refreshing slash-result rendering. Thanks to [@kubahasek](https://github.com/kubahasek) for #2089.

--- a/src/extension/public-execution.ts
+++ b/src/extension/public-execution.ts
@@ -97,8 +97,10 @@ export function normalizePublicSubagentExecution<T extends PublicSubagentExecuti
 	if (hasCapacityOverride) {
 		const capacityOverrideError = validateWorkflowCapacityOverrides(params);
 		if (capacityOverrideError) return { ok: false, error: capacityOverrideError, mode: params.action === undefined ? "workflow" : "management" };
-		if (params.action !== undefined || hasNamedWorkflow || (params.workflowScript === undefined && params.workflowScriptPath === undefined)) {
-			return { ok: false, error: "Workflow capacity overrides are only supported on top-level workflowScript or workflowScriptPath calls.", mode: params.action === undefined ? "workflow" : "management" };
+		const validatesSpawnBudget = typeof params.action === "string" && params.action.trim() === "validate"
+			&& params.globalConcurrencyLimit === undefined && params.maxSubagentSpawnsPerRun !== undefined;
+		if ((params.action !== undefined && !validatesSpawnBudget) || hasNamedWorkflow || (params.workflowScript === undefined && params.workflowScriptPath === undefined)) {
+			return { ok: false, error: "Workflow capacity overrides are only supported on top-level workflowScript or workflowScriptPath calls; validate accepts maxSubagentSpawnsPerRun for static budget checks.", mode: params.action === undefined ? "workflow" : "management" };
 		}
 	}
 	if (params.preflight !== undefined && !hasWorkflowInput) {

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -4914,7 +4914,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			if (requestParams.action?.trim() === "validate") {
-				const validation = validateWorkflowScript(requestParams.workflowScript ?? "");
+				const validation = validateWorkflowScript(requestParams.workflowScript ?? "", {
+					maxSubagentSpawnsPerRun: requestParams.maxSubagentSpawnsPerRun ?? resolveMaxSubagentSpawnsPerRun(deps.config.maxSubagentSpawnsPerRun),
+				});
 				const invalidValidation = { ...validation, ok: false, errors: [...validation.errors, { message }] };
 				return {
 					content: [{ type: "text", text: JSON.stringify(invalidValidation) }],
@@ -4925,7 +4927,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			return buildRequestedModeError(requestParams, message);
 		}
 		if (requestParams.action?.trim() === "validate") {
-			const validation = validateWorkflowScript(requestParams.workflowScript ?? "");
+			const validation = validateWorkflowScript(requestParams.workflowScript ?? "", {
+				maxSubagentSpawnsPerRun: requestParams.maxSubagentSpawnsPerRun ?? resolveMaxSubagentSpawnsPerRun(deps.config.maxSubagentSpawnsPerRun),
+			});
 			const payload = workflowPreflight ? { ...validation, preflight: workflowPreflight } : validation;
 			return {
 				content: [{ type: "text", text: JSON.stringify(payload) }],
@@ -4943,6 +4947,14 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			workflowResource = { permit: workflowResourcePermit, ...consumed };
 		}
 		if (requestParams.workflowScript !== undefined && normalizedAction === undefined) {
+			const spawnBudgetValidation = validateWorkflowScript(requestParams.workflowScript, {
+				maxSubagentSpawnsPerRun: requestParams.maxSubagentSpawnsPerRun ?? resolveMaxSubagentSpawnsPerRun(deps.config.maxSubagentSpawnsPerRun),
+			});
+			const spawnBudgetErrors = spawnBudgetValidation.errors.filter((error) => error.kind === "spawn-budget");
+			if (spawnBudgetErrors.length > 0) {
+				return buildRequestedModeError(requestParams, `workflowScript validation failed before child launch; no children launched. ${spawnBudgetErrors.map((error) => error.message).join(" ")}`);
+			}
+			for (const warning of spawnBudgetValidation.warnings ?? []) console.warn(`[pi-subagents] ${warning.message}`);
 			const acceptanceErrors = validateAcceptanceInput(requestParams.acceptance);
 			if (acceptanceErrors.length > 0) return buildRequestedModeError(requestParams, acceptanceErrors.join(" "));
 			const foregroundWorkflowRunId = encodeIndexSegment(_id);

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -24,11 +24,22 @@ export interface WorkflowScriptValidationError {
 	message: string;
 	line?: number;
 	column?: number;
+	kind?: "spawn-budget";
+}
+
+export interface WorkflowScriptValidationWarning {
+	message: string;
+	kind: "dynamic-spawn-count";
 }
 
 export interface WorkflowScriptValidationResult {
 	ok: boolean;
 	errors: WorkflowScriptValidationError[];
+	warnings?: WorkflowScriptValidationWarning[];
+}
+
+export interface WorkflowScriptValidationOptions {
+	maxSubagentSpawnsPerRun?: number;
 }
 
 const WORKER_SOURCE = String.raw`
@@ -1441,7 +1452,7 @@ function literalString(node: unknown): string | undefined {
 	return undefined;
 }
 
-function directRunsCall(node: unknown, method: "run" | "all" | "host"): node is AstNode {
+function directRunsCall(node: unknown, method: "run" | "all" | "host" | "lanes"): boolean {
 	if (!astNode(node) || node.type !== "CallExpression" || !astNode(node.callee) || node.callee.type !== "MemberExpression") return false;
 	const property = node.callee.computed === true ? literalString(node.callee.property) : astNode(node.callee.property) && node.callee.property.type === "Identifier" ? node.callee.property.name : undefined;
 	return property === method && astNode(node.callee.object) && node.callee.object.type === "Identifier" && node.callee.object.name === "runs";
@@ -1578,8 +1589,77 @@ function directRunsAllKeys(call: AstNode): Array<{ key: string; node: AstNode }>
 	});
 }
 
+function staticWorkflowLaunchPlan(workflowBody: AstNode): { keys: string[]; dynamic: boolean } {
+	const keys = new Set<string>();
+	let dynamic = false;
+	const visit = (value: unknown, conditional = false): void => {
+		if (Array.isArray(value)) {
+			for (const item of value) visit(item, conditional);
+			return;
+		}
+		if (!astNode(value)) return;
+		if (value.type === "FunctionDeclaration" || value.type === "FunctionExpression" || value.type === "ArrowFunctionExpression") {
+			walkAst(value.body, (node) => { if (directRunsCall(node, "run") || directRunsCall(node, "all") || directRunsCall(node, "lanes")) dynamic = true; });
+			return;
+		}
+		if (directRunsCall(value, "run")) {
+			const args = Array.isArray(value.arguments) ? value.arguments : [];
+			const key = literalString(args[0]);
+			if (conditional || key === undefined) dynamic = true;
+			else keys.add(key);
+			for (const argument of args) visit(argument, conditional);
+			return;
+		}
+		if (directRunsCall(value, "all")) {
+			if (conditional) {
+				dynamic = true;
+				return;
+			}
+			const args = Array.isArray(value.arguments) ? value.arguments : [];
+			const array = astNode(args[0]) && args[0].type === "ArrayExpression" && Array.isArray(args[0].elements) ? args[0] : undefined;
+			if (!array) {
+				dynamic = true;
+				return;
+			}
+			for (const item of array.elements as unknown[]) {
+				if (!astNode(item) || item.type === "SpreadElement") {
+					dynamic = true;
+					continue;
+				}
+				const key = literalString(directObjectPropertyValue(item, "key"));
+				if (key === undefined) dynamic = true;
+				else keys.add(key);
+				visit(item, conditional);
+			}
+			return;
+		}
+		if (directRunsCall(value, "lanes")) {
+			dynamic = true;
+			return;
+		}
+		if (value.type === "IfStatement" || value.type === "ConditionalExpression") {
+			visit(value.test, conditional);
+			visit(value.consequent, true);
+			visit(value.alternate, true);
+			return;
+		}
+		if (value.type === "LogicalExpression") {
+			visit(value.left, conditional);
+			visit(value.right, true);
+			return;
+		}
+		if (value.type === "ForStatement" || value.type === "ForInStatement" || value.type === "ForOfStatement" || value.type === "WhileStatement" || value.type === "DoWhileStatement" || value.type === "SwitchStatement") {
+			for (const [key, child] of Object.entries(value)) if (!AST_LOCATION_KEYS.has(key)) visit(child, key === "init" || key === "test" ? conditional : true);
+			return;
+		}
+		for (const [key, child] of Object.entries(value)) if (!AST_LOCATION_KEYS.has(key)) visit(child, conditional);
+	};
+	visit(workflowBody);
+	return { keys: [...keys], dynamic };
+}
+
 /** Parse a workflowScript and apply only rules that are decidable from its local syntax. */
-export function validateWorkflowScript(script: string): WorkflowScriptValidationResult {
+export function validateWorkflowScript(script: string, options: WorkflowScriptValidationOptions = {}): WorkflowScriptValidationResult {
 	const errors: WorkflowScriptValidationError[] = [];
 	if (!script.trim()) return { ok: false, errors: [{ message: "workflowScript must not be empty." }] };
 	let root: AstNode;
@@ -1646,7 +1726,7 @@ export function validateWorkflowScript(script: string): WorkflowScriptValidation
 			const statement = workflowBody.body[statementIndex];
 			if (!astNode(statement) || statement.type !== "VariableDeclaration" || !Array.isArray(statement.declarations)) continue;
 			for (const declaration of statement.declarations) {
-				if (!astNode(declaration) || !astNode(declaration.id) || declaration.id.type !== "Identifier" || !astNode(declaration.init) || declaration.init.type !== "AwaitExpression" || !directRunsCall(declaration.init.argument, "all")) continue;
+				if (!astNode(declaration) || !astNode(declaration.id) || declaration.id.type !== "Identifier" || !astNode(declaration.init) || declaration.init.type !== "AwaitExpression" || !astNode(declaration.init.argument) || !directRunsCall(declaration.init.argument, "all")) continue;
 				const name = declaration.id.name as string;
 				const keys = new Set(directRunsAllKeys(declaration.init.argument).map((entry) => entry.key));
 				if (keys.size === 0) continue;
@@ -1662,8 +1742,24 @@ export function validateWorkflowScript(script: string): WorkflowScriptValidation
 		}
 	}
 
+	const warnings: WorkflowScriptValidationWarning[] = [];
+	if (options.maxSubagentSpawnsPerRun !== undefined) {
+		const plan = staticWorkflowLaunchPlan(workflowBody);
+		if (plan.keys.length > options.maxSubagentSpawnsPerRun) {
+			errors.push({
+				kind: "spawn-budget",
+				message: `workflowScript statically requires child launches ${plan.keys.map((key) => `'${key}'`).join(", ")}; minimum required: ${plan.keys.length}; configured: ${options.maxSubagentSpawnsPerRun}.`,
+			});
+		}
+		if (plan.dynamic) {
+			warnings.push({
+				kind: "dynamic-spawn-count",
+				message: `workflowScript contains dynamic child launches; static validation proved ${plan.keys.length} launch(es), so runtime fan-out enforcement remains authoritative for the configured budget of ${options.maxSubagentSpawnsPerRun}.`,
+			});
+		}
+	}
 	const unique = errors.filter((error, index) => errors.findIndex((candidate) => candidate.message === error.message && candidate.line === error.line && candidate.column === error.column) === index);
-	return { ok: unique.length === 0, errors: unique };
+	return { ok: unique.length === 0, errors: unique, ...(warnings.length > 0 ? { warnings } : {}) };
 }
 function workflowStringMetadata(params: Record<string, unknown>): Pick<WorkflowScriptTraceEntry, "phase" | "label" | "agent"> {
 	return {

--- a/src/workflows/scripted-workflow.ts
+++ b/src/workflows/scripted-workflow.ts
@@ -1589,72 +1589,116 @@ function directRunsAllKeys(call: AstNode): Array<{ key: string; node: AstNode }>
 	});
 }
 
+function containsWorkflowLaunch(node: unknown): boolean {
+	let found = false;
+	walkAst(node, (candidate) => {
+		if (directRunsCall(candidate, "run") || directRunsCall(candidate, "all") || directRunsCall(candidate, "lanes")) found = true;
+	});
+	return found;
+}
+
+function containsRunsIdentifier(node: unknown): boolean {
+	let found = false;
+	walkAst(node, (candidate) => {
+		if (candidate.type === "Identifier" && candidate.name === "runs") found = true;
+	});
+	return found;
+}
+
+function invalidatesRunsBinding(workflowBody: AstNode): boolean {
+	let invalidated = false;
+	walkAst(workflowBody, (node) => {
+		if ((node.type === "VariableDeclarator" || node.type === "FunctionDeclaration" || node.type === "FunctionExpression" || node.type === "ClassDeclaration" || node.type === "ClassExpression")
+			&& containsRunsIdentifier(node.id)) invalidated = true;
+		if ((node.type === "FunctionDeclaration" || node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression") && Array.isArray(node.params)
+			&& node.params.some(containsRunsIdentifier)) invalidated = true;
+		if (node.type === "CatchClause" && containsRunsIdentifier(node.param)) invalidated = true;
+		if ((node.type === "AssignmentExpression" || node.type === "UpdateExpression") && containsRunsIdentifier(node.left ?? node.argument)) invalidated = true;
+	});
+	return invalidated;
+}
+
+function containsAbruptControl(node: AstNode): boolean {
+	let found = false;
+	walkAst(node, (candidate) => {
+		if (candidate !== node && (candidate.type === "ReturnStatement" || candidate.type === "ThrowStatement" || candidate.type === "BreakStatement" || candidate.type === "ContinueStatement")) found = true;
+	}, false);
+	return found;
+}
+
+function directLaunchCall(expression: unknown): AstNode | undefined {
+	if (!astNode(expression)) return undefined;
+	const candidate = expression.type === "AwaitExpression" && astNode(expression.argument) ? expression.argument : expression;
+	return directRunsCall(candidate, "run") || directRunsCall(candidate, "all") ? candidate : undefined;
+}
+
 function staticWorkflowLaunchPlan(workflowBody: AstNode): { keys: string[]; dynamic: boolean } {
+	if (workflowBody.type !== "BlockStatement" || !Array.isArray(workflowBody.body) || invalidatesRunsBinding(workflowBody)) {
+		return { keys: [], dynamic: containsWorkflowLaunch(workflowBody) };
+	}
 	const keys = new Set<string>();
 	let dynamic = false;
-	const visit = (value: unknown, conditional = false): void => {
-		if (Array.isArray(value)) {
-			for (const item of value) visit(item, conditional);
-			return;
-		}
-		if (!astNode(value)) return;
-		if (value.type === "FunctionDeclaration" || value.type === "FunctionExpression" || value.type === "ArrowFunctionExpression") {
-			walkAst(value.body, (node) => { if (directRunsCall(node, "run") || directRunsCall(node, "all") || directRunsCall(node, "lanes")) dynamic = true; });
-			return;
-		}
-		if (directRunsCall(value, "run")) {
-			const args = Array.isArray(value.arguments) ? value.arguments : [];
-			const key = literalString(args[0]);
-			if (conditional || key === undefined) dynamic = true;
-			else keys.add(key);
-			for (const argument of args) visit(argument, conditional);
-			return;
-		}
-		if (directRunsCall(value, "all")) {
-			if (conditional) {
-				dynamic = true;
-				return;
-			}
-			const args = Array.isArray(value.arguments) ? value.arguments : [];
-			const array = astNode(args[0]) && args[0].type === "ArrayExpression" && Array.isArray(args[0].elements) ? args[0] : undefined;
-			if (!array) {
-				dynamic = true;
-				return;
-			}
-			for (const item of array.elements as unknown[]) {
-				if (!astNode(item) || item.type === "SpreadElement") {
-					dynamic = true;
-					continue;
-				}
-				const key = literalString(directObjectPropertyValue(item, "key"));
-				if (key === undefined) dynamic = true;
-				else keys.add(key);
-				visit(item, conditional);
-			}
-			return;
-		}
-		if (directRunsCall(value, "lanes")) {
+	let remainderUncertain = false;
+	const addCall = (call: AstNode): void => {
+		const args = Array.isArray(call.arguments) ? call.arguments : [];
+		let nestedLaunch = false;
+		for (const argument of args) walkAst(argument, (node) => {
+			if (node !== call && (directRunsCall(node, "run") || directRunsCall(node, "all") || directRunsCall(node, "lanes"))) nestedLaunch = true;
+		});
+		if (nestedLaunch) {
 			dynamic = true;
 			return;
 		}
-		if (value.type === "IfStatement" || value.type === "ConditionalExpression") {
-			visit(value.test, conditional);
-			visit(value.consequent, true);
-			visit(value.alternate, true);
+		if (directRunsCall(call, "run")) {
+			const key = literalString(args[0]);
+			if (key === undefined) dynamic = true;
+			else keys.add(key);
 			return;
 		}
-		if (value.type === "LogicalExpression") {
-			visit(value.left, conditional);
-			visit(value.right, true);
+		const array = astNode(args[0]) && args[0].type === "ArrayExpression" && Array.isArray(args[0].elements) ? args[0] : undefined;
+		if (!array) {
+			dynamic = true;
 			return;
 		}
-		if (value.type === "ForStatement" || value.type === "ForInStatement" || value.type === "ForOfStatement" || value.type === "WhileStatement" || value.type === "DoWhileStatement" || value.type === "SwitchStatement") {
-			for (const [key, child] of Object.entries(value)) if (!AST_LOCATION_KEYS.has(key)) visit(child, key === "init" || key === "test" ? conditional : true);
-			return;
+		const batchKeys: string[] = [];
+		for (const item of array.elements as unknown[]) {
+			if (!astNode(item) || item.type !== "ObjectExpression" || !Array.isArray(item.properties)
+				|| item.properties.some((property) => !astNode(property) || property.type !== "Property" || staticPropertyKey(property) === undefined)) {
+				dynamic = true;
+				return;
+			}
+			const key = literalString(directObjectPropertyValue(item, "key"));
+			if (key === undefined) {
+				dynamic = true;
+				return;
+			}
+			batchKeys.push(key);
 		}
-		for (const [key, child] of Object.entries(value)) if (!AST_LOCATION_KEYS.has(key)) visit(child, conditional);
+		for (const key of batchKeys) keys.add(key);
 	};
-	visit(workflowBody);
+	for (const statement of workflowBody.body) {
+		if (!astNode(statement)) continue;
+		if (remainderUncertain) {
+			if (containsWorkflowLaunch(statement)) dynamic = true;
+			continue;
+		}
+		const expressions: unknown[] = [];
+		if (statement.type === "VariableDeclaration" && Array.isArray(statement.declarations)) {
+			for (const declaration of statement.declarations) if (astNode(declaration)) expressions.push(declaration.init);
+		} else if (statement.type === "ExpressionStatement") expressions.push(statement.expression);
+		else if (statement.type === "ReturnStatement" || statement.type === "ThrowStatement") expressions.push(statement.argument);
+		let handledLaunch = false;
+		for (const expression of expressions) {
+			const call = directLaunchCall(expression);
+			if (call) {
+				addCall(call);
+				handledLaunch = true;
+			} else if (containsWorkflowLaunch(expression)) dynamic = true;
+		}
+		if (!handledLaunch && expressions.length === 0 && containsWorkflowLaunch(statement)) dynamic = true;
+		if (statement.type === "ReturnStatement" || statement.type === "ThrowStatement") remainderUncertain = true;
+		else if (containsAbruptControl(statement)) remainderUncertain = true;
+	}
 	return { keys: [...keys], dynamic };
 }
 

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -617,6 +617,17 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			ok: false,
 			errors: [{ message: "runs.run key must be 1-128 characters using letters, numbers, '.', '_' or '-', and start with a letter or number.", line: 1, column: 17 }],
 		});
+		const budgetValidation = await executor.executePublic(
+			"offline-budget-validation",
+			{ action: "validate", maxSubagentSpawnsPerRun: 1, workflowScript: `await runs.run("first", { agent: "echo" }); return runs.run("second", { agent: "echo" });` },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+		assert.equal(budgetValidation.isError, true);
+		const budgetPayload = JSON.parse(budgetValidation.content[0]?.text ?? "null") as { errors?: Array<{ kind?: string; message?: string }> };
+		assert.equal(budgetPayload.errors?.[0]?.kind, "spawn-budget");
+		assert.match(budgetPayload.errors?.[0]?.message ?? "", /'first', 'second'.*minimum required: 2; configured: 1/);
 		const invalidPreflight = await executor.executePublic(
 			"invalid-preflight",
 			{ workflowScript: `return runs.run("child", { agent: "echo" });`, preflight: { version: 1, lanes: [{ key: "bad key" }] } },

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -566,6 +566,38 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(forwarded?.workflowScript, "return runs.run('main', { agent: 'echo' })");
 	});
 
+	it("rejects a static spawn-budget mismatch before discovering or launching children", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const before = fs.readdirSync(tempDir).sort();
+		const executor = makeExecutor([makeAgent("echo")], {}, false, undefined, true, new Map(), undefined, undefined, createEventBus(), () => {
+			throw new Error("spawn-budget validation must not discover or launch agents");
+		});
+		const script = [
+			`const results = await runs.all([`,
+			`  { key: "a", agent: "echo", task: "A" },`,
+			`  { key: "b", agent: "echo", task: "B" },`,
+			`  { key: "c", agent: "echo", task: "C" },`,
+			`]);`,
+			`const owner = await runs.run("owner", { agent: "echo", task: results[0].output });`,
+			`const review = await runs.run("review", { agent: "echo", task: owner.output });`,
+			`return runs.run("owner-fix", { resume: owner.runId, task: review.output });`,
+		].join("\n");
+
+		const result = await executor.executePublic(
+			"static-budget-mismatch",
+			{ async: false, workflowScript: script, maxSubagentSpawnsPerRun: 5 },
+			new AbortController().signal,
+			undefined,
+			makeMinimalCtx(tempDir),
+		);
+
+		assert.equal(result.isError, true);
+		assert.match(result.content[0]?.text ?? "", /validation failed before child launch; no children launched/);
+		assert.match(result.content[0]?.text ?? "", /'a', 'b', 'c', 'owner', 'review', 'owner-fix'/);
+		assert.match(result.content[0]?.text ?? "", /minimum required: 6; configured: 5/);
+		assert.equal(mockPi.callCount(), 0);
+		assert.deepEqual(fs.readdirSync(tempDir).sort(), before);
+	});
+
 	it("validates workflow scripts without launching children or creating artifacts", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
 		const before = fs.readdirSync(tempDir).sort();
 		const executor = makeExecutor([makeAgent("echo")], {}, false, undefined, true, new Map(), undefined, undefined, createEventBus(), () => {
@@ -3293,11 +3325,11 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 			makeMinimalCtx(tempDir),
 		);
 
-		assert.equal(result.isError, undefined, result.content[0]?.text ?? "workflow failed");
+		assert.equal(result.isError, true);
 		assert.equal(mockPi.callCount(), 0);
-		const children = result.details.workflow?.value as Array<{ ok: boolean; error?: string }>;
-		assert.deepEqual(children.map(({ ok }) => ok), [false, false]);
-		for (const child of children) assert.match(child.error ?? "", /workflow\[second\].*0\/1 used; 2 requested, 1 remaining/);
+		assert.match(result.content[0]?.text ?? "", /validation failed before child launch; no children launched/);
+		assert.match(result.content[0]?.text ?? "", /'first', 'second'.*minimum required: 2; configured: 1/);
+		assert.equal(result.details.workflow, undefined);
 	});
 
 	it("lets an explicit workflow spawn override exceed config", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/public-execution.test.ts
+++ b/test/unit/public-execution.test.ts
@@ -61,6 +61,10 @@ describe("public subagent execution normalization", () => {
 			{ ok: true, params: { action: "validate", workflowScriptPath: "workflow.js" } },
 		);
 		assert.deepEqual(
+			normalizePublicSubagentExecution({ action: " validate ", workflowScript: "return 1", maxSubagentSpawnsPerRun: 5 }),
+			{ ok: true, params: { action: "validate", workflowScript: "return 1", maxSubagentSpawnsPerRun: 5 } },
+		);
+		assert.deepEqual(
 			normalizePublicSubagentExecution({ action: " schedule.create ", every: "1h", workflowScript: "return 1" }),
 			{ ok: true, params: { action: "schedule.create", every: "1h", workflowScript: "return 1" } },
 		);

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -281,6 +281,22 @@ describe("scripted workflow runtime", () => {
 		assert.match(result.warnings?.[0]?.message ?? "", /proved 0 launch\(es\).*configured budget of 1/);
 	});
 
+	it("keeps uncertain control flow and shadowed workflow APIs advisory", () => {
+		for (const script of [
+			`if (true) return "done";\nawait runs.run("a", {}); await runs.run("b", {});`,
+			`try { return "done"; } catch (error) { await runs.run("a", {}); await runs.run("b", {}); }`,
+			`class Deferred { child = runs.run("a", {}); }\nreturn "done";`,
+			`maybe?.(runs.run("a", {}));\nreturn "done";`,
+			`{ const runs = { run(key) { return key; } }; runs.run("a", {}); runs.run("b", {}); }`,
+			`return runs.all([{ key: "a", agent: "worker", ...overrides }, { key: "b", agent: "worker" }]);`,
+		]) {
+			const result = validateWorkflowScript(script, { maxSubagentSpawnsPerRun: 1 });
+			assert.equal(result.ok, true, script);
+			assert.deepEqual(result.errors, [], script);
+			assert.equal(result.warnings?.[0]?.kind, "dynamic-spawn-count", script);
+		}
+	});
+
 	it("keeps dynamic workflow keys silent when no spawn budget is requested", () => {
 		const result = validateWorkflowScript([
 			`const prefix = "lane";`,

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -245,7 +245,43 @@ describe("scripted workflow runtime", () => {
 		}), /at most 32 runs\.host calls/);
 	});
 
-	it("keeps dynamic workflow keys silent during offline validation", () => {
+	it("rejects a statically provable workflow that exceeds its spawn budget", () => {
+		const script = [
+			`const [architecture, adjacent, proof] = await runs.all([`,
+			`  { key: "architecture", agent: "scout", task: "Inspect architecture" },`,
+			`  { key: "adjacent", agent: "scout", task: "Inspect adjacent scope" },`,
+			`  { key: "proof", agent: "oracle", task: "Challenge the proof" },`,
+			`]);`,
+			`const owner = await runs.run("owner", { agent: "worker", task: architecture.output });`,
+			`const review = await runs.run("review", { agent: "reviewer", task: owner.output });`,
+			`const fixed = await runs.run("owner-fix", { resume: owner.runId, task: review.output });`,
+			`return { adjacent: adjacent.output, proof: proof.output, fixed: fixed.output };`,
+		].join("\n");
+
+		const rejected = validateWorkflowScript(script, { maxSubagentSpawnsPerRun: 5 });
+		assert.equal(rejected.ok, false);
+		assert.deepEqual(rejected.errors, [{
+			kind: "spawn-budget",
+			message: "workflowScript statically requires child launches 'architecture', 'adjacent', 'proof', 'owner', 'review', 'owner-fix'; minimum required: 6; configured: 5.",
+		}]);
+		assert.deepEqual(validateWorkflowScript(script, { maxSubagentSpawnsPerRun: 6 }), { ok: true, errors: [] });
+	});
+
+	it("warns instead of guessing a dynamic spawn count", () => {
+		const result = validateWorkflowScript([
+			`const prefix = "lane";`,
+			`const child = await runs.run(prefix + "-writer", { agent: selectedAgent, task: taskText });`,
+			`const results = await runs.all(items.map((item) => ({ key: item.key, agent: item.agent, task: item.task })));`,
+			`if (needsReview) await runs.run("conditional-review", { agent: "reviewer", task: child.output });`,
+			`return { child: child.output, outputs: results.map((entry) => entry.output) };`,
+		].join("\n"), { maxSubagentSpawnsPerRun: 1 });
+		assert.equal(result.ok, true);
+		assert.deepEqual(result.errors, []);
+		assert.equal(result.warnings?.[0]?.kind, "dynamic-spawn-count");
+		assert.match(result.warnings?.[0]?.message ?? "", /proved 0 launch\(es\).*configured budget of 1/);
+	});
+
+	it("keeps dynamic workflow keys silent when no spawn budget is requested", () => {
 		const result = validateWorkflowScript([
 			`const prefix = "lane";`,
 			`const child = await runs.run(prefix + "-writer", { agent: selectedAgent, task: taskText });`,


### PR DESCRIPTION
## Summary

- statically count unconditional literal `runs.run` and `runs.all` launch keys, including resumed children
- reject a provable `maxSubagentSpawnsPerRun` mismatch before agent discovery, artifact creation, or child launch
- return advisory warnings for dynamic or conditional launch counts while preserving runtime fan-out enforcement
- apply the same effective request/config budget to offline `action: "validate"`

## Tracking

Related: https://github.com/ton77v/dotfiles/issues/271

The reported workflow declared five conceptual lanes but contained six concrete child launches. Runtime enforcement caught the sixth only after the first five had completed. This change reports every statically proven key plus `minimum required: 6; configured: 5` before any expensive work begins.

## Validation

- `npm run typecheck`
- focused unit tests: 3 passed
- focused integration tests: 4 passed
- static validation benchmark: 5,000 representative six-launch scripts averaged 0.2662 ms each
- full unit and integration suites were also run locally on Windows; existing package-agent precedence and async fixture/watchdog failures remain. The directly affected legacy fan-out assertion was updated to the new fail-fast contract and passes.
- post-push touched-file suites: `scripted-workflow.test.ts` 120 passed; `single-execution.part-1.test.ts` 93 passed, 7 platform skips.

<signature>🦀 **sent by [Agent System v0.20.2](https://antoniov.online/agentic-systems): pi | gpt-5.6-sol**</signature>
