### PR TITLE
test: capture bounded async result timeout evidence

### DIFF
--- a/test/integration/async-execution.part-1.test.ts
+++ b/test/integration/async-execution.part-1.test.ts
@@ -172,11 +172,11 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 					assert.ok(error instanceof Error);
 					assert.match(error.message, new RegExp(`"steps":\\["${stepState}"\\]`));
 					assert.ok(error.message.includes(`mock queue: readable, prompt call records=${callCount}`));
-					assert.match(error.message, /runner.stdout.log: empty/);
-					assert.match(error.message, /runner.stderr.log: unreadable \(EISDIR\)/);
-					assert.match(error.message, /process-terminal.json: absent/);
-					assert.match(error.message, /runner-startup-proceed.json: readable, \d+ bytes \(contents withheld\)/);
-					assert.match(error.message, /events.jsonl: readable/);
+					assert.match(error.message, /runner.stdout.log: \{"bytes":0,.*\} \(contents withheld\)/);
+					assert.match(error.message, /runner.stderr.log: \{"bytes":\d+,.*\} \(contents withheld\)/);
+					assert.match(error.message, /process-terminal.json: ENOENT/);
+					assert.match(error.message, /runner-startup-proceed.json: \{"bytes":\d+,.*\} \(contents withheld\)/);
+					assert.match(error.message, /events.jsonl: .*"invalidLines":1/);
 					assert.doesNotMatch(error.message, /secret-/);
 					return true;
 				});

--- a/test/support/async-execution-fixture.ts
+++ b/test/support/async-execution-fixture.ts
@@ -14,6 +14,7 @@ import { channel } from "node:diagnostics_channel";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { asyncResultTimeoutEvidence } from "./async-result-timeout-evidence.ts";
 import { createEventBus, createMockPi, createTempDir, makeAgent, removeTempDir, resolveMockPiCallArgs, tryImport } from "./helpers.ts";
 import type { MockPi } from "./helpers.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
@@ -339,25 +340,7 @@ async function waitForAsyncResultFile(id: string, timeoutMs = 15_000): Promise<s
 		if (Date.now() > deadline) {
 			const asyncDir = path.join(ASYNC_DIR, id);
 			// Summarize before teardown; never print free-form output, prompts or tokens.
-			const evidence = ["status.json", "runner-startup-proceed.json", "process-terminal.json", "events.jsonl", "runner.stdout.log", "runner.stderr.log"].map((name) => {
-				let text: string;
-				try {
-					text = fs.readFileSync(path.join(asyncDir, name), "utf-8");
-				} catch (error) {
-					const code = (error as NodeJS.ErrnoException).code;
-					return `${name}: ${code === "ENOENT" ? "absent" : `unreadable (${code ?? "unknown"})`}`;
-				}
-				if (!text.length) return `${name}: empty`;
-				const size = `${Buffer.byteLength(text)} bytes (contents withheld)`;
-				if (name !== "status.json") return `${name}: readable, ${size}`;
-				try {
-					const status = JSON.parse(text) as AsyncStatusPayload;
-					const knownState = (value: unknown) => ["pending", "running", "complete", "failed", "cancelled"].includes(String(value)) ? value : "other/absent";
-					return `${name}: ${JSON.stringify({ state: knownState(status.state), steps: status.steps?.map((step) => knownState(step.status)), endedAtPresent: typeof status.endedAt === "number" })}`;
-				} catch {
-					return `${name}: invalid status JSON, ${size}`;
-				}
-			});
+			const evidence = asyncResultTimeoutEvidence(asyncDir, id);
 			// The current fixture queue proves prompt entry, not per-run identity or settlement.
 			const queueDir = process.env.MOCK_PI_QUEUE_DIR;
 			let mockEvidence = "mock queue: not configured";

--- a/test/support/async-result-timeout-evidence.ts
+++ b/test/support/async-result-timeout-evidence.ts
@@ -1,0 +1,61 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// Failure-only observations, not terminality predicates. Never expose free-form fields.
+export function asyncResultTimeoutEvidence(asyncDir: string, id: string): string[] {
+	const record = (value: unknown): Record<string, unknown> => value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+	const number = (value: unknown) => typeof value === "number" && Number.isFinite(value) ? value : undefined;
+	const known = (value: unknown, choices: string[]) => typeof value === "string" && choices.includes(value) ? value : "other/absent";
+	const states = ["pending", "queued", "running", "complete", "completed", "failed", "cancelled", "paused", "stopped", "partial", "rejected", "observed", "unknown", "not-started"];
+	let runnerId: string | undefined;
+	const identity = (raw: Record<string, unknown>) => ({
+		runIdMatches: raw.runId === id,
+		runnerIdMatches: runnerId === undefined ? "unavailable" : raw.runnerProcessInstanceId === runnerId,
+	});
+	const proof = (raw: Record<string, unknown>) => ({
+		...identity(raw), state: known(raw.state, states), observedAt: number(raw.observedAt),
+		reason: known(raw.reason, ["observer-unavailable", "runner-candidate-missing", "runner-instance-mismatch", "writer-close-unverified", "process-tree-unverified", "canonical-session-unavailable", "canonical-session-lease-active", "canonical-session-release-unverified", "proof-write-failed", "stale-repair"]),
+		runner: Array.isArray(raw.instances) ? raw.instances.slice(0, 16).map(record).filter((entry) => entry.kind === "runner").map((entry) => ({
+			instanceMatches: runnerId === undefined ? "unavailable" : entry.processInstanceId === runnerId, closeObservedAt: number(entry.closeObservedAt),
+			exitCode: entry.exitCode === null ? null : number(entry.exitCode), signal: entry.signal === null ? null : known(entry.signal, ["SIGTERM", "SIGKILL", "SIGINT", "SIGABRT", "SIGSEGV"]),
+		})) : undefined,
+	});
+	return ["status.json", "runner-startup-proceed.json", "process-terminal.json", "process-terminal-candidate.json", "events.jsonl", "runner.stdout.log", "runner.stderr.log"].map((name) => {
+		let fd: number | undefined;
+		try {
+			fd = fs.openSync(path.join(asyncDir, name), "r");
+			const bytes = fs.fstatSync(fd).size;
+			const base = { bytes, readAt: Date.now() };
+			if (!bytes || name.endsWith(".log") || name === "runner-startup-proceed.json") return `${name}: ${JSON.stringify(base)} (contents withheld)`;
+			const limit = 16_384;
+			const offset = name === "events.jsonl" ? Math.max(0, bytes - limit) : 0;
+			if (bytes > limit && name !== "events.jsonl") return `${name}: ${JSON.stringify(base)} (oversize, contents withheld)`;
+			const buffer = Buffer.alloc(Math.min(bytes, limit));
+			const text = buffer.subarray(0, fs.readSync(fd, buffer, 0, buffer.length, offset)).toString("utf-8");
+			if (name === "events.jsonl") {
+				let invalidLines = 0;
+				let mismatchedRunEvents = 0;
+				const events = [];
+				for (const line of text.split("\n").slice(offset ? 1 : 0).filter(Boolean)) {
+					try {
+						const raw = record(JSON.parse(line));
+						if (typeof raw.type !== "string" || !["subagent.run.started", "subagent.step.completed", "subagent.step.failed", "subagent.parallel.completed", "subagent.run.completed", "subagent.run.process_terminal"].includes(raw.type)) continue;
+						if (raw.runId !== id) { mismatchedRunEvents++; continue; }
+						events.push({ type: raw.type, ts: number(raw.ts), stepIndex: number(raw.stepIndex), pid: number(raw.pid), status: known(raw.status, states), exitCode: number(raw.exitCode), ...(raw.processTerminal ? { proof: proof(record(raw.processTerminal)) } : {}) });
+					} catch { invalidLines++; }
+				}
+				return `${name}: ${JSON.stringify({ ...base, tailOnly: offset > 0, invalidLines, mismatchedRunEvents, events: events.slice(-16) })}`;
+			}
+			const raw = record(JSON.parse(text));
+			if (name === "status.json") {
+				const terminal = record(raw.processTerminal);
+				if (raw.runId === id && terminal.runId === id && typeof terminal.runnerProcessInstanceId === "string") runnerId = terminal.runnerProcessInstanceId;
+				return `${name}: ${JSON.stringify({ ...base, runIdMatches: raw.runId === id, pid: number(raw.pid), state: known(raw.state, states), lastUpdate: number(raw.lastUpdate), endedAt: number(raw.endedAt), steps: Array.isArray(raw.steps) ? raw.steps.slice(0, 16).map((step) => known(record(step).status, states)) : undefined, proof: proof(terminal) })}`;
+			}
+			if (name === "process-terminal-candidate.json") return `${name}: ${JSON.stringify({ ...base, ...identity(raw), writers: ["0", "1"].map((index) => ({ index, count: Array.isArray(record(raw.writers)[index]) ? (record(raw.writers)[index] as unknown[]).length : undefined, expected: number(record(raw.expectedWriters)[index]) })) })}`;
+			return `${name}: ${JSON.stringify({ ...base, ...proof(raw) })}`;
+		} catch (error) {
+			return `${name}: ${error instanceof SyntaxError ? "invalid JSON" : known(record(error).code, ["ENOENT", "EACCES", "EPERM", "EBUSY", "EIO", "EMFILE", "ENFILE", "ENOSPC"])}`;
+		} finally { if (fd !== undefined) fs.closeSync(fd); }
+	});
+}

--- a/test/unit/async-result-timeout-evidence.test.ts
+++ b/test/unit/async-result-timeout-evidence.test.ts
@@ -1,0 +1,53 @@
+import { it } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { asyncResultTimeoutEvidence } from "../support/async-result-timeout-evidence.ts";
+
+it("correlates timeout evidence without promoting pending sidecars or exposing contents", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "result-evidence-"));
+	try {
+		const proof = { runId: "run", runnerProcessInstanceId: "private-runner", state: "pending" };
+		fs.writeFileSync(path.join(dir, "status.json"), JSON.stringify({ runId: "run", state: "running", pid: 123, processTerminal: proof, steps: [{ status: "complete" }, { status: "complete" }], task: "SECRET" }));
+		fs.writeFileSync(path.join(dir, "process-terminal.json"), JSON.stringify(proof));
+		fs.writeFileSync(path.join(dir, "process-terminal-candidate.json"), JSON.stringify({ ...proof, writers: {}, expectedWriters: { "0": 0, "1": 0 } }));
+		fs.writeFileSync(path.join(dir, "events.jsonl"), [
+			{ type: "subagent.step.completed", runId: "run", stepIndex: 1, ts: 42, output: "SECRET" },
+			{ type: "subagent.parallel.completed", runId: "run", stepIndex: 0, ts: 43 },
+			{ type: "subagent.run.completed", runId: "other", ts: 43 },
+		].map((event) => JSON.stringify(event)).join("\n"));
+		fs.writeFileSync(path.join(dir, "runner.stderr.log"), "SECRET");
+		const evidence = asyncResultTimeoutEvidence(dir, "run").join("\n");
+		assert.match(evidence, /"state":"pending"/);
+		assert.match(evidence, /"runnerIdMatches":true/);
+		assert.match(evidence, /"mismatchedRunEvents":1/);
+		assert.match(evidence, /"stepIndex":1/);
+		assert.match(evidence, /subagent.parallel.completed/);
+		assert.match(evidence, /runner-startup-proceed.json: ENOENT/);
+		assert.doesNotMatch(evidence, /SECRET|private-runner|subagent.run.completed/);
+		fs.writeFileSync(path.join(dir, "process-terminal.json"), JSON.stringify({ ...proof, state: "observed", runnerProcessInstanceId: "other", instances: [{ kind: "runner", processInstanceId: "other", closeObservedAt: 99, exitCode: 1, signal: null }] }));
+		const mismatch = asyncResultTimeoutEvidence(dir, "run").join("\n");
+		assert.match(mismatch, /"runnerIdMatches":false/);
+		assert.match(mismatch, /"closeObservedAt":99,"exitCode":1,"signal":null/);
+	} finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+it("bounds timeout reads and output, and tolerates missing, malformed and oversized evidence", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "result-evidence-"));
+	try {
+		fs.writeFileSync(path.join(dir, "status.json"), "x".repeat(20_000));
+		fs.writeFileSync(path.join(dir, "process-terminal.json"), "{");
+		fs.writeFileSync(path.join(dir, "process-terminal-candidate.json"), JSON.stringify({ runId: "run", runnerProcessInstanceId: "private-runner" }));
+		fs.writeFileSync(path.join(dir, "runner.stdout.log"), "SECRET".repeat(100_000));
+		fs.writeFileSync(path.join(dir, "events.jsonl"), "SECRET".repeat(3_000) + "\n" + Array.from({ length: 100 }, () => JSON.stringify({ type: "subagent.run.completed", runId: "run", ts: 42 })).join("\n"));
+		const evidence = asyncResultTimeoutEvidence(dir, "run").join("\n");
+		assert.match(evidence, /oversize/);
+		assert.match(evidence, /invalid JSON/);
+		assert.match(evidence, /"tailOnly":true/);
+		assert.match(evidence, /"runnerIdMatches":"unavailable"/);
+		assert.equal(evidence.match(/subagent.run.completed/g)?.length, 16);
+		assert.ok(Buffer.byteLength(evidence) < 8_192);
+		assert.doesNotMatch(evidence, /SECRET/);
+	} finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary
Related to #2105. Diagnostic coverage only; keep the issue open. No root-cause fix is claimed.

The Windows handoff test failed with complete steps but no public result. Existing diagnostics withheld the sidecar/event contents needed to distinguish lifecycle phases. This patch adds bounded allowlisted evidence only at the existing timeout-message boundary: run/runner equality flags, selected lifecycle timestamps, proof states and finite scalar metadata. Prompts, outputs, paths, raw identities, tokens and errors remain withheld.

Assertions, the actual 10-second parallel wait, polling interval, runtime and result semantics are unchanged. Whole test duration was15.36seconds, not the parallel wait budget. No blind rerun, deadline increase or sidecar-presence-as-death inference. Not a reopening of #1906.

## Validation
- Two focused unit tests pass; exact handoff integration case and typecheck pass.
- Fresh independent review approved scope, privacy, correlation and bounds; independently reran unit tests.
- Seven fixed files, structured input caps and selected-event/step caps; sequential snapshots remain non-atomic and status-based correlation is not an independent launch receipt.
- Required exact-head Windows/other CI, Greptile and post-merge main CI remain gates. A passing run will not establish the original cause.

No release/tag.