### PR TITLE
fix: support string array and undefined systemPrompt in before_agent_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Preserve input and return shapes in `appendAdvertisedAgentPrompt` with overloads for string, array, and undefined system prompt callers in `before_agent_start`. Thanks to [@luqman-v1](https://github.com/luqman-v1) for #2107.
 - Label workflow usage as belonging to child rows instead of showing a misleading zero or overlapping wrapper totals in FleetView; preserve unrelated standalone usage in mixed summaries and distinguish summed concurrent windows from a single context window. Related to #2085; thanks to [@expoli](https://github.com/expoli).
 - Restore background SDK sessions for the official Pi 0.85.1 Linux x64 standalone release, without a separate SDK install; npm runners keep their package-root and lifecycle behavior. Thanks to [@xz-dev](https://github.com/xz-dev) for #2049.
 - Preserve the parent's active theme when foreground children start, while initializing themes in detached runners and refreshing slash-result rendering. Thanks to [@kubahasek](https://github.com/kubahasek) for #2089.

--- a/src/agents/advertised-agent-prompt.ts
+++ b/src/agents/advertised-agent-prompt.ts
@@ -57,7 +57,31 @@ export function buildAdvertisedAgentPrompt(
 	return render(entries);
 }
 
-export function appendAdvertisedAgentPrompt(systemPrompt: string, advertisedPrompt: string | undefined): string {
-	const base = systemPrompt.replace(ADVERTISED_AGENTS_BLOCK, "");
-	return advertisedPrompt ? `${base.trimEnd()}\n\n${advertisedPrompt}` : base;
+export function appendAdvertisedAgentPrompt(
+	systemPrompt: string | string[] | undefined,
+	advertisedPrompt: string | undefined,
+): string | string[] | undefined {
+	if (Array.isArray(systemPrompt)) {
+		let changed = false;
+		const cleaned = systemPrompt
+			.map((part) => {
+				if (typeof part !== "string") return part;
+				const stripped = part.replace(ADVERTISED_AGENTS_BLOCK, "");
+				if (stripped !== part) changed = true;
+				return stripped;
+			})
+			.filter((b) => typeof b === "string" && b.length > 0);
+
+		if (advertisedPrompt) {
+			return [...cleaned, advertisedPrompt];
+		}
+		return changed ? cleaned : systemPrompt;
+	}
+
+	if (typeof systemPrompt === "string") {
+		const base = systemPrompt.replace(ADVERTISED_AGENTS_BLOCK, "");
+		return advertisedPrompt ? (base.trim() ? `${base.trimEnd()}\n\n${advertisedPrompt}` : advertisedPrompt) : base;
+	}
+
+	return advertisedPrompt;
 }

--- a/src/agents/advertised-agent-prompt.ts
+++ b/src/agents/advertised-agent-prompt.ts
@@ -57,6 +57,13 @@ export function buildAdvertisedAgentPrompt(
 	return render(entries);
 }
 
+export function appendAdvertisedAgentPrompt(systemPrompt: string, advertisedPrompt: string | undefined): string;
+export function appendAdvertisedAgentPrompt(systemPrompt: string[], advertisedPrompt: string | undefined): string[];
+export function appendAdvertisedAgentPrompt(systemPrompt: undefined, advertisedPrompt: string | undefined): string | undefined;
+export function appendAdvertisedAgentPrompt(
+	systemPrompt: string | string[] | undefined,
+	advertisedPrompt: string | undefined,
+): string | string[] | undefined;
 export function appendAdvertisedAgentPrompt(
 	systemPrompt: string | string[] | undefined,
 	advertisedPrompt: string | undefined,

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -812,9 +812,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	pi.registerTool(tool);
 
 	pi.on("before_agent_start", (event, ctx) => {
-		const selectedTools = event.systemPromptOptions.selectedTools ?? pi.getActiveTools();
+		const selectedTools = event.systemPromptOptions?.selectedTools ?? (typeof pi.getActiveTools === "function" ? pi.getActiveTools() : []);
 		const sessionId = state.currentSessionId ?? resolveCurrentSessionId(ctx.sessionManager);
-		const advertisedPrompt = selectedTools.includes("subagent")
+		const advertisedPrompt = Array.isArray(selectedTools) && selectedTools.includes("subagent")
 			? buildAdvertisedAgentPrompt(advertisedAgents, resolveCurrentSubagentCapabilityCeiling(sessionId))
 			: undefined;
 		const systemPrompt = appendAdvertisedAgentPrompt(event.systemPrompt, advertisedPrompt);

--- a/test/unit/advertised-agent-prompt.test.ts
+++ b/test/unit/advertised-agent-prompt.test.ts
@@ -84,4 +84,27 @@ describe("advertised agent prompt", () => {
 		const prior = appendAdvertisedAgentPrompt("base prompt", buildAdvertisedAgentPrompt([agent("alpha", { advertise: true })]));
 		assert.equal(appendAdvertisedAgentPrompt(prior, buildAdvertisedAgentPrompt([])), "base prompt");
 	});
+
+	it("handles string array systemPrompt gracefully", () => {
+		const initial = ["section 1", "section 2"];
+		const catalog = buildAdvertisedAgentPrompt([agent("alpha", { advertise: true })]);
+		const withCatalog = appendAdvertisedAgentPrompt(initial, catalog);
+		assert.ok(Array.isArray(withCatalog));
+		assert.equal(withCatalog.length, 3);
+		assert.equal(withCatalog[0], "section 1");
+		assert.equal(withCatalog[1], "section 2");
+		assert.match(withCatalog[2]!, /<name>alpha<\/name>/);
+
+		const withoutCatalog = appendAdvertisedAgentPrompt(withCatalog, undefined);
+		assert.ok(Array.isArray(withoutCatalog));
+		assert.equal(withoutCatalog.length, 2);
+		assert.equal(withoutCatalog[0], "section 1");
+		assert.equal(withoutCatalog[1], "section 2");
+	});
+
+	it("handles undefined systemPrompt gracefully", () => {
+		const catalog = buildAdvertisedAgentPrompt([agent("alpha", { advertise: true })]);
+		assert.equal(appendAdvertisedAgentPrompt(undefined, catalog), catalog);
+		assert.equal(appendAdvertisedAgentPrompt(undefined, undefined), undefined);
+	});
 });


### PR DESCRIPTION
### Summary
In recent Oh My Pi / Pi runtime versions, `event.systemPrompt` passed to `before_agent_start` is an array of strings (`string[]`) or can be `undefined`, rather than a single `string`.

Previously, `appendAdvertisedAgentPrompt` expected a single `string` and invoked `systemPrompt.replace(...)`, which threw:
`TypeError: systemPrompt.replace is not a function`

Additionally:
- `event.systemPromptOptions` can be undefined in some host environments, so using optional chaining (`event.systemPromptOptions?.selectedTools`) avoids potential `TypeError` when reading `selectedTools`.
- `appendAdvertisedAgentPrompt` now supports `string[]`, `string`, and `undefined`, preserving all prompt sections and appending the catalog cleanly when present.

### Verification
- Added unit tests in `test/unit/advertised-agent-prompt.test.ts` covering `string[]` and `undefined` inputs.
- All unit tests pass (`bun test advertised-agent-prompt`).