### PR TITLE
ci: isolate standalone apt setup to Ubuntu sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,8 +95,10 @@ jobs:
         run: |
           node -e 'const a = require("node:assert/strict"); a.equal(process.platform, "linux"); a.equal(process.arch, "x64");'
           npm ci --ignore-scripts
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap
+          # Bubblewrap needs only Ubuntu indexes, not the runner's third-party repositories.
+          printf '%s\n' 'deb http://archive.ubuntu.com/ubuntu jammy main universe' 'deb http://archive.ubuntu.com/ubuntu jammy-updates main universe' 'deb http://security.ubuntu.com/ubuntu jammy-security main universe' > "$RUNNER_TEMP/ubuntu.sources.list"
+          sudo apt-get -o Dir::Etc::sourcelist="$RUNNER_TEMP/ubuntu.sources.list" -o Dir::Etc::sourceparts=- update
+          sudo apt-get -o Dir::Etc::sourcelist="$RUNNER_TEMP/ubuntu.sources.list" -o Dir::Etc::sourceparts=- install -y bubblewrap
       - name: Provision the checksum-pinned official binary
         shell: bash
         run: |


### PR DESCRIPTION
Fixes https://github.com/nicobailon/pi-subagents/issues/2108.

Use an explicit temporary Ubuntu Jammy source list for both apt update and bubblewrap installation. The pinned Ubuntu22.04 job does not need the runner image's third-party indexes. Default package signature checks and all existing standalone/test gates remain unchanged.

Evidence: Google Chrome Packages.gz hash mismatch blocked setup twice on unchanged main; the one authorized retry is exhausted. YAML parsing and diff hygiene pass. Fresh independent review approved exact +4/-2 diff with no findings. Actual Ubuntu CI must prove installation and all18 standalone modes; no local apt execution or skipped gate claim.

Required exact-head CI/bot and post-merge main CI still apply. No release/tag.