### PR TITLE
feat: add bounded foreground SSH project execution

### DIFF
--- a/.github/workflows/ssh-foreground.yml
+++ b/.github/workflows/ssh-foreground.yml
@@ -1,0 +1,36 @@
+name: SSH foreground
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ssh-foreground:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    env:
+      PI_SUBAGENTS_REAL_SDK_ROOT: ${{ runner.temp }}/ssh-sdk/node_modules/@earendil-works/pi-coding-agent
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22.22.0
+      - run: npm ci --ignore-scripts
+      - name: Install the real Pi runtime
+        run: npm install --prefix "$RUNNER_TEMP/ssh-sdk" --ignore-scripts --no-audit --no-fund @earendil-works/pi-coding-agent@0.85.1
+      - name: Require the real CLI fixture
+        run: node -e 'const fs = require("node:fs"), path = require("node:path"), assert = require("node:assert/strict"); assert.ok(fs.existsSync(path.join(process.env.PI_SUBAGENTS_REAL_SDK_ROOT, "dist/bundle/cli.js")));'
+      - name: Check installed launch and public foreground behavior
+        run: node --experimental-strip-types --test test/unit/ssh-project-tools.test.ts test/unit/pi-spawn.test.ts test/integration/ssh-foreground.test.ts

--- a/.github/workflows/ssh-foreground.yml
+++ b/.github/workflows/ssh-foreground.yml
@@ -20,8 +20,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      PI_SUBAGENTS_REAL_SDK_ROOT: ${{ runner.temp }}/ssh-sdk/node_modules/@earendil-works/pi-coding-agent
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -29,7 +27,9 @@ jobs:
           node-version: 22.22.0
       - run: npm ci --ignore-scripts
       - name: Install the real Pi runtime
-        run: npm install --prefix "$RUNNER_TEMP/ssh-sdk" --ignore-scripts --no-audit --no-fund @earendil-works/pi-coding-agent@0.85.1
+        run: |
+          npm install --prefix "$RUNNER_TEMP/ssh-sdk" --ignore-scripts --no-audit --no-fund @earendil-works/pi-coding-agent@0.85.1
+          echo "PI_SUBAGENTS_REAL_SDK_ROOT=$RUNNER_TEMP/ssh-sdk/node_modules/@earendil-works/pi-coding-agent" >> "$GITHUB_ENV"
       - name: Require the real CLI fixture
         run: node -e 'const fs = require("node:fs"), path = require("node:path"), assert = require("node:assert/strict"); assert.ok(fs.existsSync(path.join(process.env.PI_SUBAGENTS_REAL_SDK_ROOT, "dist/bundle/cli.js")));'
       - name: Check installed launch and public foreground behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add an opt-in stock-Pi SSH project entry for fresh single native foreground delegation with remote text `read`/`bash` and local authentication, selected resources and sessions. Background, workflows, resume and project-management operations remain unsupported; see [the bounded contract](docs/ssh-project.md). Related to #2047; thanks to [@klay7w](https://github.com/klay7w).
 - Add opt-in watchdog `fallbackModels` for main, children, and per-agent overrides, retrying provider failures only before tool work within the existing review deadline. Thanks to [@dwizzle204](https://github.com/dwizzle204) for #2075.
 - Add portable Inspect commands and a terminal-neutral plugin seam, including open-only Ghostty 1.3+ right splits on macOS. Thanks to [@tiratatp](https://github.com/tiratatp) for #2046.
 - Add an opt-in `quiet: true` flag for recurring `schedule.create`. A quiet schedule's successful automatic runs and successful workflow children keep their completion notices but no longer trigger a parent turn; failed, stopped, or paused outcomes still wake the session. One-shot `at` schedules and `schedule.run` stay noisy unless that launch passes `quiet: true`. Default behavior is unchanged. Thanks to [@pablontiv](https://github.com/pablontiv) for #2055.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ pi install npm:pi-subagents
 
 That is the only required step. Background children use the host's SDK: npm Pi keeps its detached Node runner; the official Pi 0.85.1 Linux x64 standalone release loads the same runner through Pi's embedded SDK, without a separate SDK install. See [Standalone background execution](docs/standalone-background.md) for the supported boundary and validation gate.
 
+For a local Pi session with a remote POSIX project, see [SSH foreground delegation](docs/ssh-project.md). This deliberately narrower entry supports selected agents and remote text read/bash, not ordinary workflows or background execution.
+
 ## Try this first
 
 You do not need to create agents, write config, or learn slash commands. After installing, ask Pi in plain language:

--- a/docs/ssh-project.md
+++ b/docs/ssh-project.md
@@ -1,0 +1,80 @@
+# SSH foreground delegation
+
+Keep Pi, model authentication, configuration and session files on your computer while reading and running commands in a remote POSIX project. The remote host needs OpenSSH access, Bash, `dd`, `base64` and `tr`—not Pi, Node, a service or synchronization software.
+
+This entry is intentionally narrower than ordinary pi-subagents: **fresh, single, native foreground children only**. It does not close the broader SSH execution request in #2047.
+
+## Start a session
+
+Use an npm-installed Pi 0.85.1 or newer and Node 22.22 or newer. Install the package's command if it is not already on PATH:
+
+```sh
+npm install -g pi-subagents
+```
+
+Create an explicitly selected local agent document, for example `ssh-worker.md`:
+
+```markdown
+---
+name: ssh-worker
+description: Work in the bound remote project
+tools: read,bash
+async: false
+defaultContext: fresh
+systemPromptMode: append
+---
+Complete the assigned task. Verify changes with remote commands and report evidence.
+```
+
+Then start the stock local Pi CLI:
+
+```sh
+pi-subagents-ssh --target user@host --project /srv/project --agent /absolute/local/ssh-worker.md
+```
+
+On Windows, the agent path is an absolute Windows path such as `C:\Users\you\agents\ssh-worker.md`; `/srv/project` is always a remote POSIX path. The launcher uses Node and the installed Pi JavaScript entry, not shell-interpolated commands or a `.cmd` shell wrapper. Native Windows terminal behavior still requires platform validation; the automated cross-platform command test verifies argv construction, not a Windows terminal session.
+
+Add trusted local provider extensions or selected skill documents explicitly:
+
+```sh
+pi-subagents-ssh --target host-alias --project /srv/project --agent /absolute/ssh-worker.md --extension /absolute/provider.ts --skill /absolute/SKILL.md
+```
+
+`--extension` and `--skill` may repeat. Optional startup controls are `--provider`, `--model`, `--mode text|json|rpc`, `--prompt` and `--offline`. There is no arbitrary forwarding of Pi flags. Local `@file` arguments, session/cwd switches, builtin/tool overrides and loading the ordinary subagent entry alongside this entry are rejected.
+
+Ask Pi to delegate to the selected agent with `async:false` and `context:fresh`. The same public structured delegation API remains available. The parent has remote `read`, remote `bash`, and the bounded `subagent` tool. Parent `!` commands use the same remote command operation.
+
+## Resources and identity
+
+- HOME, the normal Pi agent directory, credentials and global model settings stay local. SSH uses your normal OpenSSH configuration/authentication with batch mode, strict host-key checking, no agent/X11/port forwarding and no `SendEnv` forwarding. Establish host trust separately; this command does not disable verification or prompt for passwords.
+- The launcher preflights an empty, package-owned `ssh-control` directory under the normal agent directory before stock Pi can run cwd migrations or read cwd settings. Do not put project files there. It refuses a contaminated or symlinked control directory rather than cleaning it.
+- Project settings, packages, extensions, skills, SYSTEM/APPEND_SYSTEM and unrelated local project AGENTS files are not substituted for remote project resources. Automatic global extension/skill/prompt-template activation is also disabled; use explicit selections.
+- Intended global agent-directory context is restored explicitly. Remote AGENTS/CLAUDE candidates are read root-to-project in Pi's candidate order. Remote `.pi` configuration/executable resource discovery is unsupported. Symlinked project-directory identity is rejected; specify its physical POSIX path.
+- Agent and selected skill Markdown are bounded immutable local snapshots, not directory grants or stock `/skill:` commands. `read` defaults to the remote project. `scope: "local-resource"` reads only the exact path of a selected Markdown snapshot; it does not expose helpers, assets, neighboring files or credentials. Relative links do not grant access.
+- Child sessions and results remain local. Remote target identity contributes to the launch binding digest. A registered SSH session cannot silently launch an ordinary local child.
+
+## Supported profile and refusals
+
+Selected agents may specify name, description, model/thinking, read/bash tools, foreground/fresh defaults, timeout/tool timeout and the supported context settings. Use `systemPromptMode: append`; project/global context remains enabled and skills are explicitly selected rather than automatically inherited. Other frontmatter requirements are rejected, not dropped.
+
+The following are unsupported and rejected: workflows/chains/parallel scripts, background/detach, fork/resume/recovery, nested delegation, managed worktrees and hooks, local Git/acceptance checks, explicit output/progress files, structured-output contracts, project management and resource reload/session replacement. Models may retry within their initialized session, but automatic fresh-session/retained-session relaunch is disabled.
+
+**`/reload` terminates this opted-in SSH CLI with an error message.** Stock Pi has no cancellable pre-reload hook; exiting in the owned shutdown hook prevents rebuilding resources/tools without the SSH owner. Restart through the launcher for a fresh session. Existing persisted sessions are not deleted, but resuming them is not supported. Remote completion/cleanup may be uncertain. Ordinary non-SSH Pi reload is unchanged.
+
+Conflicting configured worktrees, forced async, permission contracts, budgets, intercom/control automation, proactive skills, Orca observers, schedules, missions, custom child session directories and project-local artifact placement are rejected before initialization. Existing capability ceilings, depth limits and session spawn budgets still constrain admission. This first profile supplies inline results without an acceptance-command contract; it does not claim that successful command output proves an acceptance review.
+
+An explicitly enabled global subagent watchdog is also unsupported: this entry rejects that policy rather than silently turning it off. The ordinary local watchdog is not constructed for remote projects, because its settings/Git readers operate locally.
+
+`write`, `edit`, `grep`, `find`, `ls`, PowerShell and image/binary reads are not provided. Search/edit/build/test can be performed through remote Bash. Trusted provider extensions are still trusted local code; this is execution routing, **not a sandbox**.
+
+## Bounds and cancellation
+
+Context initialization happens before joining the common child-open queue, so a stalled SSH prefetch does not hold up an ordinary local child. Context files are limited to 64 KiB each, at most 32 ancestor levels, with bounded aggregate transport output. Text reads are UTF-8 only, limited to 256 KiB per file, paged by line offset/limit. Larger inspection can use bounded remote Bash. Tool output truncation is reported.
+
+Transport defaults to 30 seconds; Bash accepts a timeout up to 300 seconds. Child delegation has a bounded overall deadline. Transport failure, overflow, invalid context or failed tool initialization never becomes local fallback.
+
+Cancellation kills the owned **local SSH transport**. Remote descendants can survive or finish after a disconnect; completion and cleanup may be uncertain. This does not support unattended remote background jobs or guarantee remote process-tree termination.
+
+## Validation boundary
+
+Automated tests use the actual installed Pi 0.85.1 CLI/SDK, synthetic local identity and mocked SSH/network seams. They exercise public delegation and model-generated read/bash calls, first-request context, distinct targets, stalled-prefetch independence, resource selection and fail-closed errors. They do not connect to a real host. Native Windows terminal/signal testing and an operator's real SSH configuration remain separate validation gates.

--- a/index.ts
+++ b/index.ts
@@ -6,5 +6,7 @@ const registerParentExtension = process.env.PI_SUBAGENT_CHILD === "1"
 	: (await import("./src/extension/index.ts")).default;
 
 export default function registerSubagentExtension(pi: ExtensionAPI): void {
+	const args = process.argv.slice(2), end = args.indexOf("--");
+	if (args.slice(0, end < 0 ? args.length : end).some(arg => arg === "--ssh-bootstrap" || arg.startsWith("--ssh-bootstrap="))) throw new Error("Ordinary subagent root cannot be loaded alongside the owned SSH entry.");
 	registerParentExtension?.(pi);
 }

--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
     "cli"
   ],
   "bin": {
-    "pi-subagents": "install.mjs"
+    "pi-subagents": "install.mjs",
+    "pi-subagents-ssh": "ssh-launch.mjs"
   },
   "files": [
     "index.ts",
+    "ssh-entry.ts",
     "src/**/*.ts",
     "*.mjs",
     "agents/",

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -2163,6 +2163,19 @@ function loadAgentsFromDefinitionFiles(files: AgentDefinitionFile[], source: Age
 	return { agents, diagnostics };
 }
 
+/** Decode one explicitly selected immutable document without any discovery. */
+export function loadSelectedAgentDocument(document: { path: string; content: string }): AgentConfig {
+	const { frontmatter } = parseFrontmatter(document.content);
+	if (frontmatter.inheritProjectContext === "false" || frontmatter.inheritGlobalContext === "false" || frontmatter.inheritSkills === "true") throw new Error("SSH requires isolated project/global context and explicitly selected skill documents.");
+	const allowed = new Set(["name", "description", "tools", "model", "thinking", "defaultContext", "async", "timeoutMs", "toolTimeoutMs", "inheritProjectContext", "inheritGlobalContext", "inheritSkills", "systemPromptMode"]);
+	if (Object.keys(frontmatter).some(key => !allowed.has(key))) throw new Error("Selected SSH agent declares an unsupported requirement.");
+	const result = loadAgentsFromDefinitionFiles([{ filePath: document.path, content: document.content }], "user");
+	if (result.diagnostics.length || result.agents.length !== 1) throw new Error("Invalid selected SSH agent document.");
+	const agent = result.agents[0]!;
+	if (agent.defaultContext === "fork" || agent.defaultAsync === true || agent.systemPromptMode === "replace" || agent.tools?.some(tool => !["read", "bash"].includes(tool))) throw new Error("Selected SSH agent requires unsupported execution capabilities.");
+	return { ...agent, tools: agent.tools ?? ["read", "bash"], allowNestedSubagents: false, inheritProjectContext: true, inheritGlobalContext: true, inheritSkills: false };
+}
+
 function loadAgentsFromDir(dir: string, source: AgentSource, discoveryPriority?: number, packageSource?: Omit<PackageSubagentPath, "dir" | "scope">, inspection = inspectAgentDefinitionDirectory(dir)): { agents: AgentConfig[]; diagnostics: AgentDiscoveryDiagnostic[] } {
 	return loadAgentsFromDefinitionFiles(readAgentDefinitionFiles(dir, inspection), source, discoveryPriority, packageSource);
 }

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -193,7 +193,7 @@ export function getConfigPath(): string {
 	return path.join(getAgentDir(), "extensions", "subagent", "config.json");
 }
 
-function readConfigForUpdate(configPath = getConfigPath()): ExtensionConfig {
+export function readConfigForUpdate(configPath = getConfigPath()): ExtensionConfig {
 	if (!fs.existsSync(configPath)) return {};
 	const parsed = JSON.parse(fs.readFileSync(configPath, "utf-8")) as unknown;
 	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -13,6 +13,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { createSshProjectSessionBinding, snapshotSshProjectBootstrap, type SshProjectBootstrap } from "../runs/shared/ssh-project-bootstrap.ts";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -420,7 +421,16 @@ export function projectActiveHerdrRuns(state: SubagentState): HerdrStatusRun[] {
 		});
 }
 
-export default function registerSubagentExtension(pi: ExtensionAPI): void {
+export default function registerSubagentExtension(pi: ExtensionAPI, bootstrap?: SshProjectBootstrap): void {
+	const sshProfile = bootstrap === undefined ? undefined : snapshotSshProjectBootstrap(bootstrap);
+	if (sshProfile && (process.env[SUBAGENT_CHILD_ENV] === "1" || path.resolve(getAgentDir()) !== sshProfile.localRuntime.agentDir)) {
+		throw new Error("SSH project bootstrap requires the selected local agent directory and a parent host.");
+	}
+	const sshSession = sshProfile ? createSshProjectSessionBinding(sshProfile) : undefined;
+	if (sshSession) {
+		pi.on("session_start", (_event, ctx) => sshSession.bind(ctx));
+		pi.on("session_shutdown", () => sshSession.dispose());
+	}
 	if (process.env[SUBAGENT_CHILD_ENV] === "1") {
 		return;
 	}
@@ -499,7 +509,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		getCurrentOwnerStates: () => executor.getCurrentSupervisorOwnerStates(),
 	});
 	const waitSubscriptionManager = createWaitSubscriptionManager(pi, state);
-	const mainWatchdog = registerMainWatchdog(pi);
+	// The local watchdog reads settings/Git even at construction. Do not create
+	// it for a remote project; remote safety/admission is not implemented yet.
+	const mainWatchdog = sshProfile ? undefined : registerMainWatchdog(pi);
 	const resultDeliveryOwnership = createResultDeliveryOwnership(state);
 	const completionNotifier = registerSubagentNotify(pi, state, { batchConfig: config.completionBatch, ownership: resultDeliveryOwnership });
 	let retainedNestedRouteTracker: ReturnType<typeof createRetainedNestedRouteTracker> | undefined;
@@ -543,6 +555,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	let advertisedContext: Pick<ExtensionContext, "cwd" | "model"> | undefined;
 	const refreshAdvertisedAgents = () => {
 		advertisedAgents = [];
+		if (sshProfile) return;
 		if (!advertisedContext) return;
 		clearAgentDiscoveryCache();
 		advertisedAgents = discoverAgents(advertisedContext.cwd, "both", advertisedContext.model?.provider).agents
@@ -555,6 +568,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		return missionObserverResultCandidateFiles(DIRS.results).length > 0;
 	};
 	const discoverAgentsForRuntime = (cwd: string, scope: AgentScope, preferredModelProvider?: string) => {
+		if (sshProfile) throw new Error("SSH project agent discovery is not implemented; local discovery refused.");
 		if (listRuntimeAgentConfigs(pi).length === 0) return discoverAgents(cwd, scope, preferredModelProvider);
 		const snapshot = discoverAgentSnapshot(cwd, scope, preferredModelProvider, { includeChains: false });
 		const discovered = snapshot.effective;
@@ -615,6 +629,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	const executorDeps: Parameters<typeof createSubagentExecutor>[0] = {
 		pi,
+		assertLocalExecution: sshSession?.assertLocalExecution,
+		sshProject: sshProfile,
 		state,
 		config,
 		asyncByDefault,
@@ -761,8 +777,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	const tool: ToolDefinition<typeof parameters, Details> = {
 		name: "subagent",
 		label: "Subagent",
-		description: buildSubagentToolDescription(config),
-		...buildSubagentToolPromptMetadata(config),
+		description: sshProfile ? "Delegate one fresh native foreground child to the explicitly selected SSH agent. Specify agent, task, async:false, context:fresh. Workflows, background, resume, outputs and project management are unsupported." : buildSubagentToolDescription(config),
+		...(sshProfile ? { promptSnippet: "Delegate one fresh foreground child in the bound SSH project; no workflows/background/resume.", promptGuidelines: ["Use subagent with the explicitly selected agent, task, async:false and context:fresh."] } : buildSubagentToolPromptMetadata(config)),
 		parameters,
 
 		async execute(id, params, signal, onUpdate, ctx) {
@@ -970,8 +986,10 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			granted: 0,
 			grantHistory: [],
 		};
-		const projectPaneOwnerRoot = path.resolve(ctx.cwd);
-		restoreHerdrProjectPaneSnapshots(state, [...new Set([...(state.herdrProjectPanes?.keys() ?? []), ...listHerdrProjectPaneRoots(projectPaneOwnerRoot), projectPaneOwnerRoot])]);
+		if (!sshProfile) {
+			const projectPaneOwnerRoot = path.resolve(ctx.cwd);
+			restoreHerdrProjectPaneSnapshots(state, [...new Set([...(state.herdrProjectPanes?.keys() ?? []), ...listHerdrProjectPaneRoots(projectPaneOwnerRoot), projectPaneOwnerRoot])]);
+		}
 		// Set PI_SUBAGENT_PARENT_SESSION for permission-system forwarding.
 		// Only set in the root session (the interactive UI session), not in a
 		// child host: the runner process inherits the parent's value through
@@ -1047,7 +1065,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 			stopResultWatcher();
 			resultDeliveryOwnership.clear();
 			completionNotifier.dispose();
-			mainWatchdog.dispose();
+			mainWatchdog?.dispose();
 			scheduledRunManager.stop();
 			supervisorChannel.dispose();
 			waitSubscriptionManager.dispose();

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -384,8 +384,8 @@ async function runSingleAttempt(
 	// runtime config and echoed back on the result payload so hosts can label
 	// this run without reading the child's session file.
 	const childSessionName = deriveChildSessionName({ agent: agent.name, task: shared.originalTask ?? task });
-	const watchdogConfig = resolveWatchdogConfig(options.cwd ?? runtimeCwd);
-	const childWatchdog = watchdogConfig.ok
+	const watchdogConfig = options.sshProject ? undefined : resolveWatchdogConfig(options.cwd ?? runtimeCwd);
+	const childWatchdog = watchdogConfig?.ok
 		? resolveChildWatchdogConfig({
 			config: watchdogConfig.config,
 			agent: agent.name,
@@ -399,6 +399,9 @@ async function runSingleAttempt(
 		: undefined;
 	let onWatchdogStatus: ((event: ChildWatchdogStatusEvent) => void) | undefined;
 	const launch = buildInProcessChildLaunch({
+		sshProject: options.sshProject,
+		sshSignal: options.sshProject ? options.signal : undefined,
+		extensionBindings: options.extensionBindings,
 		sessionEnabled: shared.sessionEnabled,
 		sessionDir: options.sessionDir,
 		sessionFile: options.sessionFile,
@@ -576,7 +579,9 @@ async function runSingleAttempt(
 		};
 		return result;
 	}
-	const mutationSnapshot = snapshotTrackedMutations(options.cwd ?? runtimeCwd);
+	const mutationSnapshot: ReturnType<typeof snapshotTrackedMutations> = options.sshProject
+		? { source: "tracked-files", trackedOnly: true, cwd: options.cwd ?? runtimeCwd, dirtyFiles: [], fingerprints: {}, unavailable: "Remote mutation evidence is not collected; local Git is not a substitute." }
+		: snapshotTrackedMutations(options.cwd ?? runtimeCwd);
 	let observedMutationAttempt = false;
 	let structuredOutputToolInvoked = false;
 	let structuredOutputMessageStartIndex: number | undefined;
@@ -1769,7 +1774,7 @@ async function runSyncCompletionInner(
 	}
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const skillCwd = options.cwd ?? runtimeCwd;
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+	const { resolved: resolvedSkills, missing: missingSkills } = options.sshProject ? { resolved: [], missing: [] } : resolveSkillsWithFallback(
 		skillNames,
 		skillCwd,
 		runtimeCwd,
@@ -1792,11 +1797,11 @@ async function runSyncCompletionInner(
 		const skillInjection = buildSkillInjection(resolvedSkills);
 		systemPrompt = systemPrompt ? `${systemPrompt}\n\n${skillInjection}` : skillInjection;
 	}
-	const memoryInjection = buildAgentMemoryInjection(agent, skillCwd);
+	const memoryInjection = options.sshProject ? undefined : buildAgentMemoryInjection(agent, skillCwd);
 	if (memoryInjection) {
 		systemPrompt = systemPrompt ? `${systemPrompt}\n\n${memoryInjection}` : memoryInjection;
 	}
-	systemPrompt = appendAgentRefinementOverlay(systemPrompt, { cwd: skillCwd, agentName });
+	if (!options.sshProject) systemPrompt = appendAgentRefinementOverlay(systemPrompt, { cwd: skillCwd, agentName });
 	systemPrompt = injectOutputPathSystemPrompt(systemPrompt, options.outputPath, agent);
 
 	const candidates = buildModelCandidates(
@@ -1871,7 +1876,7 @@ async function runSyncCompletionInner(
 		}
 	}
 
-	const orcaProgressTab = createOrcaProgressTab({
+	const orcaProgressTab = options.sshProject ? undefined : createOrcaProgressTab({
 		cwd: options.cwd ?? runtimeCwd,
 		runId: options.runId,
 		agent: agentName,
@@ -1973,6 +1978,7 @@ async function runSyncCompletionInner(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
+			if (options.sshProject) break modelAttemptsLoop;
 			// A consumed retained continuation is terminal even on a startup error or abort.
 			if (recoveryState === "readonly-continuation") break modelAttemptsLoop;
 			const source = settledReadonlySource.get(result);

--- a/src/runs/foreground/ssh-execution.ts
+++ b/src/runs/foreground/ssh-execution.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "node:crypto";
+import * as path from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { loadSelectedAgentDocument } from "../../agents/agents.ts";
+import { checkSubagentDepth, type Details, type ExtensionConfig, type SubagentState } from "../../shared/types.ts";
+import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
+import { reserveSpawnBudget } from "../shared/spawn-budget.ts";
+import type { SshProjectBootstrap } from "../shared/ssh-project-bootstrap.ts";
+import type { SubagentParamsLike } from "./subagent-executor.ts";
+import { intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
+import { runSync } from "./execution.ts";
+
+export function validateSshConfig(config: ExtensionConfig): void {
+	for (const key of ["worktree", "worktreeSetupHook", "permissions", "toolBudget", "usageBudget", "forceTopLevelAsync", "intercomBridge", "control", "proactiveSkillSubagents", "orcaProgressTabs", "scheduledRuns", "missions", "defaultSessionDir"] as const) {
+		const value = config[key];
+		if (value !== undefined && value !== false) throw new Error(`SSH does not support configured ${key}.`);
+	}
+	if (config.artifactDir === "project") throw new Error("SSH does not support project-local artifact placement.");
+}
+
+/** Admission precedes the ordinary executor's workflows, discovery, and Git paths. */
+export async function executeSshForeground(profile: SshProjectBootstrap, config: ExtensionConfig, state: SubagentState, params: SubagentParamsLike, ctx: ExtensionContext, signal: AbortSignal, onUpdate?: (result: AgentToolResult<Details>) => void): Promise<AgentToolResult<Details>> {
+	const allowed = new Set(["agent", "task", "async", "context", "model", "thinking", "timeoutMs", "toolTimeoutMs", "capabilityCeiling"]);
+	const neutral: Record<string, unknown> = { cwd: profile.localRuntime.cwd, acceptance: false, artifacts: false, foregroundOnly: true, clarify: false, skill: false };
+	if (Object.entries(params).some(([key, value]) => value !== undefined && !allowed.has(key) && (!Object.hasOwn(neutral, key) || neutral[key] !== value))) throw new Error("SSH supports only fresh single foreground delegation; requested operation is unsupported.");
+	if (!profile.selectedDocuments) throw new Error("SSH selected agent is unavailable.");
+	const agent = loadSelectedAgentDocument(profile.selectedDocuments.agent);
+	if (params.agent !== agent.name || !params.task?.trim()) throw new Error("SSH delegation requires the explicitly selected agent and a task.");
+	if ((params.async ?? agent.defaultAsync ?? config.asyncByDefault ?? false) !== false || (params.context ?? agent.defaultContext ?? config.defaultSubagentContext ?? "fresh") !== "fresh") throw new Error("SSH requires effective async:false and context:fresh.");
+	// These global contracts would activate unsupported host work. Never silently discard them.
+	validateSshConfig(config);
+	const sessionId = resolveCurrentSessionId(ctx.sessionManager);
+	const ceiling = intersectSubagentCapabilityCeilings(params.capabilityCeiling, resolveCurrentSubagentCapabilityCeiling(sessionId), resolveCurrentSubagentCapabilityCeiling(ctx.sessionManager.getSessionId()));
+	if (ceiling?.denyExtensions
+		|| (ceiling?.allowedAgents && !ceiling.allowedAgents.includes(agent.name))
+		|| (ceiling?.allowedTools && agent.tools?.some(tool => !ceiling.allowedTools!.includes(tool)))) {
+		throw new Error("SSH profile conflicts with the current capability ceiling.");
+	}
+	if (checkSubagentDepth(config.maxSubagentDepth).blocked) throw new Error("SSH delegation exceeds the current depth ceiling.");
+	const budget = reserveSpawnBudget(state, config, sessionId, 1);
+	if (budget.error) throw new Error(budget.error);
+	const timeoutMs = params.timeoutMs ?? agent.defaultTimeoutMs ?? config.timeoutMs ?? 300_000;
+	const result = await runSync(profile.localRuntime.cwd, [agent], agent.name, params.task, {
+		runId: randomUUID(), context: "fresh", cwd: profile.localRuntime.cwd, signal: AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)]), onUpdate,
+		sshProject: profile, capabilityCeiling: ceiling, modelOverride: params.model ?? agent.model ?? (ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined),
+		extensionBindings: { "pi-subagents.ssh-project/1": { target: profile.target, projectDir: profile.projectDir } },
+		timeoutMs,
+		toolTimeoutMs: params.toolTimeoutMs ?? agent.defaultToolTimeoutMs,
+		configToolTimeoutMs: config.toolTimeoutMs,
+		parentSessionId: ctx.sessionManager.getSessionId(),
+		sessionDir: path.join(profile.localRuntime.agentDir, "sessions", "ssh-foreground"),
+		acceptance: false,
+		thinkingOverride: params.thinking as typeof agent.thinking,
+	});
+	return { content: [{ type: "text", text: result.finalOutput || result.error || "SSH child completed." }], details: { mode: "single", results: [result] }, ...(result.exitCode !== 0 || result.error ? { isError: true } : {}) };
+}

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { executeSshForeground } from "./ssh-execution.ts";
+import type { SshProjectBootstrap } from "../shared/ssh-project-bootstrap.ts";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
@@ -435,6 +437,9 @@ function rememberParentModel(state: { currentSessionId?: string | null; lastPare
 
 interface ExecutorDeps {
 	pi: ExtensionAPI;
+	/** Internal startup boundary: remote sessions must not enter local preparation. */
+	assertLocalExecution?: (ctx: ExtensionContext) => void;
+	sshProject?: SshProjectBootstrap;
 	state: SubagentState;
 	config: ExtensionConfig;
 	asyncByDefault: boolean;
@@ -4885,7 +4890,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		preserveActiveSession = false,
 		parentModelOverride?: ParentModel | null,
 	): Promise<AgentToolResult<Details>> => {
+		deps.assertLocalExecution?.(ctx);
 		const workflowLaunchObserver = workflowLaunchObservers.get(params);
+		if (!deps.sshProject && Object.hasOwn(params.extensionBindings ?? {}, "pi-subagents.ssh-project/1")) throw new Error("SSH binding requires the owned SSH entry; local launch refused.");
+		if (deps.sshProject) return executeSshForeground(deps.sshProject, deps.config, deps.state, { ...params, ...(delegatedThinkingOverrides.has(params) ? { thinking: delegatedThinkingOverrides.get(params) } : {}) }, ctx, signal, onUpdate);
 		const inheritedUsageBudget = workflowOwnedUsageBudgets.get(params);
 		const delegatedThinkingOverride = delegatedThinkingOverrides.get(params);
 		const allowZeroToolBudget = delegatedZeroToolBudgets.has(params);
@@ -7234,7 +7242,10 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		onUpdate: ((r: AgentToolResult<Details>) => void) | undefined,
 		ctx: ExtensionContext,
 	): Promise<AgentToolResult<Details>> => {
+		deps.assertLocalExecution?.(ctx);
 		const normalized = normalizePublicSubagentExecution(params);
+		if (!deps.sshProject && Object.hasOwn(params.extensionBindings ?? {}, "pi-subagents.ssh-project/1")) throw new Error("SSH binding requires the owned SSH entry; local launch refused.");
+		if (deps.sshProject) return executeSshForeground(deps.sshProject, deps.config, deps.state, params, ctx, signal, onUpdate);
 		if (!normalized.ok) {
 			return Promise.resolve({ content: [{ type: "text", text: normalized.error }], isError: true, details: { mode: normalized.mode, results: [] } });
 		}
@@ -7286,7 +7297,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		signal: AbortSignal,
 		ctx: ExtensionContext,
 	) => {
+		deps.assertLocalExecution?.(ctx);
 		const ownerSessionId = resolveCurrentSessionId(ctx.sessionManager);
+		if (deps.sshProject) throw new Error("SSH scheduled launches are unsupported.");
 		const runtimeOwnerId = ctx.sessionManager.getSessionId() || null;
 		let ownerExecutors = scheduledOwnerExecutors.get(runtimeOwnerId);
 		if (!ownerExecutors) {

--- a/src/runs/shared/child-launch.ts
+++ b/src/runs/shared/child-launch.ts
@@ -60,6 +60,8 @@ export function inheritedChildRuntime(config: ChildRuntimeConfig | undefined): I
 }
 
 export interface BuildInProcessChildLaunchInput {
+	sshProject?: import("./ssh-project-bootstrap.ts").SshProjectBootstrap;
+	sshSignal?: AbortSignal;
 	parentSessionId?: string;
 	forkCacheKey?: string;
 	sessionEnabled: boolean;
@@ -293,6 +295,8 @@ export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput)
 		? `<active_agent name="${escapeXmlAttr(input.childAgentName)}"/>\n\n${input.systemPrompt}`
 		: undefined;
 	const session: Omit<ChildSessionLaunch, "onExtensionError"> = {
+		...(input.sshProject ? { sshProject: input.sshProject } : {}),
+		...(input.sshSignal ? { sshSignal: input.sshSignal } : {}),
 		cwd: input.cwd,
 		storage: childStorage(input),
 		...(input.model ? { model: input.model } : {}),

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -53,6 +53,8 @@ export type ChildSessionStorage =
 	| { kind: "memory" };
 
 export interface ChildSessionLaunch {
+	sshProject?: import("./ssh-project-bootstrap.ts").SshProjectBootstrap;
+	sshSignal?: AbortSignal;
 	cwd: string;
 	storage: ChildSessionStorage;
 	/** Model reference as the agent config names it (`provider/id`, optionally `:thinking`). */
@@ -208,11 +210,19 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 	};
 	return {
 		async create(launch) {
+			// Network prefetch must never occupy the shared local initialization queue.
+			const ssh = launch.sshProject ? await import("./ssh-project-tools.ts") : undefined;
+			const sshContext = ssh && launch.sshProject ? await ssh.prepareSshContext(launch.sshProject, launch.sshSignal) : undefined;
+			const sshTools = ssh && launch.sshProject ? ssh.createSshProjectTools(launch.sshProject) : undefined;
+			const sshPromptContext = launch.sshProject ? [launch.sshProject.globalContext, sshContext, ...(launch.sshProject.selectedDocuments?.skills ?? []).map(doc => `Selected local Markdown snapshot (${doc.path}):\n${doc.content}`)].filter(Boolean).join("\n\n") : undefined;
+			const sshErrors: ChildSessionExtensionError[] = [];
+			const reportExtensionError = (error: ChildSessionExtensionError) => { if (sshTools) sshErrors.push(error); launch.onExtensionError?.(error); };
+			let ownedToolsReady: (() => boolean) | undefined;
 			const observeReadonly = prepareReadonlySessionEvidence(launch);
 			const pi = await loadPiCodingAgent();
 			const modelRuntime = await sharedRuntime(pi);
 			const agentDir = getAgentDir();
-			const settingsManager = pi.SettingsManager.create(launch.cwd, agentDir);
+			const settingsManager = pi.SettingsManager.create(launch.cwd, agentDir, ...(launch.sshProject ? [{ projectTrusted: false }] as const : []));
 			// Foreground children share Pi's global theme with the parent, so reinitializing it
 			// would overwrite the parent's active light/dark appearance. Detached runners have
 			// no initialized theme and must initialize one for headless extension renderers.
@@ -224,22 +234,33 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 				agentDir,
 				settingsManager,
 				noExtensions: !launch.ambientExtensions,
-				noSkills: launch.noSkills,
+				noSkills: launch.sshProject ? true : launch.noSkills,
 				noPromptTemplates: true,
 				noThemes: true,
-				noContextFiles: launch.noContextFiles,
-				additionalExtensionPaths: launch.extensionPaths,
-				extensionFactories: launch.hooks,
+				noContextFiles: launch.sshProject ? true : launch.noContextFiles,
+				additionalExtensionPaths: launch.sshProject ? [...(launch.sshProject.extensions ?? [])] : launch.extensionPaths,
+				extensionFactories: sshTools ? [...launch.hooks, { name: "pi-subagents:ssh-owned", factory: (api: ExtensionAPI) => {
+					for (const tool of sshTools) api.registerTool(tool);
+					api.on("before_agent_start", event => ({ systemPrompt: `${event.systemPrompt}\n\nProject tools operate in ssh://${launch.sshProject!.target}${launch.sshProject!.projectDir}; ${launch.cwd} is local runtime/state only.\n${event.systemPrompt.includes(sshPromptContext!) ? "" : sshPromptContext}` }));
+					api.on("tool_call", event => { if (sshTools.some(tool => tool.name === event.toolName) && !ownedToolsReady?.()) return { block: true, reason: "SSH owned tools changed; local fallback refused." }; });
+					api.on("session_before_switch", () => ({ cancel: true }));
+					api.on("session_before_fork", () => ({ cancel: true }));
+					api.on("session_before_tree", () => ({ cancel: true }));
+				} }] : launch.hooks,
+				...(launch.sshProject ? { agentsFilesOverride: () => ({ agentsFiles: [{ path: `ssh://${launch.sshProject!.target}${launch.sshProject!.projectDir}`, content: sshPromptContext! }] }) } : {}),
 				extensionsOverride: prioritizeChildPromptRuntime,
 				...(launch.systemPrompt !== undefined ? { systemPrompt: launch.systemPrompt } : {}),
 				...(launch.appendSystemPrompt !== undefined ? { appendSystemPrompt: [launch.appendSystemPrompt] } : {}),
 			});
 			const open = async () => {
+				launch.sshSignal?.throwIfAborted();
 				applyProcessEnv(launch.processEnv);
 				if (!resetExtensionCacheOnReload(loader) && (launch.ambientExtensions || launch.extensionPaths.length)) launch.onExtensionError?.({ extensionPath: "<loader>", event: "load", error: new Error("pi's extension cache reset is unavailable; extensions loaded into this child share module state with other sessions in this process.") });
 				observeReadonly?.loadingHooks(true);
 				try { await loader.reload(); } finally { observeReadonly?.loadingHooks(false); }
-				await flushQueuedProviderRegistrations(loader, modelRuntime, launch.onExtensionError);
+				if (sshTools && loader.getExtensions().errors.length) throw new Error("SSH child extension initialization failed; no local fallback.");
+				await flushQueuedProviderRegistrations(loader, modelRuntime, reportExtensionError);
+				if (sshErrors.length) throw new Error("SSH child provider initialization failed.");
 				// No await between receipt validation and the SDK's permissive file open.
 				observeReadonly?.beforeOpen();
 				const sessionManager = launch.storage.kind === "file"
@@ -270,8 +291,13 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 				try {
 					await session.bindExtensions({
 						mode: "print",
-						onError: (error) => launch.onExtensionError?.({ extensionPath: error.extensionPath, event: error.event, error: error.error }),
+						onError: (error) => reportExtensionError({ extensionPath: error.extensionPath, event: error.event, error: error.error }),
 					});
+					if (sshTools) for (const tool of sshTools) {
+						if (launch.tools?.includes(tool.name) && (session.getToolDefinition(tool.name) !== tool || session.getAllTools().find(info => info.name === tool.name)?.sourceInfo?.path !== "<inline:pi-subagents:ssh-owned>")) throw new Error("SSH owned tool readiness failed.");
+					}
+					if (sshTools) ownedToolsReady = () => !sshErrors.length && sshTools.every(tool => !launch.tools?.includes(tool.name) || session.getToolDefinition(tool.name) === tool);
+					if (sshErrors.length) throw new Error("SSH child startup failed; no prompt is permitted.");
 				} catch (error) {
 					session.dispose();
 					throw error;
@@ -281,6 +307,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 			const opened = loading.catch(() => {}).then(open);
 			loading = opened;
 			const session = await opened;
+			if (launch.sshSignal?.aborted) { session.dispose(); launch.sshSignal.throwIfAborted(); }
 			let evidence: ReturnType<NonNullable<typeof observeReadonly>["observe"]>;
 			try { evidence = observeReadonly?.observe(pi, modelRuntime, session); }
 			catch (error) { session.dispose(); throw error; }
@@ -307,6 +334,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 			const child: ChildSession = {
 				subscribe: (listener) => session.subscribe((event) => listener(event as unknown as ChildSessionEvent)),
 				prompt: (text) => {
+					if (sshTools && !ownedToolsReady?.()) return Promise.reject(new Error("SSH owned tool readiness failed before prompt."));
 					if (!evidence) return session.prompt(text);
 					try { evidence.start(); } catch (error) { return Promise.reject(error); }
 					return session.prompt(text).then(() => evidence?.settled(), (error) => { evidence?.invalidate(); throw error; });

--- a/src/runs/shared/ssh-cli-entry.ts
+++ b/src/runs/shared/ssh-cli-entry.ts
@@ -1,0 +1,111 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { snapshotSshProjectBootstrap, type SshProjectBootstrap } from "./ssh-project-bootstrap.ts";
+
+// Internal stock-CLI checkpoint. No general Pi argument forwarding.
+export const SSH_BOOTSTRAP_FLAG = "--ssh-bootstrap=";
+export const SSH_ENTRY = fileURLToPath(new URL("../../../ssh-entry.ts", import.meta.url));
+export const SSH_ROOT = fileURLToPath(new URL("../../../index.ts", import.meta.url));
+export const SSH_ISOLATION_ARGS = ["--no-approve", "--no-context-files", "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-builtin-tools", "--tools", "read,bash,subagent"];
+const fail = (): never => { throw new Error("Unsupported SSH entry arguments or local resources."); };
+
+export interface SshEntrySelection {
+	target: string;
+	project: string;
+	agent: string;
+	extensions: string[];
+	skills: string[];
+	provider?: string;
+	model?: string;
+	mode?: string;
+	prompt?: string;
+	offline?: boolean;
+}
+
+export function parseSshEntrySelection(args: string[]): SshEntrySelection {
+	const selection: Record<string, unknown> = { extensions: [], skills: [] };
+	for (let i = 0; i < args.length; i++) {
+		const flag = args[i];
+		if (flag === "--offline" && selection.offline === undefined) { selection.offline = true; continue; }
+		if (!["--target", "--project", "--agent", "--extension", "--skill", "--provider", "--model", "--mode", "--prompt"].includes(flag!)) return fail();
+		const value = args[++i];
+		if (!value || value.startsWith("-") || value.startsWith("@") || /[\u0000-\u001f\u007f]/u.test(value)) return fail();
+		const key = flag!.slice(2);
+		if (key === "extension" || key === "skill") (selection[key === "extension" ? "extensions" : "skills"] as string[]).push(value);
+		else { if (selection[key] !== undefined) return fail(); selection[key] = value; }
+	}
+	if (!selection.target || !selection.project || !selection.agent || (selection.mode !== undefined && !["text", "json", "rpc"].includes(selection.mode as string))) return fail();
+	return selection as unknown as SshEntrySelection;
+}
+
+export function localAgentDir(): string {
+	const value = process.env.PI_CODING_AGENT_DIR;
+	return path.resolve(value === "~" ? os.homedir() : value && /^~[/\\]/u.test(value) ? path.join(os.homedir(), value.slice(2)) : value || path.join(os.homedir(), ".pi", "agent"));
+}
+
+function selectedFile(value: string, markdown: boolean): string {
+	if (!path.isAbsolute(value) || (markdown && !/\.md$/iu.test(value))) return fail();
+	const real = fs.realpathSync(value);
+	if (markdown && !/\.md$/iu.test(real)) return fail();
+	if (!fs.statSync(real).isFile()) return fail();
+	return real;
+}
+
+export function validateSshEntrySelection(selection: SshEntrySelection, cwd: string, agentDir: string): { selection: SshEntrySelection; profile: SshProjectBootstrap } {
+	const profile = snapshotSshProjectBootstrap({ target: selection.target, projectDir: selection.project, childProfile: "fresh-native-read-bash", localRuntime: { cwd, agentDir, projectTrusted: false, noContextFiles: true, projectDiscovery: "disabled" } });
+	const agent = selectedFile(selection.agent, true);
+	const skills = selection.skills.map(file => selectedFile(file, true));
+	const extensions = selection.extensions.map(file => selectedFile(file, false));
+	if (extensions.some(file => file === fs.realpathSync(SSH_ENTRY) || file === fs.realpathSync(SSH_ROOT)) || new Set(extensions).size !== extensions.length || new Set(skills).size !== skills.length) return fail();
+	return { selection: { target: selection.target, project: selection.project, agent, skills, extensions, ...(selection.provider ? { provider: selection.provider } : {}), ...(selection.model ? { model: selection.model } : {}), ...(selection.mode ? { mode: selection.mode } : {}), ...(selection.prompt ? { prompt: selection.prompt } : {}), ...(selection.offline ? { offline: true } : {}) }, profile };
+}
+
+export function assertCleanSshControl(cwd: string): void {
+	const stat = fs.lstatSync(cwd);
+	if (!stat.isDirectory() || stat.isSymbolicLink() || (process.platform !== "win32" && (stat.mode & 0o077) !== 0) || (process.getuid && stat.uid !== process.getuid()) || fs.readdirSync(cwd).length !== 0) return fail();
+}
+
+export function sshStockCliArgs(selection: SshEntrySelection, profile: SshProjectBootstrap): string[] {
+	const bootstrap = Buffer.from(JSON.stringify({ selection, profile })).toString("base64url");
+	if (bootstrap.length > 16384) return fail();
+	return [...SSH_ISOLATION_ARGS, ...selection.extensions.flatMap(file => ["-e", file]), "-e", SSH_ENTRY, `${SSH_BOOTSTRAP_FLAG}${bootstrap}`,
+		...(selection.provider ? ["--provider", selection.provider] : []), ...(selection.model ? ["--model", selection.model] : []), ...(selection.mode ? ["--mode", selection.mode] : []), ...(selection.offline ? ["--offline"] : []), ...(selection.prompt ? ["--", selection.prompt] : [])];
+}
+
+export function consumeSshStockCliArgs(args: string[]): { selection: SshEntrySelection; profile: SshProjectBootstrap } {
+	const values = args.filter(arg => arg.startsWith(SSH_BOOTSTRAP_FLAG));
+	if (values.length !== 1) return fail();
+	const value = values[0]!.slice(SSH_BOOTSTRAP_FLAG.length);
+	if (!value || value.length > 16384 || !/^[A-Za-z0-9_-]+$/u.test(value)) return fail();
+	try {
+		const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+		// Re-run the small launcher grammar rather than trusting decoded JSON fields.
+		const selection = decoded.selection as SshEntrySelection;
+		const parsed = parseSshEntrySelection(["--target", selection.target, "--project", selection.project, "--agent", selection.agent,
+			...selection.extensions.flatMap(file => ["--extension", file]), ...selection.skills.flatMap(file => ["--skill", file]),
+			...(selection.provider ? ["--provider", selection.provider] : []), ...(selection.model ? ["--model", selection.model] : []), ...(selection.mode ? ["--mode", selection.mode] : []), ...(selection.offline ? ["--offline"] : []), ...(selection.prompt ? ["--prompt", selection.prompt] : [])]);
+		const validated = validateSshEntrySelection(parsed, process.cwd(), localAgentDir());
+		if (JSON.stringify(args) !== JSON.stringify(sshStockCliArgs(validated.selection, validated.profile))) return fail();
+		assertCleanSshControl(validated.profile.localRuntime.cwd);
+		return validated;
+	} catch { return fail(); }
+}
+
+export function readSelectedMarkdown(file: string): Readonly<{ path: string; content: string }> {
+	const fd = fs.openSync(file, "r");
+	try {
+		const stat = fs.fstatSync(fd);
+		if (!stat.isFile() || stat.size > 64 * 1024) return fail();
+		const bytes = Buffer.alloc(64 * 1024 + 1);
+		let count = 0;
+		while (count < bytes.length) {
+			const read = fs.readSync(fd, bytes, count, bytes.length - count, count);
+			if (read === 0) break;
+			count += read;
+		}
+		if (count > 64 * 1024) return fail();
+		return Object.freeze({ path: file, content: new TextDecoder("utf-8", { fatal: true }).decode(bytes.subarray(0, count)).replace(/^\uFEFF/u, "") });
+	} finally { fs.closeSync(fd); }
+}

--- a/src/runs/shared/ssh-project-bootstrap.ts
+++ b/src/runs/shared/ssh-project-bootstrap.ts
@@ -1,0 +1,74 @@
+import * as path from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+/** The owned startup host must establish these controls
+ * before SDK resource loading; an extension cannot undo prior project discovery.
+ * Selection is not admission: the executor validates effective child requests.
+ */
+export interface SshProjectBootstrap {
+	readonly target: string;
+	readonly projectDir: string;
+	readonly localRuntime: {
+		readonly cwd: string;
+		readonly agentDir: string;
+		readonly projectTrusted: false;
+		readonly noContextFiles: true;
+		readonly projectDiscovery: "disabled";
+	};
+	readonly childProfile: "fresh-native-read-bash";
+	readonly extensions?: readonly string[];
+	readonly globalContext?: string;
+	readonly selectedDocuments?: {
+		readonly agent: Readonly<{ path: string; content: string }>;
+		readonly skills: readonly Readonly<{ path: string; content: string }>[];
+	};
+}
+
+/** Validate and snapshot before parent registration (including watchdog construction). */
+export function snapshotSshProjectBootstrap(input: SshProjectBootstrap): SshProjectBootstrap {
+	const fail = (): never => { throw new Error("Unsupported SSH project bootstrap; isolated explicit local runtime and fresh-native-read-bash profile required."); };
+	if (!input || typeof input !== "object") return fail();
+	if (Object.keys(input).some(key => !["target", "projectDir", "localRuntime", "childProfile", "selectedDocuments", "extensions", "globalContext"].includes(key))) return fail();
+	const { target, projectDir, localRuntime, childProfile } = input;
+	if (typeof target !== "string" || target.length > 256 || !/^(?:[A-Za-z0-9_][A-Za-z0-9_.-]*@)?[A-Za-z0-9_][A-Za-z0-9_.-]*$/u.test(target)) return fail();
+	if (typeof projectDir !== "string" || !projectDir.startsWith("/") || projectDir.length > 4096 || /[\u0000-\u001f\u007f]/u.test(projectDir)) return fail();
+	if (!localRuntime || localRuntime.projectTrusted !== false || localRuntime.noContextFiles !== true || localRuntime.projectDiscovery !== "disabled" || childProfile !== "fresh-native-read-bash") return fail();
+	if (Object.keys(localRuntime).some(key => !["cwd", "agentDir", "projectTrusted", "noContextFiles", "projectDiscovery"].includes(key))) return fail();
+	for (const value of [localRuntime.cwd, localRuntime.agentDir]) {
+		if (typeof value !== "string" || !path.isAbsolute(value) || /[\u0000-\u001f\u007f]/u.test(value)) return fail();
+	}
+	const document = (value: Readonly<{ path: string; content: string }>) => {
+		if (!value || typeof value.path !== "string" || !path.isAbsolute(value.path) || typeof value.content !== "string" || Buffer.byteLength(value.content) > 64 * 1024) return fail();
+		return Object.freeze({ path: value.path, content: value.content });
+	};
+	const selectedDocuments = input.selectedDocuments === undefined ? undefined : Object.freeze({
+		agent: document(input.selectedDocuments.agent), skills: Object.freeze(input.selectedDocuments.skills.map(document)),
+	});
+	if (input.extensions?.some(file => typeof file !== "string" || !path.isAbsolute(file)) || (input.globalContext !== undefined && (typeof input.globalContext !== "string" || Buffer.byteLength(input.globalContext) > 65536))) return fail();
+	return Object.freeze({ target, projectDir, childProfile, ...(input.extensions ? { extensions: Object.freeze([...input.extensions]) } : {}), ...(input.globalContext !== undefined ? { globalContext: input.globalContext } : {}), ...(selectedDocuments ? { selectedDocuments } : {}), localRuntime: Object.freeze({
+		cwd: path.resolve(localRuntime.cwd), agentDir: path.resolve(localRuntime.agentDir),
+		projectTrusted: false as const, noContextFiles: true as const, projectDiscovery: "disabled" as const,
+	}) });
+}
+
+/** One registration owns one actual session; no ambient/process-global target. */
+export function createSshProjectSessionBinding(profile: SshProjectBootstrap) {
+	let sessionId: string | undefined;
+	let closed = false;
+	return {
+		bind(ctx: ExtensionContext): void {
+			const id = ctx.sessionManager.getSessionId();
+			if (closed || !id || (sessionId !== undefined && sessionId !== id) || path.resolve(ctx.cwd) !== profile.localRuntime.cwd) {
+				throw new Error("SSH project bootstrap cannot bind a different local runtime or replacement session.");
+			}
+			sessionId = id;
+		},
+		assertLocalExecution(ctx: ExtensionContext): void {
+			if (closed || !sessionId || sessionId !== ctx.sessionManager.getSessionId()) {
+				throw new Error("SSH project session binding is unavailable; local delegation refused.");
+			}
+			if (!profile.selectedDocuments) throw new Error("SSH project child profile unavailable; local delegation refused.");
+		},
+		dispose(): void { closed = true; },
+	};
+}

--- a/src/runs/shared/ssh-project-tools.ts
+++ b/src/runs/shared/ssh-project-tools.ts
@@ -1,0 +1,107 @@
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+import { Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { SshProjectBootstrap } from "./ssh-project-bootstrap.ts";
+
+export const sshQuote = (value: string): string => `'${value.replace(/'/gu, `'\\''`)}'`;
+const MAX_BYTES = 512 * 1024;
+const UNCERTAIN = "Local SSH transport stopped; remote descendants/completion may be uncertain.";
+
+export async function runSshProject(profile: SshProjectBootstrap, script: string, signal?: AbortSignal, timeoutMs = 30_000, includeFailureOutput = false): Promise<string> {
+	if (signal?.aborted) throw new Error(UNCERTAIN);
+	return new Promise((resolve, reject) => {
+		const child = spawn("ssh", ["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=yes", "-o", "ForwardAgent=no", "-o", "ForwardX11=no", "-o", "ClearAllForwardings=yes", "-o", "SendEnv=-*", "-o", "ConnectTimeout=10", "--", profile.target,
+			`cd ${sshQuote(profile.projectDir)} && exec bash --noprofile --norc -o pipefail -s`], { shell: false, stdio: ["pipe", "pipe", "pipe"] });
+		const chunks: Buffer[] = [];
+		let bytes = 0;
+		let stderr = "";
+		let failure: Error | undefined;
+		const stop = (message: string) => { failure ??= new Error(`${message} ${UNCERTAIN}`); child.kill("SIGKILL"); };
+		const abort = () => stop("Aborted.");
+		const timer = setTimeout(() => stop("SSH deadline exceeded."), timeoutMs);
+		const cleanup = () => { clearTimeout(timer); signal?.removeEventListener("abort", abort); };
+		signal?.addEventListener("abort", abort, { once: true });
+		if (signal?.aborted) abort();
+		child.stdout.on("data", (chunk: Buffer) => { bytes += chunk.length; if (bytes > MAX_BYTES) stop("SSH output limit exceeded."); else chunks.push(chunk); });
+		child.stderr.on("data", (chunk: Buffer) => { if (stderr.length < 4096) stderr += chunk.toString("utf8").slice(0, 4096 - stderr.length); });
+		child.once("error", () => { cleanup(); reject(new Error("SSH could not start; no local fallback.")); });
+		child.once("close", code => { cleanup(); if (failure) reject(failure); else if (code !== 0) reject(new Error(`SSH failed (${code ?? "signal"}); no local fallback.${includeFailureOutput ? ` ${stderr}\n${Buffer.concat(chunks).toString("utf8").slice(-4096)}` : ""}`)); else resolve(Buffer.concat(chunks).toString("utf8")); });
+		child.stdin.on("error", () => {});
+		child.stdin.end(script);
+	});
+}
+
+export async function prepareSshContext(profile: SshProjectBootstrap, signal?: AbortSignal): Promise<string> {
+	const directories: string[] = [];
+	let dir = path.posix.resolve(profile.projectDir);
+	for (;;) { directories.unshift(dir); if (dir === "/") break; if (directories.length >= 32) throw new Error("SSH project ancestor limit exceeded."); dir = path.posix.dirname(dir); }
+	const names = ["AGENTS.override.md", "AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"];
+	const paths: string[] = [];
+	const script = ["set -eu", `test "$(pwd -P)" = ${sshQuote(path.posix.resolve(profile.projectDir))}`, "command -v bash >/dev/null", "command -v base64 >/dev/null", "command -v dd >/dev/null", "command -v tr >/dev/null"];
+	for (const directory of directories) {
+		script.push(`for p in ${names.map(name => sshQuote(path.posix.join(directory, name))).join(" ")}; do`);
+		for (const name of names) paths.push(path.posix.join(directory, name));
+		script.push(`if [ -f "$p" ]; then test -r "$p"; printf '%s\\n' "$p"; dd if="$p" bs=1 count=65537 2>/dev/null | base64 | tr -d '\\n'; printf '\\n'; break; fi`, "done");
+	}
+	const output = await runSshProject(profile, script.join("\n"), signal);
+	const lines = (output.endsWith("\n") ? output.slice(0, -1) : output).split("\n");
+	if (!output) return "";
+	const documents: string[] = [];
+	for (let i = 0; i < lines.length; i += 2) {
+		const file = lines[i]!, encoded = lines[i + 1];
+		if (!paths.includes(file) || encoded === undefined || !/^[A-Za-z0-9+/]*={0,2}$/u.test(encoded)) throw new Error("Invalid SSH context response.");
+		const bytes = Buffer.from(encoded, "base64");
+		if (bytes.length > 65536) throw new Error("SSH context document limit exceeded.");
+		const content = new TextDecoder("utf-8", { fatal: true }).decode(bytes).replace(/^\uFEFF/u, "");
+		documents.push(`## ssh://${profile.target}${file}\n${content}`);
+	}
+	return documents.join("\n\n");
+}
+
+export function createSshProjectTools(profile: SshProjectBootstrap): ToolDefinition[] {
+	const read: ToolDefinition = {
+		name: "read", label: "read", description: "Read bounded remote UTF-8 text, or an explicitly selected local Markdown snapshot with scope=local-resource.",
+		promptSnippet: "Read remote project text; selected local Markdown requires scope=local-resource and its exact selected path.",
+		parameters: Type.Object({ path: Type.String(), scope: Type.Optional(Type.String()), offset: Type.Optional(Type.Integer({ minimum: 1 })), limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 2000 })) }),
+		async execute(_id, raw, signal) {
+			const args = raw as { path: string; scope?: string; offset?: number; limit?: number };
+			let text: string;
+			if (args.scope === "local-resource") {
+				const selected = [profile.selectedDocuments?.agent, ...(profile.selectedDocuments?.skills ?? [])].find(doc => doc?.path === args.path);
+				if (!selected) throw new Error("Local resource was not explicitly selected; no local filesystem fallback.");
+				text = selected.content;
+			} else {
+				if (args.scope !== undefined && args.scope !== "project") throw new Error("Unsupported read scope.");
+				if (!args.path || /[\u0000-\u001f\u007f]/u.test(args.path)) throw new Error("Invalid remote path.");
+				const file = path.posix.resolve(profile.projectDir, args.path);
+				const encoded = await runSshProject(profile, `set -eu\ntest -f ${sshQuote(file)}\ntest -r ${sshQuote(file)}\ndd if=${sshQuote(file)} bs=1 count=262145 2>/dev/null | base64 | tr -d '\\n'`, signal);
+				if (!/^[A-Za-z0-9+/]*={0,2}$/u.test(encoded)) throw new Error("Invalid SSH read response.");
+				const bytes = Buffer.from(encoded, "base64");
+				if (bytes.length > 262144) throw new Error("Remote text read exceeds 256 KiB; use bounded remote bash instead.");
+				text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+				if (text.includes("\0")) throw new Error("Remote binary/image reads are unsupported.");
+			}
+			const start = (args.offset ?? 1) - 1;
+			const lines = text.split("\n"), limit = args.limit ?? 2000;
+			const page = lines.slice(start, start + limit).join("\n");
+			const truncated = page.length > 50_000 || start + limit < lines.length;
+			return { content: [{ type: "text", text: page.slice(0, 50_000) + (truncated ? "\n[Output truncated; use offset/limit or bounded remote bash for another range.]" : "") }], details: { truncated } };
+		},
+	};
+	const bash: ToolDefinition = {
+		name: "bash", label: "bash", description: "Run a command in the remote SSH project. Cancellation stops local transport only; remote descendants may survive.",
+		promptSnippet: "Execute commands only in the remote SSH project; remote descendants may survive cancellation.",
+		parameters: Type.Object({ command: Type.String(), timeout: Type.Optional(Type.Integer({ minimum: 1, maximum: 300 })) }),
+		async execute(_id, raw, signal) {
+			const args = raw as { command: string; timeout?: number };
+			const text = await runSshProject(profile, `exec 2>&1\n${args.command}`, signal, (args.timeout ?? 30) * 1000, true);
+			const truncated = text.length > 50_000;
+			return {
+				content: [{ type: "text", text: text.slice(0, 50_000) + (truncated ? "\n[Output truncated; rerun with bounded output to inspect another range.]" : "") }],
+				details: { truncated },
+			};
+		},
+	};
+	return [read, bash];
+}

--- a/src/runs/shared/ssh-stock-cli.ts
+++ b/src/runs/shared/ssh-stock-cli.ts
@@ -1,0 +1,20 @@
+import { spawn } from "node:child_process";
+
+/** Run the stock CLI with the same terminal streams on Node, including Windows.
+ * No shell/cmd parsing, detached process, model loop or agent runner is involved.
+ */
+export async function runStockPiCli(command: string, args: string[], cwd: string, agentDir: string): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, { cwd, env: { ...process.env, PI_CODING_AGENT_DIR: agentDir }, stdio: "inherit", shell: false });
+		const forwardInterrupt = () => { child.kill("SIGINT"); };
+		const forwardTermination = () => { child.kill("SIGTERM"); };
+		const cleanup = () => {
+			process.removeListener("SIGINT", forwardInterrupt);
+			process.removeListener("SIGTERM", forwardTermination);
+		};
+		process.on("SIGINT", forwardInterrupt);
+		process.on("SIGTERM", forwardTermination);
+		child.once("error", error => { cleanup(); reject(error); });
+		child.once("exit", (code, signal) => { cleanup(); resolve({ code, signal }); });
+	});
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2356,6 +2356,7 @@ export interface ForegroundChildSessionControls {
 }
 
 export interface RunSyncOptions {
+	sshProject?: import("../runs/shared/ssh-project-bootstrap.ts").SshProjectBootstrap;
 	/** Exact discovery provenance for an unknown-agent error; omission uses defensive fallback discovery. */
 	unknownAgentDiagnosticContext?: import("../agents/agents.ts").UnknownAgentDiagnosticContext;
 	/** Session factory for the in-process child; defaults to the process-wide factory. */

--- a/ssh-entry.ts
+++ b/ssh-entry.ts
@@ -1,0 +1,65 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { resolvePiPackageRoot, resolveInstalledPiPackageRoot } from "./src/runs/shared/pi-spawn.ts";
+import { consumeSshStockCliArgs, readSelectedMarkdown } from "./src/runs/shared/ssh-cli-entry.ts";
+import { createSshProjectTools, prepareSshContext, runSshProject } from "./src/runs/shared/ssh-project-tools.ts";
+import { loadSelectedAgentDocument } from "./src/agents/agents.ts";
+import { readConfigForUpdate } from "./src/extension/config.ts";
+import { validateSshConfig } from "./src/runs/foreground/ssh-execution.ts";
+
+/** Owned stock-CLI factory: all initialization failures are fatal CLI diagnostics. */
+export default async function sshEntry(pi: ExtensionAPI): Promise<void> {
+	if (process.env.PI_SUBAGENT_CHILD === "1") throw new Error("Nested SSH entry is unsupported.");
+	pi.registerFlag("ssh-bootstrap", { type: "string", description: "Internal owned SSH startup bootstrap" });
+	const { selection, profile } = consumeSshStockCliArgs(process.argv.slice(2));
+	validateSshConfig(readConfigForUpdate());
+	const settingsPath = path.join(profile.localRuntime.agentDir, "settings.json");
+	if (fs.existsSync(settingsPath) && JSON.parse(fs.readFileSync(settingsPath, "utf8"))?.subagents?.watchdog?.enabled === true) throw new Error("SSH cannot honor an enabled local watchdog; its policy must not be silently disabled.");
+	const sdkRoot = resolvePiPackageRoot() ?? resolveInstalledPiPackageRoot();
+	if (!sdkRoot) throw new Error("Installed Pi system prompt builder unavailable.");
+	const { buildSystemPrompt } = await import(pathToFileURL(path.join(sdkRoot, "dist/core/system-prompt.js")).href);
+	if (typeof buildSystemPrompt !== "function") throw new Error("Installed Pi system prompt builder unavailable.");
+	// The stock CLI owns one invocation. Reject resource reload before another
+	// transport/init effect; this marker stores no target or execution state.
+	const once = Symbol.for("pi-subagents.ssh-entry-initialized");
+	const host = globalThis as Record<symbol, unknown>;
+	if (host[once]) throw new Error("SSH resource reload/session replacement is unsupported.");
+	host[once] = true;
+	const selectedDocuments = Object.freeze({ agent: readSelectedMarkdown(selection.agent), skills: Object.freeze(selection.skills.map(readSelectedMarkdown)) });
+	const selectedAgent = loadSelectedAgentDocument(selectedDocuments.agent);
+	let globalContext = "";
+	for (const name of ["AGENTS.override.md", "AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"]) {
+		const file = path.join(profile.localRuntime.agentDir, name);
+		if (fs.existsSync(file)) { globalContext = readSelectedMarkdown(file).content; break; }
+	}
+	const bound = { ...profile, selectedDocuments, extensions: selection.extensions, globalContext };
+	const remoteContext = await prepareSshContext(bound);
+	const tools = createSshProjectTools(bound);
+	for (const tool of tools) pi.registerTool(tool);
+	pi.on("session_shutdown", event => {
+		if (event.reason === "reload") {
+			fs.writeSync(2, "SSH mode cannot safely reload; restart through pi-subagents-ssh. Persisted sessions remain local; remote completion/cleanup may be uncertain.\n");
+			process.exit(1);
+		}
+	});
+	pi.on("session_before_switch", () => ({ cancel: true }));
+	pi.on("session_before_fork", () => ({ cancel: true }));
+	pi.on("session_before_tree", () => ({ cancel: true }));
+	pi.on("user_bash", () => ({ operations: { async exec(command, _cwd, options) {
+		const output = await runSshProject(bound, `exec 2>&1\n${command}`, options.signal, options.timeout ? options.timeout * 1000 : 30_000, true);
+		options.onData(Buffer.from(output)); return { exitCode: 0 };
+	} } }));
+	pi.on("before_agent_start", event => ({ systemPrompt: buildSystemPrompt({
+		...event.systemPromptOptions, skills: [], cwd: `${bound.projectDir} (SSH ${bound.target}; local runtime ${bound.localRuntime.cwd})`,
+		contextFiles: [{ path: `ssh://${bound.target}${bound.projectDir}`, content: [`Selected subagent: ${selectedAgent.name} — ${selectedAgent.description}. Delegate with async:false, context:fresh. Local Markdown is available only through read scope=local-resource with its exact selected path; local helpers/assets are unsupported.`, globalContext, remoteContext, ...selectedDocuments.skills.map(doc => `Selected local Markdown (${doc.path}):\n${doc.content}`)].filter(Boolean).join("\n\n") }],
+	}) }));
+	pi.on("tool_call", event => {
+		if (["read", "bash"].includes(event.toolName) && !pi.getAllTools().some(info => info.name === event.toolName && info.sourceInfo?.path === fileURLToPath(import.meta.url))) {
+			return { block: true, reason: "SSH owned tool provenance changed; local fallback refused." };
+		}
+	});
+	const register = (await import("./src/extension/index.ts")).default;
+	register(pi, bound);
+}

--- a/ssh-launch.mjs
+++ b/ssh-launch.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Strict stock-Pi SSH project entry; no SDK host or separate agent runner.
+import fs from "node:fs";
+import path from "node:path";
+import { createJiti } from "jiti";
+
+try {
+	if (process.env.PI_SUBAGENT_CHILD === "1") throw new Error("Nested SSH entry is unsupported");
+	// Node cannot strip TypeScript inside an npm installation's node_modules.
+	const jiti = createJiti(import.meta.url);
+	const { parseSshEntrySelection, validateSshEntrySelection, localAgentDir, assertCleanSshControl, sshStockCliArgs } = await jiti.import("./src/runs/shared/ssh-cli-entry.ts");
+	const { getPiSpawnCommand } = await jiti.import("./src/runs/shared/pi-spawn.ts");
+	const { runStockPiCli } = await jiti.import("./src/runs/shared/ssh-stock-cli.ts");
+	const { snapshotSshProjectBootstrap } = await jiti.import("./src/runs/shared/ssh-project-bootstrap.ts");
+	const input = parseSshEntrySelection(process.argv.slice(2));
+	const agentDir = localAgentDir();
+	const cwd = path.join(agentDir, "ssh-control");
+	const { selection, profile } = validateSshEntrySelection(input, cwd, agentDir);
+	// All user options/resources are validated before creating the control directory.
+	fs.mkdirSync(cwd, { recursive: true, mode: 0o700 });
+	assertCleanSshControl(cwd);
+	const controlCwd = fs.realpathSync(cwd), runtimeDir = fs.realpathSync(agentDir);
+	const canonicalProfile = snapshotSshProjectBootstrap({ ...profile, localRuntime: { ...profile.localRuntime, cwd: controlCwd, agentDir: runtimeDir } });
+	// Existing resolver uses the installed package's JS bin with Node on Windows,
+	// avoiding npm .cmd wrappers and shell interpolation entirely.
+	const pi = getPiSpawnCommand(sshStockCliArgs(selection, canonicalProfile));
+	const result = await runStockPiCli(pi.command, pi.args, controlCwd, runtimeDir);
+	if (result.signal && process.platform !== "win32") process.kill(process.pid, result.signal);
+	else process.exitCode = result.code ?? (result.signal === "SIGINT" ? 130 : 143);
+} catch {
+	// Never echo argv, bootstrap, selected document text, or credential environment.
+	console.error("SSH entry refused: unsupported arguments, resources, control directory, or runtime. No local fallback was started.");
+	process.exitCode = 1;
+}

--- a/test/integration/ssh-foreground.test.ts
+++ b/test/integration/ssh-foreground.test.ts
@@ -8,11 +8,17 @@ import { fileURLToPath } from "node:url";
 import { parseSshEntrySelection, validateSshEntrySelection, sshStockCliArgs } from "../../src/runs/shared/ssh-cli-entry.ts";
 
 const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const tmpRoot = path.join(repo, "tmp");
 const sdkRoot = process.env.PI_SUBAGENTS_REAL_SDK_ROOT ?? "/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent";
 const available = fs.existsSync(path.join(sdkRoot, "dist/bundle/cli.js"));
 
+function createRepoTempDir(prefix: string): string {
+	fs.mkdirSync(tmpRoot, { recursive: true });
+	return fs.mkdtempSync(path.join(tmpRoot, prefix));
+}
+
 test("npm-installed SSH launcher loads TypeScript without NODE_OPTIONS", { timeout: 60_000 }, () => {
-	const root = fs.mkdtempSync(path.join(repo, "tmp/ssh-installed-"));
+	const root = createRepoTempDir("ssh-installed-");
 	const installed = path.join(root, "node_modules/pi-subagents");
 	const home = path.join(root, "home"), agentDir = path.join(home, ".pi/agent");
 	fs.mkdirSync(home, { recursive: true });
@@ -56,7 +62,7 @@ test("npm-installed SSH launcher loads TypeScript without NODE_OPTIONS", { timeo
 });
 
 test("stock CLI SSH foreground: first child model request, owned read/bash, public delegation, local identity", { skip: !available, timeout: 90_000 }, () => {
-	const root = fs.mkdtempSync(path.join(repo, "tmp/ssh-full-"));
+	const root = createRepoTempDir("ssh-full-");
 	const home = path.join(root, "home"), agentDir = path.join(home, ".pi/agent"), unrelated = path.join(root, "unrelated");
 	fs.mkdirSync(agentDir, { recursive: true }); fs.mkdirSync(unrelated);
 	fs.writeFileSync(path.join(unrelated, "AGENTS.md"), "UNRELATED_LOCAL_PROJECT");

--- a/test/integration/ssh-foreground.test.ts
+++ b/test/integration/ssh-foreground.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { devNull } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { parseSshEntrySelection, validateSshEntrySelection, sshStockCliArgs } from "../../src/runs/shared/ssh-cli-entry.ts";
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const sdkRoot = process.env.PI_SUBAGENTS_REAL_SDK_ROOT ?? "/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent";
+const available = fs.existsSync(path.join(sdkRoot, "dist/bundle/cli.js"));
+
+test("npm-installed SSH launcher loads TypeScript without NODE_OPTIONS", { timeout: 60_000 }, () => {
+	const root = fs.mkdtempSync(path.join(repo, "tmp/ssh-installed-"));
+	const installed = path.join(root, "node_modules/pi-subagents");
+	const home = path.join(root, "home"), agentDir = path.join(home, ".pi/agent");
+	fs.mkdirSync(home, { recursive: true });
+	const env: NodeJS.ProcessEnv = { ...process.env, HOME: home, USERPROFILE: home, PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: "1" };
+	for (const key of Object.keys(env)) {
+		if (/API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/iu.test(key) || /^(?:NODE_OPTIONS|NODE_PATH|JITI_|PI_SUBAGENT_|PI_SUBAGENTS_|npm_config_)/iu.test(key)) delete env[key];
+	}
+	// Materialize the actual npm file list, not a virtual loader URL or source symlink.
+	// Dependencies resolve from the checkout's node_modules as in a hoisted install.
+	const packed = spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", ["pack", "--dry-run", "--ignore-scripts", "--offline", `--userconfig=${devNull}`, "--json"], {
+		cwd: repo, env, encoding: "utf8", timeout: 30_000, shell: process.platform === "win32", maxBuffer: 1024 * 1024,
+	});
+	assert.equal(packed.status, 0, packed.stderr);
+	const manifest = JSON.parse(packed.stdout)[0] as { files: Array<{ path: string; mode: number }> };
+	for (const file of manifest.files) {
+		const destination = path.join(installed, file.path);
+		fs.mkdirSync(path.dirname(destination), { recursive: true });
+		fs.copyFileSync(path.join(repo, file.path), destination);
+		fs.chmodSync(destination, file.mode);
+	}
+	const launcher = path.join(installed, "ssh-launch.mjs");
+	const refused = spawnSync(process.execPath, [launcher, "--unsupported"], { env, encoding: "utf8", timeout: 15_000 });
+	assert.equal(refused.status, 1);
+	assert.match(refused.stderr, /SSH entry refused:/);
+	assert.doesNotMatch(refused.stderr, /ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING/);
+	// A real child executable is the stock-CLI I/O seam; actual Pi behavior stays
+	// owned by the integration test below. This smoke never invokes SSH.
+	const cli = path.join(root, "cli.mjs"), agent = path.join(root, "agent.md");
+	fs.writeFileSync(cli, "#!/usr/bin/env node\nconsole.log(JSON.stringify({args:process.argv.slice(2),cwd:process.cwd(),agentDir:process.env.PI_CODING_AGENT_DIR,nodeOptions:process.env.NODE_OPTIONS}));\n", { mode: 0o755 });
+	fs.writeFileSync(agent, "---\nname: smoke\n---\nSmoke only.\n");
+	const started = spawnSync(process.execPath, [launcher, "--target", "unused-host", "--project", "/remote", "--agent", agent], {
+		env: { ...env, PI_SUBAGENT_PI_BINARY: cli }, encoding: "utf8", timeout: 15_000,
+	});
+	assert.equal(started.status, 0, started.stderr);
+	const receipt = JSON.parse(started.stdout);
+	assert.equal(receipt.cwd, fs.realpathSync(path.join(agentDir, "ssh-control")));
+	assert.equal(receipt.agentDir, fs.realpathSync(agentDir));
+	assert.equal(receipt.nodeOptions, undefined);
+	assert(receipt.args.includes(path.join(installed, "ssh-entry.ts")));
+	assert(receipt.args.some((arg: string) => arg.startsWith("--ssh-bootstrap=")));
+});
+
+test("stock CLI SSH foreground: first child model request, owned read/bash, public delegation, local identity", { skip: !available, timeout: 90_000 }, () => {
+	const root = fs.mkdtempSync(path.join(repo, "tmp/ssh-full-"));
+	const home = path.join(root, "home"), agentDir = path.join(home, ".pi/agent"), unrelated = path.join(root, "unrelated");
+	fs.mkdirSync(agentDir, { recursive: true }); fs.mkdirSync(unrelated);
+	fs.writeFileSync(path.join(unrelated, "AGENTS.md"), "UNRELATED_LOCAL_PROJECT");
+	fs.mkdirSync(path.join(unrelated, ".pi")); fs.writeFileSync(path.join(unrelated, ".pi/settings.json"), '{"defaultModel":"UNRELATED"}');
+	fs.writeFileSync(path.join(agentDir, "settings.json"), JSON.stringify({ defaultProvider: "ssh-proof", defaultModel: "proof-model" }));
+	fs.writeFileSync(path.join(agentDir, "auth.json"), JSON.stringify({ "ssh-proof": { type: "api_key", key: "SYNTHETIC_TEST_ONLY" } }));
+	fs.writeFileSync(path.join(agentDir, "AGENTS.md"), "INTENDED_GLOBAL_CONTEXT");
+	const agent = path.join(root, "agent.md"), skill = path.join(root, "skill.md"), provider = path.join(root, "provider.ts"), preload = path.join(root, "preload.mjs"), trace = path.join(root, "trace.jsonl"), response = path.join(root, "response.json");
+	fs.writeFileSync(agent, "---\nname: ssh-worker\ndescription: SSH worker\ntools: read,bash\nasync: false\ndefaultContext: fresh\nsystemPromptMode: append\n---\nSELECTED_AGENT_PROMPT");
+	fs.writeFileSync(skill, "---\nname: selected-skill\ndescription: Selected skill\n---\nSELECTED_SKILL_TEXT");
+	fs.writeFileSync(preload, `import fs from 'node:fs';import cp from 'node:child_process';import net from 'node:net';import {EventEmitter} from 'node:events';import {PassThrough} from 'node:stream';import {syncBuiltinESMExports} from 'node:module';
+const append=fs.appendFileSync;const log=(kind,value)=>append(${JSON.stringify(trace)},JSON.stringify({kind,value})+'\\n');
+for(const key of ['readFileSync','openSync','readdirSync']){const old=fs[key];fs[key]=function(file,...args){if(String(file).startsWith(${JSON.stringify(unrelated)}))log('UNRELATED',String(file));if(process.env.SSH_PROOF_RELOAD==='1'&&String(file)===${JSON.stringify(path.join(agentDir, "settings.json"))})log('SETTINGS_READ',String(file));return old.call(this,file,...args)}}
+const realSpawn=cp.spawn;cp.spawn=function(command,args,options){
+ if(process.argv[1]===${JSON.stringify(path.join(repo, "ssh-launch.mjs"))} && command===process.execPath)return realSpawn(command,args,options);
+ if(command!=='ssh'){log('PROCESS',String(command));throw new Error('Unexpected local process')}
+ log('SSH',args);const child=new EventEmitter();child.stdin=new PassThrough();child.stdout=new PassThrough();child.stderr=new PassThrough();child.kill=()=>{queueMicrotask(()=>child.emit('close',null));return true};let script='';child.stdin.on('data',x=>script+=x);child.stdin.on('finish',()=>{log('SCRIPT',script);const target=args[args.indexOf('--')+1];if(target==='stall')return;if(target==='fail'){queueMicrotask(()=>child.emit('close',255));return}const output=script.includes('for p in')?'/srv/project/AGENTS.md\\n'+Buffer.from(target+'_REMOTE_CONTEXT').toString('base64')+'\\n':script.includes('dd if=')?Buffer.from(target+'_REMOTE_FILE').toString('base64'):'REMOTE_BASH_OUTPUT';queueMicrotask(()=>{child.stdout.emit('data',Buffer.from(output));child.emit('close',0)})});return child;
+};for(const key of ['spawnSync','exec','execSync','execFile','execFileSync'])cp[key]=(...args)=>{log('PROCESS',{key,args,stack:new Error().stack});throw new Error('Unexpected local process')};
+globalThis.fetch=async()=>{log('NETWORK','fetch');throw new Error('Network denied')};net.Socket.prototype.connect=function(){log('NETWORK','socket');throw new Error('Network denied')};syncBuiltinESMExports();`);
+	fs.writeFileSync(provider, `import fs from 'node:fs';import {registerSubagentCapabilityCeiling} from ${JSON.stringify(path.join(repo, "src/api/capability-ceiling.ts"))};import {createAssistantMessageEventStream} from ${JSON.stringify(path.join(sdkRoot, "node_modules/@earendil-works/pi-ai/dist/utils/event-stream.js"))};
+export default function(pi){const key=Symbol.for('proof.provider.loads');if(process.env.SSH_PROOF_RELOAD==='1'){globalThis[key]=(globalThis[key]||0)+1;fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:'FACTORY'})+'\\n')}
+pi.on('session_start',(_,ctx)=>{if(process.env.SSH_PROOF_CEILING==='1')registerSubagentCapabilityCeiling({sessionId:ctx.sessionManager.getSessionId(),source:'proof',ceiling:{allowedTools:['read']}})});
+pi.on('session_start',()=>{fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:'SKILL_COMMANDS',value:pi.getCommands().filter(command=>command.source==='skill').map(command=>command.name)})+'\\n')});
+pi.registerCommand('proof-reload',{description:'Proof reload',handler:async(_args,ctx)=>{fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:'BEFORE_RELOAD'})+'\\n');await ctx.reload();fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:'AFTER_RELOAD'})+'\\n')}});
+if(process.env.SSH_PROOF_CONFLICT==='1'||globalThis[key]>1)pi.registerTool({name:'read',label:'read',description:'Forbidden provider fallback',parameters:{type:'object',properties:{}},async execute(){throw new Error('PROVIDER_LOCAL_FALLBACK')}});
+pi.registerProvider('ssh-proof',{baseUrl:'http://127.0.0.1:1',api:'openai-completions',models:[{id:'proof-model',name:'Proof',reasoning:false,input:['text'],cost:{input:0,output:0,cacheRead:0,cacheWrite:0},contextWindow:32768,maxTokens:512}],streamSimple(model,context){
+ const parent=context.tools?.some(t=>t.name==='subagent')||context.tools?.length===0;fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:parent?'PARENT_MODEL':'MODEL',value:{prompt:context.systemPrompt,tools:context.tools?.map(t=>t.name),messages:context.messages}})+'\\n');
+ const stream=createAssistantMessageEventStream();const results=context.messages.filter(m=>m.role==='toolResult');const content=parent?(results.length===0&&context.tools?.length?[{type:'toolCall',id:'parent-read',name:'read',arguments:{path:${JSON.stringify(skill)},scope:'local-resource'}}]:[{type:'text',text:'PARENT_DONE'}]):results.length===0?[{type:'toolCall',id:'r',name:'read',arguments:{path:'AGENTS.md'}}]:results.length===1?[{type:'toolCall',id:'b',name:'bash',arguments:{command:'printf remote'}}]:[{type:'text',text:'REMOTE_CHILD_DONE'}];
+ const message={role:'assistant',api:model.api,provider:model.provider,model:model.id,content,stopReason:content[0].type==='toolCall'?'toolUse':'stop',timestamp:Date.now(),usage:{input:1,output:1,cacheRead:0,cacheWrite:0,totalTokens:2,cost:{input:0,output:0,cacheRead:0,cacheWrite:0,total:0}}};queueMicrotask(()=>{stream.push({type:'done',reason:message.stopReason,message});stream.end()});return stream;}});
+ pi.on('before_agent_start',async(_,ctx)=>{if(!pi.getActiveTools().includes('subagent'))return;
+ await new Promise(resolve=>{pi.events.on('prompt-template:subagent:response',result=>{fs.writeFileSync(${JSON.stringify(response)},JSON.stringify(result));resolve()});
+ pi.events.emit('prompt-template:subagent:request',{requestId:'proof',ownerRunId:'proof-owner',nodeId:'proof-node',agent:'ssh-worker',task:'Read the project and run the command',context:'fresh',cwd:ctx.cwd,model:'ssh-proof/proof-model',result:{kind:'text'}});});
+ });}`);
+	const env = { ...process.env, HOME: home, PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: "1", PI_SUBAGENTS_PI_CODING_AGENT_PACKAGE_ROOT: sdkRoot, NODE_OPTIONS: `--experimental-strip-types --import ${preload}` };
+	for (const key of Object.keys(env)) if (key.startsWith("PI_SUBAGENT_") || /API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/iu.test(key)) delete env[key as keyof typeof env];
+	for (const target of ["target-A", "target-B"]) {
+		fs.writeFileSync(trace, ""); fs.rmSync(response, { force: true });
+		const result = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", target, "--project", "/srv/project", "--agent", agent, "--skill", skill, "--extension", provider, "--mode", "json", "--prompt", "Delegate now", "--offline"], { cwd: unrelated, env, input: "", encoding: "utf8", timeout: 30_000 });
+		assert.equal(result.status, 0, JSON.stringify({ error: String(result.error), stderr: result.stderr, stdout: result.stdout }));
+		assert(fs.existsSync(response), `No delegation response: ${result.stderr}`);
+		const terminal = JSON.parse(fs.readFileSync(response, "utf8")); assert.equal(terminal.status, "completed", JSON.stringify(terminal)); assert.equal(terminal.result.text, "REMOTE_CHILD_DONE");
+		const events = fs.readFileSync(trace, "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line));
+		assert(!events.some(e => ["UNRELATED", "PROCESS", "NETWORK"].includes(e.kind)), JSON.stringify(events));
+		const skillCommands = events.filter(e => e.kind === "SKILL_COMMANDS");
+		assert(skillCommands.length > 0);
+		assert(skillCommands.every(e => e.value.length === 0), "Selected Markdown must not activate stock skill commands that reread local files.");
+		const models = events.filter(e => e.kind === "MODEL"); assert.equal(models.length, 3);
+		assert(models[0].value.prompt.includes(`${target}_REMOTE_CONTEXT`)); assert(models[0].value.prompt.includes("INTENDED_GLOBAL_CONTEXT")); assert(models[0].value.prompt.includes("SELECTED_SKILL_TEXT")); assert(models[0].value.prompt.includes("SELECTED_AGENT_PROMPT"));
+		assert.deepEqual(models[0].value.tools.sort(), ["bash", "read"]);
+		assert(JSON.stringify(models[1]).includes(`${target}_REMOTE_FILE`)); assert(JSON.stringify(models[2]).includes("REMOTE_BASH_OUTPUT"));
+		const parentModels = events.filter(e => e.kind === "PARENT_MODEL");
+		const selectedRead = parentModels.at(-1).value.messages.find((message: { role: string }) => message.role === "toolResult");
+		assert.equal(selectedRead.isError, false); assert(JSON.stringify(selectedRead).includes("SELECTED_SKILL_TEXT"));
+	}
+	// Actual factory/SDK behavior: a stalled remote fetch cannot occupy the common
+	// open queue. The unrelated ordinary local child reaches its model first.
+	const probe = path.join(root, "queue.mjs");
+	fs.writeFileSync(probe, `import assert from 'node:assert/strict';import * as sdk from ${JSON.stringify(path.join(sdkRoot, "dist/index.js"))};import {createDefaultChildSessionFactory} from ${JSON.stringify(path.join(repo, "src/runs/shared/child-session.ts"))};
+const factory=createDefaultChildSessionFactory({loadPiCodingAgent:async()=>sdk});const launch={cwd:${JSON.stringify(path.join(agentDir, "ssh-control"))},storage:{kind:'memory'},model:'ssh-proof/proof-model',tools:[],extensionPaths:[${JSON.stringify(provider)}],ambientExtensions:false,hooks:[],noSkills:true,noContextFiles:true,runtime:{fanoutChild:false,depth:1,fast:false,waitTool:{enabled:false}}};
+const controller=new AbortController();const stalled=factory.create({...launch,sshProject:{target:'stall',projectDir:'/srv/project',childProfile:'fresh-native-read-bash',localRuntime:{cwd:launch.cwd,agentDir:${JSON.stringify(agentDir)},projectTrusted:false,noContextFiles:true,projectDiscovery:'disabled'}},sshSignal:controller.signal}).then(()=>{throw new Error('Unexpected stalled readiness')},error=>error);
+const local=await factory.create(launch);await local.prompt('LOCAL_QUEUE_PROOF');controller.abort();assert.match(String(await stalled),/uncertain/);
+const remote=target=>({...launch,tools:['read','bash'],sshProject:{target,projectDir:'/srv/project',childProfile:'fresh-native-read-bash',extensions:[${JSON.stringify(provider)}],localRuntime:{cwd:launch.cwd,agentDir:${JSON.stringify(agentDir)},projectTrusted:false,noContextFiles:true,projectDiscovery:'disabled'}}});
+const [a,b]=await Promise.all([factory.create(remote('concurrent-A')),factory.create(remote('concurrent-B'))]);await Promise.all([a.prompt('A'),b.prompt('B')]);assert(JSON.stringify(a.messages).includes('concurrent-A_REMOTE_FILE'));assert(!JSON.stringify(a.messages).includes('concurrent-B_REMOTE_FILE'));assert(JSON.stringify(b.messages).includes('concurrent-B_REMOTE_FILE'));await factory.dispose();console.log('LOCAL_MODEL_BEFORE_STALLED_PREFETCH;CONCURRENT_TARGETS_ISOLATED');`);
+	const queue = spawnSync(process.execPath, [probe], { cwd: path.join(agentDir, "ssh-control"), env, encoding: "utf8", timeout: 15_000 });
+	assert.equal(queue.status, 0, `${queue.stderr}\n${queue.stdout}`); assert(queue.stdout.includes("LOCAL_MODEL_BEFORE_STALLED_PREFETCH"));
+	fs.writeFileSync(trace, "");
+	const failure = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", "fail", "--project", "/srv/project", "--agent", agent, "--extension", provider, "--mode", "json", "--prompt", "Never prompt", "--offline"], { cwd: unrelated, env, input: "", encoding: "utf8", timeout: 15_000 });
+	assert.equal(failure.status, 1); assert.match(failure.stderr, /Failed to load extension/);
+	assert(!fs.readFileSync(trace, "utf8").includes('"MODEL"')); assert(!fs.readFileSync(trace, "utf8").includes('"PARENT_MODEL"'));
+	const selectedText = fs.readFileSync(agent, "utf8");
+	for (const unsupported of [selectedText.replace("async: false", "async: true"), selectedText.replace("defaultContext: fresh", "defaultContext: fork"), selectedText.replace("tools: read,bash", "tools: read,write"), selectedText.replace("systemPromptMode: append", "acceptance: true\nsystemPromptMode: append")]) {
+		fs.writeFileSync(agent, unsupported); fs.writeFileSync(trace, "");
+		const rejected = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", "target-A", "--project", "/srv/project", "--agent", agent, "--extension", provider, "--mode", "json", "--prompt", "Never prompt", "--offline"], { cwd: unrelated, env, input: "", encoding: "utf8", timeout: 15_000 });
+		assert.equal(rejected.status, 1); assert(!fs.readFileSync(trace, "utf8").includes('"SSH"')); assert(!fs.readFileSync(trace, "utf8").includes('"MODEL"'));
+	}
+	fs.writeFileSync(agent, selectedText);
+	const config = path.join(agentDir, "extensions/subagent/config.json"); fs.mkdirSync(path.dirname(config), { recursive: true });
+	for (const defaults of [{ worktree: true }, { forceTopLevelAsync: true }, { toolBudget: { hard: 2 } }, { permissions: { rules: { read: "deny" } } }, { maxSubagentDepth: 0 }]) {
+		fs.writeFileSync(config, JSON.stringify(defaults)); fs.writeFileSync(trace, ""); fs.rmSync(response, { force: true });
+		const rejected = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", "target-A", "--project", "/srv/project", "--agent", agent, "--skill", skill, "--extension", provider, "--mode", "json", "--prompt", "Reject child defaults", "--offline"], { cwd: unrelated, env, input: "", encoding: "utf8", timeout: 15_000 });
+		if ("maxSubagentDepth" in defaults) { assert.equal(rejected.status, 0, rejected.stderr); assert.equal(JSON.parse(fs.readFileSync(response, "utf8")).status, "failed"); }
+		else { assert.equal(rejected.status, 1, rejected.stderr); assert(!fs.existsSync(response)); }
+		const events = fs.readFileSync(trace, "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line));
+		assert.equal(events.filter(e => e.kind === "SSH").length, "maxSubagentDepth" in defaults ? 1 : 0); // no child preparation
+		assert(!events.some(e => ["MODEL", "PROCESS", "UNRELATED", "NETWORK"].includes(e.kind)));
+	}
+	fs.writeFileSync(config, "{}");
+	fs.writeFileSync(trace, "");
+	const userBash = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", "target-A", "--project", "/srv/project", "--agent", agent, "--extension", provider, "--mode", "rpc", "--offline"], { cwd: unrelated, env, input: JSON.stringify({ type: "bash", id: "proof-bash", command: "printf remote" }) + "\n", encoding: "utf8", timeout: 15_000 });
+	assert.equal(userBash.status, 0, userBash.stderr); assert(userBash.stdout.includes("REMOTE_BASH_OUTPUT"), userBash.stdout);
+	const bashEvents = fs.readFileSync(trace, "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line));
+	assert.equal(bashEvents.filter(event => event.kind === "SSH").length, 2);
+	assert(!bashEvents.some(event => ["MODEL", "PARENT_MODEL", "PROCESS", "UNRELATED", "NETWORK"].includes(event.kind)));
+	fs.writeFileSync(trace, "");
+	const reload = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", "target-A", "--project", "/srv/project", "--agent", agent, "--extension", provider, "--mode", "json", "--prompt", "/proof-reload", "--offline"], { cwd: unrelated, env: { ...env, SSH_PROOF_RELOAD: "1" }, input: "", encoding: "utf8", timeout: 15_000 });
+	assert.equal(reload.status, 1); assert.match(reload.stderr, /SSH mode cannot safely reload; restart/);
+	const reloadEvents = fs.readFileSync(trace, "utf8").trim().split("\n").map(line => JSON.parse(line));
+	assert.equal(reloadEvents.filter(event => event.kind === "FACTORY").length, 1);
+	assert(!reloadEvents.some(event => ["AFTER_RELOAD", "MODEL", "PARENT_MODEL", "PROCESS", "UNRELATED", "NETWORK"].includes(event.kind)));
+	const reloadBoundary = reloadEvents.findIndex(event => event.kind === "BEFORE_RELOAD"); assert(reloadBoundary >= 0);
+	assert(!reloadEvents.slice(reloadBoundary + 1).some(event => event.kind === "SETTINGS_READ"));
+	const good = ["--target", "target-A", "--project", "/srv/project", "--agent", agent, "--extension", provider, "--mode", "json", "--prompt", "Do not prompt", "--offline"];
+	fs.writeFileSync(trace, ""); fs.rmSync(response, { force: true });
+	const narrowed = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), ...good], { cwd: unrelated, env: { ...env, SSH_PROOF_CEILING: "1" }, input: "", encoding: "utf8", timeout: 15_000 });
+	assert.equal(narrowed.status, 0, narrowed.stderr); assert.equal(JSON.parse(fs.readFileSync(response, "utf8")).status, "failed");
+	assert(!fs.readFileSync(trace, "utf8").includes('"MODEL"'));
+	fs.writeFileSync(trace, "");
+	const conflicting = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), ...good], { cwd: unrelated, env: { ...env, SSH_PROOF_CONFLICT: "1" }, input: "", encoding: "utf8", timeout: 15_000 });
+	assert.equal(conflicting.status, 1); assert.match(conflicting.stderr, /Tool "read" conflicts/);
+	assert(!fs.readFileSync(trace, "utf8").includes('"MODEL"')); assert(!fs.readFileSync(trace, "utf8").includes('"PARENT_MODEL"'));
+	for (const hostile of [["--cwd", unrelated], ["--resume"], ["--session", "session.jsonl"], ["--session-dir", unrelated], [`@${path.join(unrelated, "AGENTS.md")}`], ["--tools", "read,write"], ["--extension", path.join(repo, "index.ts")], ["--ssh-bootstrap=bad"]]) {
+		fs.writeFileSync(trace, "");
+		const result = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), ...good, ...hostile], { cwd: unrelated, env, input: "", encoding: "utf8", timeout: 15_000 });
+		assert.equal(result.status, 1); assert.equal(fs.readFileSync(trace, "utf8"), "");
+	}
+	const prepared = validateSshEntrySelection(parseSshEntrySelection(good), path.join(agentDir, "ssh-control"), agentDir);
+	const args = sshStockCliArgs(prepared.selection, prepared.profile), bootstrap = args.find(arg => arg.startsWith("--ssh-bootstrap="))!;
+	const withFlags = (...extra: string[]) => [...args.slice(0, args.indexOf("--")), ...extra, ...args.slice(args.indexOf("--"))];
+	for (const invalid of [args.filter(arg => arg !== bootstrap), withFlags(bootstrap), args.map(arg => arg === bootstrap ? "--ssh-bootstrap=bad" : arg), withFlags("-e", path.join(repo, "index.ts"))]) {
+		fs.writeFileSync(trace, "");
+		const result = spawnSync(process.execPath, [path.join(sdkRoot, "dist/bundle/cli.js"), ...invalid], { cwd: path.join(agentDir, "ssh-control"), env, input: "", encoding: "utf8", timeout: 15_000 });
+		assert.equal(result.status, 1); assert.match(result.stderr, /Failed to load extension/); assert.equal(fs.readFileSync(trace, "utf8"), "");
+	}
+});

--- a/test/integration/ssh-foreground.test.ts
+++ b/test/integration/ssh-foreground.test.ts
@@ -17,6 +17,10 @@ function createRepoTempDir(prefix: string): string {
 	return fs.mkdtempSync(path.join(tmpRoot, prefix));
 }
 
+function importHref(file: string): string {
+	return JSON.stringify(pathToFileURL(file).href);
+}
+
 test("npm-installed SSH launcher loads TypeScript without NODE_OPTIONS", { timeout: 60_000 }, () => {
 	const root = createRepoTempDir("ssh-installed-");
 	const installed = path.join(root, "node_modules/pi-subagents");
@@ -82,7 +86,7 @@ const realSpawn=cp.spawn;cp.spawn=function(command,args,options){
  log('SSH',args);const child=new EventEmitter();child.stdin=new PassThrough();child.stdout=new PassThrough();child.stderr=new PassThrough();child.kill=()=>{queueMicrotask(()=>child.emit('close',null));return true};let script='';child.stdin.on('data',x=>script+=x);child.stdin.on('finish',()=>{log('SCRIPT',script);const target=args[args.indexOf('--')+1];if(target==='stall')return;if(target==='fail'){queueMicrotask(()=>child.emit('close',255));return}const output=script.includes('for p in')?'/srv/project/AGENTS.md\\n'+Buffer.from(target+'_REMOTE_CONTEXT').toString('base64')+'\\n':script.includes('dd if=')?Buffer.from(target+'_REMOTE_FILE').toString('base64'):'REMOTE_BASH_OUTPUT';queueMicrotask(()=>{child.stdout.emit('data',Buffer.from(output));child.emit('close',0)})});return child;
 };for(const key of ['spawnSync','exec','execSync','execFile','execFileSync'])cp[key]=(...args)=>{log('PROCESS',{key,args,stack:new Error().stack});throw new Error('Unexpected local process')};
 globalThis.fetch=async()=>{log('NETWORK','fetch');throw new Error('Network denied')};net.Socket.prototype.connect=function(){log('NETWORK','socket');throw new Error('Network denied')};syncBuiltinESMExports();`);
-	fs.writeFileSync(provider, `import fs from 'node:fs';import {registerSubagentCapabilityCeiling} from ${JSON.stringify(path.join(repo, "src/api/capability-ceiling.ts"))};import {createAssistantMessageEventStream} from ${JSON.stringify(path.join(sdkRoot, "node_modules/@earendil-works/pi-ai/dist/utils/event-stream.js"))};
+	fs.writeFileSync(provider, `import fs from 'node:fs';import {registerSubagentCapabilityCeiling} from ${importHref(path.join(repo, "src/api/capability-ceiling.ts"))};import {createAssistantMessageEventStream} from ${importHref(path.join(sdkRoot, "node_modules/@earendil-works/pi-ai/dist/utils/event-stream.js"))};
 export default function(pi){const key=Symbol.for('proof.provider.loads');if(process.env.SSH_PROOF_RELOAD==='1'){globalThis[key]=(globalThis[key]||0)+1;fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:'FACTORY'})+'\\n')}
 pi.on('session_start',(_,ctx)=>{if(process.env.SSH_PROOF_CEILING==='1')registerSubagentCapabilityCeiling({sessionId:ctx.sessionManager.getSessionId(),source:'proof',ceiling:{allowedTools:['read']}})});
 pi.on('session_start',()=>{fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:'SKILL_COMMANDS',value:pi.getCommands().filter(command=>command.source==='skill').map(command=>command.name)})+'\\n')});
@@ -120,7 +124,7 @@ pi.registerProvider('ssh-proof',{baseUrl:'http://127.0.0.1:1',api:'openai-comple
 	// Actual factory/SDK behavior: a stalled remote fetch cannot occupy the common
 	// open queue. The unrelated ordinary local child reaches its model first.
 	const probe = path.join(root, "queue.mjs");
-	fs.writeFileSync(probe, `import assert from 'node:assert/strict';import * as sdk from ${JSON.stringify(path.join(sdkRoot, "dist/index.js"))};import {createDefaultChildSessionFactory} from ${JSON.stringify(path.join(repo, "src/runs/shared/child-session.ts"))};
+	fs.writeFileSync(probe, `import assert from 'node:assert/strict';import * as sdk from ${importHref(path.join(sdkRoot, "dist/index.js"))};import {createDefaultChildSessionFactory} from ${importHref(path.join(repo, "src/runs/shared/child-session.ts"))};
 const factory=createDefaultChildSessionFactory({loadPiCodingAgent:async()=>sdk});const launch={cwd:${JSON.stringify(path.join(agentDir, "ssh-control"))},storage:{kind:'memory'},model:'ssh-proof/proof-model',tools:[],extensionPaths:[${JSON.stringify(provider)}],ambientExtensions:false,hooks:[],noSkills:true,noContextFiles:true,runtime:{fanoutChild:false,depth:1,fast:false,waitTool:{enabled:false}}};
 const controller=new AbortController();const stalled=factory.create({...launch,sshProject:{target:'stall',projectDir:'/srv/project',childProfile:'fresh-native-read-bash',localRuntime:{cwd:launch.cwd,agentDir:${JSON.stringify(agentDir)},projectTrusted:false,noContextFiles:true,projectDiscovery:'disabled'}},sshSignal:controller.signal}).then(()=>{throw new Error('Unexpected stalled readiness')},error=>error);
 const local=await factory.create(launch);await local.prompt('LOCAL_QUEUE_PROOF');controller.abort();assert.match(String(await stalled),/uncertain/);

--- a/test/integration/ssh-foreground.test.ts
+++ b/test/integration/ssh-foreground.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { devNull } from "node:os";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { parseSshEntrySelection, validateSshEntrySelection, sshStockCliArgs } from "../../src/runs/shared/ssh-cli-entry.ts";
 
 const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -96,7 +96,7 @@ pi.registerProvider('ssh-proof',{baseUrl:'http://127.0.0.1:1',api:'openai-comple
  await new Promise(resolve=>{pi.events.on('prompt-template:subagent:response',result=>{fs.writeFileSync(${JSON.stringify(response)},JSON.stringify(result));resolve()});
  pi.events.emit('prompt-template:subagent:request',{requestId:'proof',ownerRunId:'proof-owner',nodeId:'proof-node',agent:'ssh-worker',task:'Read the project and run the command',context:'fresh',cwd:ctx.cwd,model:'ssh-proof/proof-model',result:{kind:'text'}});});
  });}`);
-	const env = { ...process.env, HOME: home, PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: "1", PI_SUBAGENTS_PI_CODING_AGENT_PACKAGE_ROOT: sdkRoot, NODE_OPTIONS: `--experimental-strip-types --import ${preload}` };
+	const env = { ...process.env, HOME: home, PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: "1", PI_SUBAGENTS_PI_CODING_AGENT_PACKAGE_ROOT: sdkRoot, NODE_OPTIONS: `--experimental-strip-types --import ${pathToFileURL(preload).href}` };
 	for (const key of Object.keys(env)) if (key.startsWith("PI_SUBAGENT_") || /API_KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL/iu.test(key)) delete env[key as keyof typeof env];
 	for (const target of ["target-A", "target-B"]) {
 		fs.writeFileSync(trace, ""); fs.rmSync(response, { force: true });

--- a/test/unit/ssh-project-tools.test.ts
+++ b/test/unit/ssh-project-tools.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import cp from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { syncBuiltinESMExports } from "node:module";
+import { createSshProjectTools, prepareSshContext, runSshProject, sshQuote } from "../../src/runs/shared/ssh-project-tools.ts";
+import { snapshotSshProjectBootstrap } from "../../src/runs/shared/ssh-project-bootstrap.ts";
+
+const profile = snapshotSshProjectBootstrap({ target: "user@host", projectDir: "/project ' $(touch BAD)`literal`", childProfile: "fresh-native-read-bash", localRuntime: { cwd: process.cwd(), agentDir: process.cwd(), projectTrusted: false, noContextFiles: true, projectDiscovery: "disabled" }, selectedDocuments: { agent: { path: `${process.cwd()}/agent.md`, content: "SELECTED" }, skills: [] } });
+
+test("SSH public tool operations: quoting, selected documents, errors, cancellation and byte bounds", async () => {
+	const original = cp.spawn;
+	let output = "", code: number | null = 0, hang = false, killed = false;
+	const invocations: Array<{ command: string; args: readonly string[]; options: unknown; script: string }> = [];
+	cp.spawn = ((command: string, args: readonly string[], options: unknown) => {
+		const child = new EventEmitter() as EventEmitter & { stdin: PassThrough; stdout: PassThrough; stderr: PassThrough; kill(): boolean };
+		child.stdin = new PassThrough(); child.stdout = new PassThrough(); child.stderr = new PassThrough();
+		const invocation = { command, args, options, script: "" }; invocations.push(invocation);
+		child.kill = () => { killed = true; queueMicrotask(() => child.emit("close", null)); return true; };
+		child.stdin.on("data", chunk => { invocation.script += chunk; });
+		child.stdin.on("finish", () => { if (!hang) queueMicrotask(() => { child.stdout.emit("data", Buffer.from(output)); child.emit("close", code); }); });
+		return child;
+	}) as typeof cp.spawn;
+	syncBuiltinESMExports();
+	try {
+		const read = createSshProjectTools(profile).find(tool => tool.name === "read")!;
+		const local = await read.execute("local", { path: profile.selectedDocuments!.agent.path, scope: "local-resource" }, undefined, undefined, {} as never);
+		assert.equal(local.content[0]?.type, "text"); assert.equal(invocations.length, 0);
+		await assert.rejects(() => read.execute("escape", { path: "../auth.json", scope: "local-resource" }, undefined, undefined, {} as never), /not explicitly selected/);
+		output = Buffer.from("REMOTE\nSECOND").toString("base64");
+		await read.execute("remote", { path: "file ' $(touch BAD)`literal`", offset: 2, limit: 1 }, undefined, undefined, {} as never);
+		assert.equal(invocations[0]!.command, "ssh"); assert.equal((invocations[0]!.options as { shell: boolean }).shell, false);
+		assert(invocations[0]!.args.at(-1)!.includes(sshQuote(profile.projectDir)));
+		assert(invocations[0]!.script.includes("'\\''")); assert(invocations[0]!.args.includes("ForwardAgent=no")); assert(invocations[0]!.args.includes("SendEnv=-*"));
+		code = 255; await assert.rejects(() => runSshProject(profile, "exit 1"), /no local fallback/);
+		code = 0; output = "x".repeat(512 * 1024 + 1); await assert.rejects(() => runSshProject(profile, "large"), /limit.*uncertain/su); assert(killed);
+		output = "/AGENTS.md\n\n"; await prepareSshContext(profile); // empty context document is present, not malformed
+		hang = true; const controller = new AbortController(); const pending = runSshProject(profile, "hang", controller.signal); controller.abort();
+		await assert.rejects(() => pending, /remote descendants\/completion may be uncertain/);
+		await assert.rejects(() => runSshProject(profile, "timeout", undefined, 5), /deadline.*uncertain/su);
+	} finally { cp.spawn = original; syncBuiltinESMExports(); }
+});
+
+test("POSIX operand quoting preserves literal shell metacharacters", { skip: process.platform === "win32" }, () => {
+	const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-quote-"));
+	try {
+		const operand = "space ' quote $(touch BAD) `touch BAD` $HOME ; end";
+		const result = cp.spawnSync("/bin/sh", ["-c", `printf '%s' ${sshQuote(operand)}`], { cwd, env: { PATH: "/usr/bin:/bin" }, encoding: "utf8" });
+		assert.equal(result.status, 0); assert.equal(result.stdout, operand); assert.deepEqual(fs.readdirSync(cwd), []);
+	} finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "strict": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["index.ts", "src/**/*.ts", "src/**/*.d.ts"]
+  "include": ["index.ts", "ssh-entry.ts", "src/**/*.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
Related to #2047. Thanks to [@klay7w](https://github.com/klay7w) for the detailed local-runtime/remote-project report; profile-linked Unreleased credit included. This is a bounded first slice, not full issue closure.

A thin launcher starts stock local Pi in an explicit local control directory. Authentication, selected local resources and run state remain local; project context, text read/bash and parent shell commands route through SSH. Fresh single native foreground children only. No remote Pi installation, service, SDK host or generic backend.

Unsupported workflows/background/fork/resume/nesting/worktrees/acceptance/output-file and conflicting effective policies fail before local project preparation. Selected Markdown is an immutable snapshot, not a live skill command. Explicit SSH mode terminates on reload with restart guidance before unsafe SDK rebuilding; ordinary Pi reload is unchanged. Cancellation controls local SSH transport only, not remote descendants. Trusted provider extensions remain trusted code, not sandboxed.

## Validation
- Full retained scope/invariant challenges, deslop/simplification and one fresh independent complete-candidate review completed.
- Review found one shipping blocker: native TypeScript imports under npm node_modules. Fixed using existing Jiti; physical installed-layout smoke failed before and passed after, without inherited NODE_OPTIONS. No new dependency.
- Final focused suite:27passed,0failed/skipped on macOS/Node25.2.1 using actual Pi0.85.1 with synthetic identity and mocked SSH/network seams. Includes public structured delegation, first child model context/tools, target isolation, stalled-prefetch/local launch independence, refusal/ceilings/quoting/bounds/abort and SSH reload shutdown.
- Typecheck, YAML parse, diff hygiene and offline package inclusion checks pass. Mechanical current-main composition tree verified; affected suite rerun.
- Added explicit Ubuntu/Windows Node22.22 CI with real Pi0.85.1 and a no-skip fixture presence check. Native Windows results are REQUIRED and not yet claimed. Normal required CI/Greptile and post-merge main CI also gate landing.

No live SSH host or real credential/model-network calls were used in validation. No performance-neutrality, remote-cleanup or arbitrary compatibility guarantee. No release/tag.