### PR TITLE
fix: support string array and undefined systemPrompt in before_agent_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Bound transcript previews by individual line size and total rendered body size, preserving recent context and full artifact references. Thanks to [@rtbe](https://github.com/rtbe) for #2015.
 - Await a bounded, offline model registry refresh before opening `/subagents` model and thinking pickers, and warn on refresh failures. Thanks to [@ianbmacdonald](https://github.com/ianbmacdonald) for #2008.
 - Freeze terminal FleetView detail elapsed from recorded duration or end time, omitting unknown durations while running rows keep advancing. Related to #2085 (partial); thanks to [@expoli](https://github.com/expoli).
+- Preserve input and return shapes in `appendAdvertisedAgentPrompt` with overloads for string, array, and undefined system prompt callers in `before_agent_start`. Thanks to [@luqman-v1](https://github.com/luqman-v1) for #2107.
 
 ## [0.66.0] - 2026-09-06
 

--- a/src/agents/advertised-agent-prompt.ts
+++ b/src/agents/advertised-agent-prompt.ts
@@ -57,7 +57,38 @@ export function buildAdvertisedAgentPrompt(
 	return render(entries);
 }
 
-export function appendAdvertisedAgentPrompt(systemPrompt: string, advertisedPrompt: string | undefined): string {
-	const base = systemPrompt.replace(ADVERTISED_AGENTS_BLOCK, "");
-	return advertisedPrompt ? `${base.trimEnd()}\n\n${advertisedPrompt}` : base;
+export function appendAdvertisedAgentPrompt(systemPrompt: string, advertisedPrompt: string | undefined): string;
+export function appendAdvertisedAgentPrompt(systemPrompt: string[], advertisedPrompt: string | undefined): string[];
+export function appendAdvertisedAgentPrompt(systemPrompt: undefined, advertisedPrompt: string | undefined): string | undefined;
+export function appendAdvertisedAgentPrompt(
+	systemPrompt: string | string[] | undefined,
+	advertisedPrompt: string | undefined,
+): string | string[] | undefined;
+export function appendAdvertisedAgentPrompt(
+	systemPrompt: string | string[] | undefined,
+	advertisedPrompt: string | undefined,
+): string | string[] | undefined {
+	if (Array.isArray(systemPrompt)) {
+		let changed = false;
+		const cleaned = systemPrompt
+			.map((part) => {
+				if (typeof part !== "string") return part;
+				const stripped = part.replace(ADVERTISED_AGENTS_BLOCK, "");
+				if (stripped !== part) changed = true;
+				return stripped;
+			})
+			.filter((b) => typeof b === "string" && b.length > 0);
+
+		if (advertisedPrompt) {
+			return [...cleaned, advertisedPrompt];
+		}
+		return changed ? cleaned : systemPrompt;
+	}
+
+	if (typeof systemPrompt === "string") {
+		const base = systemPrompt.replace(ADVERTISED_AGENTS_BLOCK, "");
+		return advertisedPrompt ? (base.trim() ? `${base.trimEnd()}\n\n${advertisedPrompt}` : advertisedPrompt) : base;
+	}
+
+	return advertisedPrompt;
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -812,9 +812,9 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	pi.registerTool(tool);
 
 	pi.on("before_agent_start", (event, ctx) => {
-		const selectedTools = event.systemPromptOptions.selectedTools ?? pi.getActiveTools();
+		const selectedTools = event.systemPromptOptions?.selectedTools ?? (typeof pi.getActiveTools === "function" ? pi.getActiveTools() : []);
 		const sessionId = state.currentSessionId ?? resolveCurrentSessionId(ctx.sessionManager);
-		const advertisedPrompt = selectedTools.includes("subagent")
+		const advertisedPrompt = Array.isArray(selectedTools) && selectedTools.includes("subagent")
 			? buildAdvertisedAgentPrompt(advertisedAgents, resolveCurrentSubagentCapabilityCeiling(sessionId))
 			: undefined;
 		const systemPrompt = appendAdvertisedAgentPrompt(event.systemPrompt, advertisedPrompt);

--- a/test/unit/advertised-agent-prompt.test.ts
+++ b/test/unit/advertised-agent-prompt.test.ts
@@ -84,4 +84,27 @@ describe("advertised agent prompt", () => {
 		const prior = appendAdvertisedAgentPrompt("base prompt", buildAdvertisedAgentPrompt([agent("alpha", { advertise: true })]));
 		assert.equal(appendAdvertisedAgentPrompt(prior, buildAdvertisedAgentPrompt([])), "base prompt");
 	});
+
+	it("handles string array systemPrompt gracefully", () => {
+		const initial = ["section 1", "section 2"];
+		const catalog = buildAdvertisedAgentPrompt([agent("alpha", { advertise: true })]);
+		const withCatalog = appendAdvertisedAgentPrompt(initial, catalog);
+		assert.ok(Array.isArray(withCatalog));
+		assert.equal(withCatalog.length, 3);
+		assert.equal(withCatalog[0], "section 1");
+		assert.equal(withCatalog[1], "section 2");
+		assert.match(withCatalog[2]!, /<name>alpha<\/name>/);
+
+		const withoutCatalog = appendAdvertisedAgentPrompt(withCatalog, undefined);
+		assert.ok(Array.isArray(withoutCatalog));
+		assert.equal(withoutCatalog.length, 2);
+		assert.equal(withoutCatalog[0], "section 1");
+		assert.equal(withoutCatalog[1], "section 2");
+	});
+
+	it("handles undefined systemPrompt gracefully", () => {
+		const catalog = buildAdvertisedAgentPrompt([agent("alpha", { advertise: true })]);
+		assert.equal(appendAdvertisedAgentPrompt(undefined, catalog), catalog);
+		assert.equal(appendAdvertisedAgentPrompt(undefined, undefined), undefined);
+	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is a maintainer-owned replacement for #2107. It reapplies the approved Oh My Pi `systemPrompt` `string[]` / `undefined` compatibility work onto current `main` without pushing to the contributor fork.

Reviewed source head: `f26312b88865ff7abe38467a3e3208723b06be11` by [@luqman-v1](https://github.com/luqman-v1) on `fix/system-prompt-array-compat`.
Current main at rebase: `27fe41e600bd9a45eafccec3fdc6d05b50fd4e6b`.
Replacement head: `83dc38e5ee079fcd954b514027d4add9ace443bc`.

#2107 stays open. This PR does not close it.

## What landed

- Precise overloads so official `string` callers of `appendAdvertisedAgentPrompt` stay `string`-typed.
- Runtime support for `string[]` and `undefined` `systemPrompt` in `before_agent_start`.
- Optional `event.systemPromptOptions` and a safe `selectedTools` fallback.
- Unit tests for array and undefined inputs.

Prompt-code and tests are byte-identical to the reviewed source SHA (`ebb51009` / `0367c1d9` / `428a437e`). There are no further prompt-code changes. The only conflict vs current main was `CHANGELOG.md` (mechanical). Both Unreleased entries are kept; the #2107 credited Fixed entry is at the end of Unreleased/Fixed.

## Credit

Thanks to [@luqman-v1](https://github.com/luqman-v1) for #2107.

## Validation

- `test/unit/advertised-agent-prompt.test.ts`: 8/8 passed, including `string[]` and `undefined` cases
- `test/unit/advertised-agent-refresh.test.ts`: 1/1 passed
- `npx tsc --noEmit`: passed
- `git diff --check origin/main...HEAD`: clean
- `git merge-tree` of reviewed head onto current main: `CHANGELOG.md` was the only conflict

Exact-head CI remains required. No release or tag.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7d1205f-0aab-4248-b277-8f99974e8b97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7d1205f-0aab-4248-b277-8f99974e8b97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

