### PR TITLE
fix: apply refinement overlay in launch-contract preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Apply the same project-local refinement overlay during launch-contract preflight that foreground execution already injects, so `launchContractDigest` matches the completed terminal. Thanks to [@Yivas](https://github.com/Yivas) for #2112.
 - Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement. Thanks to [@ton77v](https://github.com/ton77v) for #2101.
 - Label workflow usage as belonging to child rows instead of showing a misleading zero or overlapping wrapper totals in FleetView; preserve unrelated standalone usage in mixed summaries and distinguish summed concurrent windows from a single context window. Related to #2085; thanks to [@expoli](https://github.com/expoli).
 - Restore background SDK sessions for the official Pi 0.85.1 Linux x64 standalone release, without a separate SDK install; npm runners keep their package-root and lifecycle behavior. Thanks to [@xz-dev](https://github.com/xz-dev) for #2049.

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -5,6 +5,7 @@ import { discoverAgentSnapshot, findBlockingAgentDiagnostic, formatUnknownAgentE
 import { resolveExecutionAgentScope } from "../agents/agent-scope.ts";
 import { buildSkillInjection, normalizeSkillInput, resolveSkillsWithFallback } from "../agents/skills.ts";
 import { buildAgentMemoryInjection } from "../agents/agent-memory.ts";
+import { appendAgentRefinementOverlay } from "../agents/agent-refinements.ts";
 import { buildModelCandidates, inheritsParentModel, resolveEffectiveSubagentModel, resolveModelOrigin, type AvailableModelInfo, type ParentModel } from "../runs/shared/model-fallback.ts";
 import { resolveModelScopesForAgent } from "../runs/shared/model-scope.ts";
 import { applyThinkingSuffix, resolvePiLaunchToolPlan, type PiLaunchToolPlan } from "../runs/shared/child-tool-plan.ts";
@@ -409,6 +410,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 	}
 	const memoryInjection = buildAgentMemoryInjection(agent, effectiveCwd);
 	if (memoryInjection) effectiveSystemPrompt = effectiveSystemPrompt ? `${effectiveSystemPrompt}\n\n${memoryInjection}` : memoryInjection;
+	effectiveSystemPrompt = appendAgentRefinementOverlay(effectiveSystemPrompt, { cwd: effectiveCwd, agentName: agent.name });
 	effectiveSystemPrompt = injectOutputPathSystemPrompt(effectiveSystemPrompt, outputPath, agent);
 	const candidates = candidateList(input.agent, agent, discovery.all);
 	const shadowedCandidates = candidates.filter((candidate) => !candidate.selected);

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -30,6 +30,8 @@ import {
 import registerSubagentExtension from "../../src/extension/index.ts";
 import { handleSubagentControlNotice } from "../../src/extension/control-notices.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
+import { resolveSubagentLaunchContract } from "../../src/api/preflight.ts";
+import { createStructuredOutputRuntime } from "../../src/runs/shared/structured-output.ts";
 import {
 	SUBAGENT_DELEGATION_REQUEST_EVENT,
 	SUBAGENT_DELEGATION_RESPONSE_EVENT,
@@ -303,6 +305,97 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		assert.equal(child?.outputMode, "file-only");
 		assert.deepEqual(child?.structuredOutput, { ok: true });
 		assert.deepEqual(JSON.parse(fs.readFileSync(configuredPath, "utf-8")), { ok: true });
+	});
+
+	it("matches preflight launch digest for structured foreground execution with a project-local refinement", { skip: !runSync ? "execution not importable" : undefined }, async () => {
+		const agentName = `digest-probe-${Date.now().toString(36)}`;
+		const task = "Answer only from the supplied synthetic text and return the requested structured result.";
+		const outputSchema = { type: "object" as const, required: ["ok"], properties: { ok: { type: "boolean" }, note: { type: "string" } } };
+		const permissionExtDir = path.join(agentDir, "extensions", "pi-permission-system");
+		fs.mkdirSync(path.join(permissionExtDir, "src"), { recursive: true });
+		fs.writeFileSync(path.join(permissionExtDir, "src", "index.ts"), "export default () => {};", "utf-8");
+		fs.writeFileSync(path.join(permissionExtDir, "package.json"), JSON.stringify({ name: "test", pi: { extensions: ["./src/index.ts"] } }), "utf-8");
+		const agentPath = path.join(tempDir, ".pi", "agents", `${agentName}.md`);
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(agentPath, `---
+name: ${agentName}
+tools:
+extensions:
+systemPromptMode: replace
+inheritProjectContext: false
+inheritSkills: false
+defaultContext: fresh
+---
+
+Answer only from the supplied synthetic text and return the requested structured result.
+`, "utf-8");
+		const refinementPath = path.join(tempDir, ".pi", "subagents", "refinements", `${agentName}.md`);
+		fs.mkdirSync(path.dirname(refinementPath), { recursive: true });
+		fs.writeFileSync(refinementPath, `<!-- pi-subagents-refinement:v1
+{
+  "agent": ${JSON.stringify(agentName)},
+  "revision": 1,
+  "updatedAt": "2026-01-01T00:00:00.000Z",
+  "base": {
+    "source": "project",
+    "filePath": ${JSON.stringify(agentPath)},
+    "systemPromptSha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "evidence": {
+    "maxItems": 8,
+    "maxAgeDays": 14,
+    "itemBytes": 2048,
+    "totalBytes": 16384
+  }
+}
+-->
+
+# Current refinement for \`${agentName}\`
+
+\`\`\`pi-subagents-refinement-current
+When the task asks for a structured result, keep field names exactly as requested.
+\`\`\`
+
+# Snapshots
+
+\`\`\`pi-subagents-refinement-snapshots-json
+[]
+\`\`\`
+`, "utf-8");
+
+		const discovered = discoverAgents(tempDir).agents.find((agent) => agent.name === agentName);
+		assert.ok(discovered, "expected temporary agent definition to be discovered");
+		const launchInput = {
+			agent: agentName,
+			cwd: tempDir,
+			task,
+			context: "fresh" as const,
+			outputSchema,
+			skill: false,
+			output: false,
+			artifacts: false,
+		};
+		const preflight = await resolveSubagentLaunchContract(launchInput);
+		assert.equal(preflight.ok, true);
+		if (!preflight.ok) return;
+		const overlayMarkdown = fs.readFileSync(refinementPath, "utf-8");
+		fs.rmSync(refinementPath);
+		const withoutOverlay = await resolveSubagentLaunchContract(launchInput);
+		assert.equal(withoutOverlay.ok, true);
+		if (!withoutOverlay.ok) return;
+		assert.notEqual(withoutOverlay.contract.launchContractDigest, preflight.contract.launchContractDigest);
+		fs.writeFileSync(refinementPath, overlayMarkdown, "utf-8");
+
+		const structured = createStructuredOutputRuntime(outputSchema, tempDir);
+		mockPi.onCall({ structuredOutput: { ok: true, note: "captured" } });
+		const foreground = await runSync(tempDir, [discovered], agentName, task, {
+			runId: "digest-probe-foreground",
+			acceptance: false,
+			structuredOutput: structured,
+		});
+		assert.equal(foreground.exitCode, 0, foreground.error);
+		assert.deepEqual(foreground.structuredOutput, { ok: true, note: "captured" });
+		assert.equal((foreground as { launchContractDigest?: string }).launchContractDigest, preflight.contract.launchContractDigest);
 	});
 
 	it("does not inject a workflow child output without an aggregate or explicit output", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -319,6 +319,7 @@ describe("single sync execution", { skip: !available ? "pi packages not availabl
 		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
 		fs.writeFileSync(agentPath, `---
 name: ${agentName}
+description: Structured digest probe
 tools:
 extensions:
 systemPromptMode: replace


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the preflight/foreground `launchContractDigest` mismatch from #2112 when a project-local refinement overlay is present.

Thanks to [@Yivas](https://github.com/Yivas) for #2112.

## Invariant

Equivalent preflight and structured foreground execution inputs must produce the same `launchContractDigest`.

Foreground (and async) already call `appendAgentRefinementOverlay()` before hashing the effective system prompt. `resolveSubagentLaunchContract()` hashed the prompt without that overlay, so the digests diverged whenever a refinement existed.

## Change

- Apply the same refinement projection during preflight, in the same order as execution (after memory injection, before output-path injection), before computing `definitionDigest` and `launchContractDigest`.
- Add one integration regression: project-local refinement fixture, structured foreground execution, and exact preflight/terminal digest equality. The test also asserts that removing the overlay changes the preflight digest, so the overlay is actually in the binding.

## Out of scope

- No `expectedLaunchContractDigest` enforcement (that expands the public API).
- No execution-path or #2110/#2111 seam changes.

## Validation

- `npx tsc --noEmit`: passed
- `test/unit/preflight.test.ts` + `test/unit/agent-refinements.test.ts`: 34 passed
- Existing `matches preflight launch digest in equivalent foreground and async execution`: passed
- New `matches preflight launch digest for structured foreground execution with a project-local refinement`: passed

Does not close #2112.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbdb05e9-b8e0-4b43-9da3-21a5d5ba4b21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbdb05e9-b8e0-4b43-9da3-21a5d5ba4b21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

