### PR TITLE
fix: fail review/scout launches when permitted repo tools are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Fail review and scout launches closed when a requested, still-permitted repository tool is missing from the host runtime, and classify that gap as a lane infrastructure failure instead of a completed review. Intentionally empty or ceiling-restricted allowlists stay valid. Remaining #2058 residual; thanks to [@nicobailon](https://github.com/nicobailon).
 - Apply the same project-local refinement overlay during launch-contract preflight that foreground execution already injects, so `launchContractDigest` matches the completed terminal. Thanks to [@Yivas](https://github.com/Yivas) for #2112.
 - Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement. Thanks to [@ton77v](https://github.com/ton77v) for #2101.
 - Label workflow usage as belonging to child rows instead of showing a misleading zero or overlapping wrapper totals in FleetView; preserve unrelated standalone usage in mixed summaries and distinguish summed concurrent windows from a single context window. Related to #2085; thanks to [@expoli](https://github.com/expoli).

--- a/src/runs/shared/child-launch.ts
+++ b/src/runs/shared/child-launch.ts
@@ -117,7 +117,8 @@ export interface BuildInProcessChildLaunchInput {
 	/**
 	 * Builtin tool names the host runtime provides. When set, child tool plans
 	 * intersect declared agent tools with this set, omitting tools the host
-	 * cannot provide and failing closed when required tools are unavailable.
+	 * cannot provide. Review/scout lanes fail closed when a requested,
+	 * still-permitted repository inspection tool is missing from that set.
 	 */
 	hostAvailableBuiltins?: readonly string[];
 }

--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -62,8 +62,40 @@ const FAST_MODE_ALLOWED_MODELS = new Set([
 ]);
 const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
 const PI_BUILTIN_TOOL_NAMES = new Set(["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"]);
+const REPOSITORY_INSPECTION_TOOLS = new Set(["read", "grep", "find", "ls", "bash", "powershell"]);
+const REVIEW_OR_SCOUT_AGENT_PATTERN = /\b(?:reviewer|scout)\b/i;
 // These providers come from child hooks, not the host's builtin tool registry.
 const NATIVE_COORDINATION_TOOL_NAMES = new Set(["subagent", "contact_supervisor", "subagent_supervisor"]);
+
+export function isReviewOrScoutLaneAgent(agentName: string | undefined): boolean {
+	return typeof agentName === "string" && REVIEW_OR_SCOUT_AGENT_PATTERN.test(agentName);
+}
+
+export function missingPermittedRepositoryInspectionTools(
+	unavailableHostBuiltins: readonly string[],
+	excludeTools: readonly string[] = [],
+): string[] {
+	const excluded = new Set(excludeTools);
+	return unavailableHostBuiltins.filter((tool) => REPOSITORY_INSPECTION_TOOLS.has(tool) && !excluded.has(tool));
+}
+
+export function formatReviewLaneToolContractFailure(input: {
+	agentName?: string;
+	missingTools: readonly string[];
+	requestedTools?: readonly string[];
+	effectiveTools: readonly string[];
+	ceilingSources?: readonly string[];
+	excludeTools?: readonly string[];
+}): string {
+	const subject = input.agentName ? `Agent '${input.agentName}'` : "Subagent";
+	return [
+		`${subject}: tool contract could not be satisfied; host runtime does not provide permitted required repository tools [${input.missingTools.join(", ")}].`,
+		`Requested tool names: ${input.requestedTools ? `[${input.requestedTools.join(", ")}]` : "not explicitly specified"}; effective tool allowlist: [${input.effectiveTools.join(", ")}].`,
+		...(input.ceilingSources?.length ? [`Active capability ceiling sources: [${input.ceilingSources.join(", ")}].`] : []),
+		...(input.excludeTools?.length ? [`Explicit excludeTools: [${input.excludeTools.join(", ")}].`] : []),
+		"This is a lane infrastructure failure, not a completed review/scout result.",
+	].join(" ");
+}
 
 export function deriveForkPromptCacheKey(parentSessionId: string | undefined): string | undefined {
 	const parent = parentSessionId?.trim();
@@ -158,8 +190,10 @@ export interface ResolvePiLaunchToolPlanInput {
 	/**
 	 * When provided, child tool plans intersect declared builtin tools with
 	 * this set. Tools the agent declares but the host does not provide are
-	 * omitted with a non-fatal warning (tracked in `unavailableHostBuiltins`), and agents
-	 * that require unavailable tools fail closed with an explicit error.
+	 * omitted with a non-fatal warning (tracked in `unavailableHostBuiltins`).
+	 * Review/scout lanes fail closed when a requested, still-permitted
+	 * repository inspection tool is among those host omissions. Intentionally
+	 * empty or ceiling-restricted allowlists are not a minimum-tool contract.
 	 */
 	hostAvailableBuiltins?: readonly string[];
 }
@@ -494,6 +528,19 @@ export function resolvePiLaunchToolPlan(
 					]),
 				]
 			: undefined;
+	const missingPermittedRepositoryTools = input.tools !== undefined
+		? missingPermittedRepositoryInspectionTools(unavailableHostBuiltins, excludeTools)
+		: [];
+	if (missingPermittedRepositoryTools.length > 0 && isReviewOrScoutLaneAgent(input.agentName)) {
+		throw new Error(formatReviewLaneToolContractFailure({
+			agentName: input.agentName,
+			missingTools: missingPermittedRepositoryTools,
+			requestedTools: requestedToolNames,
+			effectiveTools: effectiveToolAllowlist,
+			ceilingSources: capabilityCeiling?.sources,
+			excludeTools,
+		}));
+	}
 	// Host pruning also happens without a ceiling (and therefore without an
 	// audit). Use the existing non-fatal launch warnings rather than inventing
 	// a ceiling or treating the requested allowlist as a minimum requirement.

--- a/test/unit/child-tool-plan-diagnostics.test.ts
+++ b/test/unit/child-tool-plan-diagnostics.test.ts
@@ -1,37 +1,64 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { resolvePiLaunchToolPlan } from "../../src/api/child-tool-plan.ts";
+import { formatReviewLaneToolContractFailure } from "../../src/runs/shared/child-tool-plan.ts";
 
 describe("public child tool plan diagnostics", () => {
-	it("reports host pruning without a capability ceiling, including an empty effective menu", () => {
+	it("fails a review/scout launch when host pruning drops permitted repository tools", () => {
+		assert.throws(
+			() => resolvePiLaunchToolPlan({
+				agentName: "scout",
+				tools: ["read", "grep", "find", "ls", "bash"],
+				hostAvailableBuiltins: [],
+			}),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.equal(error.message, formatReviewLaneToolContractFailure({
+					agentName: "scout",
+					missingTools: ["read", "grep", "find", "ls", "bash"],
+					requestedTools: ["read", "grep", "find", "ls", "bash"],
+					effectiveTools: [],
+				}));
+				assert.match(error.message, /lane infrastructure failure, not a completed review\/scout result/);
+				return true;
+			},
+		);
+	});
+
+	it("fails a reviewer when a ceiling-permitted repository tool is host-missing", () => {
+		assert.throws(
+			() => resolvePiLaunchToolPlan({
+				agentName: "reviewer",
+				tools: ["read", "grep", "bash", "write"],
+				hostAvailableBuiltins: ["bash", "write"],
+				excludeTools: ["write"],
+				capabilityCeiling: { version: 1, allowedTools: ["read", "bash", "write"], denyExtensions: false, sources: ["plan-mode"] },
+				inheritedCapabilityCeiling: { version: 1, allowedTools: ["read", "grep", "write"], denyExtensions: false, sources: ["parent-policy"] },
+			}),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.match(error.message, /Agent 'reviewer': tool contract could not be satisfied/);
+				assert.match(error.message, /permitted required repository tools \[read\]/);
+				assert.match(error.message, /Active capability ceiling sources: \[parent-policy, plan-mode\]/);
+				assert.match(error.message, /Explicit excludeTools: \[write\]/);
+				assert.match(error.message, /lane infrastructure failure/);
+				return true;
+			},
+		);
+	});
+
+	it("keeps host-pruned warnings for non-review agents, including an empty effective menu", () => {
 		const plan = resolvePiLaunchToolPlan({
-			agentName: "scout",
+			agentName: "worker",
 			tools: ["read", "grep", "find", "ls", "bash"],
 			hostAvailableBuiltins: [],
 		});
 		assert.deepEqual(plan.warnings, [
-			"Agent 'scout': host runtime tool availability omitted [read, grep, find, ls, bash]. Requested tool names: [read, grep, find, ls, bash]; effective tool allowlist: []. This is a non-fatal tool-plan diagnostic, not verification of the child's runtime tool menu.",
+			"Agent 'worker': host runtime tool availability omitted [read, grep, find, ls, bash]. Requested tool names: [read, grep, find, ls, bash]; effective tool allowlist: []. This is a non-fatal tool-plan diagnostic, not verification of the child's runtime tool menu.",
 		]);
 		assert.deepEqual(plan.effectiveToolAllowlist, []);
 		assert.deepEqual(plan.requiredChildTools, []);
 		assert.equal(plan.capabilityAudit, undefined);
-	});
-
-	it("distinguishes host omissions from the intersected ceiling and explicit exclusions", () => {
-		const plan = resolvePiLaunchToolPlan({
-			agentName: "reviewer",
-			tools: ["read", "grep", "bash", "write"],
-			hostAvailableBuiltins: ["bash", "write"],
-			excludeTools: ["write"],
-			capabilityCeiling: { version: 1, allowedTools: ["read", "bash", "write"], denyExtensions: false, sources: ["plan-mode"] },
-			inheritedCapabilityCeiling: { version: 1, allowedTools: ["read", "grep", "write"], denyExtensions: false, sources: ["parent-policy"] },
-		});
-		assert.deepEqual(plan.warnings, [
-			"Agent 'reviewer': host runtime tool availability omitted [read]. Requested tool names: [read, grep, bash, write]; effective tool allowlist: []. Active capability ceiling sources: [parent-policy, plan-mode]. Explicit excludeTools: [write]. This is a non-fatal tool-plan diagnostic, not verification of the child's runtime tool menu.",
-		]);
-		assert.deepEqual(plan.capabilityAudit?.requestedTools, ["read", "grep", "bash", "write"]);
-		assert.deepEqual(plan.capabilityAudit?.effectiveTools, []);
-		assert.deepEqual(plan.capabilityAudit?.unavailableHostBuiltins, ["read"]);
 	});
 
 	it("does not invent an explicit request, agent name, or ceiling source when absent", () => {
@@ -53,5 +80,63 @@ describe("public child tool plan diagnostics", () => {
 			const plan = resolvePiLaunchToolPlan({ tools: ["read"], ...input });
 			assert.deepEqual(plan.warnings, []);
 		}
+	});
+
+	it("does not reject an intentionally empty or ceiling-restricted review allowlist", () => {
+		const emptyAllowlist = resolvePiLaunchToolPlan({
+			agentName: "scout",
+			tools: [],
+			hostAvailableBuiltins: [],
+		});
+		assert.deepEqual(emptyAllowlist.effectiveToolAllowlist, []);
+		assert.deepEqual(emptyAllowlist.requiredChildTools, []);
+		assert.deepEqual(emptyAllowlist.unavailableHostBuiltins, []);
+		assert.deepEqual(emptyAllowlist.warnings, []);
+
+		const emptyCeiling = resolvePiLaunchToolPlan({
+			agentName: "reviewer",
+			tools: ["read", "grep"],
+			hostAvailableBuiltins: [],
+			capabilityCeiling: { version: 1, allowedTools: [], denyExtensions: false, sources: ["plan-mode"] },
+		});
+		assert.deepEqual(emptyCeiling.effectiveToolAllowlist, []);
+		assert.deepEqual(emptyCeiling.requiredChildTools, []);
+		assert.deepEqual(emptyCeiling.unavailableHostBuiltins, []);
+		assert.deepEqual(emptyCeiling.warnings, []);
+	});
+
+	it("does not treat excluded repository tools as a missing review-lane contract", () => {
+		const restricted = resolvePiLaunchToolPlan({
+			agentName: "scout",
+			tools: ["read", "grep", "bash"],
+			excludeTools: ["read", "grep"],
+			hostAvailableBuiltins: ["read", "grep", "bash"],
+		});
+		assert.deepEqual(restricted.effectiveToolAllowlist, ["bash"]);
+		assert.deepEqual(restricted.requiredChildTools, ["bash"]);
+		assert.deepEqual(restricted.unavailableHostBuiltins, []);
+		assert.deepEqual(restricted.warnings, []);
+
+		const hostMissingExcluded = resolvePiLaunchToolPlan({
+			agentName: "reviewer",
+			tools: ["read", "grep"],
+			excludeTools: ["read", "grep"],
+			hostAvailableBuiltins: [],
+		});
+		assert.deepEqual(hostMissingExcluded.effectiveToolAllowlist, []);
+		assert.deepEqual(hostMissingExcluded.requiredChildTools, []);
+		assert.deepEqual(hostMissingExcluded.unavailableHostBuiltins, ["read", "grep"]);
+		assert.match(hostMissingExcluded.warnings[0] ?? "", /host runtime tool availability omitted \[read, grep\]/);
+	});
+
+	it("keeps a scout launch when only a non-repository requested tool is host-pruned", () => {
+		const plan = resolvePiLaunchToolPlan({
+			agentName: "scout",
+			tools: ["read", "grep", "find", "ls", "bash", "write"],
+			hostAvailableBuiltins: ["read", "grep", "find", "ls", "bash"],
+		});
+		assert.deepEqual(plan.effectiveToolAllowlist, ["read", "grep", "find", "ls", "bash"]);
+		assert.deepEqual(plan.unavailableHostBuiltins, ["write"]);
+		assert.match(plan.warnings[0] ?? "", /host runtime tool availability omitted \[write\]/);
 	});
 });

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -181,6 +181,21 @@ describe("production launch path supplies hostAvailableBuiltins", () => {
 			assert.deepEqual(launch.warnings, [
 				"Agent 'test-agent': host runtime tool availability omitted [read, grep]. Requested tool names: [read, grep, bash]; effective tool allowlist: [bash]. This is a non-fatal tool-plan diagnostic, not verification of the child's runtime tool menu.",
 			]);
+			assert.throws(
+				() => buildInProcessChildLaunch({
+					host: "runner",
+					cwd,
+					childAgentName: "scout",
+					childIndex: 0,
+					sessionEnabled: false,
+					inheritProjectContext: false,
+					inheritGlobalContext: false,
+					inheritSkills: false,
+					tools: ["read", "grep", "bash"],
+					hostAvailableBuiltins: ["ipython", "bash"],
+				}),
+				/Agent 'scout': tool contract could not be satisfied.*permitted required repository tools \[read, grep\].*lane infrastructure failure/,
+			);
 		} finally {
 			if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
 			else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -969,6 +969,33 @@ Project prompt.
 		assert.equal(implicit.contract.context, "fresh");
 	});
 
+	it("fails a review/scout preflight when host pruning drops a permitted repository tool", async () => {
+		const cwd = path.join(tempDir, "repo-scout-host-prune");
+		fs.mkdirSync(cwd, { recursive: true });
+		writeAgent(path.join(cwd, ".pi", "agents", "scout.md"), `---
+name: scout
+description: Project scout
+tools:
+  - read
+  - grep
+  - find
+  - ls
+---
+Project prompt.
+`);
+
+		const result = await resolveSubagentLaunchContract({
+			agent: "scout",
+			cwd,
+			hostAvailableBuiltins: [],
+		});
+		assert.equal(result.ok, false);
+		assert.equal(result.code, "denied_required_tool");
+		assert.match(result.message, /Agent 'scout': tool contract could not be satisfied/);
+		assert.match(result.message, /permitted required repository tools \[read, grep, find, ls\]/);
+		assert.match(result.message, /lane infrastructure failure, not a completed review\/scout result/);
+	});
+
 	it("fails closed when a capability ceiling denies read required for child skills", async () => {
 		const cwd = path.join(tempDir, "repo");
 		fs.mkdirSync(cwd, { recursive: true });

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
 import { Worker } from "node:worker_threads";
+import { resolvePiLaunchToolPlan } from "../../src/runs/shared/child-tool-plan.ts";
 import { formatWorkflowJsonPreview, previewSimpleWorkflowRun, runWorkflowScript, validateWorkflowScript, WorkflowScriptError } from "../../src/workflows/scripted-workflow.ts";
+import { workflowChildSummary } from "../../src/workflows/workflow-child-summary.ts";
 import { preflightWorkflowWorktrees } from "../../src/runs/foreground/subagent-executor.ts";
 import { runSetupCommand } from "../../src/runs/shared/worktree-setup-command.ts";
 import { claimRunFanoutBatch, createRunFanoutBudget, getRunFanoutBudgetSnapshot } from "../../src/runs/shared/run-fanout-budget.ts";
@@ -852,6 +854,42 @@ describe("scripted workflow runtime", () => {
 			/workflow script global concurrency limit must be a positive integer/,
 		);
 		assert.equal(launches, 0);
+	});
+
+	it("classifies a review-lane missing tool contract as a failed child, not a completed review", async () => {
+		await assert.rejects(
+			runWorkflowScript({
+				script: `return await runs.run("review", { agent: "reviewer", task: "Review the diff" });`,
+				async launch(key) {
+					resolvePiLaunchToolPlan({
+						agentName: "reviewer",
+						tools: ["read", "grep", "find", "ls"],
+						hostAvailableBuiltins: [],
+					});
+					return { key, ok: true, output: "Unable to inspect the repository.", artifactPaths: [] };
+				},
+				async status(key) { return { key, ok: true, output: "ok", artifactPaths: [] }; },
+			}),
+			(error: unknown) => {
+				assert.ok(error instanceof WorkflowScriptError);
+				assert.match(error.message, /Run 'review' failed: Agent 'reviewer': tool contract could not be satisfied/);
+				assert.match(error.message, /lane infrastructure failure, not a completed review\/scout result/);
+				assert.equal(error.partial.children[0]?.ok, false);
+				assert.match(error.partial.children[0]?.error ?? "", /tool contract could not be satisfied/);
+				assert.equal(error.partial.trace.find((entry) => entry.key === "review" && entry.state === "failed")?.state, "failed");
+				const summary = workflowChildSummary({
+					parentToolCallId: "tool-call",
+					workflowRunId: "workflow-review",
+					workflowState: "failed",
+					inventoryComplete: true,
+					trace: error.partial.trace,
+					children: error.partial.children,
+				});
+				assert.equal(summary.children[0]?.state, "failed");
+				assert.notEqual(summary.children[0]?.state, "completed");
+				return true;
+			},
+		);
 	});
 
 	it("returns runs.all launch errors without aborting successful siblings", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to #2058. This is the remaining runtime/failure-classification residual, not full issue closure.

#2061 fixed discovery. #2092 added a non-fatal host-pruning warning. After those, a review or scout child could still launch when a requested, still-permitted repository tool was absent from the host: `requiredChildTools` was computed after host intersection, so the runtime required-tool check never fired and workflow fanout treated the child as a completed review.

## Invariant

If a review/scout agent explicitly requests repository inspection tools that survive the ceiling and `excludeTools`, and the host runtime does not provide them, fail closed before launch with a diagnostic that names the agent, requested/missing tools, and known limiting sources. Workflow fanout records that child as failed infrastructure, not a completed review/scout lane.

Intentionally empty allowlists and empty/restrictive ceilings stay valid. Non-review agents still get the existing non-fatal host-pruning warning. This is not a general minimum-tool contract.

## Change

- In `resolvePiLaunchToolPlan`, after host intersection, fail review/scout launches when a requested permitted repository tool (`read`, `grep`, `find`, `ls`, `bash`, `powershell`) is host-missing and not excluded.
- Keep host-pruned warnings for other agents and for non-repository omissions such as `write`.
- Preflight maps the throw to `denied_required_tool`. Workflow launch errors stay `ok: false` / `failed`.

## Out of scope

- No minimum-capability API.
- No SSH / launch-digest / refinement-overlay changes (#2110 / #2113).
- No inference from reviewer prose.

## Validation

- `npm run typecheck`: passed
- Focused unit tests: 178 passed, 0 failed (child-tool-plan, diagnostics, preflight, scripted-workflow, child-runtime-config)

Credit to [@nicobailon](https://github.com/nicobailon) for the report.

Does not close #2058.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6735d863-4b39-4d7a-b2fe-1edc86a7d945?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6735d863-4b39-4d7a-b2fe-1edc86a7d945&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

