### PR TITLE
Hold final-stop drain while queued steering remains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
-- Do not abort a native child during final-stop drain while steering or follow-up input is still queued, even if Pi reaches `turn_start` after the grace period. Related to #2117; thanks to [@yanqianglu](https://github.com/yanqianglu) for #2057.
+- Do not abort a native child during final-stop drain after queued steering or follow-up is observed, even if Pi drains that input before a delayed `turn_start`. Related to #2117; thanks to [@yanqianglu](https://github.com/yanqianglu) for #2057.
 - Fail review and scout launches closed when a requested, still-permitted repository tool is missing from the host runtime, and classify that gap as a lane infrastructure failure instead of a completed review. Intentionally empty or ceiling-restricted allowlists stay valid. Remaining #2058 residual; thanks to [@nicobailon](https://github.com/nicobailon).
 - Apply the same project-local refinement overlay during launch-contract preflight that foreground execution already injects, so `launchContractDigest` matches the completed terminal. Thanks to [@Yivas](https://github.com/Yivas) for #2112.
 - Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement. Thanks to [@ton77v](https://github.com/ton77v) for #2101.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Do not abort a native child during final-stop drain while steering or follow-up input is still queued, even if Pi reaches `turn_start` after the grace period. Related to #2117; thanks to [@yanqianglu](https://github.com/yanqianglu) for #2057.
 - Fail review and scout launches closed when a requested, still-permitted repository tool is missing from the host runtime, and classify that gap as a lane infrastructure failure instead of a completed review. Intentionally empty or ceiling-restricted allowlists stay valid. Remaining #2058 residual; thanks to [@nicobailon](https://github.com/nicobailon).
 - Apply the same project-local refinement overlay during launch-contract preflight that foreground execution already injects, so `launchContractDigest` matches the completed terminal. Thanks to [@Yivas](https://github.com/Yivas) for #2112.
 - Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement. Thanks to [@ton77v](https://github.com/ton77v) for #2101.

--- a/src/runs/background/run-child-session.ts
+++ b/src/runs/background/run-child-session.ts
@@ -23,7 +23,7 @@ import { formatSubagentModelVerificationError } from "../shared/model-fallback.t
 import { isMutatingTool, resolveCurrentPath } from "../shared/long-running-guard.ts";
 import { effectiveToolTimeoutMs, formatToolTimeoutMessage, toolTimeoutCallKey } from "../shared/tool-timeout.ts";
 import { createReportedChildSessionInput, type InProcessChildLaunch } from "../shared/child-launch.ts";
-import { projectChildSessionEventForJson, type ChildSession, type ChildSessionEvent, type ChildSessionFactory } from "../shared/child-session.ts";
+import { childSessionHasQueuedMessages, projectChildSessionEventForJson, type ChildSession, type ChildSessionEvent, type ChildSessionFactory } from "../shared/child-session.ts";
 import { formatSteerMessage } from "../shared/subagent-prompt-runtime.ts";
 import { getReadonlySessionEvidence, requestReadonlySessionEvidence, type SettledReadonlyEvidence } from "../shared/readonly-session-evidence.ts";
 import type { SteerDeliveryStatus, SteerRequest } from "./control-channel.ts";
@@ -317,11 +317,16 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 				return;
 			}
 			if (promptSettled || finalDrainTimer || settled) return;
+			if (childSessionHasQueuedMessages(session)) return;
+			armFinalDrainTimer();
+		}
+		function armFinalDrainTimer(): void {
+			if (promptSettled || finalDrainTimer || settled) return;
 			finalDrainTimer = setTimeout(() => {
 				if (settled || promptSettled) return;
-				if (input.launch.capture.finalDrainHeld()) {
+				if (input.launch.capture.finalDrainHeld() || childSessionHasQueuedMessages(session)) {
 					finalDrainTimer = undefined;
-					startFinalDrain();
+					armFinalDrainTimer();
 					return;
 				}
 				forcedTermination = true;

--- a/src/runs/background/run-child-session.ts
+++ b/src/runs/background/run-child-session.ts
@@ -193,6 +193,7 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 		let forcedTermination = false;
 		let cleanTerminalAssistantStopReceived = false;
 		let agentSettledReceived = false;
+		let queuedDrainHold = false;
 		let compactionStartedReceived = false;
 		let afterCompactionSettlement = false;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
@@ -311,20 +312,24 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 		}
 		// If the child emits its terminal event but its run never settles (a hook
 		// is stuck), abort it after a short grace period and then finish without it.
+		const observeQueuedDrainHold = (): boolean => {
+			if (childSessionHasQueuedMessages(session)) queuedDrainHold = true;
+			return queuedDrainHold;
+		};
 		function startFinalDrain(): void {
 			if (childWatchdogIsActive(childWatchdogState)) {
 				armWatchdogTail();
 				return;
 			}
 			if (promptSettled || finalDrainTimer || settled) return;
-			if (childSessionHasQueuedMessages(session)) return;
+			if (observeQueuedDrainHold()) return;
 			armFinalDrainTimer();
 		}
 		function armFinalDrainTimer(): void {
 			if (promptSettled || finalDrainTimer || settled) return;
 			finalDrainTimer = setTimeout(() => {
 				if (settled || promptSettled) return;
-				if (input.launch.capture.finalDrainHeld() || childSessionHasQueuedMessages(session)) {
+				if (input.launch.capture.finalDrainHeld() || observeQueuedDrainHold()) {
 					finalDrainTimer = undefined;
 					armFinalDrainTimer();
 					return;
@@ -412,6 +417,9 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 			if (event.type === "compaction_end" && event.willRetry === true) {
 				compactionStartedReceived = false;
 				afterCompactionSettlement = false;
+			}
+			if (event.type === "turn_start" || event.type === "agent_start" || event.type === "auto_retry_start") {
+				queuedDrainHold = false;
 			}
 			if (event.type === "agent_start" || event.type === "auto_retry_start") {
 				compactionStartedReceived = false;
@@ -623,6 +631,16 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 					return;
 				}
 				session = created;
+				const steer = created.steer.bind(created);
+				const followUp = created.followUp.bind(created);
+				created.steer = async (text) => {
+					if (cleanTerminalAssistantStopReceived || agentSettledReceived) queuedDrainHold = true;
+					return steer(text);
+				};
+				created.followUp = async (text) => {
+					if (cleanTerminalAssistantStopReceived || agentSettledReceived) queuedDrainHold = true;
+					return followUp(text);
+				};
 				checkContinuation();
 				if (continuation && (created.modelId !== continuation.modelId || input.launch.capture.completionIntentContext?.()?.model?.api !== continuation.expected.api)) throw new Error("Read-only continuation model changed");
 				unsubscribe = created.subscribe(processEvent);

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -113,7 +113,7 @@ import {
 	type ChildWatchdogStatusEvent,
 } from "../../watchdog/child-status.ts";
 import { buildInProcessChildLaunch, createReportedChildSessionInput } from "../shared/child-launch.ts";
-import { childSessionFactory, projectChildSessionEventForJson, type ChildSession, type ChildSessionEvent } from "../shared/child-session.ts";
+import { childSessionFactory, childSessionHasQueuedMessages, projectChildSessionEventForJson, type ChildSession, type ChildSessionEvent } from "../shared/child-session.ts";
 
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
 const acceptanceOutputByResult = new WeakMap<SingleResult, string>();
@@ -719,11 +719,16 @@ async function runSingleAttempt(
 				return;
 			}
 			if (sessionSettled || finalDrainTimer || lifecycleFinished) return;
+			if (childSessionHasQueuedMessages(session)) return;
+			armFinalDrainTimer();
+		};
+		const armFinalDrainTimer = () => {
+			if (sessionSettled || finalDrainTimer || lifecycleFinished) return;
 			finalDrainTimer = setTimeout(() => {
 				if (lifecycleFinished || sessionSettled) return;
-				if (capture.finalDrainHeld()) {
+				if (capture.finalDrainHeld() || childSessionHasQueuedMessages(session)) {
 					finalDrainTimer = undefined;
-					startFinalDrain();
+					armFinalDrainTimer();
 					return;
 				}
 				forcedTermination = true;

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -687,6 +687,7 @@ async function runSingleAttempt(
 		let forcedTermination = false;
 		let cleanTerminalAssistantStopReceived = false;
 		let agentSettledReceived = false;
+		let queuedDrainHold = false;
 		let compactionStartedReceived = false;
 		let finalDrainTimer: NodeJS.Timeout | undefined;
 		let finalHardFinishTimer: NodeJS.Timeout | undefined;
@@ -713,20 +714,24 @@ async function runSingleAttempt(
 				finalHardFinishTimer = undefined;
 			}
 		};
+		const observeQueuedDrainHold = (): boolean => {
+			if (childSessionHasQueuedMessages(session)) queuedDrainHold = true;
+			return queuedDrainHold;
+		};
 		const startFinalDrain = () => {
 			if (childWatchdogIsActive(childWatchdogState)) {
 				armWatchdogTail();
 				return;
 			}
 			if (sessionSettled || finalDrainTimer || lifecycleFinished) return;
-			if (childSessionHasQueuedMessages(session)) return;
+			if (observeQueuedDrainHold()) return;
 			armFinalDrainTimer();
 		};
 		const armFinalDrainTimer = () => {
 			if (sessionSettled || finalDrainTimer || lifecycleFinished) return;
 			finalDrainTimer = setTimeout(() => {
 				if (lifecycleFinished || sessionSettled) return;
-				if (capture.finalDrainHeld() || childSessionHasQueuedMessages(session)) {
+				if (capture.finalDrainHeld() || observeQueuedDrainHold()) {
 					finalDrainTimer = undefined;
 					armFinalDrainTimer();
 					return;
@@ -1009,6 +1014,9 @@ async function runSingleAttempt(
 			if (evt.type === "compaction_end" && evt.willRetry === true) {
 				compactionStartedReceived = false;
 				afterCompactionSettlement = false;
+			}
+			if (evt.type === "turn_start" || evt.type === "agent_start" || evt.type === "auto_retry_start") {
+				queuedDrainHold = false;
 			}
 			if (evt.type === "agent_start" || evt.type === "auto_retry_start") {
 				compactionStartedReceived = false;
@@ -1396,6 +1404,16 @@ async function runSingleAttempt(
 					return;
 				}
 				session = created;
+				const steer = created.steer.bind(created);
+				const followUp = created.followUp.bind(created);
+				created.steer = async (text) => {
+					if (cleanTerminalAssistantStopReceived || agentSettledReceived) queuedDrainHold = true;
+					return steer(text);
+				};
+				created.followUp = async (text) => {
+					if (cleanTerminalAssistantStopReceived || agentSettledReceived) queuedDrainHold = true;
+					return followUp(text);
+				};
 				created.detached = detached;
 				unsubscribe = created.subscribe((event) => processEvent(event as Parameters<typeof processEvent>[0]));
 				if (abortedBySignal || interruptedByControl || result.timedOut) {

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -108,7 +108,11 @@ export interface ChildSession {
 }
 
 export function childSessionHasQueuedMessages(session: ChildSession | undefined): boolean {
-	return session?.hasQueuedMessages?.() === true;
+	try {
+		return session?.hasQueuedMessages?.() === true;
+	} catch {
+		return false;
+	}
 }
 
 export interface ChildSessionFactory {
@@ -348,7 +352,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 				steer: (text) => { evidence?.invalidate(); return session.steer(text); },
 				followUp: (text) => { evidence?.invalidate(); return session.followUp(text); },
 				abort: () => { evidence?.invalidate(); return session.abort(); },
-				hasQueuedMessages: () => session.agent.hasQueuedMessages(),
+				hasQueuedMessages: () => session.agent?.hasQueuedMessages?.() === true,
 				dispose: () => {
 					if (!pending) {
 						live.delete(child);

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -95,6 +95,8 @@ export interface ChildSession {
 	abort(): Promise<void>;
 	/** Emits `session_shutdown` to the child's extensions and disposes the session; resolves once that shutdown work is done. */
 	dispose(): Promise<void>;
+	/** True while Pi still has steering or follow-up input that has not started a turn. */
+	hasQueuedMessages?(): boolean;
 	readonly messages: readonly AgentMessage[];
 	readonly sessionFile: string | undefined;
 	readonly sessionId: string;
@@ -103,6 +105,10 @@ export interface ChildSession {
 	detached?: boolean;
 	/** Set by `factory.dispose()` before it aborts the child, so the host can report the stop truthfully. */
 	shutDown?: boolean;
+}
+
+export function childSessionHasQueuedMessages(session: ChildSession | undefined): boolean {
+	return session?.hasQueuedMessages?.() === true;
 }
 
 export interface ChildSessionFactory {
@@ -342,6 +348,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 				steer: (text) => { evidence?.invalidate(); return session.steer(text); },
 				followUp: (text) => { evidence?.invalidate(); return session.followUp(text); },
 				abort: () => { evidence?.invalidate(); return session.abort(); },
+				hasQueuedMessages: () => session.agent.hasQueuedMessages(),
 				dispose: () => {
 					if (!pending) {
 						live.delete(child);

--- a/test/integration/async-execution.part-4.test.ts
+++ b/test/integration/async-execution.part-4.test.ts
@@ -17,7 +17,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { setChildSessionFactoryModule } from "../../src/runs/shared/child-session.ts";
 import { createEventBus, createTempDir, events, makeAgent, removeTempDir } from "../support/helpers.ts";
-import { deliverInterruptRequest, deliverStopRequest } from "../../src/runs/background/control-channel.ts";
+import { deliverInterruptRequest, deliverStopRequest, requestAsyncSteer } from "../../src/runs/background/control-channel.ts";
 import { SUBAGENT_PROCESS_TERMINAL_EVENT } from "../../src/shared/types.ts";
 import { waitForSubagents } from "../../src/runs/background/subagent-wait.ts";
 import type { AsyncResultPayload, AsyncStatusPayload } from "../support/async-execution-fixture.ts";
@@ -599,6 +599,35 @@ setTimeout(() => process.exit(90), 15000).unref();
 			assert.equal(check?.status, "failed");
 			assert.match(check?.message ?? "", /Unresolved watchdog blocker/);
 		});
+	});
+
+	it("background does not abort when a steer arrives after the final stop and turn_start is delayed", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		mockPi.onCall({
+			jsonl: [events.assistantMessage("before steer")],
+			keepAliveAfterFinalMessageMs: 15_000,
+			queuedMessageTurnStartDelayMs: 1400,
+			queuedMessageOutput: "after steer",
+		});
+		const id = `async-queued-steer-after-final-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: "worker", task: "Do work", agentConfig: makeAgent("worker"),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2,
+		});
+		await waitForMockPiCall(mockPi, 0, 10_000);
+		const scriptedFinal = path.join(mockPi.dir, "scripted-final.jsonl");
+		const deadline = Date.now() + 10_000;
+		while (!fs.existsSync(scriptedFinal)) {
+			if (Date.now() > deadline) assert.fail("Timed out waiting for scripted final message");
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		requestAsyncSteer(path.join(ASYNC_DIR, id), { message: "Continue after the final stop.", id: "after-final", ts: Date.now() });
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, true, payload.results[0]?.error);
+		assert.equal(payload.results[0]?.error, undefined);
+		assert.equal(payload.results[0]?.output, "after steer");
+		assert.doesNotMatch(JSON.stringify(payload), /did not settle within \d+ms after its terminal event/);
 	});
 
 	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {

--- a/test/integration/in-process-child.test.ts
+++ b/test/integration/in-process-child.test.ts
@@ -111,6 +111,28 @@ describe("in-process foreground child", () => {
 		]);
 	});
 
+	it("does not abort when a steer arrives after the final stop and turn_start is delayed", async () => {
+		mockPi.onCall({
+			jsonl: [events.assistantMessage("before steer")],
+			keepAliveAfterFinalMessageMs: 15_000,
+			queuedMessageTurnStartDelayMs: 1400,
+			queuedMessageOutput: "after steer",
+		});
+		let controls: ForegroundChildSessionControls | undefined;
+		const run = runSync(tempDir, makeAgentConfigs(["echo"]), "echo", "Task", {
+			runId: "queued-steer-after-final",
+			onChildSession: (next) => { controls = next; },
+		});
+		await waitFor(() => controls !== undefined && mockPi.sessions[0]?.scriptedFinalEmitted === true);
+		await controls!.steer("Continue after the final stop.");
+		const result = await run;
+		assert.equal(result.exitCode, 0, result.error);
+		assert.equal(result.error, undefined);
+		assert.equal(result.finalOutput, "after steer");
+		assert.equal(mockPi.sessions[0]?.aborted, false);
+		assert.deepEqual(mockPi.sessions[0]?.steers, [{ text: "Continue after the final stop.", mode: "steer" }]);
+	});
+
 	for (const type of ["turn_start", "agent_start", "auto_retry_start"]) {
 		it(`foreground keeps resumed work alive after ${type}`, async () => {
 			mockPi.onCall({

--- a/test/support/fake-child-session.ts
+++ b/test/support/fake-child-session.ts
@@ -42,7 +42,7 @@ export interface FakeChildResponse {
 	createError?: string;
 	/** Keeps the run open until the parent aborts it. */
 	hangUntilAbort?: boolean;
-	/** Delay before emitting `turn_start` when draining a steer/follow-up queued after the scripted final message. */
+	/** After draining a post-final steer/follow-up into pending (hasQueuedMessages false), delay before `turn_start`. */
 	queuedMessageTurnStartDelayMs?: number;
 	/** Assistant text emitted for that delayed queued-message turn. */
 	queuedMessageOutput?: string;
@@ -262,11 +262,11 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 			};
 			const drainQueuedBoundary = async (response: FakeChildResponse, task: string): Promise<void> => {
 				while (queued.length > 0 && !record.aborted) {
+					const drained = queued.splice(0);
 					const delay = response.queuedMessageTurnStartDelayMs ?? 0;
 					if (delay > 0) await sleep(delay, abortedPromise);
-					if (record.aborted || queued.length === 0) return;
+					if (record.aborted) return;
 					emit({ type: "turn_start" });
-					const drained = queued.splice(0);
 					const output = response.queuedMessageOutput ?? drained[0]?.text ?? "continued after queued input";
 					await emitEntries([defaultAssistantMessage(output, model)], task);
 					if (record.aborted) return;

--- a/test/support/fake-child-session.ts
+++ b/test/support/fake-child-session.ts
@@ -42,6 +42,10 @@ export interface FakeChildResponse {
 	createError?: string;
 	/** Keeps the run open until the parent aborts it. */
 	hangUntilAbort?: boolean;
+	/** Delay before emitting `turn_start` when draining a steer/follow-up queued after the scripted final message. */
+	queuedMessageTurnStartDelayMs?: number;
+	/** Assistant text emitted for that delayed queued-message turn. */
+	queuedMessageOutput?: string;
 }
 
 export interface FakeChildSessionRecord {
@@ -51,6 +55,7 @@ export interface FakeChildSessionRecord {
 	aborted: boolean;
 	disposed: boolean;
 	settled: boolean;
+	scriptedFinalEmitted: boolean;
 	session?: ChildSession;
 }
 
@@ -205,10 +210,13 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 	let disposeCalls = 0;
 	const factory: ChildSessionFactory = {
 		async create(launch) {
-			const record: FakeChildSessionRecord = { launch, task: undefined, steers: [], aborted: false, disposed: false, settled: false };
+			const record: FakeChildSessionRecord = { launch, task: undefined, steers: [], aborted: false, disposed: false, settled: false, scriptedFinalEmitted: false };
 			sessions.push(record);
 			const listeners = new Set<(event: ChildSessionEvent) => void>();
 			const messages: AgentMessage[] = [];
+			const queued: Array<{ text: string; mode: "steer" | "followUp" }> = [];
+			const queuedWaiters: Array<() => void> = [];
+			let boundaryOpen = false;
 			const model = reportedModel(launch.model);
 			let abortResolve: (() => void) | undefined;
 			const abortedPromise = new Promise<void>((resolve) => { abortResolve = resolve; });
@@ -228,6 +236,42 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 					fs.appendFileSync(path.join(queueDir(), "steers.jsonl"), `${JSON.stringify({ sessionId, text, mode })}\n`, "utf-8");
 				} catch {
 					// Observability for tests only.
+				}
+			};
+			const wakeQueuedWaiters = (): void => {
+				for (const resolve of queuedWaiters.splice(0)) resolve();
+			};
+			const enqueue = (text: string, mode: "steer" | "followUp"): void => {
+				record.steers.push({ text, mode });
+				recordSteer(text, mode);
+				if (!boundaryOpen) return;
+				queued.push({ text, mode });
+				wakeQueuedWaiters();
+			};
+			const waitForQueuedMessage = (): Promise<void> => {
+				if (queued.length > 0 || record.aborted) return Promise.resolve();
+				return new Promise((resolve) => { queuedWaiters.push(resolve); });
+			};
+			const markScriptedFinal = (): void => {
+				record.scriptedFinalEmitted = true;
+				try {
+					fs.appendFileSync(path.join(queueDir(), "scripted-final.jsonl"), `${JSON.stringify({ sessionId })}\n`, "utf-8");
+				} catch {
+					// Observability for tests only.
+				}
+			};
+			const drainQueuedBoundary = async (response: FakeChildResponse, task: string): Promise<void> => {
+				while (queued.length > 0 && !record.aborted) {
+					const delay = response.queuedMessageTurnStartDelayMs ?? 0;
+					if (delay > 0) await sleep(delay, abortedPromise);
+					if (record.aborted || queued.length === 0) return;
+					emit({ type: "turn_start" });
+					const drained = queued.splice(0);
+					const output = response.queuedMessageOutput ?? drained[0]?.text ?? "continued after queued input";
+					await emitEntries([defaultAssistantMessage(output, model)], task);
+					if (record.aborted) return;
+					emit({ type: "agent_end", messages: [...messages], willRetry: false });
+					emit({ type: "agent_settled" });
 				}
 			};
 			const emit = (event: unknown): void => {
@@ -322,9 +366,20 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 				if (record.aborted) return;
 				emit({ type: "agent_end", messages: [...messages], willRetry: false });
 				emit({ type: "agent_settled" });
-				if (typeof response.keepAliveAfterFinalMessageMs === "number" && response.keepAliveAfterFinalMessageMs > 0) {
-					await Promise.race([sleep(response.keepAliveAfterFinalMessageMs), abortedPromise]);
+				boundaryOpen = true;
+				markScriptedFinal();
+				const keepAliveMs = typeof response.keepAliveAfterFinalMessageMs === "number" && response.keepAliveAfterFinalMessageMs > 0
+					? response.keepAliveAfterFinalMessageMs
+					: 0;
+				if (!record.aborted && queued.length === 0 && (keepAliveMs > 0 || response.hangUntilAbort)) {
+					await Promise.race([
+						...(keepAliveMs > 0 ? [sleep(keepAliveMs, abortedPromise)] : []),
+						...(response.hangUntilAbort ? [abortedPromise] : []),
+						waitForQueuedMessage(),
+					]);
 				}
+				await drainQueuedBoundary(response, task);
+				if (record.aborted) return;
 				if (response.hangUntilAbort) await abortedPromise;
 				if (typeof response.exitCode === "number" && response.exitCode !== 0) {
 					throw new Error(response.stderr?.trim() || `mock child exited with code ${response.exitCode}`);
@@ -376,16 +431,18 @@ export function createFakeChildSessions(queueDir: () => string): FakeChildSessio
 					}
 				},
 				async steer(text) {
-					record.steers.push({ text, mode: "steer" });
-					recordSteer(text, "steer");
+					enqueue(text, "steer");
 				},
 				async followUp(text) {
-					record.steers.push({ text, mode: "followUp" });
-					recordSteer(text, "followUp");
+					enqueue(text, "followUp");
+				},
+				hasQueuedMessages() {
+					return queued.length > 0;
 				},
 				async abort() {
 					record.aborted = true;
 					abortResolve?.();
+					wakeQueuedWaiters();
 				},
 				async dispose() {
 					record.disposed = true;

--- a/test/unit/child-session-queued.test.ts
+++ b/test/unit/child-session-queued.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	childSessionHasQueuedMessages,
+	createDefaultChildSessionFactory,
+	type ChildSession,
+	type ChildSessionLaunch,
+	type PiCodingAgentModule,
+} from "../../src/runs/shared/child-session.ts";
+
+describe("childSessionHasQueuedMessages", () => {
+	it("treats a missing session or method as no queued input", () => {
+		assert.equal(childSessionHasQueuedMessages(undefined), false);
+		assert.equal(childSessionHasQueuedMessages({} as ChildSession), false);
+	});
+
+	it("keeps the drain hold when the session reports queued input", () => {
+		assert.equal(childSessionHasQueuedMessages({ hasQueuedMessages: () => true } as ChildSession), true);
+		assert.equal(childSessionHasQueuedMessages({ hasQueuedMessages: () => false } as ChildSession), false);
+	});
+
+	it("does not throw when hasQueuedMessages reads a missing agent", () => {
+		const session = {
+			hasQueuedMessages() {
+				const agent: { hasQueuedMessages?: () => boolean } | undefined = undefined;
+				return agent!.hasQueuedMessages!();
+			},
+		} as ChildSession;
+		assert.equal(childSessionHasQueuedMessages(session), false);
+	});
+});
+
+describe("default factory queued-message probe", () => {
+	it("reports no queued messages for an agent-less wrapped session", async () => {
+		const factory = createDefaultChildSessionFactory({
+			loadPiCodingAgent: async () => ({
+				ModelRuntime: { create: async () => ({}) },
+				SettingsManager: { create: () => ({}) },
+				DefaultResourceLoader: class { async reload() {} },
+				SessionManager: { inMemory: () => ({}) },
+				resolveCliModel: () => ({}),
+				createAgentSession: async () => ({
+					session: {
+						bindExtensions: async () => {},
+						dispose() {},
+						extensionRunner: { hasHandlers: () => false },
+						subscribe: () => () => {},
+						prompt: async () => {},
+						abort: async () => {},
+						steer: async () => {},
+						followUp: async () => {},
+						messages: [],
+						sessionId: "agent-less",
+					},
+				}),
+			} as unknown as PiCodingAgentModule),
+		});
+		const child = await factory.create({
+			cwd: process.cwd(),
+			storage: { kind: "memory" },
+			extensionPaths: [],
+			ambientExtensions: false,
+			hooks: [],
+			noSkills: true,
+			noContextFiles: true,
+			runtime: { fanoutChild: false, depth: 1, waitTool: { enabled: false }, fast: false } as ChildSessionLaunch["runtime"],
+		});
+		assert.equal(child.hasQueuedMessages?.(), false);
+		assert.equal(childSessionHasQueuedMessages(child), false);
+	});
+
+	it("re-arms from a wrapped session whose agent reports queued input", async () => {
+		const factory = createDefaultChildSessionFactory({
+			loadPiCodingAgent: async () => ({
+				ModelRuntime: { create: async () => ({}) },
+				SettingsManager: { create: () => ({}) },
+				DefaultResourceLoader: class { async reload() {} },
+				SessionManager: { inMemory: () => ({}) },
+				resolveCliModel: () => ({}),
+				createAgentSession: async () => ({
+					session: {
+						agent: { hasQueuedMessages: () => true },
+						bindExtensions: async () => {},
+						dispose() {},
+						extensionRunner: { hasHandlers: () => false },
+						subscribe: () => () => {},
+						prompt: async () => {},
+						abort: async () => {},
+						steer: async () => {},
+						followUp: async () => {},
+						messages: [],
+						sessionId: "queued",
+					},
+				}),
+			} as unknown as PiCodingAgentModule),
+		});
+		const child = await factory.create({
+			cwd: process.cwd(),
+			storage: { kind: "memory" },
+			extensionPaths: [],
+			ambientExtensions: false,
+			hooks: [],
+			noSkills: true,
+			noContextFiles: true,
+			runtime: { fanoutChild: false, depth: 1, waitTool: { enabled: false }, fast: false } as ChildSessionLaunch["runtime"],
+		});
+		assert.equal(child.hasQueuedMessages?.(), true);
+		assert.equal(childSessionHasQueuedMessages(child), true);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The final-stop grace drain in both native child hosts no longer aborts a session after queued steering or follow-up is observed, even when Pi 0.85.1 drains that input into `pendingMessages` before `prepareNextTurn` / compaction and before `turn_start`.

## Invariant

The final-stop drain never aborts a session that still has queued steering or follow-up input, regardless of how long Pi takes to reach `turn_start`. Once that input is observed after a terminal stop, the hold lasts until a lifecycle cancel (`turn_start` / `agent_start` / `auto_retry_start`), not only while `hasQueuedMessages()` remains true.

## What changed

- Both native hosts latch a post-terminal queued-input hold (probe at drain time, or `steer` / `followUp` after the terminal stop).
- The timer re-arms while that hold is set. Ordinary stop, interrupt, timeout, watchdog, and hard-finish still abort on their own paths.
- The scripted child now follows Pi’s order: drain the post-final steer (probe false), delay, then `turn_start`, then continuation.
- Foreground and background regressions assert no abort and kept continuation output under that order.

## Out of scope

- #2116 delivery accounting
- Broad settlement-error suppression
- SSH / other unrelated changes

Related to #2117.

Thanks to [@yanqianglu](https://github.com/yanqianglu) for #2057 (split into #2117).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4dff62cd-8138-48c0-af4c-d4b3ef088c1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4dff62cd-8138-48c0-af4c-d4b3ef088c1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

