### PR TITLE
fix: recover transiently excluded models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Document task-derived behavior labels for workflow launches in the built-in pi-subagents skill, including reviews and retained follow-ups.
 
 ### Fixed
+- Re-probe one cached model after a transient transport/provider outage only when every launch candidate is excluded for a recoverable availability reason. Foreground and detached runners use bounded cross-process ownership, clear only a successful probe's matching exclusion, and keep auth, quota, disabled, unknown-model, request, explicit-model, and model-scope failures fail-closed.
 - Label workflow usage as belonging to child rows instead of showing a misleading zero or overlapping wrapper totals in FleetView; preserve unrelated standalone usage in mixed summaries and distinguish summed concurrent windows from a single context window. Related to #2085; thanks to [@expoli](https://github.com/expoli).
 - Restore background SDK sessions for the official Pi 0.85.1 Linux x64 standalone release, without a separate SDK install; npm runners keep their package-root and lifecycle behavior. Thanks to [@xz-dev](https://github.com/xz-dev) for #2049.
 - Preserve the parent's active theme when foreground children start, while initializing themes in detached runners and refreshing slash-result rendering. Thanks to [@kubahasek](https://github.com/kubahasek) for #2089.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -112,7 +112,8 @@ import { buildTimeoutRecoverySummary, collectTrackedMutationEvidence, snapshotTr
 import { collectDynamicResults, DynamicFanoutError, materializeDynamicParallelStep, validateDynamicCollection } from "../shared/dynamic-fanout.ts";
 import { claimRunFanoutBatch, getRunFanoutBudgetSnapshot } from "../shared/run-fanout-budget.ts";
 import { nestedSummaryFromAsyncStatus, projectNestedEvents, resolveNestedAsyncDir, writeNestedEvent } from "../shared/nested-events.ts";
-import { formatModelAttemptNote, formatSubagentModelVerificationError, isContextOverflow, isRetryableModelFailureAttempt, recordRetryableModelFailure } from "../shared/model-fallback.ts";
+import { formatModelAttemptNote, formatSubagentModelVerificationError, formatTransientRecoveryProbeFailure, isContextOverflow, isRetryableModelFailureAttempt, recordRetryableModelFailure, TRANSIENT_RECOVERY_PROBE_IN_FLIGHT } from "../shared/model-fallback.ts";
+import { claimTransientModelRecoveryProbe, releaseTransientModelRecoveryProbe } from "../shared/model-exclusions.ts";
 import { markProcessTerminalCandidateLeaseRelease, processTerminalPath, writeProcessTerminalCandidate, type ProcessTerminalCandidate } from "./process-terminal.ts";
 import { createSteeringStatus, recordSteeringRequest, steeringStatus, terminalSteeringNoticeState, updateSteeringTarget } from "./steering.ts";
 import { PROMPT_REDACTED, detectSubagentError, extractTextFromContent, extractToolArgsPreview, formatEmptyTerminalAssistantResponseError, getFinalOutput, hasEmptyTerminalAssistantResponse, readStatus } from "../../shared/utils.ts";
@@ -1184,7 +1185,15 @@ export async function runSingleStepInner(
 		// Each attempt rewrites the step output log; synchronous appends keep a
 		// retried attempt from interleaving with the previous attempt's flush.
 		fs.writeFileSync(ctx.outputFile, "", "utf-8");
-		const run = await runChildSession(omitUndefinedProperties({
+		// All validation, structured-output cleanup, and launch construction above
+		// happen before ownership. The only claimed region begins at the request.
+		const probeClaim = candidates.length === 1 && candidate ? claimTransientModelRecoveryProbe(candidate) : undefined;
+		if (probeClaim?.status === "in-flight") {
+			return omitUndefinedProperties({ agent: step.agent, output: TRANSIENT_RECOVERY_PROBE_IN_FLIGHT, error: TRANSIENT_RECOVERY_PROBE_IN_FLIGHT, exitCode: 1, context: step.context });
+		}
+		let run: RunChildSessionResult;
+		try {
+			run = await runChildSession(omitUndefinedProperties({
 			factory: ctx.childSessions,
 			launch,
 			collectReadonlyEvidence: true,
@@ -1217,7 +1226,15 @@ export async function runSingleStepInner(
 			modelVerificationRegistry: step.modelVerificationRegistry,
 			modelResponseAliases: step.modelResponseAliases,
 			mutationTools: step.mutationTools,
-		}));
+			}));
+		} catch (error) {
+			if (probeClaim?.status === "claimed") releaseTransientModelRecoveryProbe(probeClaim.probe, false);
+			throw error;
+		}
+		// Finalized success is determined below, after every local completion
+		// diagnostic. Keep ownership through this block; any diagnostic throw
+		// releases without clearing before it escapes.
+		try {
 		// A parked run still owes completion evidence when it actually finishes.
 		// Stopped/timedOut runs already have terminal failures; checking completion evidence there is meaningless.
 		const completionDiagnosticsEligible = !run.interrupted && !run.stopped && !run.timedOut;
@@ -1368,6 +1385,21 @@ export async function runSingleStepInner(
 		});
 		const fileMutationEffect = completionEvidence.fileMutation ?? (missingRequiredOutputAfterMutation ? { status: "observed" as const, expected: completionEvidence.mutationExpected, attempted: true, evidence: mutationEvidence } : undefined);
 		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect || settlementDiagnostic ? { effects: { ...(fileMutationEffect ? { fileMutation: fileMutationEffect } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunChildSessionResult;
+		if (probeClaim?.status === "claimed") {
+			if (attempt.success) {
+				releaseTransientModelRecoveryProbe(probeClaim.probe, true);
+			} else {
+				if (isRetryableModelFailureAttempt({ error, messages: run.messages, toolCount: run.toolCount })) {
+					recordRetryableModelFailure(candidate ?? run.model ?? step.model, error);
+				}
+				releaseTransientModelRecoveryProbe(probeClaim.probe, false);
+				const diagnostic = formatTransientRecoveryProbeFailure(error);
+				attempt.error = diagnostic;
+				finalResult.error = diagnostic;
+				attemptNotes.push(`[fallback] ${diagnostic}`);
+				break modelAttemptsLoop;
+			}
+		}
 		const abortRecovery = !attempt.success ? planAbortRecovery({
 			messages: run.messages,
 			error,
@@ -1455,6 +1487,10 @@ export async function runSingleStepInner(
 		if (!retryableModelFailure || modelIndex === candidates.length - 1) break modelAttemptsLoop;
 		attemptNotes.push(formatModelAttemptNote(attempt, candidates[modelIndex + 1]));
 		modelIndex += 1;
+		} catch (error) {
+			if (probeClaim?.status === "claimed") releaseTransientModelRecoveryProbe(probeClaim.probe, false);
+			throw error;
+		}
 	}
 
 	const rawOutput = finalResult?.finalOutput ?? "";

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -80,10 +80,13 @@ import {
 	buildModelCandidates,
 	formatSubagentModelVerificationError,
 	formatModelAttemptNote,
+	formatTransientRecoveryProbeFailure,
 	isContextOverflow,
 	isRetryableModelFailureAttempt,
 	recordRetryableModelFailure,
+	TRANSIENT_RECOVERY_PROBE_IN_FLIGHT,
 } from "../shared/model-fallback.ts";
+import { claimTransientModelRecoveryProbe, releaseTransientModelRecoveryProbe } from "../shared/model-exclusions.ts";
 import {
 	createMutatingFailureState,
 	didMutatingToolFail,
@@ -1934,7 +1937,20 @@ async function runSyncCompletionInner(
 			const verifyModel = Boolean(candidate) && !(options.modelOverrideFromParent && modelIndex === 0);
 			const outputSnapshot = captureSingleOutputSnapshot(options.outputPath);
 			if (recoveryState === "readonly-continuation") attemptOptions.deadlineAt = continuationDeadline;
-			const result = await runSingleAttempt(runtimeCwd, agent, attemptTask, candidate, attemptOptions, {
+			// Acquire only after all loop/preflight state is ready and immediately before
+			// the child session is constructed. A thrown setup path below releases it.
+			const probeClaim = modelsToTry.length === 1 && candidate ? claimTransientModelRecoveryProbe(candidate) : undefined;
+			if (probeClaim?.status === "in-flight") {
+				lastResult = withRunContext({
+					index: options.index ?? 0, agent: agent.name, task, exitCode: 1, messages: [], usage: emptyUsage(),
+					error: TRANSIENT_RECOVERY_PROBE_IN_FLIGHT, model: candidate,
+				}, options.context);
+				attemptNotes.push(`[fallback] ${TRANSIENT_RECOVERY_PROBE_IN_FLIGHT}`);
+				break modelAttemptsLoop;
+			}
+			let result: SingleResult;
+			try {
+				result = await runSingleAttempt(runtimeCwd, agent, attemptTask, candidate, attemptOptions, {
 				sessionEnabled,
 				systemPrompt,
 				acceptancePrompt,
@@ -1955,7 +1971,11 @@ async function runSyncCompletionInner(
 				readonlyExpected,
 				readonlyModel,
 				readonlyHandoffAllowed: readonlyExpected ? readonlyHandoffAllowed : undefined,
-			});
+				});
+			} catch (error) {
+				if (probeClaim?.status === "claimed") releaseTransientModelRecoveryProbe(probeClaim.probe, false);
+				throw error;
+			}
 			lastResult = result;
 			if (!recoveringAbort) {
 				if (result.model) attemptedModels.push(result.model);
@@ -1965,6 +1985,7 @@ async function runSyncCompletionInner(
 			totalToolCount += result.progressSummary?.toolCount ?? 0;
 			totalDurationMs += result.progressSummary?.durationMs ?? 0;
 			const attemptSucceeded = result.exitCode === 0 && !result.error;
+			if (probeClaim?.status === "claimed" && attemptSucceeded) releaseTransientModelRecoveryProbe(probeClaim.probe, true);
 			const attempt: ModelAttempt = {
 				model: result.model ?? candidate ?? agent.model ?? "default",
 				success: attemptSucceeded,
@@ -1973,6 +1994,16 @@ async function runSyncCompletionInner(
 				usage: { ...result.usage },
 			};
 			modelAttempts.push(attempt);
+			if (probeClaim?.status === "claimed" && !attemptSucceeded) {
+				if (isRetryableModelFailureAttempt({ error: result.error, messages: result.messages, toolCount: result.progressSummary?.toolCount })) {
+					recordRetryableModelFailure(result.model ?? candidate, result.error);
+				}
+				releaseTransientModelRecoveryProbe(probeClaim.probe, false);
+				result.error = formatTransientRecoveryProbeFailure(result.error);
+				attempt.error = result.error;
+				attemptNotes.push(`[fallback] ${result.error}`);
+				break modelAttemptsLoop;
+			}
 			// A consumed retained continuation is terminal even on a startup error or abort.
 			if (recoveryState === "readonly-continuation") break modelAttemptsLoop;
 			const source = settledReadonlySource.get(result);
@@ -2036,8 +2067,7 @@ async function runSyncCompletionInner(
 					nextAttemptTask = abortRecovery.prompt;
 					attemptNotes.push("[abort-recovery] provider/transport abort after useful progress; resuming the retained child session once.");
 					continue;
-				}
-				if (abortRecovery.diagnostic) {
+				} else if (abortRecovery.diagnostic) {
 					result.error = result.error ? `${result.error}\n${abortRecovery.diagnostic}` : abortRecovery.diagnostic;
 					attempt.error = result.error;
 					break modelAttemptsLoop;

--- a/src/runs/shared/model-exclusions.ts
+++ b/src/runs/shared/model-exclusions.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createHash, randomUUID } from "node:crypto";
 import { splitKnownThinkingSuffix } from "../../shared/model-info.ts";
 import { TEMP_ROOT_DIR } from "../../shared/types.ts";
 import { getAgentDir } from "../../shared/utils.ts";
@@ -13,6 +14,20 @@ export type ModelExclusion = ModelExclusionTarget & {
 	recordedAt: number;
 	expiresAt: number;
 };
+
+export interface ModelRecoveryProbe {
+	candidate: string;
+	exclusion: Readonly<ModelExclusion>;
+}
+
+export interface ClaimedModelRecoveryProbe extends ModelRecoveryProbe {
+	owner: string;
+}
+
+export type ModelRecoveryProbeClaim =
+	| { status: "claimed"; probe: ClaimedModelRecoveryProbe }
+	| { status: "in-flight" }
+	| { status: "not-eligible" };
 
 type RecordModelFailureOptions = ModelExclusionTarget & {
 	reason?: string;
@@ -64,8 +79,7 @@ function invalidateAuthExclusions(): void {
 	if (authStoreMtimeMs === undefined) return;
 	const retained = exclusions.filter((entry) => !isAuthModelExclusion(entry) || authStoreMtimeMs <= entry.recordedAt);
 	if (retained.length === exclusions.length) return;
-	exclusions = retained;
-	schedulePersist();
+	exclusions = withExclusionStoreMutation((current) => current.filter((entry) => !isAuthModelExclusion(entry) || authStoreMtimeMs <= entry.recordedAt));
 }
 
 /**
@@ -101,18 +115,12 @@ export function getExclusionsFilePath(): string {
  * (and in tests).
  */
 export function flushPersist(): void {
-	const file = getExclusionsFilePath();
-	try {
-		fs.mkdirSync(path.dirname(file), { recursive: true });
-		const tmpPath = `${file}.${process.pid}.${persistSeq++}.tmp`;
-		fs.writeFileSync(tmpPath, JSON.stringify({
-			version: 1,
-			exclusions: deduplicate(exclusions),
-		}, null, 2), "utf-8");
-		fs.renameSync(tmpPath, file);
-	} catch (error) {
-		console.error(`[model-exclusions] Failed to persist exclusions to ${file}:`, error);
-	}
+	// All public mutations persist immediately. This remains for callers that
+	// need a barrier and applies only the durable TTL policy to current disk.
+	withExclusionStoreMutation((current) => {
+		if (loadedTTLCeilingMs !== undefined) shortenExclusionsToTTL(current, loadedTTLCeilingMs, Date.now());
+		return current;
+	});
 }
 
 function schedulePersist(): void {
@@ -123,6 +131,166 @@ function schedulePersist(): void {
 	}, 5000);
 	// Never hold the process open just to flush exclusions.
 	persistTimer.unref?.();
+}
+
+function readPersistedExclusionsForMutation(): ModelExclusion[] {
+	try {
+		const data = JSON.parse(fs.readFileSync(getExclusionsFilePath(), "utf-8")) as { version?: unknown; exclusions?: unknown };
+		if (data.version !== 1 || !Array.isArray(data.exclusions)) return [];
+		const now = Date.now();
+		return deduplicate(data.exclusions.flatMap((entry, index) => {
+			const parsed = readPersistedExclusion(entry, index);
+			return parsed.ok && parsed.exclusion.expiresAt > now ? [parsed.exclusion] : [];
+		}));
+	} catch {
+		// A mutation is also the recovery path for a corrupt/missing store.
+		return [];
+	}
+}
+
+function writePersistedExclusions(next: ModelExclusion[]): void {
+	const file = getExclusionsFilePath();
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	const tmpPath = `${file}.${process.pid}.${persistSeq++}.tmp`;
+	fs.writeFileSync(tmpPath, JSON.stringify({ version: 1, exclusions: deduplicate(next) }, null, 2), "utf-8");
+	fs.renameSync(tmpPath, file);
+}
+
+const MUTATION_LOCK_WAIT_MS = 5_000;
+
+/** Linux's start-time tick is immutable for a process lifetime and detects PID reuse. */
+function processStartIdentity(pid: number): string | undefined {
+	try {
+		const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+		const closeParen = stat.lastIndexOf(")");
+		const fields = closeParen === -1 ? [] : stat.slice(closeParen + 2).trim().split(/\s+/);
+		return fields[19] || undefined; // field 22; fields begin at field 3 after comm/state.
+	} catch {
+		return undefined;
+	}
+}
+
+function sleepForClaim(): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+}
+
+function claimIsLive(claim: StoredClaim | undefined): boolean {
+	if (!claim || !isLiveProcess(claim.pid)) return false;
+	if (!claim.processStart) return true; // Legacy/unverifiable identity: conservatively never steal a live PID.
+	const currentStart = processStartIdentity(claim.pid);
+	return currentStart === undefined || currentStart === claim.processStart;
+}
+
+const MAX_CLAIM_SUCCESSOR_DEPTH = 16;
+
+type ClaimNode =
+	| { status: "missing" }
+	| { status: "present"; raw: string; claim: StoredClaim | undefined }
+	| { status: "unreadable" };
+
+/** Read a node once so a successor is tied to the exact immutable predecessor bytes. */
+function readClaimNode(claimPath: string): ClaimNode {
+	let raw: string;
+	try {
+		raw = fs.readFileSync(claimPath, "utf-8");
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "ENOENT" ? { status: "missing" } : { status: "unreadable" };
+	}
+	try {
+		const value = JSON.parse(raw) as Partial<StoredClaim>;
+		const legacyPid = typeof value.owner === "string" ? Number(/^([1-9]\d*)-/.exec(value.owner)?.[1]) : NaN;
+		const pid = typeof value.pid === "number" ? value.pid : legacyPid;
+		const claim = typeof value.owner === "string" && Number.isSafeInteger(pid) && pid > 0
+			&& typeof value.expiresAt === "number" && Number.isFinite(value.expiresAt)
+			&& (value.processStart === undefined || typeof value.processStart === "string")
+			? { owner: value.owner, pid, expiresAt: value.expiresAt, ...(typeof value.processStart === "string" ? { processStart: value.processStart } : {}) }
+			: undefined;
+		return { status: "present", raw, claim };
+	} catch {
+		// A partial or malformed file is an immutable dead generation, not a path
+		// that a contender may remove.
+		return { status: "present", raw, claim: undefined };
+	}
+}
+
+/**
+ * A successor is named from both its predecessor pathname and exact bytes. All
+ * contenders that observe one stale node therefore link the same absent name;
+ * no recovery path ever renames or unlinks a stale node.
+ */
+function successorClaimPath(predecessorPath: string, predecessorContents: string): string {
+	const identity = createHash("sha256").update(predecessorPath).update("\0").update(predecessorContents).digest("hex");
+	return path.join(path.dirname(predecessorPath), `${path.basename(predecessorPath)}.successor-${identity}`);
+}
+
+/**
+ * Acquire an append-only claim chain. A live owner blocks even after TTL expiry.
+ * A dead, reused-PID, or malformed predecessor stays immutable and selects one
+ * deterministic successor through link(O_EXCL). Normal release unlinks only the
+ * owner's current node, allowing the same successor of a stale predecessor to be
+ * recreated without ever changing that predecessor.
+ */
+function acquireCanonicalClaim(genesisPath: string, owner: string, waitMs = MUTATION_LOCK_WAIT_MS): { owner: string; claimPath: string } | undefined {
+	const deadline = Date.now() + waitMs;
+	for (;;) {
+		try { fs.mkdirSync(path.dirname(genesisPath), { recursive: true, mode: 0o700 }); } catch { return undefined; }
+		let claimPath = genesisPath;
+		let restart = false;
+		for (let depth = 0; depth <= MAX_CLAIM_SUCCESSOR_DEPTH; depth++) {
+			const node = readClaimNode(claimPath);
+			if (node.status === "unreadable") return undefined; // Fail closed on filesystem corruption/errors.
+			if (node.status === "missing") {
+				if (writeImmutableClaim(path.dirname(claimPath), owner, path.basename(claimPath))) return { owner, claimPath };
+				restart = true; // A concurrent link won; inspect its complete node.
+				break;
+			}
+			if (node.claim && claimIsLive(node.claim)) {
+				restart = true;
+				break;
+			}
+			claimPath = successorClaimPath(claimPath, node.raw);
+		}
+		if (!restart) return undefined; // The immutable chain is excessive.
+		if (Date.now() >= deadline) return undefined;
+		sleepForClaim();
+	}
+}
+
+function releaseCanonicalClaim(claimPath: string, owner: string): void {
+	// O_EXCL publication means no protocol participant can replace this pathname
+	// while it exists. Check the exact token, then unlink only this owner's node.
+	if (readClaim(claimPath)?.owner !== owner) return;
+	try { fs.unlinkSync(claimPath); } catch { /* a filesystem error leaves this immutable node recoverable */ }
+}
+
+/** Locate an owner's current successor without ever changing its predecessors. */
+function findClaimPathForOwner(genesisPath: string, owner: string): string | undefined {
+	let claimPath = genesisPath;
+	for (let depth = 0; depth <= MAX_CLAIM_SUCCESSOR_DEPTH; depth++) {
+		const node = readClaimNode(claimPath);
+		if (node.status !== "present") return undefined;
+		if (node.claim?.owner === owner) return claimPath;
+		claimPath = successorClaimPath(claimPath, node.raw);
+	}
+	return undefined;
+}
+
+function acquireImmutableMutationClaim(): { owner: string; claimPath: string } | undefined {
+	const owner = `${process.pid}-${randomUUID()}`;
+	return acquireCanonicalClaim(`${getExclusionsFilePath()}.mutation-claim.json`, owner);
+}
+
+function withExclusionStoreMutation(mutator: (current: ModelExclusion[]) => ModelExclusion[]): ModelExclusion[] {
+	const claim = acquireImmutableMutationClaim();
+	if (!claim) throw new Error(`Unable to acquire exclusion persistence mutation claim within ${MUTATION_LOCK_WAIT_MS}ms.`);
+	try {
+		const next = deduplicate(mutator(readPersistedExclusionsForMutation()));
+		writePersistedExclusions(next);
+		exclusions = next;
+		return next;
+	} finally {
+		releaseCanonicalClaim(claim.claimPath, claim.owner);
+	}
 }
 
 function ensureLoaded(): void {
@@ -218,10 +386,12 @@ export function recordModelFailure(options: RecordModelFailureOptions): void {
 		recordedAt: now,
 		expiresAt: now + ttl,
 	};
-	exclusions.unshift(exclusion);
-	exclusions = deduplicate(exclusions);
-	if (exclusions.length > 200) exclusions.length = 200;
-	flushPersist();
+	exclusions = withExclusionStoreMutation((current) => {
+		if (loadedTTLCeilingMs !== undefined) shortenExclusionsToTTL(current, loadedTTLCeilingMs, now);
+		const next = deduplicate([exclusion, ...current]);
+		if (next.length > 200) next.length = 200;
+		return next;
+	});
 }
 
 /**
@@ -230,8 +400,10 @@ export function recordModelFailure(options: RecordModelFailureOptions): void {
 export function clearExpiredExclusions(): void {
 	ensureLoaded();
 	invalidateAuthExclusions();
-	prune(exclusions, Date.now());
-	schedulePersist();
+	const now = Date.now();
+	if (exclusions.some((entry) => entry.expiresAt <= now)) {
+		exclusions = withExclusionStoreMutation((current) => current.filter((entry) => entry.expiresAt > now));
+	}
 }
 
 /**
@@ -239,8 +411,7 @@ export function clearExpiredExclusions(): void {
  */
 export function clearExclusions(): void {
 	ensureLoaded();
-	exclusions.length = 0;
-	schedulePersist();
+	exclusions = withExclusionStoreMutation(() => []);
 }
 
 /**
@@ -282,6 +453,138 @@ export function findModelExclusion(fullId: string, now = Date.now()): Readonly<M
 	invalidateAuthExclusions();
 	const { provider, modelId } = parseModelKey(fullId);
 	return exclusions.find((entry) => entryMatches(entry, modelId, provider, now));
+}
+
+// Keep recovery probes strictly narrower than ordinary fallback failures: credential,
+// quota, model-registry, and request-shape failures must stay fail-closed for 24h.
+const NON_RECOVERABLE_PROBE_REASON_PATTERNS = [
+	/auth(?:entication)?/i, /unauthori[sz]ed/i, /forbidden/i, /api key/i, /token expired/i, /invalid key/i,
+	/\b(?:401|402|403|429)\b/, /rate\s*limit/i, /request[_\s-]*limit/i, /quota/i, /billing/i, /credit/i,
+	/model.*not found/i, /unknown model/i, /model.*disabled/i,
+	/\b(?:bad[ _]request|invalid[ _]argument|invalid_request_error|invalid request|request validation|malformed payload|invalid config(?:uration)?)\b/i,
+	/\b(?:permission denied|access denied)\b/i,
+];
+const RECOVERABLE_PROBE_REASON_PATTERNS = [
+	/fetch failed/i, /\b(?:connection|network|socket)\b.*\b(?:error|reset|closed|refused|abort(?:ed)?)\b/i, /socket hang up/i,
+	/stream.*(?:abort|ended|closed|reset)/i, /\b(?:timed?\s*out|timeout)\b/i,
+	/overload(?:ed)?/i, /service\s+(?:temporarily\s+)?unavailable/i, /temporar(?:ily)? unavailable/i,
+	/provider\s+(?:temporarily\s+)?unavailable/i, /\bupstream\s+(?:error|timeout|unavailable|overload(?:ed)?|5\d\d)\b/i,
+	/\b(?:500|502|503|504|5xx)\b/i, /internal server error/i, /cold.?start/i,
+	/empty response/i, /produced no output/i,
+];
+
+/** True only for transport/provider-availability exclusions safe to re-probe. */
+export function isReprobeEligibleTransientReason(reason: string | undefined): boolean {
+	if (!reason) return false;
+	return !NON_RECOVERABLE_PROBE_REASON_PATTERNS.some((pattern) => pattern.test(reason))
+		&& RECOVERABLE_PROBE_REASON_PATTERNS.some((pattern) => pattern.test(reason));
+}
+
+/**
+ * Return one probe only when every supplied candidate is cache-excluded solely
+ * for a narrowly re-probe-eligible transient reason. This plans only; it never
+ * acquires ownership or sends a request, so preflight remains side-effect free.
+ */
+export function planTransientModelRecoveryProbe(candidates: readonly string[]): ModelRecoveryProbe | undefined {
+	if (candidates.length === 0) return undefined;
+	const matches = candidates.map((candidate) => ({ candidate, exclusion: findModelExclusion(candidate) }));
+	if (!matches.every((match) => match.exclusion && isReprobeEligibleTransientReason(match.exclusion.reason))) return undefined;
+	const first = matches[0]!;
+	return { candidate: first.candidate, exclusion: first.exclusion! };
+}
+
+const PROBE_LOCK_TTL_MS = 30 * 60_000;
+
+type StoredClaim = { owner: string; pid: number; expiresAt: number; processStart?: string };
+
+function probeClaimsDirectory(candidate: string): string {
+	return path.join(`${getExclusionsFilePath()}.recovery-probes`, Buffer.from(candidate).toString("base64url"));
+}
+
+function isLiveProcess(pid: unknown): boolean {
+	if (typeof pid !== "number" || !Number.isSafeInteger(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		// EPERM means the process exists but is not signalable by this user. Treat it
+		// as live: an unnecessary wait is safe; a duplicate provider request is not.
+		return (error as NodeJS.ErrnoException).code === "EPERM";
+	}
+}
+
+function readClaim(claimPath: string): StoredClaim | undefined {
+	const node = readClaimNode(claimPath);
+	return node.status === "present" ? node.claim : undefined;
+}
+
+function writeImmutableClaim(claimDir: string, owner: string, filename: string): string | undefined {
+	const claimPath = path.join(claimDir, filename);
+	const temporaryPath = `${claimPath}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		fs.writeFileSync(temporaryPath, JSON.stringify({
+			version: 2, owner, pid: process.pid, processStart: processStartIdentity(process.pid), expiresAt: Date.now() + PROBE_LOCK_TTL_MS,
+		}), { encoding: "utf-8", mode: 0o600 });
+		const fd = fs.openSync(temporaryPath, "r");
+		try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+		// link is create-only: the canonical path is complete or absent.
+		fs.linkSync(temporaryPath, claimPath);
+		return claimPath;
+	} catch {
+		return undefined;
+	} finally {
+		try { fs.rmSync(temporaryPath, { force: true }); } catch { /* best effort */ }
+	}
+}
+
+/** Atomically own a planned probe across foreground and detached processes. */
+export function claimTransientModelRecoveryProbe(candidate: string): ModelRecoveryProbeClaim {
+	const planned = planTransientModelRecoveryProbe([candidate]);
+	if (!planned) return { status: "not-eligible" };
+	const claimDir = probeClaimsDirectory(candidate);
+	const owner = `${process.pid}-${randomUUID()}`;
+	try {
+		fs.mkdirSync(claimDir, { recursive: true, mode: 0o700 });
+	} catch {
+		return { status: "in-flight" };
+	}
+	// A previous-version single-file claim remains compatible. A verified-live
+	// legacy PID wins even after expiry; an expired dead claim no longer blocks.
+	const legacy = readClaim(`${claimDir}.json`);
+	if (legacy && claimIsLive(legacy)) return { status: "in-flight" };
+	// The fixed canonical generation is an O_EXCL election: exactly one link can
+	// succeed. A contender that arrives before the winner publishes loses on
+	// EEXIST; a contender arriving after observes the same live generation. Thus
+	// there is no publish-then-scan interleaving that can elect zero owners.
+	const claim = acquireCanonicalClaim(path.join(claimDir, "canonical.json"), owner, 0);
+	if (!claim) return { status: "in-flight" };
+	return { status: "claimed", probe: { ...planned, owner } };
+}
+
+/** Release ownership and, after a successful real child attempt, clear only its recorded transient exclusion. */
+export function releaseTransientModelRecoveryProbe(probe: ClaimedModelRecoveryProbe, succeeded: boolean): void {
+	try {
+		if (succeeded) clearRecoveredTransientExclusion(probe);
+	} finally {
+		const claimDir = probeClaimsDirectory(probe.candidate);
+		const claimPath = findClaimPathForOwner(path.join(claimDir, "canonical.json"), probe.owner);
+		if (claimPath) releaseCanonicalClaim(claimPath, probe.owner);
+	}
+}
+
+function clearRecoveredTransientExclusion(probe: ClaimedModelRecoveryProbe): void {
+	// Reload under the store mutation lease so a successful clear removes exactly
+	// its recorded entry while retaining failures written by other processes.
+	withExclusionStoreMutation((current) => {
+		const { provider, modelId } = parseModelKey(probe.candidate);
+		return current.filter((entry) => !(entry.provider === probe.exclusion.provider
+			&& entry.modelId === probe.exclusion.modelId
+			&& entry.recordedAt === probe.exclusion.recordedAt
+			&& entry.expiresAt === probe.exclusion.expiresAt
+			&& entry.reason === probe.exclusion.reason
+			&& entryMatches(entry, modelId, provider, Date.now())
+			&& isReprobeEligibleTransientReason(entry.reason)));
+	});
 }
 
 /**

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -1,6 +1,6 @@
 import { splitKnownThinkingSuffix as splitThinkingSuffix, type ModelInfo as AvailableModelInfo } from "../../shared/model-info.ts";
 import type { Usage } from "../../shared/types.ts";
-import { filterFallbackCandidates, findModelExclusion, parseModelKey, recordModelFailure } from "./model-exclusions.ts";
+import { filterFallbackCandidates, findModelExclusion, parseModelKey, planTransientModelRecoveryProbe, recordModelFailure } from "./model-exclusions.ts";
 import { checkModelScope, type ModelScopeCheckRule, type ModelScopeViolation, type ModelSource } from "./model-scope.ts";
 import { redactSecretValues } from "./permissions.ts";
 
@@ -315,24 +315,6 @@ function formatExcludedCandidateEvidence(candidate: string, exclusion: NonNullab
 	return `${displayCandidate} — model: ${displayModel}; provider: ${displayProvider}; reason: ${reason}; expires: ${formatModelExclusionExpiry(exclusion.expiresAt)}`;
 }
 
-const MODEL_UNAVAILABLE_EXCLUSION_PATTERNS = [
-	/model.*not found/i,
-	/unknown model/i,
-	/model.*unavailable/i,
-	/model.*disabled/i,
-];
-
-function isCurrentRegistryModel(candidate: string, availableModels: AvailableModelInfo[] | undefined): boolean {
-	if (!availableModels || availableModels.length === 0) return false;
-	const { baseModel } = splitThinkingSuffix(candidate);
-	return availableModels.some((entry) => entry.fullId === baseModel);
-}
-
-function ignoreStaleModelUnavailableExclusion(candidate: string, exclusion: NonNullable<ReturnType<typeof findModelExclusion>>, availableModels: AvailableModelInfo[] | undefined): boolean {
-	const reason = exclusion.reason ?? "";
-	return MODEL_UNAVAILABLE_EXCLUSION_PATTERNS.some((pattern) => pattern.test(reason)) && isCurrentRegistryModel(candidate, availableModels);
-}
-
 function throwForExplicitModelExclusion(model: string): void {
 	const exclusion = findModelExclusion(model);
 	if (!exclusion) return;
@@ -432,7 +414,7 @@ export interface BuildModelCandidatesOptions {
 }
 
 const ZERO_USABLE_MODEL_CANDIDATES_ERROR =
-	"No usable subagent models remain after registry, scope, and cached-exclusion filtering.";
+	"No usable subagent models remain after registry, scope, and cached-exclusion filtering (cache-blocked/unprobed).";
 
 export function resolveModelOrigin(input: {
 	explicitModel?: string | boolean;
@@ -511,11 +493,19 @@ export function buildModelCandidates(
 		seen.add(normalized);
 		candidates.push(normalized);
 	}
-	const resolved = filterFallbackCandidates(candidates, {
-		onExcluded: warnCachedExclusion,
-		ignoreExclusion: (candidate, exclusion) => ignoreStaleModelUnavailableExclusion(candidate, exclusion, availableModels),
-	});
+	const resolved = filterFallbackCandidates(candidates, { onExcluded: warnCachedExclusion });
 	if (resolved.length === 0) {
+		// Deliberately plan rather than claim here: this same helper is used by
+		// preflight, which must describe a viable runtime probe without consuming it.
+		const recoveryProbe = origin === "explicit" ? undefined : planTransientModelRecoveryProbe(candidates);
+		if (recoveryProbe) {
+			// A probe can refresh only a fully resolved configuration. Otherwise an
+			// excluded live candidate could mask a configured typo.
+			if (skippedPrimary) resolveRequiredSubagentModelCandidate(skippedPrimary, availableModels, preferredProvider);
+			if (skippedFallback) resolveRequiredSubagentModelCandidate(skippedFallback, availableModels, preferredProvider);
+			console.warn(`[pi-subagents] Cached exclusions leave no ordinary candidate; planning one transient recovery probe for '${sanitizeModelExclusionDiagnostic(recoveryProbe.candidate, "unknown")}'.`);
+			return [recoveryProbe.candidate];
+		}
 		if (skippedPrimary) resolveRequiredSubagentModelCandidate(skippedPrimary, availableModels, preferredProvider);
 		if (candidates.length === 0 && skippedFallback) resolveRequiredSubagentModelCandidate(skippedFallback, availableModels, preferredProvider);
 		if (candidates.length > 0) {
@@ -654,3 +644,11 @@ export function formatModelAttemptNote(attempt: ModelAttemptSummary, nextModel?:
 		? `[fallback] ${attempt.model} failed: ${failure}. Retrying with ${nextModel}.`
 		: `[fallback] ${attempt.model} failed: ${failure}.`;
 }
+
+/** Sanitized terminal diagnostics for the one real request allowed to refresh a transient exclusion. */
+export function formatTransientRecoveryProbeFailure(error: string | undefined): string {
+	return `Transient recovery probe failed; provider remains live-unavailable: ${sanitizeModelExclusionDiagnostic(error, "runtime-failure")}.`;
+}
+
+export const TRANSIENT_RECOVERY_PROBE_IN_FLIGHT =
+	"Transient recovery probe already in flight; provider remains cache-blocked/unprobed.";

--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -63,7 +63,7 @@ import { discardPreservedWorktrees } from "../../src/runs/shared/parallel-handof
 import { createWorktrees } from "../../src/runs/shared/worktree.ts";
 import { resolveAsyncResumeTarget } from "../../src/runs/background/async-resume.ts";
 import { createResultWatcher } from "../../src/runs/background/result-watcher.ts";
-import { clearExclusions, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
+import { clearExclusions, findModelExclusion, recordModelFailure } from "../../src/runs/shared/model-exclusions.ts";
 import { createWorkflowChildPermit, workflowChildPermitConsumed } from "../../src/shared/workflow-child-permit.ts";
 import { toSubagentDelegationExecutionParams } from "../../src/slash/delegation-adapters.ts";
 
@@ -2424,6 +2424,39 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 		assert.match(result.content[0]?.text ?? "", /Invalid request: malformed payload/u);
 		assert.match(result.details.results[0]?.error ?? "", /Invalid request: malformed payload/u);
 		assert.equal(mockPi.callCount(), 1);
+	});
+
+	it("re-probes one transiently excluded model and clears only the successful exclusion", async () => {
+		clearExclusions();
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "503 service unavailable" });
+		recordModelFailure({ modelId: "claude-sonnet-4", provider: "anthropic", reason: "fetch failed" });
+		mockPi.onCall({ output: "Recovered live provider" });
+		try {
+			const result = await runSync(tempDir, [makeAgent("worker", {
+				model: "openai/gpt-5-mini", fallbackModels: ["anthropic/claude-sonnet-4"],
+			})], "worker", "Do work", { acceptance: false, runId: "transient-recovery-success" });
+			assert.equal(result.exitCode, 0);
+			assert.equal(mockPi.callCount(), 1);
+			assert.equal(findModelExclusion("openai/gpt-5-mini"), undefined);
+			assert.equal(findModelExclusion("anthropic/claude-sonnet-4")?.reason, "fetch failed");
+		} finally { clearExclusions(); }
+	});
+
+	it("does not try a second excluded model when the real transient recovery probe fails", async () => {
+		clearExclusions();
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "503 service unavailable" });
+		recordModelFailure({ modelId: "claude-sonnet-4", provider: "anthropic", reason: "fetch failed" });
+		mockPi.onCall({ stderr: "503 service unavailable", exitCode: 1 });
+		mockPi.onCall({ output: "must not run" });
+		try {
+			const result = await runSync(tempDir, [makeAgent("worker", {
+				model: "openai/gpt-5-mini", fallbackModels: ["anthropic/claude-sonnet-4"],
+			})], "worker", "Do work", { acceptance: false, runId: "transient-recovery-failure" });
+			assert.equal(result.exitCode, 1);
+			assert.match(result.error ?? "", /Transient recovery probe failed; provider remains live-unavailable/);
+			assert.equal(mockPi.callCount(), 1);
+			assert.equal(findModelExclusion("openai/gpt-5-mini")?.reason, "503 service unavailable");
+		} finally { clearExclusions(); }
 	});
 
 	it("fails closed before spawn when cached exclusions leave zero launch candidates", async () => {

--- a/test/unit/model-exclusions.test.ts
+++ b/test/unit/model-exclusions.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -13,6 +14,10 @@ import {
 	getExclusionsFilePath,
 	isExcluded,
 	parseModelKey,
+	planTransientModelRecoveryProbe,
+	claimTransientModelRecoveryProbe,
+	releaseTransientModelRecoveryProbe,
+	isReprobeEligibleTransientReason,
 	recordModelFailure,
 	reloadFromDisk,
 	MAX_MODEL_EXCLUSION_TTL_MS,
@@ -36,6 +41,29 @@ function captureConsole(method: "error" | "warn", run: () => void): unknown[][] 
 }
 process.env.PI_CODING_AGENT_DIR = testAgentDir;
 const authPath = path.join(testAgentDir, "auth.json");
+
+function runIsolatedModule(script: string, environment: NodeJS.ProcessEnv): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, ["--experimental-strip-types", "--input-type=module", "--eval", script], {
+			cwd: process.cwd(), env: environment, stdio: ["ignore", "pipe", "pipe"],
+		});
+		let output = "";
+		let error = "";
+		child.stdout.on("data", (chunk) => { output += chunk; });
+		child.stderr.on("data", (chunk) => { error += chunk; });
+		child.on("error", reject);
+		child.on("close", (code) => code === 0 ? resolve(output.trim()) : reject(new Error(error || `child exited ${code}`)));
+	});
+}
+
+async function waitForFiles(directory: string, count: number): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	while (Date.now() < deadline) {
+		if (fs.readdirSync(directory).length >= count) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for ${count} claim readers.`);
+}
 
 // The exclusion store is a process-wide singleton persisted under TEMP_ROOT_DIR
 // (isolated per test run by test/support/isolated-temp-root.mjs). Clear it
@@ -90,6 +118,157 @@ describe("model exclusions — record & query", () => {
 		recordModelFailure({ modelId: "gpt-4", provider: "openai" });
 		recordModelFailure({ modelId: "claude", provider: "anthropic" });
 		assert.equal(getExcludedCount(), 2);
+	});
+});
+
+describe("model exclusions — transient recovery probes", () => {
+	it("classifies only narrow transient transport/provider reasons", () => {
+		for (const reason of ["fetch failed", "socket hang up", "request timed out", "503 service unavailable", "upstream 502", "cold-start empty response"]) {
+			assert.equal(isReprobeEligibleTransientReason(reason), true, reason);
+		}
+		for (const reason of ["upstream", "invalid api key", "429 rate limit", "quota exceeded", "model not found", "model disabled", "invalid_request_error", "invalid request: upstream 503", "permission denied: 503", "access denied: upstream 5xx"]) {
+			assert.equal(isReprobeEligibleTransientReason(reason), false, reason);
+		}
+	});
+
+	it("plans and atomically owns one probe only when every candidate is transiently excluded", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "503 service unavailable" });
+		recordModelFailure({ modelId: "claude", provider: "anthropic", reason: "fetch failed" });
+		assert.equal(planTransientModelRecoveryProbe(["openai/gpt-4", "anthropic/claude"])?.candidate, "openai/gpt-4");
+		const first = claimTransientModelRecoveryProbe("openai/gpt-4");
+		assert.equal(first.status, "claimed");
+		assert.equal(claimTransientModelRecoveryProbe("openai/gpt-4").status, "in-flight");
+		if (first.status === "claimed") releaseTransientModelRecoveryProbe(first.probe, true);
+		assert.equal(findModelExclusion("openai/gpt-4"), undefined);
+		assert.equal(findModelExclusion("anthropic/claude")?.reason, "fetch failed");
+	});
+
+	it("does not plan a probe for mixed or permanent exclusions and preserves failed probes", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "503 service unavailable" });
+		recordModelFailure({ modelId: "claude", provider: "anthropic", reason: "quota exceeded" });
+		assert.equal(planTransientModelRecoveryProbe(["openai/gpt-4", "anthropic/claude"]), undefined);
+		assert.equal(planTransientModelRecoveryProbe(["openai/gpt-4"])?.candidate, "openai/gpt-4");
+		const claim = claimTransientModelRecoveryProbe("openai/gpt-4");
+		if (claim.status === "claimed") releaseTransientModelRecoveryProbe(claim.probe, false);
+		assert.equal(findModelExclusion("openai/gpt-4")?.reason, "503 service unavailable");
+	});
+
+	it("clears only the exact provider/model target when immutable metadata collides", () => {
+		const now = Date.now();
+		fs.writeFileSync(getExclusionsFilePath(), JSON.stringify({ version: 1, exclusions: [
+			{ provider: "openai", reason: "503", recordedAt: now, expiresAt: now + 60_000 },
+			{ provider: "openai", modelId: "gpt-4", reason: "503", recordedAt: now, expiresAt: now + 60_000 },
+		] }), "utf-8");
+		reloadFromDisk();
+		const claim = claimTransientModelRecoveryProbe("openai/gpt-4");
+		assert.equal(claim.status, "claimed");
+		if (claim.status === "claimed") releaseTransientModelRecoveryProbe(claim.probe, true);
+		reloadFromDisk();
+		assert.equal(findModelExclusion("openai/gpt-4")?.modelId, "gpt-4");
+	});
+
+	it("recovers from a malformed canonical node without changing that predecessor", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "503 service unavailable" });
+		const claimDir = path.join(`${getExclusionsFilePath()}.recovery-probes`, Buffer.from("openai/gpt-4").toString("base64url"));
+		fs.mkdirSync(claimDir, { recursive: true });
+		const canonical = path.join(claimDir, "canonical.json");
+		fs.writeFileSync(canonical, "{", "utf-8");
+		const first = claimTransientModelRecoveryProbe("openai/gpt-4");
+		assert.equal(first.status, "claimed");
+		const firstSuccessors = fs.readdirSync(claimDir).filter((file) => file.includes(".successor-"));
+		assert.equal(firstSuccessors.length, 1);
+		if (first.status === "claimed") releaseTransientModelRecoveryProbe(first.probe, false);
+		assert.equal(fs.readdirSync(claimDir).filter((file) => file.includes(".successor-")).length, 0);
+		const second = claimTransientModelRecoveryProbe("openai/gpt-4");
+		assert.equal(second.status, "claimed");
+		assert.deepEqual(fs.readdirSync(claimDir).filter((file) => file.includes(".successor-")), firstSuccessors);
+		if (second.status === "claimed") releaseTransientModelRecoveryProbe(second.probe, false);
+		assert.equal(fs.readFileSync(canonical, "utf-8"), "{");
+	});
+
+	it("reclaims a reused PID generation but never steals an expired verified-live generation", () => {
+		recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "503 service unavailable" });
+		const candidate = "openai/gpt-4";
+		const claimDir = path.join(`${getExclusionsFilePath()}.recovery-probes`, Buffer.from(candidate).toString("base64url"));
+		fs.mkdirSync(claimDir, { recursive: true });
+		const stat = fs.readFileSync(`/proc/${process.pid}/stat`, "utf-8");
+		const processStart = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/)[19]!;
+		const canonical = path.join(claimDir, "canonical.json");
+		fs.writeFileSync(canonical, JSON.stringify({ owner: "old", pid: process.pid, processStart: "different-generation", expiresAt: Date.now() + 60_000 }), "utf-8");
+		const reclaimed = claimTransientModelRecoveryProbe(candidate);
+		assert.equal(reclaimed.status, "claimed");
+		if (reclaimed.status === "claimed") releaseTransientModelRecoveryProbe(reclaimed.probe, false);
+		fs.writeFileSync(canonical, JSON.stringify({ owner: "live", pid: process.pid, processStart, expiresAt: Date.now() - 1 }), "utf-8");
+		assert.equal(claimTransientModelRecoveryProbe(candidate).status, "in-flight");
+		fs.rmSync(claimDir, { recursive: true, force: true });
+	});
+
+	it("elects one successor after both OS-process contenders read the same stale genesis", async () => {
+		const store = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "pi-probe-contention-")), "exclusions.json");
+		const candidate = "openai/gpt-4";
+		const claimDir = path.join(`${store}.recovery-probes`, Buffer.from(candidate).toString("base64url"));
+		const canonical = path.join(claimDir, "canonical.json");
+		const stale = JSON.stringify({ owner: "dead", pid: 999_999_999, expiresAt: Date.now() - 1 });
+		const barrier = path.join(path.dirname(store), "barrier");
+		const ready = path.join(barrier, "ready");
+		const go = path.join(barrier, "go");
+		const published = path.join(barrier, "published");
+		fs.mkdirSync(ready, { recursive: true });
+		fs.mkdirSync(claimDir, { recursive: true });
+		fs.writeFileSync(canonical, stale, "utf-8");
+		fs.writeFileSync(store, JSON.stringify({ version: 1, exclusions: [{ modelId: "gpt-4", provider: "openai", reason: "503 service unavailable", recordedAt: Date.now(), expiresAt: Date.now() + 60_000 }] }), "utf-8");
+		const modulePath = path.resolve("src/runs/shared/model-exclusions.ts");
+		const makeScript = (role: "a" | "b") => `
+			import { createRequire } from "node:module";
+			import { syncBuiltinESMExports } from "node:module";
+			const require = createRequire(import.meta.url); const fs = require("node:fs");
+			const canonical = ${JSON.stringify(canonical)}, ready = ${JSON.stringify(ready)}, go = ${JSON.stringify(go)}, published = ${JSON.stringify(published)};
+			const sleep = () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+			const read = fs.readFileSync; let paused = false;
+			fs.readFileSync = (...args) => { const value = read(...args); if (!paused && args[0] === canonical) { paused = true; fs.writeFileSync(ready + "/${role}", ""); while (!fs.existsSync(go)) sleep(); } return value; };
+			${role === "a" ? "const link = fs.linkSync; fs.linkSync = (...args) => { const value = link(...args); fs.writeFileSync(published, \"\"); return value; };" : "const exists = fs.existsSync; fs.existsSync = (file) => { if (file === canonical) while (!exists(published)) sleep(); return exists(file); };"}
+			syncBuiltinESMExports();
+			const { claimTransientModelRecoveryProbe } = await import(${JSON.stringify(modulePath)});
+			console.log(claimTransientModelRecoveryProbe(${JSON.stringify(candidate)}).status);
+			setTimeout(() => {}, 100);
+		`;
+		const environment = { ...process.env, ["PI_MODEL_EXCLUSIONS_PATH"]: store };
+		try {
+			const contenders = [runIsolatedModule(makeScript("a"), environment), runIsolatedModule(makeScript("b"), environment)];
+			await waitForFiles(ready, 2);
+			fs.writeFileSync(go, "");
+			const results = await Promise.all(contenders);
+			assert.equal(results.filter((result) => result === "claimed").length, 1);
+			assert.equal(fs.readFileSync(canonical, "utf-8"), stale);
+			assert.equal(fs.readdirSync(claimDir).filter((file) => file.includes(".successor-")).length, 1);
+		} finally {
+			fs.rmSync(path.dirname(store), { recursive: true, force: true });
+		}
+	});
+
+	it("merges a concurrent auth write when a successful probe clears its transient exclusion", async () => {
+		const store = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "pi-probe-merge-")), "exclusions.json");
+		const previousStore = process.env.PI_MODEL_EXCLUSIONS_PATH;
+		process.env.PI_MODEL_EXCLUSIONS_PATH = store;
+		try {
+			reloadFromDisk();
+			recordModelFailure({ modelId: "gpt-4", provider: "openai", reason: "503 service unavailable" });
+			const claim = claimTransientModelRecoveryProbe("openai/gpt-4");
+			assert.equal(claim.status, "claimed");
+			const modulePath = path.resolve("src/runs/shared/model-exclusions.ts");
+			const script = `import { recordModelFailure } from ${JSON.stringify(modulePath)}; recordModelFailure({ modelId: "claude", provider: "anthropic", reason: "invalid api key" });`;
+			const writer = runIsolatedModule(script, { ...process.env, ["PI_MODEL_EXCLUSIONS_PATH"]: store });
+			if (claim.status === "claimed") releaseTransientModelRecoveryProbe(claim.probe, true);
+			await writer;
+			reloadFromDisk();
+			assert.equal(findModelExclusion("openai/gpt-4"), undefined);
+			assert.equal(findModelExclusion("anthropic/claude")?.reason, "invalid api key");
+		} finally {
+			if (previousStore === undefined) delete process.env.PI_MODEL_EXCLUSIONS_PATH;
+			else process.env.PI_MODEL_EXCLUSIONS_PATH = previousStore;
+			reloadFromDisk();
+			fs.rmSync(path.dirname(store), { recursive: true, force: true });
+		}
 	});
 });
 
@@ -217,6 +396,8 @@ describe("model exclusions — persistence", () => {
 		reloadFromDisk();
 		assert.equal(findModelExclusion("openai/gpt-4"), undefined);
 		assert.equal(isExcluded("gpt-4", "openai"), false);
+		reloadFromDisk();
+		assert.equal(findModelExclusion("openai/gpt-4"), undefined);
 	});
 
 	it("keeps a non-auth exclusion after auth.json is modified", () => {

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -357,17 +357,7 @@ describe("model fallback helpers", () => {
 		);
 	});
 
-	it("ignores stale model-not-found exclusions when the model is back in the registry", () => {
-		recordModelFailure({
-			modelId: "gpt-5-mini",
-			provider: "openai",
-			reason: 'Model "openai/gpt-5-mini" not found. Use --list-models to see available models.',
-		});
-		assert.deepEqual(buildModelCandidates("openai/gpt-5-mini", undefined, availableModels), ["openai/gpt-5-mini"]);
-	});
-
-	it("keeps provider-wide exclusions when ignoring a stale model-not-found entry", () => {
-		recordModelFailure({ provider: "openai", reason: "quota exceeded" });
+	it("keeps model-not-found exclusions fail-closed even when the registry later lists the model", () => {
 		recordModelFailure({
 			modelId: "gpt-5-mini",
 			provider: "openai",
@@ -375,7 +365,7 @@ describe("model fallback helpers", () => {
 		});
 		assert.throws(
 			() => buildModelCandidates("openai/gpt-5-mini", undefined, availableModels),
-			/No usable subagent models remain after registry, scope, and cached-exclusion filtering/,
+			/cache-blocked\/unprobed/,
 		);
 	});
 
@@ -406,6 +396,40 @@ describe("model fallback helpers", () => {
 				scope: { enforce: true, allow: ["openai/*"] },
 			}),
 			/outside the configured subagent model scope/,
+		);
+	});
+
+	it("plans one runtime probe when every candidate is excluded for a transient provider outage", () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "503 service unavailable" });
+		recordModelFailure({ modelId: "claude-sonnet-4", provider: "anthropic", reason: "fetch failed" });
+		assert.deepEqual(
+			buildModelCandidates("openai/gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
+			["openai/gpt-5-mini"],
+		);
+	});
+
+	it("does not plan a probe for a mixed auth/quota/permanent exclusion set", () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "503 service unavailable" });
+		recordModelFailure({ modelId: "claude-sonnet-4", provider: "anthropic", reason: "quota exceeded" });
+		assert.throws(
+			() => buildModelCandidates("openai/gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels),
+			/cache-blocked\/unprobed/,
+		);
+	});
+
+	it("does not let a transient fallback probe mask an unknown configured primary", () => {
+		recordModelFailure({ modelId: "claude-sonnet-4", provider: "anthropic", reason: "503 service unavailable" });
+		assert.throws(
+			() => buildModelCandidates("does-not-exist", ["anthropic/claude-sonnet-4"], availableModels),
+			/Unknown subagent model 'does-not-exist'/,
+		);
+	});
+
+	it("does not let a transient primary probe mask an unknown configured fallback", () => {
+		recordModelFailure({ modelId: "gpt-5-mini", provider: "openai", reason: "503 service unavailable" });
+		assert.throws(
+			() => buildModelCandidates("openai/gpt-5-mini", ["does-not-exist"], availableModels),
+			/Unknown subagent model 'does-not-exist'/,
 		);
 	});
 


### PR DESCRIPTION
## Summary
- re-probe one configured model when every candidate is excluded only by transient transport/provider failures
- bound recovery with an exactly-one cross-process append-only claim and targeted exclusion clearing
- keep auth, quota, rate-limit, request-shape, explicit-model, configuration, and model-scope errors fail-closed

## Validation
- `npm run typecheck`
- model exclusion/fallback unit tests: 145 passed
- `single-execution.part-2`: 198 passed
- full suite: 3075 passed; the same 20 failures as pristine base, with no patch-only failures
- independent reviewer: OK with notes
- final techlead: ACCEPT-WITH-WARNINGS
- live configured launch after installation/reload reached `openai-codex/gpt-5.6-sol` through the new runtime

## Notes
The remaining warnings are non-blocking: bounded synchronous mutation-lock contention and two additional coverage opportunities.