### PR TITLE
feat: add SSH child text edit for bound remote projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add remote text `edit` for admitted SSH children when the bound agent explicitly selects it. An edit performs one exact unique replacement in the bound remote POSIX project, reuses the protected write path, and never falls back to the local filesystem. Related to #2047; leaves #2047 open. Thanks to [@klay7w](https://github.com/klay7w) for #2047.
 - Add Pi-compatible remote text `write` for admitted SSH children when the bound agent explicitly selects it. Writes target only the bound remote POSIX project, refuse symlink escape, and never fall back to the local filesystem. Related to #2047; leaves #2047 open. Thanks to [@klay7w](https://github.com/klay7w) for #2047.
 - Add an opt-in stock-Pi SSH project entry for fresh single native foreground delegation with remote text `read`/`bash` and local authentication, selected resources and sessions. Background, workflows, resume and project-management operations remain unsupported; see [the bounded contract](docs/ssh-project.md). Related to #2047; thanks to [@klay7w](https://github.com/klay7w).
 - Add opt-in watchdog `fallbackModels` for main, children, and per-agent overrides, retrying provider failures only before tool work within the existing review deadline. Thanks to [@dwizzle204](https://github.com/dwizzle204) for #2075.

--- a/docs/ssh-project.md
+++ b/docs/ssh-project.md
@@ -50,12 +50,12 @@ Ask Pi to delegate to the selected agent with `async:false` and `context:fresh`.
 - The launcher preflights an empty, package-owned `ssh-control` directory under the normal agent directory before stock Pi can run cwd migrations or read cwd settings. Do not put project files there. It refuses a contaminated or symlinked control directory rather than cleaning it.
 - Project settings, packages, extensions, skills, SYSTEM/APPEND_SYSTEM and unrelated local project AGENTS files are not substituted for remote project resources. Automatic global extension/skill/prompt-template activation is also disabled; use explicit selections.
 - Intended global agent-directory context is restored explicitly. Remote AGENTS/CLAUDE candidates are read root-to-project in Pi's candidate order. Remote `.pi` configuration/executable resource discovery is unsupported. Symlinked project-directory identity is rejected; specify its physical POSIX path.
-- Agent and selected skill Markdown are bounded immutable local snapshots, not directory grants or stock `/skill:` commands. `read` defaults to the remote project. `scope: "local-resource"` reads only the exact path of a selected Markdown snapshot; it does not expose helpers, assets, neighboring files or credentials. Relative links do not grant access. Text `write` stays in the bound remote project and refuses symlink escape; it does not follow a swapped-outward leaf or dest component. This remains execution routing, **not a sandbox**.
+- Agent and selected skill Markdown are bounded immutable local snapshots, not directory grants or stock `/skill:` commands. `read` defaults to the remote project. `scope: "local-resource"` reads only the exact path of a selected Markdown snapshot; it does not expose helpers, assets, neighboring files or credentials. Relative links do not grant access. Text `write` and `edit` stay in the bound remote project and refuse symlink escape; they do not follow a swapped-outward leaf or dest component. `edit` performs one exact unique replacement and reuses the protected write path. This remains execution routing, **not a sandbox**.
 - Child sessions and results remain local. Remote target identity contributes to the launch binding digest. A registered SSH session cannot silently launch an ordinary local child.
 
 ## Supported profile and refusals
 
-Selected agents may specify name, description, model/thinking, read/bash tools, optional text `write`, foreground/fresh defaults, timeout/tool timeout and the supported context settings. Use `systemPromptMode: append`; project/global context remains enabled and skills are explicitly selected rather than automatically inherited. Other frontmatter requirements are rejected, not dropped. `write` is provided only when the bound agent lists it.
+Selected agents may specify name, description, model/thinking, read/bash tools, optional text `write`/`edit`, foreground/fresh defaults, timeout/tool timeout and the supported context settings. Use `systemPromptMode: append`; project/global context remains enabled and skills are explicitly selected rather than automatically inherited. Other frontmatter requirements are rejected, not dropped. `write` and `edit` are provided only when the bound agent lists them.
 
 The following are unsupported and rejected: workflows/chains/parallel scripts, background/detach, fork/resume/recovery, nested delegation, managed worktrees and hooks, local Git/acceptance checks, explicit output/progress files, structured-output contracts, project management and resource reload/session replacement. Models may retry within their initialized session, but automatic fresh-session/retained-session relaunch is disabled.
 
@@ -65,7 +65,7 @@ Conflicting configured worktrees, forced async, permission contracts, budgets, i
 
 An explicitly enabled global subagent watchdog is also unsupported: this entry rejects that policy rather than silently turning it off. The ordinary local watchdog is not constructed for remote projects, because its settings/Git readers operate locally.
 
-`edit`, `grep`, `find`, `ls`, PowerShell and image/binary reads are not provided. Search/edit/build/test can be performed through remote Bash. Trusted provider extensions are still trusted local code; this is execution routing, **not a sandbox**.
+`grep`, `find`, `ls`, PowerShell and image/binary reads are not provided. Search/build/test can be performed through remote Bash. Trusted provider extensions are still trusted local code; this is execution routing, **not a sandbox**.
 
 ## Bounds and cancellation
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -2172,7 +2172,7 @@ export function loadSelectedAgentDocument(document: { path: string; content: str
 	const result = loadAgentsFromDefinitionFiles([{ filePath: document.path, content: document.content }], "user");
 	if (result.diagnostics.length || result.agents.length !== 1) throw new Error("Invalid selected SSH agent document.");
 	const agent = result.agents[0]!;
-	if (agent.defaultContext === "fork" || agent.defaultAsync === true || agent.systemPromptMode === "replace" || agent.tools?.some(tool => !["read", "bash", "write"].includes(tool))) throw new Error("Selected SSH agent requires unsupported execution capabilities.");
+	if (agent.defaultContext === "fork" || agent.defaultAsync === true || agent.systemPromptMode === "replace" || agent.tools?.some(tool => !["read", "bash", "write", "edit"].includes(tool))) throw new Error("Selected SSH agent requires unsupported execution capabilities.");
 	return { ...agent, tools: agent.tools ?? ["read", "bash"], allowNestedSubagents: false, inheritProjectContext: true, inheritGlobalContext: true, inheritSkills: false };
 }
 

--- a/src/runs/shared/ssh-project-tools.ts
+++ b/src/runs/shared/ssh-project-tools.ts
@@ -67,6 +67,28 @@ function resolveBoundRemoteFile(projectDir: string, raw: string): string {
 	return file;
 }
 
+async function readRemoteUtf8(profile: SshProjectBootstrap, file: string, signal?: AbortSignal): Promise<string> {
+	const encoded = await runSshProject(profile, `set -eu\ntest -f ${sshQuote(file)}\ntest -r ${sshQuote(file)}\ndd if=${sshQuote(file)} bs=1 count=262145 2>/dev/null | base64 | tr -d '\\n'`, signal);
+	if (!/^[A-Za-z0-9+/]*={0,2}$/u.test(encoded)) throw new Error("Invalid SSH read response.");
+	const bytes = Buffer.from(encoded, "base64");
+	if (bytes.length > 262144) throw new Error("Remote text read exceeds 256 KiB; use bounded remote bash instead.");
+	const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+	if (text.includes("\0")) throw new Error("Remote binary/image reads are unsupported.");
+	return text;
+}
+
+function assertRemoteEditReplacement(oldText: string, newText: string): void {
+	if (typeof oldText !== "string" || typeof newText !== "string" || oldText.includes("\0") || newText.includes("\0")) throw new Error("Remote binary/image writes are unsupported.");
+	if (!oldText) throw new Error("Remote edit requires one unique exact oldText match.");
+}
+
+function applyUniqueExactReplacement(text: string, oldText: string, newText: string): string {
+	assertRemoteEditReplacement(oldText, newText);
+	const parts = text.split(oldText);
+	if (parts.length === 2) return `${parts[0]}${newText}${parts[1]}`;
+	throw new Error(parts.length < 2 ? "Remote edit oldText was not found." : "Remote edit oldText is not unique.");
+}
+
 function remoteWriteScript(file: string, encoded: string): string {
 	return [
 		"set -eu",
@@ -132,13 +154,7 @@ export function createSshProjectTools(profile: SshProjectBootstrap, selectedTool
 			} else {
 				if (args.scope !== undefined && args.scope !== "project") throw new Error("Unsupported read scope.");
 				if (!args.path || /[\u0000-\u001f\u007f]/u.test(args.path)) throw new Error("Invalid remote path.");
-				const file = path.posix.resolve(profile.projectDir, args.path);
-				const encoded = await runSshProject(profile, `set -eu\ntest -f ${sshQuote(file)}\ntest -r ${sshQuote(file)}\ndd if=${sshQuote(file)} bs=1 count=262145 2>/dev/null | base64 | tr -d '\\n'`, signal);
-				if (!/^[A-Za-z0-9+/]*={0,2}$/u.test(encoded)) throw new Error("Invalid SSH read response.");
-				const bytes = Buffer.from(encoded, "base64");
-				if (bytes.length > 262144) throw new Error("Remote text read exceeds 256 KiB; use bounded remote bash instead.");
-				text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-				if (text.includes("\0")) throw new Error("Remote binary/image reads are unsupported.");
+				text = await readRemoteUtf8(profile, path.posix.resolve(profile.projectDir, args.path), signal);
 			}
 			const start = (args.offset ?? 1) - 1;
 			const lines = text.split("\n"), limit = args.limit ?? 2000;
@@ -176,5 +192,24 @@ export function createSshProjectTools(profile: SshProjectBootstrap, selectedTool
 			return { content: [{ type: "text", text: `Wrote ${bytes.length} bytes to ${file}` }], details: { path: file, bytes: bytes.length } };
 		},
 	};
-	return selectedTools?.includes("write") ? [read, bash, write] : [read, bash];
+	const edit: ToolDefinition = {
+		name: "edit", label: "edit", description: "Replace one unique exact UTF-8 occurrence in a bound remote SSH project file.",
+		promptSnippet: "Edit remote project text with one exact unique replacement; no local filesystem fallback.",
+		parameters: Type.Object({ path: Type.String(), oldText: Type.String(), newText: Type.String(), scope: Type.Optional(Type.String()) }),
+		async execute(_id, raw, signal) {
+			const args = raw as { path: string; oldText: string; newText: string; scope?: string };
+			if (args.scope !== undefined && args.scope !== "project") throw new Error("Unsupported edit scope.");
+			assertRemoteEditReplacement(args.oldText, args.newText);
+			const file = resolveBoundRemoteFile(profile.projectDir, args.path);
+			const next = applyUniqueExactReplacement(await readRemoteUtf8(profile, file, signal), args.oldText, args.newText);
+			const bytes = Buffer.from(next, "utf8");
+			if (bytes.length > 262144) throw new Error("Remote text write exceeds 256 KiB.");
+			await runSshProject(profile, remoteWriteScript(file, bytes.toString("base64")), signal);
+			return { content: [{ type: "text", text: `Edited ${file}` }], details: { path: file, bytes: bytes.length } };
+		},
+	};
+	const tools: ToolDefinition[] = [read, bash];
+	if (selectedTools?.includes("write")) tools.push(write);
+	if (selectedTools?.includes("edit")) tools.push(edit);
+	return tools;
 }

--- a/test/integration/ssh-foreground.test.ts
+++ b/test/integration/ssh-foreground.test.ts
@@ -95,7 +95,7 @@ pi.registerCommand('proof-reload',{description:'Proof reload',handler:async(_arg
 if(process.env.SSH_PROOF_CONFLICT==='1'||globalThis[key]>1)pi.registerTool({name:'read',label:'read',description:'Forbidden provider fallback',parameters:{type:'object',properties:{}},async execute(){throw new Error('PROVIDER_LOCAL_FALLBACK')}});
 pi.registerProvider('ssh-proof',{baseUrl:'http://127.0.0.1:1',api:'openai-completions',models:[{id:'proof-model',name:'Proof',reasoning:false,input:['text'],cost:{input:0,output:0,cacheRead:0,cacheWrite:0},contextWindow:32768,maxTokens:512}],streamSimple(model,context){
  const parent=context.tools?.some(t=>t.name==='subagent')||context.tools?.length===0;fs.appendFileSync(${JSON.stringify(trace)},JSON.stringify({kind:parent?'PARENT_MODEL':'MODEL',value:{prompt:context.systemPrompt,tools:context.tools?.map(t=>t.name),messages:context.messages}})+'\\n');
- const stream=createAssistantMessageEventStream();const results=context.messages.filter(m=>m.role==='toolResult');const writeProof=process.env.SSH_PROOF_WRITE==='1';const content=parent?(results.length===0&&context.tools?.length?[{type:'toolCall',id:'parent-read',name:'read',arguments:{path:${JSON.stringify(skill)},scope:'local-resource'}}]:[{type:'text',text:'PARENT_DONE'}]):writeProof?(results.length===0?[{type:'toolCall',id:'w',name:'write',arguments:{path:'notes \\' $(touch BAD)\`x\`.txt',content:'hello $HOME && \`touch LOCAL\`\\nsecond'}}]:[{type:'text',text:'REMOTE_WRITE_DONE'}]):results.length===0?[{type:'toolCall',id:'r',name:'read',arguments:{path:'AGENTS.md'}}]:results.length===1?[{type:'toolCall',id:'b',name:'bash',arguments:{command:'printf remote'}}]:[{type:'text',text:'REMOTE_CHILD_DONE'}];
+ const stream=createAssistantMessageEventStream();const results=context.messages.filter(m=>m.role==='toolResult');const writeProof=process.env.SSH_PROOF_WRITE==='1';const editProof=process.env.SSH_PROOF_EDIT==='1';const content=parent?(results.length===0&&context.tools?.length?[{type:'toolCall',id:'parent-read',name:'read',arguments:{path:${JSON.stringify(skill)},scope:'local-resource'}}]:[{type:'text',text:'PARENT_DONE'}]):writeProof?(results.length===0?[{type:'toolCall',id:'w',name:'write',arguments:{path:'notes \\' $(touch BAD)\`x\`.txt',content:'hello $HOME && \`touch LOCAL\`\\nsecond'}}]:[{type:'text',text:'REMOTE_WRITE_DONE'}]):editProof?(results.length===0?[{type:'toolCall',id:'e',name:'edit',arguments:{path:'notes \\' $(touch BAD)\`x\`.txt',oldText:'target-edit_REMOTE_FILE',newText:'hello $HOME && \`touch LOCAL\`\\nsecond'}}]:[{type:'text',text:'REMOTE_EDIT_DONE'}]):results.length===0?[{type:'toolCall',id:'r',name:'read',arguments:{path:'AGENTS.md'}}]:results.length===1?[{type:'toolCall',id:'b',name:'bash',arguments:{command:'printf remote'}}]:[{type:'text',text:'REMOTE_CHILD_DONE'}];
  const message={role:'assistant',api:model.api,provider:model.provider,model:model.id,content,stopReason:content[0].type==='toolCall'?'toolUse':'stop',timestamp:Date.now(),usage:{input:1,output:1,cacheRead:0,cacheWrite:0,totalTokens:2,cost:{input:0,output:0,cacheRead:0,cacheWrite:0,total:0}}};queueMicrotask(()=>{stream.push({type:'done',reason:message.stopReason,message});stream.end()});return stream;}});
  pi.on('before_agent_start',async(_,ctx)=>{if(!pi.getActiveTools().includes('subagent'))return;
  await new Promise(resolve=>{pi.events.on('prompt-template:subagent:response',result=>{fs.writeFileSync(${JSON.stringify(response)},JSON.stringify(result));resolve()});
@@ -157,8 +157,27 @@ const [a,b]=await Promise.all([factory.create(remote('concurrent-A')),factory.cr
 	assert(!fs.existsSync(path.join(unrelated, "notes ' $(touch BAD)`x`.txt")));
 	const writeParents = writeEvents.filter(e => e.kind === "PARENT_MODEL");
 	assert(writeParents.every(e => !e.value.tools?.includes("write")));
+	fs.writeFileSync(agent, selectedText.replace("tools: read,bash", "tools: read,edit"));
+	fs.writeFileSync(trace, ""); fs.rmSync(response, { force: true });
+	const beforeEdit = new Set(fs.readdirSync(unrelated, { recursive: true }).map(String));
+	const editRun = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", "target-edit", "--project", "/srv/project", "--agent", agent, "--skill", skill, "--extension", provider, "--mode", "json", "--prompt", "Edit now", "--offline"], { cwd: unrelated, env: { ...env, SSH_PROOF_EDIT: "1" }, input: "", encoding: "utf8", timeout: 30_000 });
+	assert.equal(editRun.status, 0, JSON.stringify({ error: String(editRun.error), stderr: editRun.stderr, stdout: editRun.stdout }));
+	assert.equal(JSON.parse(fs.readFileSync(response, "utf8")).status, "completed");
+	assert.equal(JSON.parse(fs.readFileSync(response, "utf8")).result.text, "REMOTE_EDIT_DONE");
+	const editEvents = fs.readFileSync(trace, "utf8").trim().split("\n").filter(Boolean).map(line => JSON.parse(line));
+	assert(!editEvents.some(e => ["UNRELATED", "PROCESS", "NETWORK"].includes(e.kind)), JSON.stringify(editEvents));
+	const editModels = editEvents.filter(e => e.kind === "MODEL"); assert.equal(editModels.length, 2);
+	assert.deepEqual(editModels[0].value.tools.sort(), ["edit", "read"]);
+	const editWrite = editEvents.find(e => e.kind === "SCRIPT" && String(e.value).includes("dd of="))?.value as string;
+	assert(editWrite, JSON.stringify(editEvents));
+	assert(editWrite.includes(sshQuote("/srv/project/notes ' $(touch BAD)`x`.txt")));
+	assert(editWrite.includes(sshQuote(Buffer.from("hello $HOME && `touch LOCAL`\nsecond", "utf8").toString("base64"))));
+	assert.deepEqual(new Set(fs.readdirSync(unrelated, { recursive: true }).map(String)), beforeEdit);
+	assert(!fs.existsSync(path.join(unrelated, "notes ' $(touch BAD)`x`.txt")));
+	const editParents = editEvents.filter(e => e.kind === "PARENT_MODEL");
+	assert(editParents.every(e => !e.value.tools?.includes("edit")));
 	fs.writeFileSync(agent, selectedText);
-	for (const unsupported of [selectedText.replace("async: false", "async: true"), selectedText.replace("defaultContext: fresh", "defaultContext: fork"), selectedText.replace("tools: read,bash", "tools: read,edit"), selectedText.replace("systemPromptMode: append", "acceptance: true\nsystemPromptMode: append")]) {
+	for (const unsupported of [selectedText.replace("async: false", "async: true"), selectedText.replace("defaultContext: fresh", "defaultContext: fork"), selectedText.replace("tools: read,bash", "tools: read,grep"), selectedText.replace("systemPromptMode: append", "acceptance: true\nsystemPromptMode: append")]) {
 		fs.writeFileSync(agent, unsupported); fs.writeFileSync(trace, "");
 		const rejected = spawnSync(process.execPath, [path.join(repo, "ssh-launch.mjs"), "--target", "target-A", "--project", "/srv/project", "--agent", agent, "--extension", provider, "--mode", "json", "--prompt", "Never prompt", "--offline"], { cwd: unrelated, env, input: "", encoding: "utf8", timeout: 15_000 });
 		assert.equal(rejected.status, 1); assert(!fs.readFileSync(trace, "utf8").includes('"SSH"')); assert(!fs.readFileSync(trace, "utf8").includes('"MODEL"'));

--- a/test/unit/ssh-project-tools.test.ts
+++ b/test/unit/ssh-project-tools.test.ts
@@ -46,17 +46,20 @@ test("SSH public tool operations: quoting, selected documents, errors, cancellat
 	} finally { cp.spawn = original; syncBuiltinESMExports(); }
 });
 
-test("SSH write is omitted unless the bound agent selects it", () => {
+test("SSH write and edit are omitted unless the bound agent selects them", () => {
 	assert.deepEqual(createSshProjectTools(profile).map(tool => tool.name), ["read", "bash"]);
 	assert.deepEqual(createSshProjectTools(profile, ["read", "bash"]).map(tool => tool.name), ["read", "bash"]);
 	assert.deepEqual(createSshProjectTools(profile, ["read", "write"]).map(tool => tool.name), ["read", "bash", "write"]);
+	assert.deepEqual(createSshProjectTools(profile, ["read", "edit"]).map(tool => tool.name), ["read", "bash", "edit"]);
+	assert.deepEqual(createSshProjectTools(profile, ["read", "write", "edit"]).map(tool => tool.name), ["read", "bash", "write", "edit"]);
 });
 
-test("SSH selected agent may list write and still refuses edit", () => {
+test("SSH selected agent may list write or edit and still refuses grep", () => {
 	const agent = (tools: string) => `---\nname: ssh-worker\ndescription: SSH worker\ntools: ${tools}\nasync: false\ndefaultContext: fresh\nsystemPromptMode: append\n---\nBody`;
 	assert.deepEqual(loadSelectedAgentDocument({ path: `${process.cwd()}/agent.md`, content: agent("read,bash") }).tools, ["read", "bash"]);
 	assert.deepEqual(loadSelectedAgentDocument({ path: `${process.cwd()}/agent.md`, content: agent("read,write") }).tools, ["read", "write"]);
-	assert.throws(() => loadSelectedAgentDocument({ path: `${process.cwd()}/agent.md`, content: agent("read,edit") }), /unsupported execution capabilities/);
+	assert.deepEqual(loadSelectedAgentDocument({ path: `${process.cwd()}/agent.md`, content: agent("read,edit") }).tools, ["read", "edit"]);
+	assert.throws(() => loadSelectedAgentDocument({ path: `${process.cwd()}/agent.md`, content: agent("read,grep") }), /unsupported execution capabilities/);
 });
 
 test("SSH write rejects unsafe scope and path before transport and never touches the local project", async () => {
@@ -207,6 +210,139 @@ test("POSIX write refuses leaf and parent-dir symlink escape", { skip: process.p
 		const open = cp.spawnSync("/bin/dd", ["of=" + path.join(remote, "realdir", "swap.txt"), "oflag=nofollow"], { input: "ESCAPED", encoding: "utf8" });
 		assert.notEqual(open.status, 0);
 		assert.equal(fs.readFileSync(path.join(outside, "escape.txt"), "utf8"), "SAFE");
+		assert.deepEqual(fs.readdirSync(local), []);
+	} finally {
+		restore();
+		fs.rmSync(remote, { recursive: true, force: true });
+		fs.rmSync(outside, { recursive: true, force: true });
+		fs.rmSync(local, { recursive: true, force: true });
+	}
+});
+
+test("SSH edit rejects unsafe scope and path before transport and never touches the local project", async () => {
+	const localRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-edit-local-"));
+	const original = cp.spawn;
+	const invocations: unknown[] = [];
+	cp.spawn = ((command: string, args: readonly string[], options: unknown) => {
+		invocations.push({ command, args, options });
+		throw new Error("transport must not start");
+	}) as typeof cp.spawn;
+	syncBuiltinESMExports();
+	try {
+		fs.writeFileSync(path.join(localRoot, "canary.txt"), "LOCAL");
+		const edit = createSshProjectTools(profile, ["edit"]).find(tool => tool.name === "edit")!;
+		await assert.rejects(() => edit.execute("scope", { path: "ok.txt", oldText: "a", newText: "b", scope: "local-resource" }, undefined, undefined, {} as never), /Unsupported edit scope/);
+		await assert.rejects(() => edit.execute("abs", { path: "/etc/passwd", oldText: "a", newText: "b" }, undefined, undefined, {} as never), /outside the bound project/);
+		await assert.rejects(() => edit.execute("escape", { path: "../secret", oldText: "a", newText: "b" }, undefined, undefined, {} as never), /outside the bound project/);
+		await assert.rejects(() => edit.execute("root", { path: ".", oldText: "a", newText: "b" }, undefined, undefined, {} as never), /outside the bound project/);
+		await assert.rejects(() => edit.execute("empty", { path: "", oldText: "a", newText: "b" }, undefined, undefined, {} as never), /Invalid remote path/);
+		await assert.rejects(() => edit.execute("ctrl", { path: "a\nb", oldText: "a", newText: "b" }, undefined, undefined, {} as never), /Invalid remote path/);
+		await assert.rejects(() => edit.execute("empty-old", { path: "ok.txt", oldText: "", newText: "b" }, undefined, undefined, {} as never), /unique exact/);
+		await assert.rejects(() => edit.execute("bin-old", { path: "ok.txt", oldText: "a\0b", newText: "x" }, undefined, undefined, {} as never), /binary/);
+		await assert.rejects(() => edit.execute("bin-new", { path: "ok.txt", oldText: "a", newText: "a\0b" }, undefined, undefined, {} as never), /binary/);
+		assert.deepEqual(invocations, []);
+		assert.deepEqual(fs.readdirSync(localRoot), ["canary.txt"]);
+		assert.equal(fs.readFileSync(path.join(localRoot, "canary.txt"), "utf8"), "LOCAL");
+	} finally { cp.spawn = original; syncBuiltinESMExports(); fs.rmSync(localRoot, { recursive: true, force: true }); }
+});
+
+test("SSH edit performs one unique replacement, refuses non-unique matches, and fails closed", async () => {
+	const localRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-edit-cwd-"));
+	const original = cp.spawn;
+	const invocations: Array<{ command: string; args: readonly string[]; options: unknown; script: string }> = [];
+	let output = "", code: number | null = 0, hang = false, killed = false;
+	cp.spawn = ((command: string, args: readonly string[], options: unknown) => {
+		const child = new EventEmitter() as EventEmitter & { stdin: PassThrough; stdout: PassThrough; stderr: PassThrough; kill(): boolean };
+		child.stdin = new PassThrough(); child.stdout = new PassThrough(); child.stderr = new PassThrough();
+		const invocation = { command, args, options, script: "" }; invocations.push(invocation);
+		child.kill = () => { killed = true; queueMicrotask(() => child.emit("close", null)); return true; };
+		child.stdin.on("data", chunk => { invocation.script += chunk; });
+		child.stdin.on("finish", () => { if (!hang) queueMicrotask(() => { child.stdout.emit("data", Buffer.from(output)); child.emit("close", code); }); });
+		return child;
+	}) as typeof cp.spawn;
+	syncBuiltinESMExports();
+	try {
+		fs.writeFileSync(path.join(localRoot, "canary.txt"), "LOCAL");
+		const edit = createSshProjectTools(profile, ["edit"]).find(tool => tool.name === "edit")!;
+		const relative = "dir ' $(touch BAD)`x`/file ' $(touch BAD)`.txt";
+		const file = path.posix.resolve(profile.projectDir, relative);
+		const source = "alpha $HOME && `touch LOCAL` ; unique\nalpha";
+		const next = "beta $HOME && `touch LOCAL` ; unique\nalpha";
+		output = Buffer.from(source).toString("base64");
+		const result = await edit.execute("first", { path: relative, oldText: "alpha $HOME && `touch LOCAL` ; unique", newText: "beta $HOME && `touch LOCAL` ; unique" }, undefined, undefined, {} as never);
+		assert.equal((result.details as { path: string; bytes: number }).path, file);
+		assert.equal((result.details as { bytes: number }).bytes, Buffer.byteLength(next));
+		assert.equal(invocations.length, 2);
+		assert(invocations[0]!.script.includes(`dd if=${sshQuote(file)}`));
+		assert(!invocations[0]!.script.includes("oflag=nofollow"));
+		assert(invocations[1]!.script.includes(sshQuote(file)));
+		assert(invocations[1]!.script.includes(sshQuote(Buffer.from(next, "utf8").toString("base64"))));
+		assert(invocations[1]!.script.includes("pwd -P"));
+		assert(invocations[1]!.script.includes('dd of="./$base" oflag=nofollow'));
+		assert(invocations[1]!.script.includes("set -C"));
+		assert(!invocations[1]!.script.includes(source));
+		output = Buffer.from("same same").toString("base64");
+		await assert.rejects(() => edit.execute("dup", { path: "ok.txt", oldText: "same", newText: "other" }, undefined, undefined, {} as never), /not unique/);
+		assert.equal(invocations.length, 3);
+		output = Buffer.from("nope").toString("base64");
+		await assert.rejects(() => edit.execute("missing", { path: "ok.txt", oldText: "absent", newText: "other" }, undefined, undefined, {} as never), /not found/);
+		assert.equal(invocations.length, 4);
+		code = 255; output = Buffer.from("ok").toString("base64");
+		await assert.rejects(() => edit.execute("fail", { path: "ok.txt", oldText: "ok", newText: "nope" }, undefined, undefined, {} as never), /no local fallback/);
+		hang = true; const controller = new AbortController();
+		const pending = edit.execute("abort", { path: "ok.txt", oldText: "ok", newText: "nope" }, controller.signal, undefined, {} as never);
+		controller.abort();
+		await assert.rejects(() => pending, /remote descendants\/completion may be uncertain/);
+		assert(killed);
+		assert.deepEqual(fs.readdirSync(localRoot), ["canary.txt"]);
+		assert.equal(fs.readFileSync(path.join(localRoot, "canary.txt"), "utf8"), "LOCAL");
+		assert(!fs.existsSync(path.join(localRoot, "ok.txt")));
+	} finally { cp.spawn = original; syncBuiltinESMExports(); fs.rmSync(localRoot, { recursive: true, force: true }); }
+});
+
+test("POSIX edit recipe replaces one unique occurrence and refuses non-unique or missing text", { skip: process.platform === "win32" }, async () => {
+	const remote = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-edit-remote-"));
+	const local = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-edit-local-"));
+	fs.writeFileSync(path.join(local, "canary.txt"), "LOCAL");
+	const relative = "dir ' $(touch BAD)`x`/file ' $(touch BAD)`.txt";
+	fs.mkdirSync(path.dirname(path.join(remote, relative)), { recursive: true });
+	const source = "hello $HOME && `touch LOCAL` ; unique\nhello";
+	fs.writeFileSync(path.join(remote, relative), source);
+	const bound = snapshotSshProjectBootstrap({ target: "user@host", projectDir: remote, childProfile: "fresh-native-read-bash", localRuntime: { cwd: local, agentDir: local, projectTrusted: false, noContextFiles: true, projectDiscovery: "disabled" } });
+	const restore = installLocalSsh(remote);
+	try {
+		const edit = createSshProjectTools(bound, ["edit"]).find(tool => tool.name === "edit")!;
+		await edit.execute("first", { path: relative, oldText: "hello $HOME && `touch LOCAL` ; unique", newText: "edited $HOME && `touch LOCAL` ; unique" }, undefined, undefined, {} as never);
+		assert.equal(fs.readFileSync(path.join(remote, relative), "utf8"), "edited $HOME && `touch LOCAL` ; unique\nhello");
+		await assert.rejects(() => edit.execute("dup", { path: relative, oldText: "e", newText: "X" }, undefined, undefined, {} as never), /not unique/);
+		await assert.rejects(() => edit.execute("missing", { path: relative, oldText: "absent", newText: "X" }, undefined, undefined, {} as never), /not found/);
+		assert.equal(fs.readFileSync(path.join(remote, relative), "utf8"), "edited $HOME && `touch LOCAL` ; unique\nhello");
+		assert.deepEqual(fs.readdirSync(local), ["canary.txt"]);
+		assert.equal(fs.readFileSync(path.join(local, "canary.txt"), "utf8"), "LOCAL");
+	} finally {
+		restore();
+		fs.rmSync(remote, { recursive: true, force: true });
+		fs.rmSync(local, { recursive: true, force: true });
+	}
+});
+
+test("POSIX edit refuses leaf and parent-dir symlink escape", { skip: process.platform === "win32" }, async () => {
+	const remote = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-edit-bound-"));
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-edit-out-"));
+	const local = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-edit-cwd-"));
+	fs.writeFileSync(path.join(outside, "escape.txt"), "SAFE unique");
+	fs.symlinkSync(path.join(outside, "escape.txt"), path.join(remote, "leaf"));
+	fs.symlinkSync(outside, path.join(remote, "parent"));
+	fs.writeFileSync(path.join(outside, "nested.txt"), "SAFE unique");
+	const bound = snapshotSshProjectBootstrap({ target: "user@host", projectDir: remote, childProfile: "fresh-native-read-bash", localRuntime: { cwd: local, agentDir: local, projectTrusted: false, noContextFiles: true, projectDiscovery: "disabled" } });
+	const restore = installLocalSsh(remote);
+	try {
+		const edit = createSshProjectTools(bound, ["edit"]).find(tool => tool.name === "edit")!;
+		for (const [id, file] of [["leaf", "leaf"], ["parent", "parent/nested.txt"]] as const) {
+			await assert.rejects(() => edit.execute(id, { path: file, oldText: "SAFE unique", newText: "ESCAPED" }, undefined, undefined, {} as never), /no local fallback/);
+		}
+		assert.equal(fs.readFileSync(path.join(outside, "escape.txt"), "utf8"), "SAFE unique");
+		assert.equal(fs.readFileSync(path.join(outside, "nested.txt"), "utf8"), "SAFE unique");
 		assert.deepEqual(fs.readdirSync(local), []);
 	} finally {
 		restore();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to #2047; leaves #2047 open.

Thanks to [@klay7w](https://github.com/klay7w) for #2047.

## Summary

This is the next bounded SSH slice after #2115. It adds remote text `edit` on the existing `createSshProjectTools` seam for admitted foreground children.

An explicitly selected `edit` performs one exact, unique text replacement inside the bound remote POSIX project, using the existing protected write path, with no local filesystem fallback.

- Text `edit` is provided only when the bound agent explicitly lists it.
- Parent isolation stays `read`/`bash`/`subagent`; the parent does not gain write or edit.
- Unsupported scopes, empty `oldText`, binary payloads, and unsafe/invalid paths are rejected before transport.
- A successful edit reads the remote file, requires exactly one exact `oldText` match, and writes the result through the #2115 containment (`pwd -P`, symlink refusal, `oflag=nofollow` / noclobber staging).
- Missing or non-unique `oldText` fail closed without writing. Transport failure never becomes local fallback.
- Search/list tools, binary edits, background, resume, nesting, workflows, worktrees, Git, acceptance, reload, and remote configuration discovery remain out of scope.

## Review

- Compose remote read + protected write; do not invent a second write path.
- Related to #2047; leaves #2047 open. Credit: Thanks to [@klay7w](https://github.com/klay7w) for #2047.

Residual: SSH remains execution routing, not a sandbox. Concurrent remote Bash can still mutate the project; this edit does not follow a swapped-outward dest-component, staging-dir, or leaf symlink.

## Validation

Local evidence (no live SSH host), head `3f867f561ef62d7afe554b6f190fa43682b479ff`:

- `test/unit/ssh-project-tools.test.ts`: 12 passed, including unique replacement, missing/non-unique refusal, and leaf/parent symlink escape.
- `test/integration/ssh-foreground.test.ts`: 2 passed against real Pi 0.85.1 with mocked SSH. Child `edit` is admitted only when listed; parent does not gain `edit`; replacement bytes go through the protected write script; the local project is untouched.
- `tsc --noEmit` passed.

Related to #2047; leaves #2047 open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f3b34e9-e28c-4001-9099-9f8a7b03e9ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f3b34e9-e28c-4001-9099-9f8a7b03e9ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

