### PR TITLE
fix: delete terminal prior-session schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - Do not abort a native child during final-stop drain after queued steering or follow-up is observed, even if Pi drains that input before a delayed `turn_start`. Related to #2117; thanks to [@yanqianglu](https://github.com/yanqianglu) for #2057.
+- Allow explicit deletion of a session-only schedule from another session when the recorded exact async run has terminal status, while continuing to refuse deletion without matching terminal evidence (#2125).
 - Fail review and scout launches closed when a requested, still-permitted repository tool is missing from the host runtime, and classify that gap as a lane infrastructure failure instead of a completed review. Intentionally empty or ceiling-restricted allowlists stay valid. Remaining #2058 residual; thanks to [@nicobailon](https://github.com/nicobailon).
 - Apply the same project-local refinement overlay during launch-contract preflight that foreground execution already injects, so `launchContractDigest` matches the completed terminal. Thanks to [@Yivas](https://github.com/Yivas) for #2112.
 - Reject workflow scripts whose statically provable child launches exceed `maxSubagentSpawnsPerRun` before discovery, artifact creation, or child launch; dynamic launch counts remain advisory and retain runtime enforcement. Thanks to [@ton77v](https://github.com/ton77v) for #2101.

--- a/src/runs/background/scheduled-runs.ts
+++ b/src/runs/background/scheduled-runs.ts
@@ -724,8 +724,16 @@ export class ScheduledRunManager {
 
 	private remove(params: SubagentParamsLike): AgentToolResult<Details> {
 		const schedule = this.resolve(params);
-		if (schedule.activeRunId) return textResult(`Schedule ${schedule.id} has active run ${schedule.activeRunId}; stop that run before deleting the schedule.`, [schedule], undefined, true);
 		const store = this.requireStore();
+		if (schedule.activeRunId) {
+			const run = store.history(schedule.id).find((item) => item.id === schedule.activeRunId);
+			let terminal = false;
+			if (run?.scheduleId === schedule.id && run.state === "running" && run.asyncId && run.asyncDir) {
+				const status = readJson(path.join(run.asyncDir, "status.json"), "async status") as Partial<AsyncStatus>;
+				terminal = status.runId === run.asyncId && typeof status.state === "string" && ["complete", "failed", "stopped", "rejected"].includes(status.state);
+			}
+			if (!terminal) return textResult(`Schedule ${schedule.id} has active run ${schedule.activeRunId}; stop that run before deleting the schedule.`, [schedule], undefined, true);
+		}
 		this.clearTimer(store, schedule.id);
 		store.appendEvent(schedule, "schedule.deleted");
 		store.delete(schedule.id);

--- a/test/unit/scheduled-runs.test.ts
+++ b/test/unit/scheduled-runs.test.ts
@@ -385,6 +385,41 @@ describe("project schedule management", () => {
 		assert.match(text(await h.manager.handleToolCall({ action: "schedule.list" }, h.ctx)), /No project schedules/);
 	});
 
+	it("deletes a foreign session-only schedule only after its exact async run is terminal", async () => {
+		const owner = harness({ sessionId: "owner-session" });
+		await owner.manager.handleToolCall({ action: "schedule.create", id: "owner-only", every: "1h", sessionOnly: true, workflowScript: "return runs.run('main', { agent: 'worker' })" }, owner.ctx);
+		const running = owner.manager.handleToolCall({ action: "schedule.run", id: "owner-only" }, owner.ctx);
+		await flush();
+		const asyncDir = path.join(owner.root, "async-owner-only");
+		fs.mkdirSync(asyncDir);
+		owner.launches[0]!.resolve({ content: [{ type: "text", text: "Async" }], details: { mode: "single", results: [], asyncId: "async-owner-only", asyncDir } });
+		await running;
+		owner.manager.stop();
+
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ runId: "async-owner-only", mode: "single", state: "running", startedAt: owner.clock.now }), "utf-8");
+		const other = createScheduledRunManager({
+			config: { scheduledRuns: { enabled: true } },
+			storeRoot: path.join(owner.root, "stores"),
+			now: () => owner.clock.now,
+			timers: new FakeTimers(),
+			launch: async () => ({ content: [{ type: "text", text: "unused" }], details: { mode: "management", results: [] } }),
+		});
+		const otherCtx = context(owner.ctx.cwd, "other-session");
+		other.bindSession(otherCtx);
+		const refused = await other.handleToolCall({ action: "schedule.delete", id: "owner-only" }, otherCtx);
+		assert.equal(refused.isError, true);
+		assert.match(text(refused), /has active run/);
+
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ runId: "async-owner-only", mode: "single", state: ["failed"], startedAt: owner.clock.now, endedAt: owner.clock.now }), "utf-8");
+		const malformed = await other.handleToolCall({ action: "schedule.delete", id: "owner-only" }, otherCtx);
+		assert.equal(malformed.isError, true);
+		assert.match(text(malformed), /has active run/);
+
+		fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({ runId: "async-owner-only", mode: "single", state: "failed", startedAt: owner.clock.now, endedAt: owner.clock.now }), "utf-8");
+		assert.match(text(await other.handleToolCall({ action: "schedule.delete", id: "owner-only" }, otherCtx)), /Deleted/);
+		assert.match(text(await other.handleToolCall({ action: "schedule.list" }, otherCtx)), /No project schedules/);
+	});
+
 	it("ignores schedules deleted by another session while a timer is still armed", async () => {
 		const first = harness();
 		await first.manager.handleToolCall({ action: "schedule.create", id: "stale", every: "1h", workflowScript: "return runs.run('main', { agent: 'worker' })" }, first.ctx);


### PR DESCRIPTION
## Summary

Allow explicit deletion of a prior session's schedule only when its recorded async run has matching terminal evidence. Keep active or unknown runs protected and leave session-only execution ownership unchanged.

Closes #2125.

## Validation

- 44 schedule unit tests passed, including refusal while running or with malformed evidence, and deletion after matching terminal evidence
- Typecheck and diff hygiene passed
- Fresh independent review completed; its one malformed-state finding was corrected and the focused checks rerun

No new scheduler modes, flags, or background lifecycle behavior.
