### PR TITLE
fix: detect host builtins by name so extension overrides count

### DIFF
--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -341,6 +341,11 @@ export function resolvePermissionSystemExtension(): string | undefined {
  * `hostAvailableBuiltins` to `resolvePiLaunchToolPlan` so child tool plans
  * intersect declared agent tools with what the host actually supports.
  *
+ * Extensions may override a builtin by registering a tool under the same name
+ * (pi's docs/extensions.md), which replaces the registry entry and its
+ * `builtin` provenance, so a builtin name counts as host-provided whatever
+ * source reports it.
+ *
  * Returns `undefined` when builtin tool discovery fails or yields nothing,
  * so callers skip the intersection (fail-safe to allowing all declared tools).
  * This handles test mocks without proper tool registration and hosts whose
@@ -352,7 +357,7 @@ export function getHostBuiltinToolNames(pi: Pick<ExtensionAPI, "getAllTools">): 
 			.getAllTools()
 			.filter((tool) => {
 				const source = (tool.sourceInfo as { source?: string } | undefined)?.source;
-				return source === "builtin" || (source === "auto" && PI_BUILTIN_TOOL_NAMES.has(tool.name));
+				return source === "builtin" || PI_BUILTIN_TOOL_NAMES.has(tool.name);
 			})
 			.map((tool) => tool.name);
 		return builtins.length > 0 ? builtins : undefined;

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -217,6 +217,45 @@ describe("production launch path supplies hostAvailableBuiltins", () => {
 		assert.deepEqual(builtins, ["read", "bash"]);
 	});
 
+	it("getHostBuiltinToolNames keeps builtin names an extension override re-registered", () => {
+		const wrappedPi = {
+			getAllTools: () => [
+				...["read", "bash", "edit", "write", "grep", "find", "ls"].map((name) => ({ name, sourceInfo: { source: "npm:pi-tool-display" } })),
+				{ name: "powershell", sourceInfo: { source: "builtin" } },
+				{ name: "custom-tool", sourceInfo: { source: "npm:pi-tool-display" } },
+			],
+		};
+		const builtins = getHostBuiltinToolNames(wrappedPi);
+		assert.deepEqual(builtins, ["read", "bash", "edit", "write", "grep", "find", "ls", "powershell"]);
+		const plan = resolvePiLaunchToolPlan({
+			agentName: "explore",
+			tools: ["read", "grep", "find", "ls", "bash"],
+			hostAvailableBuiltins: builtins,
+		});
+		assert.deepEqual(plan.effectiveToolAllowlist, ["read", "grep", "find", "ls", "bash"]);
+		assert.deepEqual(plan.unavailableHostBuiltins, []);
+		assert.deepEqual(plan.warnings, []);
+	});
+
+	it("getHostBuiltinToolNames still prunes declared tools a restricted host omits", () => {
+		const restrictedPi = {
+			getAllTools: () => [
+				{ name: "read", sourceInfo: { source: "builtin" } },
+				{ name: "ls", sourceInfo: { source: "builtin" } },
+				{ name: "mcp-tool", sourceInfo: { source: "mcp" } },
+			],
+		};
+		const builtins = getHostBuiltinToolNames(restrictedPi);
+		assert.deepEqual(builtins, ["read", "ls"]);
+		const plan = resolvePiLaunchToolPlan({
+			agentName: "worker",
+			tools: ["read", "grep", "find", "ls", "bash"],
+			hostAvailableBuiltins: builtins,
+		});
+		assert.deepEqual(plan.effectiveToolAllowlist, ["read", "ls"]);
+		assert.deepEqual(plan.unavailableHostBuiltins, ["grep", "find", "bash"]);
+	});
+
 	it("getHostBuiltinToolNames returns undefined on failure or empty results", () => {
 		const throwingPi = {
 			getAllTools: () => { throw new Error("Not available"); },


### PR DESCRIPTION
Every child launch lost its entire tool allowlist down to `contact_supervisor` on any host where an extension re-registers Pi's builtin tools, so review and scout lanes failed closed and agents given implementation wording failed for want of mutation-capable tools.

Host discovery treated `sourceInfo.source === "builtin"` as proof that the host provides a tool, but overriding a builtin by registering a tool under the same name is documented Pi behaviour, and pi core replaces the registry entry so a wrapped `read` reports its wrapper as the source. Because `powershell` is not usually wrapped it survived as the lone builtin-sourced entry, which made discovery look successful and defeated the zero-results fail-safe that would otherwise have skipped the intersection entirely.

I deliberately did not take the wider `source === "auto"` form suggested in the issue, because an existing test pins non-builtin `auto` names out of the builtin-name set and the name check alone subsumes the previous `auto` case.

Fixes #2135
