### PR TITLE
fix: keep host-discovered tool names that extensions provide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep host-discovered tool names that extensions provide: core tool slots resolve by name whatever their source (extensions that re-register a core tool shadowed it with an extension source, so child tool plans pruned every requested tool and foreground scout/reviewer launches failed), and extension tool names survive on launches that load ambient extensions in the parent's project (runner launches). Foreground launches, cross-project launches, capability ceilings, and explicit extension lists still fail closed. (#2132, #2133, #2135)
+
 ## [0.67.0] - 2026-09-10
 
 ### Highlights

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -88,7 +88,7 @@ export interface SubagentLaunchContractInput {
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	/** Builtin tool names the host runtime provides; used to intersect agent-declared tools. */
-	hostAvailableBuiltins?: readonly string[];
+	hostToolNames?: readonly string[];
 	/** Per-launch bridge config; replaces the global `intercomBridge` config exactly as the tool and delegation overrides do. */
 	intercomBridge?: IntercomBridgeConfig;
 	/**
@@ -415,7 +415,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 			capabilityCeiling: effectiveCapabilityCeiling,
 			agentName: agent.name,
 			permissionRules,
-			hostAvailableBuiltins: input.hostAvailableBuiltins,
+			hostToolNames: input.hostToolNames,
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/src/api/preflight.ts
+++ b/src/api/preflight.ts
@@ -89,6 +89,8 @@ export interface SubagentLaunchContractInput {
 	inheritedCapabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	/** Builtin tool names the host runtime provides; used to intersect agent-declared tools. */
 	hostToolNames?: readonly string[];
+	/** Whether the launch loads ambient extensions (foreground parent-hosted launches do not). */
+	ambientExtensions?: boolean;
 	/** Per-launch bridge config; replaces the global `intercomBridge` config exactly as the tool and delegation overrides do. */
 	intercomBridge?: IntercomBridgeConfig;
 	/**
@@ -416,6 +418,7 @@ export async function resolveSubagentLaunchContract(input: SubagentLaunchContrac
 			agentName: agent.name,
 			permissionRules,
 			hostToolNames: input.hostToolNames,
+			ambientExtensions: input.ambientExtensions,
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -14,7 +14,7 @@ import { createAtomicJsonWriter, writePrivateAtomicJson } from "../../shared/ato
 import { buildEffectiveSystemPrompt } from "../shared/effective-system-prompt.ts";
 import { currentCompletionOwnerId } from "../../shared/completion-owner.ts";
 import { planChildLaunch, resolveStepBehavior, suppressProgressForReadOnlyTask, type ResolvedStepBehavior } from "../shared/child-launch-plan.ts";
-import { applyThinkingSuffix, getHostBuiltinToolNames, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/child-tool-plan.ts";
+import { applyThinkingSuffix, getHostToolNames, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/child-tool-plan.ts";
 import { injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { applyWatchdogLaunchRules, sendRuleViolationWarning } from "../../watchdog/rules.ts";
 import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveExistingReadInstructionPaths, resolveExistingReadPaths, writeInitialProgressFile, type ChainStep, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
@@ -963,7 +963,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		const launchRuleError = applyWatchdogLaunchRules({ cwd: stepCwd, agent: a.name, model: modelCandidates[0] ?? model, warn: (violation) => sendRuleViolationWarning(ctx.pi, violation) });
 		if (launchRuleError) throw new AsyncStartValidationError(launchRuleError);
 		const fast = s.fast ?? params.fast ?? a.fast;
-		const hostAvailableBuiltins = getHostBuiltinToolNames(ctx.pi);
+		const hostToolNames = getHostToolNames(ctx.pi);
 		const toolPlan = resolvePiLaunchToolPlan({
 			tools: a.tools,
 			excludeTools: a.excludeTools,
@@ -982,7 +982,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			agentName: a.name,
 			permissionRules,
 			runtimeSnapshotHost: ctx.pi,
-			hostAvailableBuiltins,
+			hostToolNames,
 		});
 		const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
 		if (externalRunner && permissionRules) {
@@ -1379,7 +1379,7 @@ export function executeAsyncChain(
 				deadlineAt,
 				globalConcurrencyLimit: params.globalConcurrencyLimit,
 				runFanoutBudget,
-				hostAvailableBuiltins: getHostBuiltinToolNames(ctx.pi),
+				hostToolNames: getHostToolNames(ctx.pi),
 				workflowGraph,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
@@ -1752,7 +1752,7 @@ export function executeAsyncSingle(
 			return formatAsyncStartError("single", error instanceof Error ? error.message : String(error));
 		}
 	}
-	const hostAvailableBuiltins = getHostBuiltinToolNames(ctx.pi);
+	const hostToolNames = getHostToolNames(ctx.pi);
 	const toolPlan = resolvePiLaunchToolPlan({
 		tools: agentConfig.tools,
 		excludeTools: agentConfig.excludeTools,
@@ -1771,7 +1771,7 @@ export function executeAsyncSingle(
 		agentName: agentConfig.name,
 		permissionRules: resolvePermissionRules(ctx.permissions, agentConfig.permissions),
 		runtimeSnapshotHost: ctx.pi,
-		hostAvailableBuiltins,
+		hostToolNames,
 	});
 	const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
 	if (!externalRunner) {
@@ -1976,7 +1976,7 @@ export function executeAsyncSingle(
 				launchContractDigest,
 				launchResolvedExtensions,
 				runFanoutBudget,
-				hostAvailableBuiltins,
+				hostToolNames,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
 				...(lane ? { lane } : {}),

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -785,6 +785,10 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 	const chainSkills = params.chainSkills ?? [];
 	const availableModels = params.availableModels;
 	const runnerCwd = resolveChildCwd(ctx.cwd, cwd);
+	// Ambient discovery in the runner happens in the runner cwd: only trust
+	// the parent registry snapshot for ambient names when the child stays in
+	// the parent's project; cross-project launches fail closed instead.
+	const ambientExtensions = runnerCwd === ctx.cwd;
 	let managedWorktreeProvider: "native" | "worktrunk" | undefined;
 	try {
 		if (chain.some((step) => "worktree" in step && step.worktree === true)) {
@@ -983,6 +987,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			permissionRules,
 			runtimeSnapshotHost: ctx.pi,
 			hostToolNames,
+			ambientExtensions,
 		});
 		const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
 		if (externalRunner && permissionRules) {
@@ -1380,6 +1385,7 @@ export function executeAsyncChain(
 				globalConcurrencyLimit: params.globalConcurrencyLimit,
 				runFanoutBudget,
 				hostToolNames: getHostToolNames(ctx.pi),
+				ambientExtensions: runnerCwd === ctx.cwd,
 				workflowGraph,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
@@ -1614,6 +1620,10 @@ export function executeAsyncSingle(
 		return formatAsyncStartError("single", error instanceof Error ? error.message : String(error));
 	}
 	const runnerCwd = resolveChildCwd(ctx.cwd, cwd);
+	// Ambient discovery in the runner happens in the runner cwd: only trust
+	// the parent registry snapshot for ambient names when the child stays in
+	// the parent's project; cross-project launches fail closed instead.
+	const ambientExtensions = runnerCwd === ctx.cwd;
 	let managedWorktreeProvider: "native" | "worktrunk" | undefined;
 	if (params.worktree === true) {
 		try {
@@ -1772,6 +1782,7 @@ export function executeAsyncSingle(
 		permissionRules: resolvePermissionRules(ctx.permissions, agentConfig.permissions),
 		runtimeSnapshotHost: ctx.pi,
 		hostToolNames,
+		ambientExtensions,
 	});
 	const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
 	if (!externalRunner) {
@@ -1977,6 +1988,7 @@ export function executeAsyncSingle(
 				launchResolvedExtensions,
 				runFanoutBudget,
 				hostToolNames,
+				ambientExtensions,
 				...(params.parentWorkflowRunId ? { parentWorkflowRunId: params.parentWorkflowRunId } : {}),
 				...(params.workflowKey ? { workflowKey: params.workflowKey } : {}),
 				...(lane ? { lane } : {}),

--- a/src/runs/background/runner-child-launch.ts
+++ b/src/runs/background/runner-child-launch.ts
@@ -18,7 +18,7 @@ export interface RunnerChildLaunchContext {
 	runFanoutBudget?: BuildInProcessChildLaunchInput["runFanoutBudget"];
 	capabilityCeiling?: BuildInProcessChildLaunchInput["capabilityCeiling"];
 	inheritedChildRuntime?: InheritedChildRuntime;
-	hostAvailableBuiltins?: readonly string[];
+	hostToolNames?: readonly string[];
 }
 
 export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChildLaunchContext, attempt: {
@@ -82,7 +82,7 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 		thinkingCeiling: step.thinkingCeiling,
 		maxSubagentDepth: step.maxSubagentDepth,
 		inherited: ctx.inheritedChildRuntime,
-		hostAvailableBuiltins: ctx.hostAvailableBuiltins,
+		hostToolNames: ctx.hostToolNames,
 		host: "runner",
 	});
 }

--- a/src/runs/background/runner-child-launch.ts
+++ b/src/runs/background/runner-child-launch.ts
@@ -19,6 +19,8 @@ export interface RunnerChildLaunchContext {
 	capabilityCeiling?: BuildInProcessChildLaunchInput["capabilityCeiling"];
 	inheritedChildRuntime?: InheritedChildRuntime;
 	hostToolNames?: readonly string[];
+	/** Whether the runner-hosted child loads ambient extensions (cwd-dependent). */
+	ambientExtensions?: boolean;
 }
 
 export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChildLaunchContext, attempt: {
@@ -83,6 +85,7 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 		maxSubagentDepth: step.maxSubagentDepth,
 		inherited: ctx.inheritedChildRuntime,
 		hostToolNames: ctx.hostToolNames,
+		ambientExtensions: ctx.ambientExtensions,
 		host: "runner",
 	});
 }

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -233,7 +233,7 @@ export interface SubagentRunConfig {
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	/** Builtin tool names the host runtime provides; used to intersect agent-declared tools. */
-	hostAvailableBuiltins?: readonly string[];
+	hostToolNames?: readonly string[];
 	launchContractDigest?: string;
 	launchResolvedExtensions?: LaunchResolvedChildExtensions;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensions;
@@ -699,7 +699,7 @@ interface SingleStepContext {
 	nestedRoute?: NestedRouteInfo;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	runFanoutBudget?: RunFanoutBudgetDescriptor;
-	hostAvailableBuiltins?: readonly string[];
+	hostToolNames?: readonly string[];
 	onAttemptStart?: (attempt: { model?: string; thinking?: string; contextLimit?: number }) => void;
 	onChildEvent?: (event: ChildEvent) => void;
 	onExternalProcess?: (process: ExternalProcessStatus) => void;
@@ -816,7 +816,7 @@ export async function runSingleStepInner(
 			capabilityCeiling: step.capabilityCeiling ?? ctx.capabilityCeiling,
 			inheritedCapabilityCeiling: ctx.inheritedChildRuntime?.capabilityCeiling,
 			permissionRules: step.permissionRules,
-			hostAvailableBuiltins: ctx.hostAvailableBuiltins,
+			hostToolNames: ctx.hostToolNames,
 		}));
 		const contractTools = resolvedTaskToolPlan.explicitToolAllowlist ? resolvedTaskToolPlan.effectiveToolAllowlist : undefined;
 		const contractError = validateImplementationToolContract({
@@ -1155,7 +1155,7 @@ export async function runSingleStepInner(
 				capabilityCeiling: step.capabilityCeiling ?? ctx.capabilityCeiling,
 				inheritedCapabilityCeiling: ctx.inheritedChildRuntime?.capabilityCeiling,
 				permissionRules: step.permissionRules,
-				hostAvailableBuiltins: ctx.hostAvailableBuiltins,
+				hostToolNames: ctx.hostToolNames,
 			}));
 			launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
 			actualLaunchContractDigest = resolveLaunchBinding({
@@ -3695,7 +3695,7 @@ export async function runSubagent(
 					nestedRoute: config.nestedRoute,
 					capabilityCeiling: config.capabilityCeiling,
 					runFanoutBudget: config.runFanoutBudget,
-					hostAvailableBuiltins: config.hostAvailableBuiltins,
+					hostToolNames: config.hostToolNames,
 					registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 					registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 					registerStop: (stop) => registerStepStop(fi, stop),
@@ -4107,7 +4107,7 @@ export async function runSubagent(
 							nestedRoute: config.nestedRoute,
 							capabilityCeiling: config.capabilityCeiling,
 							runFanoutBudget: config.runFanoutBudget,
-							hostAvailableBuiltins: config.hostAvailableBuiltins,
+							hostToolNames: config.hostToolNames,
 							registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 							registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 							registerStop: (stop) => registerStepStop(fi, stop),
@@ -4509,7 +4509,7 @@ export async function runSubagent(
 				nestedRoute: config.nestedRoute,
 				capabilityCeiling: config.capabilityCeiling,
 				runFanoutBudget: config.runFanoutBudget,
-				hostAvailableBuiltins: config.hostAvailableBuiltins,
+				hostToolNames: config.hostToolNames,
 				registerInterrupt: (interrupt) => registerStepInterrupt(flatIndex, interrupt),
 				registerTimeout: (interrupt) => registerStepTimeout(flatIndex, interrupt),
 				registerStop: (stop) => registerStepStop(flatIndex, stop),

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -234,6 +234,7 @@ export interface SubagentRunConfig {
 	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	/** Builtin tool names the host runtime provides; used to intersect agent-declared tools. */
 	hostToolNames?: readonly string[];
+	ambientExtensions?: boolean;
 	launchContractDigest?: string;
 	launchResolvedExtensions?: LaunchResolvedChildExtensions;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensions;
@@ -700,6 +701,7 @@ interface SingleStepContext {
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	hostToolNames?: readonly string[];
+	ambientExtensions?: boolean;
 	onAttemptStart?: (attempt: { model?: string; thinking?: string; contextLimit?: number }) => void;
 	onChildEvent?: (event: ChildEvent) => void;
 	onExternalProcess?: (process: ExternalProcessStatus) => void;
@@ -817,6 +819,7 @@ export async function runSingleStepInner(
 			inheritedCapabilityCeiling: ctx.inheritedChildRuntime?.capabilityCeiling,
 			permissionRules: step.permissionRules,
 			hostToolNames: ctx.hostToolNames,
+			ambientExtensions: ctx.ambientExtensions,
 		}));
 		const contractTools = resolvedTaskToolPlan.explicitToolAllowlist ? resolvedTaskToolPlan.effectiveToolAllowlist : undefined;
 		const contractError = validateImplementationToolContract({
@@ -1156,6 +1159,7 @@ export async function runSingleStepInner(
 				inheritedCapabilityCeiling: ctx.inheritedChildRuntime?.capabilityCeiling,
 				permissionRules: step.permissionRules,
 				hostToolNames: ctx.hostToolNames,
+				ambientExtensions: ctx.ambientExtensions,
 			}));
 			launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
 			actualLaunchContractDigest = resolveLaunchBinding({
@@ -3696,6 +3700,7 @@ export async function runSubagent(
 					capabilityCeiling: config.capabilityCeiling,
 					runFanoutBudget: config.runFanoutBudget,
 					hostToolNames: config.hostToolNames,
+					ambientExtensions: config.ambientExtensions,
 					registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 					registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 					registerStop: (stop) => registerStepStop(fi, stop),
@@ -4108,6 +4113,7 @@ export async function runSubagent(
 							capabilityCeiling: config.capabilityCeiling,
 							runFanoutBudget: config.runFanoutBudget,
 							hostToolNames: config.hostToolNames,
+							ambientExtensions: config.ambientExtensions,
 							registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 							registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 							registerStop: (stop) => registerStepStop(fi, stop),
@@ -4510,6 +4516,7 @@ export async function runSubagent(
 				capabilityCeiling: config.capabilityCeiling,
 				runFanoutBudget: config.runFanoutBudget,
 				hostToolNames: config.hostToolNames,
+				ambientExtensions: config.ambientExtensions,
 				registerInterrupt: (interrupt) => registerStepInterrupt(flatIndex, interrupt),
 				registerTimeout: (interrupt) => registerStepTimeout(flatIndex, interrupt),
 				registerStop: (stop) => registerStepStop(flatIndex, stop),

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -442,7 +442,7 @@ async function runSingleAttempt(
 		thinkingCeiling: options.thinkingCeiling,
 		maxSubagentDepth: options.maxSubagentDepth,
 		runtimeSnapshotHost: options.runtimeSnapshotHost,
-		hostAvailableBuiltins: options.hostAvailableBuiltins,
+		hostToolNames: options.hostToolNames,
 		inherited: options.childRuntime,
 		host: "parent",
 	});

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -29,7 +29,7 @@ import { handleWatchdogToolAction, WATCHDOG_TOOL_ACTIONS } from "../../watchdog/
 import type { MainWatchdogRuntime } from "../../watchdog/runtime.ts";
 import { applyWatchdogLaunchRules } from "../../watchdog/rules.ts";
 import { buildModelCandidates, normalizeParentModel, resolveEffectiveSubagentModel, resolveModelOrigin, type ModelOrigin, type ParentModel } from "../shared/model-fallback.ts";
-import { getHostBuiltinToolNames } from "../shared/child-tool-plan.ts";
+import { getHostToolNames } from "../shared/child-tool-plan.ts";
 import { formatRetainedChildren, listRetainedChildren } from "../background/retained-children.ts";
 import { resolveModelScopesForAgent, type ModelScopeConfig } from "../shared/model-scope.ts";
 import { recordRun } from "../shared/run-history.ts";
@@ -3892,7 +3892,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		const launched = await runSync(ctx.cwd, agents, params.agent!, task, compactOptional<Parameters<typeof runSync>[4]>({
 			permissions: deps.config.permissions,
 			runtimeSnapshotHost: deps.pi,
-			hostAvailableBuiltins: getHostBuiltinToolNames(deps.pi),
+			hostToolNames: getHostToolNames(deps.pi),
 			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 			llmIntentArbiter: createTaskMutationArbiter({ model: ctx.model, modelRegistry: ctx.modelRegistry, sessionId: ctx.sessionManager.getSessionId() }),
 			childRuntime: deps.childRuntime,

--- a/src/runs/shared/child-launch.ts
+++ b/src/runs/shared/child-launch.ts
@@ -118,7 +118,7 @@ export interface BuildInProcessChildLaunchInput {
 	 * cannot provide. Review/scout lanes fail closed when a requested,
 	 * still-permitted repository inspection tool is missing from that set.
 	 */
-	hostAvailableBuiltins?: readonly string[];
+	hostToolNames?: readonly string[];
 }
 
 export interface InProcessChildCapture {
@@ -200,7 +200,7 @@ export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput)
 		agentName: input.childAgentName,
 		permissionRules: input.permissionRules,
 		runtimeSnapshotHost: input.runtimeSnapshotHost,
-		hostAvailableBuiltins: input.hostAvailableBuiltins,
+		hostToolNames: input.hostToolNames,
 	});
 
 	const inherited = input.inherited;

--- a/src/runs/shared/child-launch.ts
+++ b/src/runs/shared/child-launch.ts
@@ -119,6 +119,8 @@ export interface BuildInProcessChildLaunchInput {
 	 * still-permitted repository inspection tool is missing from that set.
 	 */
 	hostToolNames?: readonly string[];
+	/** Whether the child loads ambient extensions (foreground parent-hosted children never do). */
+	ambientExtensions?: boolean;
 }
 
 export interface InProcessChildCapture {

--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -195,7 +195,7 @@ export interface ResolvePiLaunchToolPlanInput {
 	 * repository inspection tool is among those host omissions. Intentionally
 	 * empty or ceiling-restricted allowlists are not a minimum-tool contract.
 	 */
-	hostAvailableBuiltins?: readonly string[];
+	hostToolNames?: readonly string[];
 }
 
 export interface PiLaunchToolPlan {
@@ -337,25 +337,26 @@ export function resolvePermissionSystemExtension(): string | undefined {
 }
 
 /**
- * Extract the names of builtin tools the host provides. Use this to pass
- * `hostAvailableBuiltins` to `resolvePiLaunchToolPlan` so child tool plans
- * intersect declared agent tools with what the host actually supports.
+ * Extract every tool name the host runtime has registered, whatever its source.
+ * Use this to pass `hostToolNames` to `resolvePiLaunchToolPlan` so child tool
+ * plans intersect declared agent tools with what the host actually provides.
  *
- * Returns `undefined` when builtin tool discovery fails or yields nothing,
- * so callers skip the intersection (fail-safe to allowing all declared tools).
- * This handles test mocks without proper tool registration and hosts whose
+ * Core tool names may be shadowed by extensions that re-register the same
+ * name (pi-tool-display wraps bash/grep/find/ls/edit/write, pi-hashline-edit-pro
+ * wraps read): their sourceInfo.source is the extension, not "builtin", but the
+ * child launch resolves tools by name, so the name is what matters. Extension
+ * tool names (mcp__slack, web_search, ...) are reported too; the tool plan
+ * decides whether the child will actually load them.
+ *
+ * Returns `undefined` when tool discovery fails or yields nothing, so callers
+ * skip the intersection (fail-safe to allowing all declared tools). This
+ * handles test mocks without proper tool registration and hosts whose
  * getAllTools() throws before extensions load.
  */
-export function getHostBuiltinToolNames(pi: Pick<ExtensionAPI, "getAllTools">): string[] | undefined {
+export function getHostToolNames(pi: Pick<ExtensionAPI, "getAllTools">): string[] | undefined {
 	try {
-		const builtins = pi
-			.getAllTools()
-			.filter((tool) => {
-				const source = (tool.sourceInfo as { source?: string } | undefined)?.source;
-				return source === "builtin" || (source === "auto" && PI_BUILTIN_TOOL_NAMES.has(tool.name));
-			})
-			.map((tool) => tool.name);
-		return builtins.length > 0 ? builtins : undefined;
+		const names = pi.getAllTools().map((tool) => tool.name);
+		return names.length > 0 ? names : undefined;
 	} catch {
 		return undefined;
 	}
@@ -373,9 +374,9 @@ export function resolvePiLaunchToolPlan(
 			? undefined
 			: new Set(capabilityCeiling.allowedTools);
 	const hostAvailableSet =
-		input.hostAvailableBuiltins === undefined
+		input.hostToolNames === undefined
 			? undefined
-			: new Set(input.hostAvailableBuiltins);
+			: new Set(input.hostToolNames);
 	const requestedBuiltinTools =
 		input.tools?.filter(
 			(tool) =>
@@ -404,12 +405,25 @@ export function resolvePiLaunchToolPlan(
 					? ["read", ...requestedBuiltinTools]
 					: requestedBuiltinTools
 				).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
-	const declaredBuiltinTools = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => hostAvailableSet.has(tool) || NATIVE_COORDINATION_TOOL_NAMES.has(tool))
-		: ceilingFilteredBuiltinTools;
-	const unavailableHostBuiltins = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => !hostAvailableSet.has(tool) && !NATIVE_COORDINATION_TOOL_NAMES.has(tool))
-		: [];
+	// Core tool slots (read, bash, ...) resolve by name no matter which provider
+	// wins the registration: pi core ships them, and extensions that re-register
+	// a core name shadow it with sourceInfo.source set to the extension. When a
+	// launch denies extensions the wrapper is gone, but pi core still provides
+	// the slot, so the name stays resolvable either way. Extension tool names
+	// (mcp__slack, web_search, ...) only reach the child when it loads the same
+	// ambient extension set, so they stay pruned for launches that deny extensions.
+	const childInheritsAmbientExtensions = capabilityCeiling?.denyExtensions !== true && input.extensions === undefined;
+	const resolvesInChild = (tool: string): boolean =>
+		NATIVE_COORDINATION_TOOL_NAMES.has(tool)
+		|| hostAvailableSet !== undefined
+			&& hostAvailableSet.has(tool)
+			&& (PI_BUILTIN_TOOL_NAMES.has(tool) || childInheritsAmbientExtensions);
+	const declaredBuiltinTools = hostAvailableSet === undefined
+		? ceilingFilteredBuiltinTools
+		: ceilingFilteredBuiltinTools.filter((tool) => resolvesInChild(tool));
+	const unavailableHostBuiltins = hostAvailableSet === undefined
+		? []
+		: ceilingFilteredBuiltinTools.filter((tool) => !resolvesInChild(tool));
 	const excludeTools = [...new Set((input.excludeTools ?? []).map((tool) => tool.trim()).filter(Boolean))];
 	const excludedToolSet = new Set(excludeTools);
 	const effectiveDeclaredBuiltinTools = declaredBuiltinTools.filter((tool) => !excludedToolSet.has(tool));

--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -196,6 +196,14 @@ export interface ResolvePiLaunchToolPlanInput {
 	 * empty or ceiling-restricted allowlists are not a minimum-tool contract.
 	 */
 	hostToolNames?: readonly string[];
+	/**
+	 * Whether the child launch loads ambient extensions. Foreground launches
+	 * hosted by the parent process never do (buildInProcessChildLaunch derives
+	 * this from its host); detached runner launches do when the extension policy
+	 * allows them and the child stays in the parent's project. Defaults to true
+	 * for callers that do not specify it.
+	 */
+	ambientExtensions?: boolean;
 }
 
 export interface PiLaunchToolPlan {
@@ -412,7 +420,9 @@ export function resolvePiLaunchToolPlan(
 	// the slot, so the name stays resolvable either way. Extension tool names
 	// (mcp__slack, web_search, ...) only reach the child when it loads the same
 	// ambient extension set, so they stay pruned for launches that deny extensions.
-	const childInheritsAmbientExtensions = capabilityCeiling?.denyExtensions !== true && input.extensions === undefined;
+	const childInheritsAmbientExtensions = input.ambientExtensions !== false
+		&& capabilityCeiling?.denyExtensions !== true
+		&& input.extensions === undefined;
 	const resolvesInChild = (tool: string): boolean =>
 		NATIVE_COORDINATION_TOOL_NAMES.has(tool)
 		|| hostAvailableSet !== undefined
@@ -504,9 +514,12 @@ export function resolvePiLaunchToolPlan(
 		...(fanoutAuthorized ? [FANOUT_CHILD_EXTENSION_PATH] : []),
 		...(permSystemExt ? [permSystemExt] : []),
 	];
+	// Mirror the childInheritsAmbientExtensions decision so launch previews and
+	// contract digests report the ambient policy the launch will actually use.
 	const disableAmbientExtensions =
 		capabilityCeiling?.denyExtensions === true ||
-		input.extensions !== undefined;
+		input.extensions !== undefined ||
+		input.ambientExtensions === false;
 	const warnings: string[] = [];
 	// An explicit empty list disables ambient extensions, including model providers.
 	if (capabilityCeiling?.denyExtensions !== true && Array.isArray(input.extensions) && input.extensions.length === 0) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2442,7 +2442,7 @@ export interface RunSyncOptions {
 	/** Parent Pi event host used to snapshot runtime-registered MCP servers before child launch. */
 	runtimeSnapshotHost?: import("../runs/shared/mcp-direct-tool-allowlist.ts").McpRuntimeSnapshotHost;
 	/** Builtin tool names the host runtime provides; used to intersect agent-declared tools. */
-	hostAvailableBuiltins?: readonly string[];
+	hostToolNames?: readonly string[];
 	/** Optional subagent model-scope enforcement for fallback candidates */
 	modelScope?: ModelScopeRule | ModelScopeRule[];
 	/** Skills to make available (overrides agent default if provided) */

--- a/test/smoke/pi085-child.ts
+++ b/test/smoke/pi085-child.ts
@@ -38,7 +38,7 @@ try {
 	]) {
 		const launch = buildInProcessChildLaunch({
 			host: "runner", cwd: process.cwd(), childAgentName: "coordinator-smoke", childIndex: 0,
-			sessionEnabled: false, model: "pi085-smoke/local", tools, hostAvailableBuiltins: ["read"],
+			sessionEnabled: false, model: "pi085-smoke/local", tools, hostToolNames: ["read"],
 			runId: `coordination-${tools.length}`, parentSessionId: "root-A", orchestratorIntercomTarget: "root-A",
 			extensions: [`${process.cwd()}/pi085-extension.ts`],
 			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,

--- a/test/unit/child-tool-plan-diagnostics.test.ts
+++ b/test/unit/child-tool-plan-diagnostics.test.ts
@@ -9,7 +9,7 @@ describe("public child tool plan diagnostics", () => {
 			() => resolvePiLaunchToolPlan({
 				agentName: "scout",
 				tools: ["read", "grep", "find", "ls", "bash"],
-				hostAvailableBuiltins: [],
+				hostToolNames: [],
 			}),
 			(error: unknown) => {
 				assert.ok(error instanceof Error);
@@ -30,7 +30,7 @@ describe("public child tool plan diagnostics", () => {
 			() => resolvePiLaunchToolPlan({
 				agentName: "reviewer",
 				tools: ["read", "grep", "bash", "write"],
-				hostAvailableBuiltins: ["bash", "write"],
+				hostToolNames: ["bash", "write"],
 				excludeTools: ["write"],
 				capabilityCeiling: { version: 1, allowedTools: ["read", "bash", "write"], denyExtensions: false, sources: ["plan-mode"] },
 				inheritedCapabilityCeiling: { version: 1, allowedTools: ["read", "grep", "write"], denyExtensions: false, sources: ["parent-policy"] },
@@ -51,7 +51,7 @@ describe("public child tool plan diagnostics", () => {
 		const plan = resolvePiLaunchToolPlan({
 			agentName: "worker",
 			tools: ["read", "grep", "find", "ls", "bash"],
-			hostAvailableBuiltins: [],
+			hostToolNames: [],
 		});
 		assert.deepEqual(plan.warnings, [
 			"Agent 'worker': host runtime tool availability omitted [read, grep, find, ls, bash]. Requested tool names: [read, grep, find, ls, bash]; effective tool allowlist: []. This is a non-fatal tool-plan diagnostic, not verification of the child's runtime tool menu.",
@@ -63,7 +63,7 @@ describe("public child tool plan diagnostics", () => {
 
 	it("does not invent an explicit request, agent name, or ceiling source when absent", () => {
 		const plan = resolvePiLaunchToolPlan({
-			hostAvailableBuiltins: [],
+			hostToolNames: [],
 			capabilityCeiling: { version: 1, allowedTools: ["read"], denyExtensions: false, sources: [] },
 		});
 		assert.deepEqual(plan.warnings, [
@@ -74,8 +74,8 @@ describe("public child tool plan diagnostics", () => {
 	it("does not invent host omissions when availability is unknown or a ceiling alone prunes tools", () => {
 		for (const input of [
 			{},
-			{ hostAvailableBuiltins: ["read"] },
-			{ hostAvailableBuiltins: [], capabilityCeiling: { version: 1 as const, allowedTools: [], denyExtensions: false, sources: ["plan-mode"] } },
+			{ hostToolNames: ["read"] },
+			{ hostToolNames: [], capabilityCeiling: { version: 1 as const, allowedTools: [], denyExtensions: false, sources: ["plan-mode"] } },
 		]) {
 			const plan = resolvePiLaunchToolPlan({ tools: ["read"], ...input });
 			assert.deepEqual(plan.warnings, []);
@@ -86,7 +86,7 @@ describe("public child tool plan diagnostics", () => {
 		const emptyAllowlist = resolvePiLaunchToolPlan({
 			agentName: "scout",
 			tools: [],
-			hostAvailableBuiltins: [],
+			hostToolNames: [],
 		});
 		assert.deepEqual(emptyAllowlist.effectiveToolAllowlist, []);
 		assert.deepEqual(emptyAllowlist.requiredChildTools, []);
@@ -96,7 +96,7 @@ describe("public child tool plan diagnostics", () => {
 		const emptyCeiling = resolvePiLaunchToolPlan({
 			agentName: "reviewer",
 			tools: ["read", "grep"],
-			hostAvailableBuiltins: [],
+			hostToolNames: [],
 			capabilityCeiling: { version: 1, allowedTools: [], denyExtensions: false, sources: ["plan-mode"] },
 		});
 		assert.deepEqual(emptyCeiling.effectiveToolAllowlist, []);
@@ -110,7 +110,7 @@ describe("public child tool plan diagnostics", () => {
 			agentName: "scout",
 			tools: ["read", "grep", "bash"],
 			excludeTools: ["read", "grep"],
-			hostAvailableBuiltins: ["read", "grep", "bash"],
+			hostToolNames: ["read", "grep", "bash"],
 		});
 		assert.deepEqual(restricted.effectiveToolAllowlist, ["bash"]);
 		assert.deepEqual(restricted.requiredChildTools, ["bash"]);
@@ -121,7 +121,7 @@ describe("public child tool plan diagnostics", () => {
 			agentName: "reviewer",
 			tools: ["read", "grep"],
 			excludeTools: ["read", "grep"],
-			hostAvailableBuiltins: [],
+			hostToolNames: [],
 		});
 		assert.deepEqual(hostMissingExcluded.effectiveToolAllowlist, []);
 		assert.deepEqual(hostMissingExcluded.requiredChildTools, []);
@@ -133,7 +133,7 @@ describe("public child tool plan diagnostics", () => {
 		const plan = resolvePiLaunchToolPlan({
 			agentName: "scout",
 			tools: ["read", "grep", "find", "ls", "bash", "write"],
-			hostAvailableBuiltins: ["read", "grep", "find", "ls", "bash"],
+			hostToolNames: ["read", "grep", "find", "ls", "bash"],
 		});
 		assert.deepEqual(plan.effectiveToolAllowlist, ["read", "grep", "find", "ls", "bash"]);
 		assert.deepEqual(plan.unavailableHostBuiltins, ["write"]);

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it } from "node:test";
-import { getHostBuiltinToolNames, resolvePiLaunchToolPlan } from "../../src/runs/shared/child-tool-plan.ts";
+import { getHostToolNames, resolvePiLaunchToolPlan } from "../../src/runs/shared/child-tool-plan.ts";
 import { buildInProcessChildLaunch } from "../../src/runs/shared/child-launch.ts";
 import { MCP_RUNTIME_SNAPSHOT_EVENT, MCP_RUNTIME_SNAPSHOT_VERSION, type McpRuntimeSnapshotHost } from "../../src/runs/shared/mcp-direct-tool-allowlist.ts";
 
@@ -37,7 +37,7 @@ describe("child tool plan host builtin intersection", () => {
 	it("intersects declared tools with host-available builtins", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "find", "ls", "bash"],
-			hostAvailableBuiltins: ["ipython", "bash"],
+			hostToolNames: ["ipython", "bash"],
 		});
 		assert.deepEqual(plan.declaredBuiltinTools, ["bash"]);
 		assert.deepEqual(plan.unavailableHostBuiltins, ["read", "grep", "find", "ls"]);
@@ -46,7 +46,7 @@ describe("child tool plan host builtin intersection", () => {
 
 	it("keeps requested native coordination tools through host builtin filtering, but not ceilings or exclusions", () => {
 		const tools = ["read", "subagent", "contact_supervisor", "subagent_supervisor"];
-		const input = { tools, hostAvailableBuiltins: ["read"] };
+		const input = { tools, hostToolNames: ["read"] };
 		const plan = resolvePiLaunchToolPlan(input);
 		assert.deepEqual(plan.effectiveToolAllowlist, tools);
 		assert.deepEqual(plan.requiredChildTools, ["read", "subagent", "subagent_supervisor"]);
@@ -71,20 +71,20 @@ describe("child tool plan host builtin intersection", () => {
 			{ tools: ["read", "subagent", "subagent_supervisor"], excludeTools: ["subagent"] },
 			{ tools: ["read", "subagent", "subagent_supervisor"], capabilityCeiling: { version: 1 as const, allowedTools: ["read", "subagent_supervisor"], sources: ["test"] } },
 		]) {
-			assert.throws(() => resolvePiLaunchToolPlan({ ...input, hostAvailableBuiltins: ["read"] }), /subagent_supervisor.*requires fanout authorization/);
+			assert.throws(() => resolvePiLaunchToolPlan({ ...input, hostToolNames: ["read"] }), /subagent_supervisor.*requires fanout authorization/);
 		}
 	});
 
 	it("keeps all tools when host provides them", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "bash"],
-			hostAvailableBuiltins: ["read", "grep", "bash", "write", "find"],
+			hostToolNames: ["read", "grep", "bash", "write", "find"],
 		});
 		assert.deepEqual(plan.declaredBuiltinTools, ["read", "grep", "bash"]);
 		assert.deepEqual(plan.unavailableHostBuiltins, []);
 	});
 
-	it("works without hostAvailableBuiltins (standard Pi hosts)", () => {
+	it("works without hostToolNames (standard Pi hosts)", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "find", "ls"],
 		});
@@ -92,12 +92,52 @@ describe("child tool plan host builtin intersection", () => {
 		assert.deepEqual(plan.unavailableHostBuiltins, []);
 	});
 
+	describe("shadowed core tools and extension tool names", () => {
+		const tools = ["read", "web_search", "fetch_content"];
+		const hostToolNames = ["read", "web_search", "fetch_content", "source_check"];
+
+		it("keeps core tool names a package wrapper shadows", () => {
+			// pi-tool-display and pi-hashline-edit-pro re-register core names, so the
+			// host reports them with the extension as source; the slot still resolves
+			const plan = resolvePiLaunchToolPlan({ tools: ["read", "bash"], hostToolNames: ["read", "bash"] });
+			assert.deepEqual(plan.effectiveToolAllowlist, ["read", "bash"]);
+			assert.deepEqual(plan.unavailableHostBuiltins, []);
+		});
+
+		it("keeps extension tool names when the child inherits ambient extensions", () => {
+			const plan = resolvePiLaunchToolPlan({ tools, hostToolNames });
+			assert.deepEqual(plan.declaredBuiltinTools, tools);
+			assert.deepEqual(plan.unavailableHostBuiltins, []);
+		});
+
+		it("prunes extension tool names when a capability ceiling denies extensions", () => {
+			const plan = resolvePiLaunchToolPlan({
+				tools,
+				hostToolNames,
+				capabilityCeiling: { version: 1 as const, denyExtensions: true, sources: ["test"] },
+			});
+			assert.deepEqual(plan.declaredBuiltinTools, ["read"]);
+			assert.deepEqual(plan.unavailableHostBuiltins, ["web_search", "fetch_content"]);
+		});
+
+		it("prunes extension tool names when the launch sets an explicit extension list", () => {
+			const plan = resolvePiLaunchToolPlan({ tools, hostToolNames, extensions: [] });
+			assert.deepEqual(plan.declaredBuiltinTools, ["read"]);
+			assert.deepEqual(plan.unavailableHostBuiltins, ["web_search", "fetch_content"]);
+		});
+
+		it("still prunes names the host does not have at all", () => {
+			const plan = resolvePiLaunchToolPlan({ tools: ["read", "bash"], hostToolNames: ["read"] });
+			assert.deepEqual(plan.declaredBuiltinTools, ["read"]);
+			assert.deepEqual(plan.unavailableHostBuiltins, ["bash"]);
+		});
+	});
 	it("fails when requireReadTool is true but host does not provide read", () => {
 		assert.throws(
 			() => resolvePiLaunchToolPlan({
 				tools: ["bash"],
 				requireReadTool: true,
-				hostAvailableBuiltins: ["ipython", "bash"],
+				hostToolNames: ["ipython", "bash"],
 				agentName: "oracle",
 			}),
 			/Host runtime does not provide required tool 'read' for agent 'oracle'/,
@@ -106,7 +146,7 @@ describe("child tool plan host builtin intersection", () => {
 			() => resolvePiLaunchToolPlan({
 				tools: ["bash"],
 				requireReadTool: true,
-				hostAvailableBuiltins: ["bash"],
+				hostToolNames: ["bash"],
 			}),
 			/Host runtime does not provide required tool 'read'/,
 		);
@@ -115,7 +155,7 @@ describe("child tool plan host builtin intersection", () => {
 	it("includes unavailableHostBuiltins in capability audit", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "bash"],
-			hostAvailableBuiltins: ["bash"],
+			hostToolNames: ["bash"],
 			capabilityCeiling: {
 				version: 1,
 				allowedTools: ["read", "bash"],
@@ -129,7 +169,7 @@ describe("child tool plan host builtin intersection", () => {
 	it("respects both capability ceiling and host availability", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "bash", "write"],
-			hostAvailableBuiltins: ["read", "grep", "bash"],
+			hostToolNames: ["read", "grep", "bash"],
 			capabilityCeiling: {
 				version: 1,
 				allowedTools: ["read", "bash"],
@@ -144,7 +184,7 @@ describe("child tool plan host builtin intersection", () => {
 	it("tracks tools removed by host even when ceiling allows them", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "bash"],
-			hostAvailableBuiltins: ["bash"],
+			hostToolNames: ["bash"],
 			capabilityCeiling: {
 				version: 1,
 				allowedTools: ["read", "grep", "bash"],
@@ -157,8 +197,8 @@ describe("child tool plan host builtin intersection", () => {
 	});
 });
 
-describe("production launch path supplies hostAvailableBuiltins", () => {
-	it("buildInProcessChildLaunch passes hostAvailableBuiltins to tool plan resolution", () => {
+describe("production launch path supplies hostToolNames", () => {
+	it("buildInProcessChildLaunch passes hostToolNames to tool plan resolution", () => {
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-launch-builtins-"));
 		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 		process.env.PI_CODING_AGENT_DIR = cwd;
@@ -173,7 +213,7 @@ describe("production launch path supplies hostAvailableBuiltins", () => {
 				inheritGlobalContext: false,
 				inheritSkills: false,
 				tools: ["read", "grep", "bash"],
-				hostAvailableBuiltins: ["ipython", "bash"],
+				hostToolNames: ["ipython", "bash"],
 			});
 			assert.deepEqual(launch.toolPlan.declaredBuiltinTools, ["bash"]);
 			assert.deepEqual(launch.toolPlan.unavailableHostBuiltins, ["read", "grep"]);
@@ -192,7 +232,7 @@ describe("production launch path supplies hostAvailableBuiltins", () => {
 					inheritGlobalContext: false,
 					inheritSkills: false,
 					tools: ["read", "grep", "bash"],
-					hostAvailableBuiltins: ["ipython", "bash"],
+					hostToolNames: ["ipython", "bash"],
 				}),
 				/Agent 'scout': tool contract could not be satisfied.*permitted required repository tools \[read, grep\].*lane infrastructure failure/,
 			);
@@ -203,7 +243,7 @@ describe("production launch path supplies hostAvailableBuiltins", () => {
 		}
 	});
 
-	it("getHostBuiltinToolNames extracts builtin tools from ExtensionAPI", () => {
+	it("getHostToolNames extracts every registered tool name from ExtensionAPI", () => {
 		const mockPi = {
 			getAllTools: () => [
 				{ name: "read", sourceInfo: { source: "builtin" } },
@@ -213,26 +253,26 @@ describe("production launch path supplies hostAvailableBuiltins", () => {
 				{ name: "mcp-tool", sourceInfo: { source: "mcp" } },
 			],
 		};
-		const builtins = getHostBuiltinToolNames(mockPi);
-		assert.deepEqual(builtins, ["read", "bash"]);
+		const names = getHostToolNames(mockPi);
+		assert.deepEqual(names, ["read", "bash", "custom-auto-tool", "custom-tool", "mcp-tool"]);
 	});
 
-	it("getHostBuiltinToolNames returns undefined on failure or empty results", () => {
+	it("getHostToolNames returns undefined on failure or empty results", () => {
 		const throwingPi = {
 			getAllTools: () => { throw new Error("Not available"); },
 		};
-		assert.equal(getHostBuiltinToolNames(throwingPi), undefined);
+		assert.equal(getHostToolNames(throwingPi), undefined);
 
 		const emptyPi = {
 			getAllTools: () => [],
 		};
-		assert.equal(getHostBuiltinToolNames(emptyPi), undefined);
+		assert.equal(getHostToolNames(emptyPi), undefined);
 
-		const noBuiltinsPi = {
+		const extensionOnlyPi = {
 			getAllTools: () => [
 				{ name: "custom-tool", sourceInfo: { source: "extension" } },
 			],
 		};
-		assert.equal(getHostBuiltinToolNames(noBuiltinsPi), undefined);
+		assert.deepEqual(getHostToolNames(extensionOnlyPi), ["custom-tool"]);
 	});
 });

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -110,6 +110,20 @@ describe("child tool plan host builtin intersection", () => {
 			assert.deepEqual(plan.unavailableHostBuiltins, []);
 		});
 
+		it("prunes extension tool names for a foreground launch that never loads ambient extensions", () => {
+			const plan = resolvePiLaunchToolPlan({ tools, hostToolNames, ambientExtensions: false });
+			assert.deepEqual(plan.declaredBuiltinTools, ["read"]);
+			assert.deepEqual(plan.unavailableHostBuiltins, ["web_search", "fetch_content"]);
+		});
+
+		it("prunes extension tool names when the child runs outside the parent project", () => {
+			// A detached runner does ambient discovery in its own cwd; when the
+			// launch moves the child to another project the parent snapshot no
+			// longer describes the child menu, so ambient names fail closed
+			const plan = resolvePiLaunchToolPlan({ tools, hostToolNames, ambientExtensions: false });
+			assert.deepEqual(plan.declaredBuiltinTools, ["read"]);
+		});
+
 		it("prunes extension tool names when a capability ceiling denies extensions", () => {
 			const plan = resolvePiLaunchToolPlan({
 				tools,

--- a/test/unit/preflight.test.ts
+++ b/test/unit/preflight.test.ts
@@ -1082,7 +1082,7 @@ Project prompt.
 		const result = await resolveSubagentLaunchContract({
 			agent: "scout",
 			cwd,
-			hostAvailableBuiltins: [],
+			hostToolNames: [],
 		});
 		assert.equal(result.ok, false);
 		assert.equal(result.code, "denied_required_tool");

--- a/test/unit/readonly-session-evidence.test.ts
+++ b/test/unit/readonly-session-evidence.test.ts
@@ -26,7 +26,7 @@ import { releaseActiveRunIndex, updateActiveRunIndex } from "../../src/runs/back
 import { resolveChildWatchdogConfig } from "../../src/watchdog/child-status.ts";
 import { DEFAULT_WATCHDOG_CONFIG } from "../../src/watchdog/settings.ts";
 import { DEFAULT_CONTROL_CONFIG } from "../../src/runs/shared/subagent-control.ts";
-import { getHostBuiltinToolNames } from "../../src/runs/shared/child-tool-plan.ts";
+import { getHostToolNames } from "../../src/runs/shared/child-tool-plan.ts";
 
 function launch(cwd: string): ChildSessionLaunch & { storage: Extract<ChildSessionLaunch["storage"], { kind: "file" }> } {
 	return { cwd, storage: { kind: "file", sessionFile: join(cwd, "session.jsonl") }, model: "baseten/model-a", tools: ["read"], extensionPaths: [],
@@ -213,12 +213,12 @@ export default function (pi) {
 		l.ambientExtensions = true;
 		const host = await factory.create({ ...l, storage: { kind: "memory" }, tools: ["read", "grep", "find", "ls", "bash"] });
 		assert.equal(captured[0]?.session.getAllTools().find((tool) => tool.name === "read")?.sourceInfo.source, "auto");
-		const discovered = getHostBuiltinToolNames(captured[0]!.session);
+		const discovered = getHostToolNames(captured[0]!.session);
 		await host.dispose();
 
 		const launch = buildInProcessChildLaunch({
 			cwd: l.cwd, host: "runner", sessionEnabled: false, model: l.model,
-			tools: ["read"], hostAvailableBuiltins: discovered, allowNestedSubagents: false, waitToolEnabled: false,
+			tools: ["read"], hostToolNames: discovered, allowNestedSubagents: false, waitToolEnabled: false,
 			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
 			parentSessionId: "tool-proof-parent", runId: "auto-builtin-override", childAgentName: "reviewer", childIndex: 0,
 			systemPrompt: "Read marker.txt exactly once.",

--- a/test/unit/scripted-workflow.test.ts
+++ b/test/unit/scripted-workflow.test.ts
@@ -864,7 +864,7 @@ describe("scripted workflow runtime", () => {
 					resolvePiLaunchToolPlan({
 						agentName: "reviewer",
 						tools: ["read", "grep", "find", "ls"],
-						hostAvailableBuiltins: [],
+						hostToolNames: [],
 					});
 					return { key, ok: true, output: "Unable to inspect the repository.", artifactPaths: [] };
 				},


### PR DESCRIPTION
Fixes #2132, fixes #2133, fixes #2134, fixes #2135.

## Summary

In 0.67.0, `getHostBuiltinToolNames()` only trusted tools whose `sourceInfo.source` is `builtin` or `auto`. Extensions that re-register a core tool under the same name (e.g. "pi-tool-display" wraps bash/grep/find/ls/edit/write, "pi-hashline-edit-pro" wraps read) report the extension as the source, so the computed host set lost those names. The child tool plan then pruned every requested tool:

- reviewer and scout launches were refused outright ("tool contract could not be satisfied", #2132, #2133, #2135)
- other agents launched silently with a degraded allowlist, so children genuinely never got `read` (#2133)
- extension tool names declared in agent `tools:` lists (`mcp__*`, `web_search`, ...) were always dropped, because the intersection filtered every non-builtin name (#2134)
- the completion guard then rejected implementation-shaped tasks with "no mutation-capable tools", and tool-less children could answer without reading anything, inventing tool results

## Fix

Discovery now returns every registered tool name regardless of source, and the tool plan applies a two-tier rule in `resolvePiLaunchToolPlan`:

- core tool slots (`read`, `bash`, ...) resolve by name whatever their source. pi core ships them, so the name stays resolvable even when a launch denies extensions and the wrapper is absent
- extension tool names are only kept when the child loads the same ambient extension set. For example, `denyExtensions` or an explicit `extensions` list on the launch, keeps pruning them, so those launches still fais as expected.

## Testing

- new plan-level tests: shadowed core names are kept, extension names are kept when the child inherits ambient extensions and pruned under `denyExtensions` or `extensions: []`, and names absent from the host are still pruned
- new discovery tests: names are reported whatever their source (`builtin`, `auto`, package, `mcp`), and `undefined` is still returned on failure or when nothing is registered
- existing tests updated to the new discovery contract; the fail-closed paths (absent names, review-lane contract, `requireReadTool`) still hold