### PR TITLE
fix: preserve extension-provided child tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Reject invalid global `checkpointBeforeDeadlineMs` values during config loading instead of silently disabling the requested checkpoint.
+- Preserve wrapped Pi core tools and explicitly requested non-core tools in child launches. Core slots still respect host availability; non-core tools are validated in the child's runtime after ceilings and exclusions (#2132, #2133, #2134, #2135, #2140). Thanks to [@carlesba](https://github.com/carlesba) for #2137 and [@clementprevot](https://github.com/clementprevot) for #2138.
 
 ### Added
 

--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -64,8 +64,6 @@ const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
 const PI_BUILTIN_TOOL_NAMES = new Set(["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"]);
 const REPOSITORY_INSPECTION_TOOLS = new Set(["read", "grep", "find", "ls", "bash", "powershell"]);
 const REVIEW_OR_SCOUT_AGENT_PATTERN = /\b(?:reviewer|scout)\b/i;
-// These providers come from child hooks, not the host's builtin tool registry.
-const NATIVE_COORDINATION_TOOL_NAMES = new Set(["subagent", "contact_supervisor", "subagent_supervisor"]);
 
 export function isReviewOrScoutLaneAgent(agentName: string | undefined): boolean {
 	return typeof agentName === "string" && REVIEW_OR_SCOUT_AGENT_PATTERN.test(agentName);
@@ -188,12 +186,13 @@ export interface ResolvePiLaunchToolPlanInput {
 	permissionRules?: PermissionRules;
 	runtimeSnapshotHost?: McpRuntimeSnapshotHost;
 	/**
-	 * When provided, child tool plans intersect declared builtin tools with
-	 * this set. Tools the agent declares but the host does not provide are
+	 * When provided, child tool plans intersect known Pi core tool slots with
+	 * this set. Core tools the agent declares but the host does not provide are
 	 * omitted with a non-fatal warning (tracked in `unavailableHostBuiltins`).
 	 * Review/scout lanes fail closed when a requested, still-permitted
 	 * repository inspection tool is among those host omissions. Intentionally
 	 * empty or ceiling-restricted allowlists are not a minimum-tool contract.
+	 * Non-core names remain allowed and are validated in the child's registry.
 	 */
 	hostAvailableBuiltins?: readonly string[];
 }
@@ -339,7 +338,8 @@ export function resolvePermissionSystemExtension(): string | undefined {
 /**
  * Extract the names of builtin tools the host provides. Use this to pass
  * `hostAvailableBuiltins` to `resolvePiLaunchToolPlan` so child tool plans
- * intersect declared agent tools with what the host actually supports.
+ * intersect known core slots with what the host actually supports. Wrapped
+ * core slots count regardless of source; host-specific builtins count too.
  *
  * Returns `undefined` when builtin tool discovery fails or yields nothing,
  * so callers skip the intersection (fail-safe to allowing all declared tools).
@@ -352,7 +352,7 @@ export function getHostBuiltinToolNames(pi: Pick<ExtensionAPI, "getAllTools">): 
 			.getAllTools()
 			.filter((tool) => {
 				const source = (tool.sourceInfo as { source?: string } | undefined)?.source;
-				return source === "builtin" || (source === "auto" && PI_BUILTIN_TOOL_NAMES.has(tool.name));
+				return source === "builtin" || PI_BUILTIN_TOOL_NAMES.has(tool.name);
 			})
 			.map((tool) => tool.name);
 		return builtins.length > 0 ? builtins : undefined;
@@ -405,10 +405,10 @@ export function resolvePiLaunchToolPlan(
 					: requestedBuiltinTools
 				).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
 	const declaredBuiltinTools = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => hostAvailableSet.has(tool) || NATIVE_COORDINATION_TOOL_NAMES.has(tool))
+		? ceilingFilteredBuiltinTools.filter((tool) => !PI_BUILTIN_TOOL_NAMES.has(tool) || hostAvailableSet.has(tool))
 		: ceilingFilteredBuiltinTools;
 	const unavailableHostBuiltins = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => !hostAvailableSet.has(tool) && !NATIVE_COORDINATION_TOOL_NAMES.has(tool))
+		? ceilingFilteredBuiltinTools.filter((tool) => PI_BUILTIN_TOOL_NAMES.has(tool) && !hostAvailableSet.has(tool))
 		: [];
 	const excludeTools = [...new Set((input.excludeTools ?? []).map((tool) => tool.trim()).filter(Boolean))];
 	const excludedToolSet = new Set(excludeTools);

--- a/test/integration/async-execution.part-2.test.ts
+++ b/test/integration/async-execution.part-2.test.ts
@@ -14,6 +14,8 @@ import * as path from "node:path";
 import { createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir, resolveMockPiCallArgs } from "../support/helpers.ts";
 import { deliverInterruptRequest, deliverStopRequest, deliverTimeoutRequest, requestAsyncSteer } from "../../src/runs/background/control-channel.ts";
 import { writeAtomicJson } from "../../src/shared/atomic-json.ts";
+import { runSync } from "../../src/runs/foreground/execution.ts";
+import { getHostBuiltinToolNames } from "../../src/runs/shared/child-tool-plan.ts";
 import { SUBAGENT_ASYNC_STARTED_EVENT, SUBAGENT_LIFECYCLE_ARTIFACT_VERSION } from "../../src/shared/types.ts";
 import type { AsyncResultPayload, AsyncStatusPayload, MockPiCallRecord } from "../support/async-execution-fixture.ts";
 import {
@@ -22,7 +24,7 @@ import {
 	pruneStatusCacheForAsyncRoot, ASYNC_DIR, RESULTS_DIR, createSubagentExecutor,
 	createRepo, waitForAsyncResultFile, waitForAsyncEvent, waitForAsyncState,
 	waitForMockPiCall, readMockPiArgs, readMockPiArgsMatching, tempDir, mockPi,
-	makeAsyncExecutor, readAsyncPayload,
+	makeAsyncExecutor, readAsyncPayload, readMockPiRequiredTools,
 } from "../support/async-execution-fixture.ts";
 
 describe("async execution utilities", { skip: !available ? "pi packages not available" : undefined }, () => {
@@ -1074,6 +1076,44 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		await waitForAsyncResultFile(chainId, 10_000);
 	});
 
+	it("preserves the same tool menu and runtime requirements in foreground and background children", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
+		const host = { events: { emit() {} }, getAllTools: () => [
+			{ name: "read", sourceInfo: { source: "extension" } },
+			{ name: "bash", sourceInfo: { source: "builtin" } },
+		] };
+		const tools = ["read", "fixture_search", "__proto__"];
+		const agent = makeAgent("extension-worker", { tools, subagentOnlyExtensions: [path.join(tempDir, "child-provider.ts")] });
+		fs.writeFileSync(agent.subagentOnlyExtensions![0]!, "export default function () {}\n");
+		mockPi.onCall({ output: "foreground done" });
+		const foreground = await runSync(tempDir, [agent], agent.name, "Inspect using fixture search", {
+			hostAvailableBuiltins: getHostBuiltinToolNames(host), acceptance: false,
+		});
+		assert.equal(foreground.exitCode, 0, foreground.error);
+		assert.deepEqual(mockPi.sessions[0]?.launch.tools, tools);
+		assert.deepEqual(mockPi.sessions[0]?.launch.runtime.requiredTools, tools);
+
+		mockPi.onCall({ output: "background done" });
+		const id = `async-tool-menu-parity-${Date.now().toString(36)}`;
+		executeAsyncSingle(id, {
+			agent: agent.name, task: "Inspect using fixture search", agentConfig: agent,
+			ctx: { pi: host, cwd: tempDir, currentSessionId: "session-1" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false, sessionRoot: path.join(tempDir, "sessions"), maxSubagentDepth: 2, acceptance: false,
+		});
+		const payload = await readAsyncPayload(id);
+		assert.equal(payload.success, true);
+		const args = readMockPiArgs(mockPi, 1);
+		assert.equal(args[args.indexOf("--tools") + 1], tools.join(","));
+		assert.deepEqual(readMockPiRequiredTools(mockPi, 1), tools);
+
+		mockPi.onCall({ output: "Incorrect success", missingTools: ["fixture_search"] });
+		const missing = await runSync(tempDir, [agent], agent.name, "Inspect using fixture search", {
+			hostAvailableBuiltins: getHostBuiltinToolNames(host), acceptance: false,
+		});
+		assert.notEqual(missing.exitCode, 0);
+		assert.match(missing.error ?? "", /child tools were unavailable: fixture_search/);
+	});
+
 	it("fails background chains when requested extension tools are unavailable", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		mockPi.onCall({ output: "Model incorrectly claimed success", missingTools: ["fixture_search"] });
 		const id = `async-missing-extension-tool-${Date.now().toString(36)}`;
@@ -1081,7 +1121,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 		executeAsyncChain(id, {
 			chain: [{ agent: "extension-worker", task: "Use fixture search" }],
 			agents: [makeAgent("extension-worker", { tools: ["read", "fixture_search"] })],
-			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			ctx: { pi: { events: { emit() {} }, getAllTools: () => [{ name: "read", sourceInfo: { source: "extension" } }, { name: "bash", sourceInfo: { source: "builtin" } }] }, cwd: tempDir, currentSessionId: "session-1" },
 			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
 			shareEnabled: false,
 			maxSubagentDepth: 2,
@@ -1103,7 +1143,7 @@ describe("async execution utilities", { skip: !available ? "pi packages not avai
 			agent: "worker",
 			task: "Implement the requested source fix",
 			agentConfig: makeAgent("worker", { tools: ["read", "fixture_search"] }),
-			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-1" },
+			ctx: { pi: { events: { emit() {} }, getAllTools: () => [{ name: "read", sourceInfo: { source: "builtin" } }] }, cwd: tempDir, currentSessionId: "session-1" },
 			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
 			shareEnabled: false,
 			sessionRoot: path.join(tempDir, "sessions"),

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -34,6 +34,55 @@ describe("child tool plan", () => {
 });
 
 describe("child tool plan host builtin intersection", () => {
+	it("keeps wrapped core slots regardless of source, including read for lazy skills", () => {
+		for (const source of ["builtin", "auto", "extension", "custom", undefined]) {
+			const hostAvailableBuiltins = getHostBuiltinToolNames({ getAllTools: () => [
+				...["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"].map((name) => ({ name, sourceInfo: source ? { source } : undefined })),
+				{ name: "ipython", sourceInfo: { source: "builtin" } },
+				{ name: "parent_only", sourceInfo: { source: "extension" } },
+			] });
+			assert.deepEqual(hostAvailableBuiltins, ["read", "bash", "powershell", "edit", "write", "grep", "find", "ls", "ipython"]);
+			const plan = resolvePiLaunchToolPlan({ tools: ["bash"], requireReadTool: true, hostAvailableBuiltins });
+			assert.deepEqual(plan.requiredChildTools, ["read", "bash"]);
+			assert.deepEqual(plan.unavailableHostBuiltins, []);
+		}
+	});
+
+	it("preserves arbitrary non-core requirements without inferring their child providers", () => {
+		const tools = ["read", "fixture_search", "__proto__", "ipython"];
+		for (const configuration of [
+			{},
+			{ extensions: [] },
+			{ extensions: ["/child/provider.ts"] },
+			{ subagentOnlyExtensions: ["/child/provider.ts"] },
+			{ capabilityCeiling: { version: 1 as const, denyExtensions: true, sources: ["test"] } },
+		]) {
+			const plan = resolvePiLaunchToolPlan({ tools, hostAvailableBuiltins: ["bash"], ...configuration });
+			assert.deepEqual(plan.effectiveToolAllowlist, tools.slice(1));
+			assert.deepEqual(plan.requiredChildTools, tools.slice(1));
+			assert.deepEqual(plan.unavailableHostBuiltins, ["read"]);
+		}
+		const restricted = resolvePiLaunchToolPlan({
+			tools, hostAvailableBuiltins: ["read"], excludeTools: ["__proto__"],
+			capabilityCeiling: { version: 1, allowedTools: ["fixture_search", "__proto__"], sources: ["test"] },
+		});
+		assert.deepEqual(restricted.effectiveToolAllowlist, ["fixture_search"]);
+		assert.deepEqual(restricted.requiredChildTools, ["fixture_search"]);
+		for (const restriction of [{ tools: [] }, { capabilityCeiling: { version: 1 as const, allowedTools: [], sources: ["test"] } }]) {
+			const empty = resolvePiLaunchToolPlan({ tools, hostAvailableBuiltins: ["read"], ...restriction });
+			assert.deepEqual(empty.effectiveToolAllowlist, []);
+			assert.deepEqual(empty.requiredChildTools, []);
+		}
+	});
+
+	it("retains the supervisor pairing exception but requires a lone intercom", () => {
+		for (const tools of [["intercom"], ["intercom", "contact_supervisor"]]) {
+			const plan = resolvePiLaunchToolPlan({ tools, hostAvailableBuiltins: ["read"] });
+			assert.deepEqual(plan.effectiveToolAllowlist, tools);
+			assert.deepEqual(plan.requiredChildTools, tools.length === 1 ? tools : []);
+		}
+	});
+
 	it("intersects declared tools with host-available builtins", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "find", "ls", "bash"],


### PR DESCRIPTION
## Summary

- preserve explicitly requested non-core tools through parent host-tool planning
- continue intersecting Pi core tool slots with actual host availability
- validate required extension tools in the child runtime after ceilings and exclusions
- add unit and integration coverage for wrapped core tools and extension-provided tools

This is the focused maintainer replacement for #2137 and #2138. Thanks to @carlesba and @clementprevot for identifying and contributing fixes for these regressions.

Closes #2132
Closes #2133
Closes #2134
Closes #2135
Closes #2140

## Validation

- 132 focused unit tests
- 92 focused integration tests
- `npm run typecheck`
- fresh independent review: OK