### PR TITLE
fix: re-drive after compaction only when it interrupted the parent run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Reject invalid global `checkpointBeforeDeadlineMs` values during config loading instead of silently disabling the requested checkpoint.
+- Send the `subagent-compaction-resume` re-drive only when a manual compaction actually cut a parent run. Threshold compaction runs inline inside the same run since pi 0.84.4 and overflow compaction retries the turn itself, so re-driving them started a spurious "resume the parent task" turn after runs that had already finished.
 
 ### Added
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -823,7 +823,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 
 	registerWaitTool(pi, state, waitToolConfig.enabled, waitSubscriptionManager, waitToolConfig.defaultTimeoutMs);
 
-	pi.on("agent_end", async (_event, ctx) => {
+	pi.on("agent_end", async (event, ctx) => {
+		parentRunAborted = lastAssistantStopReason(event?.messages) === "aborted";
 		if (!ctx.hasUI) await drainOutstandingWork({ state, events: pi.events });
 		const ownerSessionId = state.currentSessionId;
 		if (!ownerSessionId) return;
@@ -1094,6 +1095,15 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		},
 	};
 
+	const lastAssistantStopReason = (messages: unknown): string | undefined => {
+		if (!Array.isArray(messages)) return undefined;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const m = messages[i] as { role?: string; stopReason?: string } | undefined;
+			if (m?.role === "assistant") return m.stopReason;
+		}
+		return undefined;
+	};
+
 	const installRuntime = (ctx: ExtensionContext) => {
 		if (runtimeCleaned) {
 			throw new Error("Cannot restart a cleaned pi-subagents extension runtime; register a new extension instance.");
@@ -1123,7 +1133,17 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		}
 	};
 
+	// A compaction only needs a re-drive when it CUT a parent run. Since pi 0.84.4 threshold compaction
+	// runs inline between a tool batch and the next assistant response (the run continues by itself), and
+	// overflow compaction retries the aborted turn (`willRetry`). Only manual compaction (`/compact` or
+	// `ctx.compact()`) aborts first and "never continues the interrupted agent turn" — and only when a
+	// run was actually in flight. Re-driving in the other cases queued a spurious "resume the parent task"
+	// turn after runs that had already finished.
+	let parentRunAborted = false;
+	let compactionInterruptedRun = false;
+
 	pi.on("agent_start", () => {
+		parentRunAborted = false;
 		resumeWidgetsAfterCompaction();
 		herdrStatusBridge.agentStarted();
 	});
@@ -1133,10 +1153,15 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("session_before_compact", (event) => {
+		compactionInterruptedRun = event.reason === "manual" && parentRunAborted;
 		if (event.reason !== "manual") suspendWidgetsForCompaction();
 	});
 
 	pi.on("session_compact", () => {
+		const interrupted = compactionInterruptedRun;
+		compactionInterruptedRun = false;
+		parentRunAborted = false;
+		if (!interrupted) return;
 		const hasActiveAsyncWork = [...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running");
 		if (!hasActiveAsyncWork || !withLastUiContext(() => true)) return;
 		pi.sendMessage(

--- a/test/unit/compaction-resume.test.ts
+++ b/test/unit/compaction-resume.test.ts
@@ -42,7 +42,31 @@ describe("async compaction resume", () => {
 			for (const handler of handlers.get("agent_start")) await handler();
 			const restored = widgets.filter(([_, value]) => value !== undefined).map(([key]) => key).sort();
 			if (JSON.stringify(restored) !== JSON.stringify(["subagent-async", "subagent-fleet-status"])) throw new Error(JSON.stringify(widgets));
-			if (sent.length !== 1 || sent[0].options?.triggerTurn !== true || sent[0].message?.customType !== "subagent-compaction-resume") throw new Error(JSON.stringify(sent));
+			// threshold compaction runs inline inside the same run (pi >= 0.84.4): the parent continues by itself
+			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("re-drove an inline threshold compaction: " + JSON.stringify(sent));
+
+			// manual compaction that CUT a run (agent_end saw an aborted assistant turn) is the one case that needs the re-drive
+			sent.length = 0;
+			for (const handler of handlers.get("agent_end")) await handler({ messages: [{ role: "user", content: "go" }, { role: "assistant", content: [], stopReason: "aborted" }] }, ctx);
+			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "manual", signal: new AbortController().signal });
+			for (const handler of handlers.get("session_compact")) await handler({ reason: "manual" });
+			if (sent.length !== 1 || sent[0].options?.triggerTurn !== true || sent[0].message?.customType !== "subagent-compaction-resume") throw new Error("manual compaction after an aborted run must resume: " + JSON.stringify(sent));
+
+			// manual compaction at idle (last run ended with stop) must not start an unasked turn
+			sent.length = 0;
+			for (const handler of handlers.get("agent_start")) await handler();
+			for (const handler of handlers.get("agent_end")) await handler({ messages: [{ role: "assistant", content: [], stopReason: "stop" }] }, ctx);
+			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "manual", signal: new AbortController().signal });
+			for (const handler of handlers.get("session_compact")) await handler({ reason: "manual" });
+			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("re-drove a manual compaction of a finished run: " + JSON.stringify(sent));
+
+			// overflow compaction retries the aborted turn itself (willRetry)
+			sent.length = 0;
+			for (const handler of handlers.get("agent_end")) await handler({ messages: [{ role: "assistant", content: [], stopReason: "aborted" }] }, ctx);
+			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "overflow", willRetry: true, signal: new AbortController().signal });
+			for (const handler of handlers.get("session_compact")) await handler({ reason: "overflow", willRetry: true });
+			for (const handler of handlers.get("agent_start")) await handler();
+			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("re-drove an overflow compaction pi retries itself: " + JSON.stringify(sent));
 
 			sent.length = 0;
 			events.emit("subagent:async-complete", { id: "running-2", sessionId: "compact-session", agent: "worker", success: true, summary: "done" });


### PR DESCRIPTION
## Problem

`session_compact` sends the `subagent-compaction-resume` message (`triggerTurn: true`, "Resume the parent task now") after **every** compaction while async work is active. That matched pi's behaviour when the re-drive was added (#f54af731, 2026-08-04): compaction aborted the parent, so something had to restart it.

Two of the three compaction reasons no longer interrupt the parent:

- **threshold** — since pi 0.84.4 ("Pi now compacts between tool execution and the next assistant response in the same run", earendil-works/pi#6879) the run simply continues. The extra message then lands as a follow-up turn after the run has finished: a spurious "resume the parent task" prompt with nothing to resume. Measured in a long interactive session: 1 in 4 threshold compactions produced one.
- **overflow** — pi retries the aborted turn itself (`willRetry: true`).

Only **manual** compaction (`/compact`, `ctx.compact()`) aborts first and, per the `AgentSession.compact()` doc, "never retries or continues the interrupted agent turn" — and even then only when a run was actually in flight.

## Fix

- `agent_end` records whether the last assistant message ended with `stopReason: "aborted"`.
- `session_before_compact` with `reason === "manual"` arms the re-drive from that flag.
- `session_compact` consumes the flag; threshold and overflow never re-drive. Async-work and UI checks unchanged.

No wall-clock, no new config. `event.reason` has been on both compaction events since pi 0.6x.

## Tests

`test/unit/compaction-resume.test.ts` now covers the four cases: inline threshold (no re-drive), manual after an aborted run (re-drive), manual at idle (no re-drive), overflow with `willRetry` (no re-drive). `npm run test:unit`: 3126 pass / 0 fail; `tsc --noEmit` clean.
