### PR TITLE
feat: exclude agent discovery subtrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Add `checkpointBeforeDeadlineMs` for async single-agent runs (call param, with a global config default): the runner requests that the child "checkpoint and stop" that many milliseconds before its run deadline. This best-effort handoff request uses the normal steering lifecycle at the child's next tool boundary, so its receipt appears in status and events; the ordinary `timeoutMs` kill still applies. Absent option keeps the current behavior. Thanks to [@freezscholte](https://github.com/freezscholte) for #2141.
 
+- Add `subagents.agentExcludeDirs` to prune directory subtrees from agent discovery, including nested plugin sources, without disabling ordinary legacy agents. Exclusions respect symlink aliases and apply to explicit/package roots, diagnostics, and agent cache fingerprints. Thanks to [@xarillian](https://github.com/xarillian) for #2131.
+
 ## [0.67.0] - 2026-09-10
 
 ### Highlights

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -28,6 +28,7 @@ Discovery notes:
 - Project discovery also reads legacy `.agents/**/*.md` files. If both `.agents/` and the project config agents directory define the same parsed runtime agent name, the project config directory wins.
 - Nested subdirectories are discovered recursively. `.chain.md` files do not define agents.
 - User and project settings can add extra recursive scan roots with `subagents.agentScanDirs`; fixed user/project agent directories keep higher priority than same-name agents from scan roots.
+- Use `subagents.agentExcludeDirs` to prune literal directory subtrees without disabling legacy agents. See [configuration.md](configuration.md#excluded-agent-directories-settings) for path resolution, scope, and exemptions.
 - Installed Pi packages can expose agent directories from either `{"pi-subagents":{"agents":["./agents"]}}` or `{"pi":{"subagents":{"agents":["./agents"]}}}` in their package manifest. Package agents load above builtins and below user/project agents.
 - Use `agentScope: "user" | "project" | "both"` to control discovery. `both` is the default, and project definitions win runtime-name collisions.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 `pi-subagents` reads optional JSON config from `~/.pi/agent/extensions/subagent/config.json`. This page lists every key, plus the environment variables and the settings-file keys that affect config resolution.
 
-Settings-level keys (`subagents.defaultModel`, `defaultProvider`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `agentScanDirs`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. `modelScope.agents.<name>` adds per-agent restrictions, and `allow: ["inherit"]` permits the current parent model. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
+Settings-level keys (`subagents.defaultModel`, `defaultProvider`, `defaultThinking`, `defaultExtensions`, `agentOverrides`, `agentScanDirs`, `agentExcludeDirs`, `modelScope`, `disableThinking`, `disableBuiltins`, watchdog settings) live in Pi settings files, not this config file. `modelScope.agents.<name>` adds per-agent restrictions, and `allow: ["inherit"]` permits the current parent model. See [models.md](models.md), [agents.md](agents.md), and [watchdog.md](watchdog.md).
 
 ## Project root resolution (settings)
 
@@ -31,6 +31,22 @@ Add recursive user or project agent roots with `subagents.agentScanDirs` in Pi s
 ```
 
 Entries support `~` expansion. A single `*` path segment expands one directory level, so package-like folders can each expose an `agents/` directory. Missing directories are ignored. Fixed user/project agent directories still win over same-name agents from scan roots.
+
+## Excluded agent directories (settings)
+
+Prune directory subtrees from recursive agent-definition discovery with `subagents.agentExcludeDirs`:
+
+```json
+{
+  "subagents": {
+    "agentExcludeDirs": ["~/.agents/plugins", "../.agents/plugins"]
+  }
+}
+```
+
+Entries are literal directory paths (no globs), supporting `~` and absolute paths. Relative paths resolve from the directory containing their settings file: the user agent config directory for user settings, or the project config directory (normally `.pi/`) for project settings. Thus `../.agents/plugins` in project `.pi/settings.json` excludes the project's legacy plugin subtree without excluding ordinary `.agents/*.md` agents.
+
+User and nearest-project exclusions are combined for every discovery scope, including all-source diagnostics. They apply before traversal and definition reads; explicit scan roots, environment roots, and installed packages cannot re-include an excluded tree. Normalized and real-path containment also excludes symlink aliases without matching sibling directory prefixes. Settings changes invalidate cached discovery. Excluded agent trees are not fingerprinted; chain discovery keeps its own unchanged watches when it shares a directory. Skills, chains, and the extension's bundled builtin snapshot are outside this setting's scope.
 
 ## `modelResponseAliases`
 

--- a/src/agents/agents.ts
+++ b/src/agents/agents.ts
@@ -195,6 +195,7 @@ interface SubagentSettings {
 	overrides: Record<string, BuiltinAgentOverrideConfig>;
 	providerOverrides: Record<string, Record<string, BuiltinAgentOverrideConfig>>;
 	agentScanDirs?: string[];
+	agentExcludeDirs?: string[];
 	defaultModel?: string;
 	defaultProvider?: string;
 	defaultThinking?: string;
@@ -1191,6 +1192,14 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		}
 		agentScanDirs = subagentsObject.agentScanDirs.map((item) => item.trim());
 	}
+	let agentExcludeDirs: string[] | undefined;
+	if ("agentExcludeDirs" in subagentsObject) {
+		if (!Array.isArray(subagentsObject.agentExcludeDirs)
+			|| subagentsObject.agentExcludeDirs.some((item) => typeof item !== "string" || !item.trim())) {
+			throw new Error(`Subagent settings in '${filePath}' have invalid 'agentExcludeDirs'; expected an array of non-empty strings.`);
+		}
+		agentExcludeDirs = subagentsObject.agentExcludeDirs.map((item) => item.trim());
+	}
 	const modelScope = parseModelScopeConfig(subagentsObject.modelScope, { filePath });
 
 	const parsed: Record<string, BuiltinAgentOverrideConfig> = {};
@@ -1206,6 +1215,7 @@ function readSubagentSettings(filePath: string | null): SubagentSettings {
 		...(maxThinking !== undefined ? { maxThinking } : {}),
 		...(defaultExtensions !== undefined ? { defaultExtensions } : {}),
 		...(agentScanDirs !== undefined ? { agentScanDirs } : {}),
+		...(agentExcludeDirs !== undefined ? { agentExcludeDirs } : {}),
 		...(disableBuiltins !== undefined ? { disableBuiltins } : {}),
 		...(disableThinking !== undefined ? { disableThinking } : {}),
 		...(modelScope !== undefined ? { modelScope } : {}),
@@ -1778,8 +1788,9 @@ const DEFAULT_AGENT_DEFINITION_INSPECTION_FS: AgentDefinitionInspectionFs = {
  * state. A nested unreadable directory makes the whole inspection unavailable,
  * preventing a partial traversal from being reported as empty or complete.
  */
-export function inspectAgentDefinitionDirectory(dir: string, operations: AgentDefinitionInspectionFs = DEFAULT_AGENT_DEFINITION_INSPECTION_FS): AgentDefinitionInspection {
+export function inspectAgentDefinitionDirectory(dir: string, operations: AgentDefinitionInspectionFs = DEFAULT_AGENT_DEFINITION_INSPECTION_FS, isExcluded: (filePath: string) => boolean = () => false): AgentDefinitionInspection {
 	const root = path.resolve(dir);
+	if (isExcluded(root)) return rememberAgentDefinitionInspection({ files: [], state: "empty" }, []);
 	try {
 		if (!operations.existsSync(root)) return rememberAgentDefinitionInspection({ files: [], state: "absent" }, [root]);
 		if (!operations.statSync(root).isDirectory()) return rememberAgentDefinitionInspection({ files: [], state: "not-directory" }, [root]);
@@ -1811,6 +1822,7 @@ export function inspectAgentDefinitionDirectory(dir: string, operations: AgentDe
 		}
 		for (const entry of entries) {
 			const filePath = path.join(current, entry.name);
+			if (isExcluded(filePath)) continue;
 			let isDirectory = entry.isDirectory();
 			if (entry.isSymbolicLink()) {
 				try {
@@ -2268,31 +2280,60 @@ interface AgentScanDirs {
 	watchPaths: string[];
 }
 
-function readConfiguredAgentScanDirs(filePath: string | null): string[] {
+function readConfiguredAgentScanDirs(filePath: string | null, key: "agentScanDirs" | "agentExcludeDirs" = "agentScanDirs"): string[] {
 	if (!filePath) return [];
 	try {
 		const settings = readSettingsFileStrict(filePath);
 		const subagents = settings.subagents;
 		if (!subagents || typeof subagents !== "object" || Array.isArray(subagents)) return [];
-		const dirs = (subagents as { agentScanDirs?: unknown }).agentScanDirs;
+		const dirs = (subagents as Record<string, unknown>)[key];
 		return Array.isArray(dirs) ? dirs.filter((dir): dir is string => typeof dir === "string" && dir.trim().length > 0) : [];
 	} catch {
 		return [];
 	}
 }
 
-function expandAgentScanDirPattern(pattern: string): AgentScanDirs {
+// Resolve existing ancestors to canonicalize missing descendants of symlinks.
+function canonicalAgentPath(filePath: string): string {
+	const resolved = path.resolve(filePath);
+	try {
+		return fs.realpathSync(resolved);
+	} catch {
+		const parent = path.dirname(resolved);
+		return parent === resolved ? resolved : path.join(canonicalAgentPath(parent), path.basename(resolved));
+	}
+}
+
+function agentExclusionRoots(userSettingsPath: string, projectSettingsPath: string | null): Array<{ resolved: string; real: string }> {
+	return [userSettingsPath, projectSettingsPath].flatMap((settingsPath) => settingsPath
+		? readConfiguredAgentScanDirs(settingsPath, "agentExcludeDirs").map((entry) => {
+			const resolved = path.resolve(path.dirname(settingsPath), expandHomePath(entry.trim()).replace(/[\\/]+/g, path.sep));
+			return { resolved, real: canonicalAgentPath(resolved) };
+		}) : []);
+}
+
+function agentExclusions(roots: Array<{ resolved: string; real: string }>): (filePath: string) => boolean {
+	return (filePath) => {
+		if (!roots.length) return false;
+		if (roots.some((root) => isPathWithin(root.resolved, filePath))) return true;
+		const real = canonicalAgentPath(filePath);
+		return roots.some((root) => isPathWithin(root.real, real));
+	};
+}
+
+function expandAgentScanDirPattern(pattern: string, isExcluded: (filePath: string) => boolean): AgentScanDirs {
 	const expanded = expandHomePath(pattern.trim()).replace(/[\\/]+/g, path.sep);
 	if (!expanded) return { dirs: [], watchPaths: [] };
 	const wildcardMatches = [...expanded.matchAll(/\*/g)];
 	if (wildcardMatches.length === 0) {
 		const dir = path.resolve(expanded);
-		return { dirs: fs.existsSync(dir) ? [dir] : [], watchPaths: [dir] };
+		return { dirs: !isExcluded(dir) && fs.existsSync(dir) ? [dir] : [], watchPaths: [dir] };
 	}
 	const parts = expanded.split(path.sep);
 	const wildcardIndex = parts.findIndex((part) => part.includes("*"));
 	if (wildcardMatches.length !== 1 || wildcardIndex === -1 || parts[wildcardIndex] !== "*") return { dirs: [], watchPaths: [] };
 	const base = path.resolve(parts.slice(0, wildcardIndex).join(path.sep) || path.sep);
+	if (isExcluded(base)) return { dirs: [], watchPaths: [base] };
 	const rest = parts.slice(wildcardIndex + 1);
 	let entries: fs.Dirent[];
 	try {
@@ -2302,16 +2343,16 @@ function expandAgentScanDirPattern(pattern: string): AgentScanDirs {
 	}
 	const candidateDirs = entries.filter((entry) => entry.isDirectory()).map((entry) => path.join(base, entry.name, ...rest));
 	return {
-		dirs: candidateDirs.filter((dir) => fs.existsSync(dir)),
+		dirs: candidateDirs.filter((dir) => !isExcluded(dir) && fs.existsSync(dir)),
 		watchPaths: [base, ...candidateDirs],
 	};
 }
 
-function settingsAgentScanDirs(entries: string[]): AgentScanDirs {
+function settingsAgentScanDirs(entries: string[], isExcluded: (filePath: string) => boolean): AgentScanDirs {
 	const dirs = new Set<string>();
 	const watchPaths = new Set<string>();
 	for (const entry of entries) {
-		const expanded = expandAgentScanDirPattern(entry);
+		const expanded = expandAgentScanDirPattern(entry, isExcluded);
 		for (const dir of expanded.dirs) dirs.add(dir);
 		for (const watchPath of expanded.watchPaths) watchPaths.add(watchPath);
 	}
@@ -2378,6 +2419,10 @@ interface AgentDiscoverySources {
 	userChains?: ReturnType<typeof loadChainsFromDir>;
 	projectChainLoaded?: Array<{ dir: string; loaded: ReturnType<typeof loadChainsFromDir> }>;
 	packageChainLoaded?: Array<{ entry: PackageChainPath; loaded: ReturnType<typeof loadChainsFromDir> }>;
+	isExcluded: (filePath: string) => boolean;
+	exclusionRoots: Array<{ resolved: string; real: string }>;
+	identityWatchPaths: string[];
+	chainWatchPaths?: Set<string>;
 	watchPaths: string[];
 }
 
@@ -2390,7 +2435,7 @@ const agentDiscoveryCache = new Map<string, AgentDiscoveryCacheEntry>();
 
 function isPathWithin(root: string, candidate: string): boolean {
 	const relative = path.relative(path.resolve(root), path.resolve(candidate));
-	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+	return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }
 
 function addDirectoryWatchPaths(paths: Set<string>, root: string, files: readonly string[], directories: readonly string[] = []): void {
@@ -2413,13 +2458,14 @@ function addDirectoryWatchPaths(paths: Set<string>, root: string, files: readonl
 	}
 }
 
-function watchPathSignature(filePath: string): string {
+function watchPathSignature(filePath: string, isExcluded?: (filePath: string) => boolean): string {
 	try {
 		const stat = fs.statSync(filePath);
 		if (stat.isDirectory()) {
 			const entries = fs.readdirSync(filePath, { withFileTypes: true })
+				.filter((entry) => !isExcluded || !isExcluded(path.join(filePath, entry.name)))
 				.sort((left, right) => left.name.localeCompare(right.name))
-				.map((entry) => `${entry.name}:${entry.isDirectory() ? "d" : entry.isSymbolicLink() ? "l" : "f"}`)
+				.map((entry) => `${entry.name}:${entry.isDirectory() ? "d" : entry.isSymbolicLink() ? (isExcluded ? `l:${canonicalAgentPath(path.join(filePath, entry.name))}` : "l") : "f"}`)
 				.join("|");
 			return `directory:${entries}`;
 		}
@@ -2429,10 +2475,17 @@ function watchPathSignature(filePath: string): string {
 	}
 }
 
-function discoveryFingerprint(paths: readonly string[]): string {
-	return [...new Set(paths)]
+function discoveryFingerprint(sources: AgentDiscoverySources): string {
+	const exclusionIdentity = JSON.stringify(sources.exclusionRoots.map((root) => ({ resolved: root.resolved, real: canonicalAgentPath(root.resolved) })));
+	// A retargeted exclusion needs a fresh scan before fingerprinting old roots.
+	if (exclusionIdentity !== JSON.stringify(sources.exclusionRoots)) return exclusionIdentity;
+	const rootIdentities = JSON.stringify(sources.identityWatchPaths.map((root) => [root, canonicalAgentPath(root)]));
+	// Package metadata can redirect agents outside an excluded tree without chains.
+	const unfilteredPaths = new Set([...sources.packageSubagentPaths.watchPaths, ...(sources.chainWatchPaths ?? [])]);
+	return exclusionIdentity + "\n" + rootIdentities + "\n" + [...new Set([...sources.watchPaths, ...unfilteredPaths])]
+		.filter((filePath) => unfilteredPaths.has(filePath) || filePath === sources.userSettingsPath || filePath === sources.projectSettingsPath || !sources.isExcluded(filePath))
 		.sort((left, right) => left.localeCompare(right))
-		.map((filePath) => `${filePath}:${watchPathSignature(filePath)}`)
+		.map((filePath) => `${filePath}:${watchPathSignature(filePath, sources.exclusionRoots.length && !unfilteredPaths.has(filePath) ? sources.isExcluded : undefined)}`)
 		.join("\n");
 }
 
@@ -2478,21 +2531,23 @@ function buildAgentDiscoverySources(cwd: string, preferredModelProvider?: string
 	const userSettingsPath = getUserAgentSettingsPath();
 	const projectSettingsPath = getProjectAgentSettingsPath(effectiveCwd);
 	const packageSubagentPaths = collectPackageSubagentPaths(effectiveCwd);
-	const userScanDirs = settingsAgentScanDirs(readConfiguredAgentScanDirs(userSettingsPath));
-	const projectScanDirs = settingsAgentScanDirs(readConfiguredAgentScanDirs(projectSettingsPath));
+	const exclusionRoots = agentExclusionRoots(userSettingsPath, projectSettingsPath);
+	const isExcluded = agentExclusions(exclusionRoots);
+	const userScanDirs = settingsAgentScanDirs(readConfiguredAgentScanDirs(userSettingsPath), isExcluded);
+	const projectScanDirs = settingsAgentScanDirs(readConfiguredAgentScanDirs(projectSettingsPath), isExcluded);
 
 	const builtinLoaded = loadAgentsFromDefinitionFiles(BUILTIN_AGENT_DEFINITION_FILES, "builtin");
-	const userLoaded = [...extraUserAgentDirs(), ...userScanDirs.dirs, userDirOld, userDirNew].map((dir, discoveryPriority): LoadedAgentDirectory => {
-		const inspection = inspectAgentDefinitionDirectory(dir);
+	const userLoaded = [...extraUserAgentDirs(), ...userScanDirs.dirs, userDirOld, userDirNew].filter((dir) => !isExcluded(dir)).map((dir, discoveryPriority): LoadedAgentDirectory => {
+		const inspection = inspectAgentDefinitionDirectory(dir, undefined, isExcluded);
 		return { dir, inspection, loaded: loadAgentsFromDir(dir, "user", discoveryPriority, undefined, inspection) };
 	});
-	const projectInspections = new Map(projectCandidateDirs.map((dir) => [dir, inspectAgentDefinitionDirectory(dir)]));
-	const projectLoaded = [...projectScanDirs.dirs, ...projectAgentDirs].map((dir, discoveryPriority): LoadedAgentDirectory => {
-		const inspection = projectInspections.get(dir) ?? inspectAgentDefinitionDirectory(dir);
+	const projectInspections = new Map(projectCandidateDirs.filter((dir) => !isExcluded(dir)).map((dir) => [dir, inspectAgentDefinitionDirectory(dir, undefined, isExcluded)]));
+	const projectLoaded = [...projectScanDirs.dirs, ...projectAgentDirs].filter((dir) => !isExcluded(dir)).map((dir, discoveryPriority): LoadedAgentDirectory => {
+		const inspection = projectInspections.get(dir) ?? inspectAgentDefinitionDirectory(dir, undefined, isExcluded);
 		return { dir, inspection, loaded: loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : discoveryPriority, undefined, inspection) };
 	});
-	const packageLoaded = packageSubagentPaths.agents.map((entry, index): LoadedAgentDirectory => {
-		const inspection = inspectAgentDefinitionDirectory(entry.dir);
+	const packageLoaded = packageSubagentPaths.agents.filter((entry) => !isExcluded(entry.dir)).map((entry, index): LoadedAgentDirectory => {
+		const inspection = inspectAgentDefinitionDirectory(entry.dir, undefined, isExcluded);
 		return { dir: entry.dir, inspection, packageEntry: entry, loaded: loadAgentsFromDir(entry.dir, "package", packageSubagentPaths.agents.length - index, entry, inspection) };
 	});
 
@@ -2522,7 +2577,7 @@ function buildAgentDiscoverySources(cwd: string, preferredModelProvider?: string
 		userDirNew,
 		userChainDir,
 		projectAgentDirs,
-		projectCandidateDirs,
+		projectCandidateDirs: projectCandidateDirs.filter((dir) => !isExcluded(dir)),
 		projectAgentsDir,
 		projectChainDirs,
 		projectChainDir,
@@ -2534,7 +2589,17 @@ function buildAgentDiscoverySources(cwd: string, preferredModelProvider?: string
 		projectLoaded,
 		projectInspections,
 		packageLoaded,
-		watchPaths: [...watchPaths],
+		isExcluded,
+		exclusionRoots,
+		// Aliases outside excluded lexical subtrees can be retargeted into allowed
+		// storage. Watch only their identity, never the excluded target's contents.
+		identityWatchPaths: [...new Set([
+			...userScanDirs.watchPaths, ...projectScanDirs.watchPaths,
+			...extraUserAgentDirs(), userDirOld, userDirNew, ...projectCandidateDirs,
+			...packageSubagentPaths.agents.map((entry) => entry.dir),
+		])]
+			.filter((dir) => !exclusionRoots.some((root) => isPathWithin(root.resolved, dir)) && isExcluded(dir)),
+		watchPaths: [...watchPaths].filter((filePath) => !isExcluded(filePath) || filePath === userSettingsPath || filePath === projectSettingsPath),
 	};
 }
 
@@ -2543,29 +2608,30 @@ function ensureDiscoveryChains(sources: AgentDiscoverySources): void {
 	sources.packageChainLoaded = sources.packageSubagentPaths.chains.map((entry) => ({ entry, loaded: loadChainsFromDir(entry.dir, "package") }));
 	sources.userChains = loadChainsFromDir(sources.userChainDir, "user");
 	sources.projectChainLoaded = sources.projectChainDirs.map((dir) => ({ dir, loaded: loadChainsFromDir(dir, "project") }));
-	const watchPaths = new Set(sources.watchPaths);
+	const watchPaths = new Set(sources.packageSubagentPaths.watchPaths);
 	addDirectoryWatchPaths(watchPaths, sources.userChainDir, sources.userChains.files, sources.userChains.directories);
 	for (const chain of sources.projectChainLoaded) addDirectoryWatchPaths(watchPaths, chain.dir, chain.loaded.files, chain.loaded.directories);
 	for (const chain of sources.packageChainLoaded) addDirectoryWatchPaths(watchPaths, chain.entry.dir, chain.loaded.files, chain.loaded.directories);
-	sources.watchPaths = [...watchPaths];
+	sources.chainWatchPaths = watchPaths;
+	sources.watchPaths = [...new Set([...sources.watchPaths, ...watchPaths])];
 }
 
 function getAgentDiscoverySources(cwd: string, preferredModelProvider?: string, includeChains = false): AgentDiscoverySources {
 	const key = discoveryCacheKey(cwd, preferredModelProvider);
 	const cached = agentDiscoveryCache.get(key);
-	if (cached && cached.fingerprint === discoveryFingerprint(cached.sources.watchPaths)) {
+	if (cached && cached.fingerprint === discoveryFingerprint(cached.sources)) {
 		if (includeChains) {
 			ensureDiscoveryChains(cached.sources);
-			cached.fingerprint = discoveryFingerprint(cached.sources.watchPaths);
+			cached.fingerprint = discoveryFingerprint(cached.sources);
 		}
 		return cached.sources;
 	}
 	const sources = buildAgentDiscoverySources(cwd, preferredModelProvider);
-	const entry = { sources, fingerprint: discoveryFingerprint(sources.watchPaths) };
+	const entry = { sources, fingerprint: discoveryFingerprint(sources) };
 	agentDiscoveryCache.set(key, entry);
 	if (includeChains) {
 		ensureDiscoveryChains(sources);
-		entry.fingerprint = discoveryFingerprint(sources.watchPaths);
+		entry.fingerprint = discoveryFingerprint(sources);
 	}
 	return sources;
 }
@@ -2761,27 +2827,28 @@ function discoverAgentsUncached(cwd: string, scope: AgentScope, preferredModelPr
 	const defaultExtensions = resolveSubagentDefaultExtensions(userSettings, projectSettings, projectSettingsPath);
 	const modelScope = projectSettings.modelScope ?? userSettings.modelScope;
 	const packageSubagentPaths = collectPackageSubagentPaths(effectiveCwd, { includeUser: scope !== "project", includeProject: scope !== "user" });
+	const isExcluded = agentExclusions(agentExclusionRoots(userSettingsPath, projectSettingsPath));
 	const directories: AgentDefinitionDirectoryReport[] = [reportAgentDefinitionDirectory("builtin", BUILTIN_AGENTS_DIR, BUILTIN_AGENT_DEFINITION_INSPECTION)];
 	const builtinLoaded = loadAgentsFromDefinitionFiles(BUILTIN_AGENT_DEFINITION_FILES, "builtin");
 	const builtinAgents = applyBuiltinOverrides(applySubagentDefaults(builtinLoaded.agents, defaultModel, defaultProvider, defaultThinking, defaultExtensions), userSettings, projectSettings, userSettingsPath, projectSettingsPath);
-	const userScanDirs = settingsAgentScanDirs(userSettings.agentScanDirs ?? []);
-	const projectScanDirs = settingsAgentScanDirs(projectSettings.agentScanDirs ?? []);
-	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), ...userScanDirs.dirs, userDirOld, userDirNew].map((dir, discoveryPriority) => {
-		const inspection = inspectAgentDefinitionDirectory(dir);
+	const userScanDirs = settingsAgentScanDirs(userSettings.agentScanDirs ?? [], isExcluded);
+	const projectScanDirs = settingsAgentScanDirs(projectSettings.agentScanDirs ?? [], isExcluded);
+	const userLoaded = scope === "project" ? [] : [...extraUserAgentDirs(), ...userScanDirs.dirs, userDirOld, userDirNew].filter((dir) => !isExcluded(dir)).map((dir, discoveryPriority) => {
+		const inspection = inspectAgentDefinitionDirectory(dir, undefined, isExcluded);
 		directories.push(reportAgentDefinitionDirectory("user", dir, inspection));
 		return loadAgentsFromDir(dir, "user", discoveryPriority, undefined, inspection);
 	});
 	const userAgents = applyCustomAgentOverrides(applySubagentDefaults(userLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions), userSettings, projectSettings, userSettingsPath, projectSettingsPath);
-	const projectInspections = scope === "user" ? new Map<string, AgentDefinitionInspection>() : new Map(projectCandidateDirs.map((dir) => [dir, inspectAgentDefinitionDirectory(dir)]));
-	if (scope !== "user") for (const dir of projectCandidateDirs) directories.push(reportAgentDefinitionDirectory("project", dir, projectInspections.get(dir)!));
-	const projectLoaded = scope === "user" ? [] : [...projectScanDirs.dirs, ...projectAgentDirs].map((dir, discoveryPriority) => {
-		const inspection = projectInspections.get(dir) ?? inspectAgentDefinitionDirectory(dir);
+	const projectInspections = scope === "user" ? new Map<string, AgentDefinitionInspection>() : new Map(projectCandidateDirs.filter((dir) => !isExcluded(dir)).map((dir) => [dir, inspectAgentDefinitionDirectory(dir, undefined, isExcluded)]));
+	if (scope !== "user") for (const [dir, inspection] of projectInspections) directories.push(reportAgentDefinitionDirectory("project", dir, inspection));
+	const projectLoaded = scope === "user" ? [] : [...projectScanDirs.dirs, ...projectAgentDirs].filter((dir) => !isExcluded(dir)).map((dir, discoveryPriority) => {
+		const inspection = projectInspections.get(dir) ?? inspectAgentDefinitionDirectory(dir, undefined, isExcluded);
 		if (!projectInspections.has(dir)) directories.push(reportAgentDefinitionDirectory("project", dir, inspection));
 		return loadAgentsFromDir(dir, "project", dir === projectAgentsDir ? 1 : discoveryPriority, undefined, inspection);
 	});
 	const projectAgents = applyCustomAgentOverrides(applySubagentDefaults(projectLoaded.flatMap((loaded) => loaded.agents), defaultModel, defaultProvider, defaultThinking, defaultExtensions), userSettings, projectSettings, userSettingsPath, projectSettingsPath);
-	const packageLoaded = packageSubagentPaths.agents.map((entry, index) => {
-		const inspection = inspectAgentDefinitionDirectory(entry.dir);
+	const packageLoaded = packageSubagentPaths.agents.filter((entry) => !isExcluded(entry.dir)).map((entry, index) => {
+		const inspection = inspectAgentDefinitionDirectory(entry.dir, undefined, isExcluded);
 		directories.push(reportAgentDefinitionDirectory("package", entry.dir, inspection));
 		return loadAgentsFromDir(entry.dir, "package", packageSubagentPaths.agents.length - index, entry, inspection);
 	});

--- a/test/unit/agent-exclude-dirs.test.ts
+++ b/test/unit/agent-exclude-dirs.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
+import fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearAgentDiscoveryCache, discoverAgents, discoverAgentsAll, discoverAgentSnapshot } from "../../src/agents/agents.ts";
+
+function writeAgent(dir: string, name: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, `${name}.md`), `---\nname: ${name}\ndescription: exclusion test\n---\nbody\n`);
+}
+
+function recordReads(): string[] {
+	const reads: string[] = [];
+	const readdir = fs.readdirSync;
+	const readFile = fs.readFileSync;
+	mock.method(fs, "readdirSync", (...args: Parameters<typeof fs.readdirSync>) => {
+		reads.push(String(args[0]));
+		return readdir(...args);
+	});
+	mock.method(fs, "readFileSync", (...args: Parameters<typeof fs.readFileSync>) => {
+		reads.push(String(args[0]));
+		return readFile(...args);
+	});
+	return reads;
+}
+
+describe("settings subagents.agentExcludeDirs", () => {
+	let root: string;
+	let user: string;
+	let project: string;
+	let previousAgentDir: string | undefined;
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-exclude-"));
+		user = path.join(root, "user");
+		project = path.join(root, "project");
+		fs.mkdirSync(user);
+		fs.mkdirSync(path.join(project, ".pi"), { recursive: true });
+		previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = user;
+		clearAgentDiscoveryCache();
+	});
+	afterEach(() => {
+		mock.restoreAll();
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+		fs.rmSync(root, { recursive: true, force: true });
+		clearAgentDiscoveryCache();
+	});
+	function settings(dir: string, subagents: unknown, extra = {}): void {
+		fs.writeFileSync(path.join(dir, "settings.json"), JSON.stringify({ subagents, ...extra }));
+	}
+
+	it("prunes nested sources, diagnostics and explicit roots in every projection while retaining legacy agents", () => {
+		const userPlugins = path.join(user, "agents", "plugins");
+		const projectPlugins = path.join(project, ".agents", "plugins");
+		writeAgent(path.join(user, "agents"), "user-legacy");
+		writeAgent(path.join(project, ".agents"), "project-legacy");
+		for (const dir of [userPlugins, projectPlugins]) {
+			writeAgent(path.join(dir, "nested", "agents"), "plugin-only");
+			writeAgent(dir, "user-legacy");
+			fs.writeFileSync(path.join(dir, "invalid.md"), "---\nname: invalid\n---\nbody");
+		}
+		settings(user, { agentExcludeDirs: ["agents/plugins"], agentScanDirs: [userPlugins, projectPlugins] });
+		settings(path.join(project, ".pi"), { agentExcludeDirs: ["../.agents/plugins"] });
+		for (const scope of ["user", "project", "both"] as const) {
+			for (const result of [discoverAgents(project, scope), discoverAgentSnapshot(project, scope, undefined, { includeChains: false }).effective]) {
+				assert.equal(result.agents.some((agent) => agent.name === "plugin-only"), false);
+				assert.equal(result.agents.some((agent) => agent.name === (scope === "project" ? "project-legacy" : "user-legacy")), true);
+				assert.equal(result.agentDiagnostics?.some((diagnostic) => diagnostic.filePath.includes("plugins")), false);
+				assert.equal(result.directories?.some((directory) => directory.path.includes("plugins")), false);
+			}
+		}
+		const all = discoverAgentsAll(project);
+		assert.equal([...all.user, ...all.project, ...all.package].some((agent) => agent.name === "plugin-only"), false);
+		assert.equal([...all.user, ...all.project, ...all.package].some((agent) => agent.filePath.includes("plugins")), false, "collision inputs must not retain excluded definitions");
+		assert.equal(all.agentDiagnostics?.some((diagnostic) => diagnostic.filePath.includes("plugins")), false);
+	});
+
+	it("invalidates cached exclusions when settings change and discovers later additions after removal", () => {
+		const plugins = path.join(user, "agents", "plugins");
+		writeAgent(plugins, "plugin-cache");
+		assert.equal(discoverAgents(project, "both").agents.some((agent) => agent.name === "plugin-cache"), true);
+		settings(user, { agentExcludeDirs: ["agents/plugins"] });
+		assert.equal(discoverAgents(project, "both").agents.some((agent) => agent.name === "plugin-cache"), false);
+		writeAgent(plugins, "late-plugin");
+		settings(user, { agentExcludeDirs: [] });
+		assert.equal(discoverAgents(project, "both").agents.some((agent) => agent.name === "late-plugin"), true);
+	});
+
+	it("matches real paths and symlink aliases without matching sibling prefixes", () => {
+		const plugins = path.join(user, "agents", "plugins");
+		writeAgent(plugins, "hidden-alias");
+		writeAgent(`${plugins}-kept`, "sibling-kept");
+		writeAgent(path.join(plugins, "..kept"), "hidden-descendant");
+		fs.symlinkSync(plugins, path.join(user, "agents", "alias"), "dir");
+		fs.symlinkSync(path.join(plugins, "hidden-alias.md"), path.join(user, "agents", "alias.md"));
+		fs.symlinkSync(plugins, path.join(root, "excluded-alias"), "dir");
+		settings(user, { agentExcludeDirs: [path.join(root, "excluded-alias", ".")], agentScanDirs: [plugins] });
+		const names = discoverAgents(project, "both").agents.map((agent) => agent.name);
+		assert.equal(names.includes("hidden-alias"), false);
+		assert.equal(names.includes("hidden-descendant"), false);
+		assert.equal(names.includes("sibling-kept"), true);
+		fs.unlinkSync(path.join(root, "excluded-alias"));
+		fs.symlinkSync(`${plugins}-kept`, path.join(root, "excluded-alias"), "dir");
+		const retargeted = discoverAgents(project, "both").agents.map((agent) => agent.name);
+		assert.equal(retargeted.includes("hidden-alias"), true);
+		assert.equal(retargeted.includes("sibling-kept"), false);
+	});
+
+	it("invalidates excluded explicit scan-root aliases when retargeted to allowed storage", () => {
+		const hidden = path.join(root, "hidden");
+		const allowed = path.join(root, "allowed");
+		writeAgent(hidden, "hidden-retarget");
+		writeAgent(allowed, "allowed-retarget");
+		for (const scope of ["user", "project"] as const) {
+			clearAgentDiscoveryCache();
+			const alias = path.join(root, `${scope}-scan-alias`);
+			fs.symlinkSync(hidden, alias, "dir");
+			settings(user, { agentExcludeDirs: [hidden], ...(scope === "user" ? { agentScanDirs: [alias] } : {}) });
+			settings(path.join(project, ".pi"), scope === "project" ? { agentScanDirs: [alias] } : {});
+			const reads = recordReads();
+			for (let attempt = 0; attempt < 2; attempt++) {
+				const initial = discoverAgentSnapshot(project, "both", undefined, { includeChains: false });
+				assert.equal(initial.effective.agents.some((agent) => agent.name.endsWith("-retarget")), false);
+			}
+			assert.equal(reads.some((filePath) => [hidden, alias].some((dir) => filePath === dir || filePath.startsWith(`${dir}${path.sep}`))), false);
+			mock.restoreAll();
+			fs.unlinkSync(alias);
+			fs.symlinkSync(allowed, alias, "dir");
+			const cached = discoverAgentSnapshot(project, "both", undefined, { includeChains: false });
+			assert.equal(cached.effective.agents.some((agent) => agent.name === "allowed-retarget"), true);
+			assert.equal(cached.all[scope].some((agent) => agent.name === "allowed-retarget"), true);
+			clearAgentDiscoveryCache();
+			assert.deepEqual(cached.effective.agents.map((agent) => agent.filePath), discoverAgents(project, "both").agents.map((agent) => agent.filePath));
+		}
+	});
+
+	for (const source of ["wildcard", "environment", "package", "fixed"] as const) it(`invalidates excluded ${source} root aliases on reverse retarget`, () => {
+		const hidden = path.join(root, "hidden");
+		const allowed = path.join(root, "allowed");
+		const container = path.join(root, "sources", "child");
+		fs.mkdirSync(container, { recursive: true });
+		const alias = path.join(source === "fixed" ? user : container, "agents");
+		writeAgent(hidden, "hidden-source");
+		writeAgent(allowed, "allowed-source");
+		fs.symlinkSync(hidden, alias, "dir");
+		const previousExtraDirs = process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
+		try {
+			if (source === "environment") process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS = alias;
+			if (source === "package") fs.writeFileSync(path.join(container, "package.json"), JSON.stringify({ name: "alias-fixture", "pi-subagents": { agents: ["./agents"] } }));
+			settings(user, { agentExcludeDirs: [hidden], ...(source === "wildcard" ? { agentScanDirs: [path.join(root, "sources", "*", "agents")] } : {}) }, source === "package" ? { packages: [container] } : {});
+			assert.equal(discoverAgents(project, "both").agents.some((agent) => agent.name === "allowed-source"), false);
+			fs.unlinkSync(alias);
+			fs.symlinkSync(allowed, alias, "dir");
+			assert.equal(discoverAgents(project, "both").agents.some((agent) => agent.name === "allowed-source"), true);
+			assert.equal(discoverAgents(project, "user").agents.some((agent) => agent.name === "allowed-source"), true);
+			const all = discoverAgentsAll(project);
+			assert.equal([...all.user, ...all.package].some((agent) => agent.name === "allowed-source"), true);
+		} finally {
+			if (previousExtraDirs === undefined) delete process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS;
+			else process.env.PI_SUBAGENT_EXTRA_AGENT_DIRS = previousExtraDirs;
+		}
+	});
+
+	it("resolves home paths and missing descendants through symlinked ancestors", () => {
+		const previousHome = process.env.HOME;
+		const previousUserProfile = process.env.USERPROFILE;
+		try {
+			process.env.HOME = root;
+			process.env.USERPROFILE = root;
+			const plugins = path.join(user, "agents", "plugins");
+			fs.mkdirSync(plugins, { recursive: true });
+			fs.symlinkSync(plugins, path.join(root, "plugin-alias"), "dir");
+			settings(user, { agentExcludeDirs: ["~/plugin-alias/later"], agentScanDirs: [path.join(plugins, "*", "agents")] });
+			discoverAgents(project, "both");
+			writeAgent(path.join(plugins, "later", "agents"), "missing-hidden");
+			writeAgent(path.join(plugins, "later-kept", "agents"), "missing-kept");
+			const names = discoverAgents(project, "both").agents.map((agent) => agent.name);
+			assert.equal(names.includes("missing-hidden"), false);
+			assert.equal(names.includes("missing-kept"), true);
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+			if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+			else process.env.USERPROFILE = previousUserProfile;
+		}
+	});
+
+	it("does not read or traverse excluded trees on fresh scans or cache fingerprints", () => {
+		const plugins = path.join(user, "agents", "plugins");
+		writeAgent(plugins, "never-read");
+		writeAgent(path.join(user, "agents"), "kept");
+		settings(user, { agentExcludeDirs: [plugins] });
+		const reads = recordReads();
+		for (const scope of ["user", "project", "both"] as const) discoverAgents(project, scope);
+		discoverAgentsAll(project);
+		assert.equal(reads.some((filePath) => filePath === plugins || filePath.startsWith(`${plugins}${path.sep}`)), false);
+		reads.length = 0;
+		writeAgent(path.join(plugins, "late"), "still-hidden");
+		discoverAgents(project, "both");
+		assert.equal(reads.some((filePath) => filePath === plugins || filePath.startsWith(`${plugins}${path.sep}`)), false);
+		assert.equal(reads.includes(path.join(user, "agents", "kept.md")), false, "excluded changes must not force a source reload");
+	});
+
+	it("does not re-include excluded package roots or change chain discovery", () => {
+		const pkg = path.join(root, "pkg");
+		writeAgent(path.join(pkg, "agents"), "package-hidden");
+		fs.writeFileSync(path.join(pkg, "package.json"), JSON.stringify({ name: "exclude-fixture", "pi-subagents": { agents: ["./agents"], chains: ["./agents"] } }));
+		fs.writeFileSync(path.join(pkg, "agents", "kept.chain.json"), JSON.stringify({ name: "kept-chain", description: "Retained chain", chain: [{ agent: "scout", task: "Inspect" }] }));
+		settings(user, {}, { packages: [pkg] });
+		assert.equal(discoverAgentsAll(project).package.some((agent) => agent.name === "package-hidden"), true);
+		settings(user, { agentExcludeDirs: [path.join(pkg, "agents")] }, { packages: [pkg] });
+		const all = discoverAgentsAll(project);
+		assert.equal(all.package.some((agent) => agent.name === "package-hidden"), false);
+		assert.equal(all.chains.some((chain) => chain.name === "kept-chain"), true);
+		fs.writeFileSync(path.join(pkg, "agents", "late.chain.json"), JSON.stringify({ name: "late-chain", description: "New chain", chain: [{ agent: "scout", task: "Inspect" }] }));
+		assert.equal(discoverAgentsAll(project).chains.some((chain) => chain.name === "late-chain"), true);
+	});
+
+	it("invalidates agent-only discovery when an excluded package declares an allowed external root", () => {
+		const pkg = path.join(root, "pkg");
+		const excludedAgents = path.join(pkg, "agents");
+		writeAgent(excludedAgents, "package-hidden");
+		writeAgent(path.join(root, "allowed"), "outside");
+		const manifest = path.join(pkg, "package.json");
+		fs.writeFileSync(manifest, JSON.stringify({ name: "fixture", "pi-subagents": { agents: ["./agents"] } }));
+		settings(user, { agentExcludeDirs: [pkg] }, { packages: [pkg] });
+		const reads = recordReads();
+		assert.equal(discoverAgents(project, "both").agents.some((agent) => agent.name === "outside"), false);
+		fs.writeFileSync(manifest, JSON.stringify({ name: "fixture", "pi-subagents": { agents: ["../allowed"] } }));
+		const cached = discoverAgents(project, "both");
+		assert.equal(cached.agents.some((agent) => agent.name === "outside"), true);
+		assert.equal(cached.agents.some((agent) => agent.name === "package-hidden"), false);
+		assert.equal(discoverAgentSnapshot(project, "both", undefined, { includeChains: false }).all.package.some((agent) => agent.name === "outside"), true);
+		clearAgentDiscoveryCache();
+		assert.deepEqual(cached.agents.map((agent) => agent.filePath), discoverAgents(project, "both").agents.map((agent) => agent.filePath));
+		assert.equal(reads.some((filePath) => filePath === excludedAgents || filePath.startsWith(`${excludedAgents}${path.sep}`)), false);
+	});
+
+	it("rejects malformed exclusions in participating settings", () => {
+		settings(user, { agentExcludeDirs: [42] });
+		assert.throws(() => discoverAgents(project, "user"), /invalid 'agentExcludeDirs'/);
+		assert.throws(() => discoverAgents(project, "both"), /invalid 'agentExcludeDirs'/);
+	});
+});


### PR DESCRIPTION
## Summary

- add `subagents.agentExcludeDirs` to prune configured agent-discovery subtrees before traversal
- apply exclusions consistently to explicit, package, scan, diagnostic, and cache-fingerprint paths while retaining bundled snapshot behavior
- preserve package metadata watches so manifest redirects to allowed roots invalidate cached discovery

Closes #2131.

Thanks to [@xarillian](https://github.com/xarillian) for reporting #2131.

## Validation

- 119 focused agent discovery/frontmatter tests
- `npm run typecheck`
- cached/fresh parity and snapshot-first package-manifest invalidation reproduction
- `git diff --check`

## Review evidence

The substantial candidate completed scope challenge, second challenge, deslop, simplification, and fresh independent review. A targeted follow-up review validated the package-manifest cache correction. Promotion onto current `main` changed only CHANGELOG placement; focused tests and typecheck were rerun on this exact head.
