### PR TITLE
fix(reviewers): provide bounded diff evidence

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -50,7 +50,8 @@ Review a PR or issue by understanding the context, then verifying:
 - Tests and docs are updated as needed.
 
 ## Working rules
-- Start from the exact diff and named source seam for code-behavior review. Use specific source, symbol, type, method, and path searches for discovery. Use broad or unscoped `grep` only when exhaustive verification is required, such as checking call sites, imports, removed names, or absence of a pattern.
+- Start from `watchdog_diff` for bounded current-change evidence when it is available, then inspect changed files with `read`, `grep`, `find`, and `ls`. Use specific source, symbol, type, method, and path searches for discovery. Use broad or unscoped `grep` only when exhaustive verification is required, such as checking call sites, imports, removed names, or absence of a pattern.
+- Never read `.git` paths. If `watchdog_diff` is unavailable, fail closed: ask the parent for the exact diff or changed-file list instead of probing Git internals.
 - Read the relevant files first. Read plan and progress when the task supplies them.
 - Repo-local `progress.md` files are allowed scratch/memory files. Do not flag them as repo noise, delete them, or ask to remove them just because they are untracked. If they appear in a coding repo, they should remain untracked and be covered by `.gitignore`.
 - Do not use shell commands or write files. Report any test or Git command that a supervisor must run.

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -17,6 +17,7 @@ import { planChildLaunch, resolveStepBehavior, suppressProgressForReadOnlyTask, 
 import { applyThinkingSuffix, getHostBuiltinToolNames, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/child-tool-plan.ts";
 import { injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { applyWatchdogLaunchRules, sendRuleViolationWarning } from "../../watchdog/rules.ts";
+import { resolveWatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 import { buildChainInstructions, isDynamicParallelStep, isParallelStep, resolveExistingReadInstructionPaths, resolveExistingReadPaths, writeInitialProgressFile, type ChainStep, type SequentialStep, type StepOverrides } from "../../shared/settings.ts";
 import type { RunnerStep } from "../shared/parallel-utils.ts";
 import type { ContextMode } from "../shared/context-mode.ts";
@@ -150,6 +151,8 @@ interface AsyncExecutionContext {
 	interactive?: boolean;
 	/** The executor's own child runtime when the launch comes from an in-process child. */
 	childRuntime?: ChildRuntimeConfig;
+	/** Session-start repository baseline exposed to reviewer lanes through watchdog_diff. */
+	watchdogDiffBaseline?: import("../../watchdog/diff-tool.ts").WatchdogDiffBaseline;
 }
 
 export const DEFAULT_ASYNC_TIMEOUT_MS = 30 * 60 * 1000;
@@ -891,6 +894,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			resolvedBehavior,
 		});
 		const { stepCwd, instructionCwd, readExistenceCwd, behavior, namespaceOutputPath, outputPath, skillNames } = launchPlan;
+		const stepWatchdogDiffBaseline = resolveWatchdogDiffBaseline(stepCwd, ctx.watchdogDiffBaseline, true);
 		const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
 			skillNames,
 			stepCwd,
@@ -983,6 +987,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			permissionRules,
 			runtimeSnapshotHost: ctx.pi,
 			hostAvailableBuiltins,
+			watchdogDiffBaseline: stepWatchdogDiffBaseline,
 		});
 		const launchResolvedExtensions = externalRunner ? undefined : projectLaunchResolvedChildExtensions(toolPlan);
 		if (externalRunner && permissionRules) {
@@ -1362,6 +1367,7 @@ export function executeAsyncChain(
 				piPackageRoot,
 				childSessionFactoryModule: childSessionFactoryModule(),
 				inheritedChildRuntime: inheritedChildRuntime(ctx.childRuntime),
+				watchdogDiffBaseline: ctx.watchdogDiffBaseline,
 				worktreeSetupHook,
 				worktreeSetupHookTimeoutMs,
 				worktreeBaseDir,
@@ -1858,6 +1864,7 @@ export function executeAsyncSingle(
 		...(params.acceptance !== undefined ? { acceptance: params.acceptance } : {}),
 		...(controlConfig ? { controlConfig } : {}),
 		...(params.context ? { context: params.context } : {}),
+		...(ctx.watchdogDiffBaseline ? { watchdogDiffBaseline: ctx.watchdogDiffBaseline } : {}),
 		...(params.intercomBridge !== undefined ? { intercomBridge: params.intercomBridge } : {}),
 		...(params.baseRef !== undefined ? { baseRef: params.baseRef } : {}),
 		...(deadlineAt !== undefined ? { absoluteDeadlineAt: deadlineAt } : {}),
@@ -1958,6 +1965,7 @@ export function executeAsyncSingle(
 				piPackageRoot,
 				childSessionFactoryModule: childSessionFactoryModule(),
 				inheritedChildRuntime: inheritedChildRuntime(ctx.childRuntime),
+				watchdogDiffBaseline: ctx.watchdogDiffBaseline,
 				worktreeSetupHook,
 				worktreeSetupHookTimeoutMs,
 				worktreeBaseDir,

--- a/src/runs/background/async-resume.ts
+++ b/src/runs/background/async-resume.ts
@@ -17,6 +17,7 @@ import { intersectThinkingCeilings, parseThinkingLevel, type ThinkingLevel } fro
 import { assertWorkflowGraphHostSteps } from "../shared/host-step-status.ts";
 import { validateIntercomBridgeConfig } from "../../intercom/intercom-bridge.ts";
 import { validateModelResponseAliases } from "../../shared/model-response-aliases.ts";
+import type { WatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 
 export interface AsyncResumeParams {
 	id?: string;
@@ -59,6 +60,7 @@ export type AsyncResumeTarget = {
 	launchContractDigest?: string;
 	runner?: NonNullable<AsyncStatus["steps"]>[number]["runner"];
 	externalJob?: NonNullable<AsyncStatus["steps"]>[number]["externalJob"];
+	watchdogDiffBaseline?: WatchdogDiffBaseline;
 };
 
 interface AsyncResultFile {
@@ -323,7 +325,7 @@ export function readAsyncRecoveryDescriptor(asyncDir: string | undefined): Steer
 		"subagentOnlyExtensions", "mcpDirectTools", "excludeTools", "mutationTools", "systemPrompt", "systemPromptMode", "inheritProjectContext", "inheritGlobalContext", "inheritSkills", "skills",
 		"skillPath", "agentFilePath", "completionGuard", "memory", "outputPath", "outputMode", "structuredOutputSchema", "acceptance", "sessionDir", "artifactConfig",
 		"artifactsDir", "maxOutput", "controlConfig", "context", "intercomBridge", "absoluteDeadlineAt", "initialTurnBudget", "initialToolBudget", "maxSubagentDepth", "share", "capabilityCeiling",
-		"launchResolvedExtensions", "runFanoutBudget", "lane", "baseRef",
+		"launchResolvedExtensions", "runFanoutBudget", "lane", "baseRef", "watchdogDiffBaseline",
 		"extensionBindings",
 	]);
 	for (const field of Object.keys(parsed)) {
@@ -509,6 +511,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 					...(capabilityCeiling ? { capabilityCeiling } : {}),
 					...(selectedStep.thinkingCeiling ? { thinkingCeiling: selectedStep.thinkingCeiling } : {}),
 					...(recoveryDescriptor ? { recoveryDescriptor } : {}),
+					...(status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline ? { watchdogDiffBaseline: status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline } : {}),
 				};
 			}
 			if (selectedStep?.status === "pending") throw new Error(`Async run '${runId}' child ${requestedIndex} is pending and has not started yet. Wait for it to run or complete before resuming.`);
@@ -541,6 +544,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 				...(capabilityCeiling ? { capabilityCeiling } : {}),
 				...(selected.step.thinkingCeiling ? { thinkingCeiling: selected.step.thinkingCeiling } : {}),
 				...(recoveryDescriptor ? { recoveryDescriptor } : {}),
+				...(status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline ? { watchdogDiffBaseline: status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline } : {}),
 			};
 		}
 	}
@@ -588,6 +592,7 @@ export function resolveAsyncResumeTarget(params: AsyncResumeParams, deps: AsyncR
 		...(capabilityCeiling ? { capabilityCeiling } : {}),
 		...(thinkingCeiling ? { thinkingCeiling } : {}),
 		...(recoveryDescriptor ? { recoveryDescriptor } : {}),
+		...(status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline ? { watchdogDiffBaseline: status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline } : {}),
 	};
 }
 

--- a/src/runs/background/runner-child-launch.ts
+++ b/src/runs/background/runner-child-launch.ts
@@ -2,6 +2,7 @@
 import * as path from "node:path";
 import { buildInProcessChildLaunch, type BuildInProcessChildLaunchInput, type InheritedChildRuntime } from "../shared/child-launch.ts";
 import { deriveForkPromptCacheKey } from "../shared/child-tool-plan.ts";
+import { resolveWatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 import { normalizeExtensionBindings } from "../shared/extension-bindings.ts";
 import type { RunnerSubagentStep } from "../shared/parallel-utils.ts";
 import { formatAcceptancePrompt } from "../shared/acceptance.ts";
@@ -19,6 +20,7 @@ export interface RunnerChildLaunchContext {
 	capabilityCeiling?: BuildInProcessChildLaunchInput["capabilityCeiling"];
 	inheritedChildRuntime?: InheritedChildRuntime;
 	hostAvailableBuiltins?: readonly string[];
+	watchdogDiffBaseline?: BuildInProcessChildLaunchInput["watchdogDiffBaseline"];
 }
 
 export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChildLaunchContext, attempt: {
@@ -83,6 +85,7 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 		maxSubagentDepth: step.maxSubagentDepth,
 		inherited: ctx.inheritedChildRuntime,
 		hostAvailableBuiltins: ctx.hostAvailableBuiltins,
+		watchdogDiffBaseline: resolveWatchdogDiffBaseline(step.cwd ?? ctx.cwd, ctx.watchdogDiffBaseline, true),
 		host: "runner",
 	});
 }

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -160,6 +160,7 @@ import { effectiveToolTimeoutMs, formatToolTimeoutMessage, toolTimeoutCallKey } 
 import { usageBudgetExceededMessage, usageBudgetState } from "../shared/usage-budget.ts";
 import { formatParallelHandoffError, formatParallelHandoffReference, parallelHandoffPath, writeParallelHandoffGroup, writeWorktreeSetupHandoff } from "../shared/parallel-handoff.ts";
 import { resolveWatchdogConfig } from "../../watchdog/settings.ts";
+import { resolveWatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 import { acquireSessionLease, type SessionLeaseRequest } from "../shared/session-lease.ts";
 import { buildExternalCliPrompt, runExternalCli } from "../shared/external-cli-runner.ts";
 import { resolveClaudeCodeLaunch } from "../shared/claude-code-adapter.ts";
@@ -234,6 +235,8 @@ export interface SubagentRunConfig {
 	runFanoutBudget?: RunFanoutBudgetDescriptor;
 	/** Builtin tool names the host runtime provides; used to intersect agent-declared tools. */
 	hostAvailableBuiltins?: readonly string[];
+	/** Session-start repository baseline exposed to reviewer lanes through watchdog_diff. */
+	watchdogDiffBaseline?: import("../../watchdog/diff-tool.ts").WatchdogDiffBaseline;
 	launchContractDigest?: string;
 	launchResolvedExtensions?: LaunchResolvedChildExtensions;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensions;
@@ -679,6 +682,8 @@ interface SingleStepContext {
 	childSessions: ChildSessionFactory;
 	/** The launching executor's own child runtime; nested route, depth, and ceilings come from here. */
 	inheritedChildRuntime?: InheritedChildRuntime;
+	/** Session-start repository baseline exposed to reviewer lanes through watchdog_diff. */
+	watchdogDiffBaseline?: import("../../watchdog/diff-tool.ts").WatchdogDiffBaseline;
 	registerInterrupt?: (interrupt: (() => void) | undefined) => void;
 	registerTimeout?: (interrupt: (() => void) | undefined) => void;
 	registerStop?: (stop: (() => void) | undefined) => void;
@@ -816,6 +821,7 @@ export async function runSingleStepInner(
 			capabilityCeiling: step.capabilityCeiling ?? ctx.capabilityCeiling,
 			inheritedCapabilityCeiling: ctx.inheritedChildRuntime?.capabilityCeiling,
 			permissionRules: step.permissionRules,
+			watchdogDiffBaseline: resolveWatchdogDiffBaseline(step.cwd ?? ctx.cwd, ctx.watchdogDiffBaseline, true),
 			hostAvailableBuiltins: ctx.hostAvailableBuiltins,
 		}));
 		const contractTools = resolvedTaskToolPlan.explicitToolAllowlist ? resolvedTaskToolPlan.effectiveToolAllowlist : undefined;
@@ -1155,6 +1161,7 @@ export async function runSingleStepInner(
 				capabilityCeiling: step.capabilityCeiling ?? ctx.capabilityCeiling,
 				inheritedCapabilityCeiling: ctx.inheritedChildRuntime?.capabilityCeiling,
 				permissionRules: step.permissionRules,
+				watchdogDiffBaseline: resolveWatchdogDiffBaseline(step.cwd ?? ctx.cwd, ctx.watchdogDiffBaseline, true),
 				hostAvailableBuiltins: ctx.hostAvailableBuiltins,
 			}));
 			launchResolvedExtensions = projectLaunchResolvedChildExtensions(toolPlan);
@@ -2109,6 +2116,7 @@ export async function runSubagent(
 		...(config.usageBudget ? { usageBudget: usageBudgetState(config.usageBudget, undefined) } : {}),
 		pid: process.pid,
 		cwd,
+		...(config.watchdogDiffBaseline ? { watchdogDiffBaseline: config.watchdogDiffBaseline } : {}),
 		currentStep: 0,
 		chainStepCount: steps.length,
 		parallelGroups,
@@ -3696,6 +3704,7 @@ export async function runSubagent(
 					capabilityCeiling: config.capabilityCeiling,
 					runFanoutBudget: config.runFanoutBudget,
 					hostAvailableBuiltins: config.hostAvailableBuiltins,
+					watchdogDiffBaseline: config.watchdogDiffBaseline,
 					registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 					registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 					registerStop: (stop) => registerStepStop(fi, stop),
@@ -4108,6 +4117,7 @@ export async function runSubagent(
 							capabilityCeiling: config.capabilityCeiling,
 							runFanoutBudget: config.runFanoutBudget,
 							hostAvailableBuiltins: config.hostAvailableBuiltins,
+							watchdogDiffBaseline: config.watchdogDiffBaseline,
 							registerInterrupt: (interrupt) => registerStepInterrupt(fi, interrupt),
 							registerTimeout: (interrupt) => registerStepTimeout(fi, interrupt),
 							registerStop: (stop) => registerStepStop(fi, stop),
@@ -4510,6 +4520,7 @@ export async function runSubagent(
 				capabilityCeiling: config.capabilityCeiling,
 				runFanoutBudget: config.runFanoutBudget,
 				hostAvailableBuiltins: config.hostAvailableBuiltins,
+				watchdogDiffBaseline: config.watchdogDiffBaseline,
 				registerInterrupt: (interrupt) => registerStepInterrupt(flatIndex, interrupt),
 				registerTimeout: (interrupt) => registerStepTimeout(flatIndex, interrupt),
 				registerStop: (stop) => registerStepStop(flatIndex, stop),

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -443,6 +443,7 @@ async function runSingleAttempt(
 		maxSubagentDepth: options.maxSubagentDepth,
 		runtimeSnapshotHost: options.runtimeSnapshotHost,
 		hostAvailableBuiltins: options.hostAvailableBuiltins,
+		watchdogDiffBaseline: options.watchdogDiffBaseline,
 		inherited: options.childRuntime,
 		host: "parent",
 	});

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -28,6 +28,7 @@ import { runSync } from "./execution.ts";
 import { handleWatchdogToolAction, WATCHDOG_TOOL_ACTIONS } from "../../watchdog/tool-actions.ts";
 import type { MainWatchdogRuntime } from "../../watchdog/runtime.ts";
 import { applyWatchdogLaunchRules } from "../../watchdog/rules.ts";
+import { resolveWatchdogDiffBaseline, type WatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 import { buildModelCandidates, normalizeParentModel, resolveEffectiveSubagentModel, resolveModelOrigin, type ModelOrigin, type ParentModel } from "../shared/model-fallback.ts";
 import { getHostBuiltinToolNames } from "../shared/child-tool-plan.ts";
 import { formatRetainedChildren, listRetainedChildren } from "../background/retained-children.ts";
@@ -522,6 +523,7 @@ interface ExecutionContextData {
 	topLevelAsyncCapacityEligible: boolean;
 	activeAsyncCapacity?: ActiveAsyncCapacityHandle;
 	workflowChildPermitLaunch?: WorkflowChildPermitContext;
+	watchdogDiffBaseline?: WatchdogDiffBaseline;
 }
 
 function resolveRequestedCwd(runtimeCwd: string, requestedCwd: string | undefined): string {
@@ -746,7 +748,7 @@ function foregroundChildActivityFromProgress(progress: SingleResult["progress"] 
 	};
 }
 
-function rememberForegroundRun(state: SubagentState, input: { modelResponseAliases?: Record<string, string[]>; runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; results: SingleResult[]; params: SubagentParamsLike; effectiveOutput?: string | boolean; effectiveOutputMode: OutputMode; extensionBindings?: ExtensionBindings }): void {
+function rememberForegroundRun(state: SubagentState, input: { modelResponseAliases?: Record<string, string[]>; runId: string; mode: "single" | "parallel" | "chain"; cwd: string; sessionId: string | null; results: SingleResult[]; params: SubagentParamsLike; effectiveOutput?: string | boolean; effectiveOutputMode: OutputMode; extensionBindings?: ExtensionBindings; watchdogDiffBaseline?: WatchdogDiffBaseline }): void {
 	state.foregroundRuns ??= new Map();
 	const previous = state.foregroundRuns.get(input.runId);
 	const updatedAt = Date.now();
@@ -755,6 +757,7 @@ function rememberForegroundRun(state: SubagentState, input: { modelResponseAlias
 		mode: input.mode,
 		cwd: input.cwd,
 		...(input.sessionId ? { sessionId: input.sessionId } : {}),
+		...(input.watchdogDiffBaseline ? { watchdogDiffBaseline: input.watchdogDiffBaseline } : {}),
 		updatedAt,
 		children: input.results.map((result, index) => {
 			const resumeContract = omitUndefinedProperties({
@@ -917,7 +920,7 @@ function updateRememberedForegroundChild(state: SubagentState, input: { runId: s
 	});
 }
 
-function resolveForegroundResumeTarget(params: SubagentParamsLike, state: SubagentState, options: { exactOnly?: boolean } = {}): { runId: string; mode: SubagentRunMode; state: "complete"; agent: string; index: number; cwd: string; sessionFile: string; model?: string; thinking?: string; launchContractDigest?: string; resumeContract?: ForegroundResumeChild["resumeContract"]; extensionBindings?: ExtensionBindings; capabilityCeiling?: ResolvedSubagentCapabilityCeiling } | undefined {
+function resolveForegroundResumeTarget(params: SubagentParamsLike, state: SubagentState, options: { exactOnly?: boolean } = {}): { runId: string; mode: SubagentRunMode; state: "complete"; agent: string; index: number; cwd: string; sessionFile: string; model?: string; thinking?: string; launchContractDigest?: string; resumeContract?: ForegroundResumeChild["resumeContract"]; extensionBindings?: ExtensionBindings; capabilityCeiling?: ResolvedSubagentCapabilityCeiling; watchdogDiffBaseline?: WatchdogDiffBaseline } | undefined {
 	const requested = (params.id ?? params.runId)?.trim();
 	if (!requested || !state.foregroundRuns?.size || !state.currentSessionId) return undefined;
 	const direct = state.foregroundRuns.get(requested);
@@ -951,6 +954,7 @@ function resolveForegroundResumeTarget(params: SubagentParamsLike, state: Subage
 		...(child.resumeContract ? { resumeContract: child.resumeContract } : {}),
 		...(child.extensionBindings ? { extensionBindings: normalizeExtensionBindings(child.extensionBindings)!.value } : {}),
 		...(child.capabilityCeiling ? { capabilityCeiling: child.capabilityCeiling } : {}),
+		...(run.watchdogDiffBaseline ? { watchdogDiffBaseline: run.watchdogDiffBaseline } : {}),
 	};
 }
 
@@ -969,6 +973,7 @@ type NestedResumeSourceTarget = {
 	thinking?: AgentConfig["thinking"];
 	launchContractDigest?: string;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
+	watchdogDiffBaseline?: WatchdogDiffBaseline;
 	recoveryDescriptor?: SteeringRecoveryDescriptor;
 };
 type ResumeSourceTarget = AsyncResumeSourceTarget | ForegroundResumeSourceTarget | NestedResumeSourceTarget;
@@ -1322,6 +1327,7 @@ function appendStepToAsyncChain(input: {
 		};
 	}
 
+	const watchdogDiffBaseline = status.watchdogDiffBaseline;
 	const scope: AgentScope = resolveExecutionAgentScope(input.params.agentScope);
 	const discoveredForAppend = input.deps.discoverAgents(input.requestCwd, scope, input.parentModel?.provider);
 	const agents = discoveredForAppend.agents;
@@ -1341,6 +1347,7 @@ function appendStepToAsyncChain(input: {
 		interactive: input.ctx.hasUI,
 		permissions: input.deps.config.permissions,
 		childRuntime: input.deps.childRuntime,
+		watchdogDiffBaseline,
 	});
 	const built = buildAsyncRunnerSteps(resolved.id, compactOptional<Parameters<typeof buildAsyncRunnerSteps>[1]>({
 		chain: wrapChainTasksForFork(chain, contextPolicy),
@@ -1440,6 +1447,17 @@ function pathWithin(base: string, candidate: string): boolean {
 	return resolvedCandidate === resolvedBase || resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`);
 }
 
+function validateNestedResumeCwd(runId: string, cwd: string | undefined): string | undefined {
+	if (!cwd) return undefined;
+	const resolved = path.resolve(cwd);
+	try {
+		if (!fs.statSync(resolved).isDirectory()) throw new Error("path is not a directory");
+	} catch (error) {
+		throw new Error(`Nested run '${runId}' required cwd does not exist: ${cwd}`, { cause: error instanceof Error ? error : undefined });
+	}
+	return resolved;
+}
+
 function validateNestedSessionFile(run: NestedRunSummary, trustedSessionRoots: string[]): string {
 	const sessionFile = nestedRunSessionFile(run);
 	if (!sessionFile) throw new Error(`Nested run '${run.id}' does not have a persisted session file to resume from.`);
@@ -1470,7 +1488,7 @@ export function readNestedRecoveryDescriptor(asyncDir: string | undefined, runId
 	return recoveryDescriptor;
 }
 
-function resolveNestedResumeTarget(match: ResolvedSubagentRunId & { kind: "nested" }, trustedSessionRoots: string[]): NestedResumeSourceTarget {
+export function resolveNestedResumeTarget(match: ResolvedSubagentRunId & { kind: "nested" }, trustedSessionRoots: string[]): NestedResumeSourceTarget {
 	const run = match.match.run;
 	if (run.state === "running" || run.state === "queued") throw new Error(`Nested run '${run.id}' is live; route the follow-up to the owner process instead.`);
 	if (run.state === "stopped") throw new Error(`Nested run '${run.id}' was stopped and cannot be resumed. Start a new run instead.`);
@@ -1479,6 +1497,7 @@ function resolveNestedResumeTarget(match: ResolvedSubagentRunId & { kind: "neste
 	const state = run.state === "complete" || run.state === "failed" || run.state === "paused" ? run.state : "failed";
 	const asyncDir = resolveNestedAsyncDir(match.match.rootRunId, run);
 	const recoveryDescriptor = readNestedRecoveryDescriptor(asyncDir, run.id, agent);
+	const status = asyncDir ? readStatus(asyncDir) : undefined;
 	return compactOptional<NestedResumeSourceTarget>({
 		kind: "revive",
 		source: "nested",
@@ -1486,9 +1505,12 @@ function resolveNestedResumeTarget(match: ResolvedSubagentRunId & { kind: "neste
 		state,
 		agent,
 		index: 0,
-		cwd: asyncDir ? path.dirname(asyncDir) : undefined,
+		cwd: validateNestedResumeCwd(run.id, status?.cwd ?? recoveryDescriptor?.cwd ?? (asyncDir ? path.dirname(asyncDir) : undefined)),
 		sessionFile: validateNestedSessionFile(run, trustedSessionRoots),
 		...(run.capabilityCeiling ? { capabilityCeiling: run.capabilityCeiling } : {}),
+		...((status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline)
+			? { watchdogDiffBaseline: status?.watchdogDiffBaseline ?? recoveryDescriptor?.watchdogDiffBaseline }
+			: {}),
 		...(recoveryDescriptor ? { recoveryDescriptor } : {}),
 	});
 }
@@ -1653,6 +1675,7 @@ async function resumeExternalJobFollowUp(input: {
 	intercomBridge: IntercomBridgeState;
 	parentSessionFile: string | null;
 	absoluteDeadlineAt?: number;
+	watchdogDiffBaseline?: WatchdogDiffBaseline;
 }): Promise<AgentToolResult<Details>> {
 	if (input.target.kind === "live" || input.target.state === "running" || input.target.state === "queued") {
 		return { content: [{ type: "text", text: `External-job run '${input.target.runId}' is still running. Wait for completion, then use subagent({ action: "resume", id: "${input.target.runId}", message: "..." }).` }], isError: true, details: { mode: "management", results: [] } };
@@ -1723,6 +1746,7 @@ async function resumeExternalJobFollowUp(input: {
 			interactive: input.ctx.hasUI,
 			permissions: input.deps.config.permissions,
 			childRuntime: input.deps.childRuntime,
+			watchdogDiffBaseline: input.watchdogDiffBaseline,
 		}),
 		cwd: input.effectiveCwd,
 		artifactsDir,
@@ -1848,6 +1872,11 @@ async function resumeAsyncRun(input: {
 
 	input.deps.state.currentSessionId = resolveCurrentSessionId(input.ctx.sessionManager);
 	const effectiveCwd = target.cwd ?? input.requestCwd;
+	const targetWatchdogDiffBaseline = resolveWatchdogDiffBaseline(
+		effectiveCwd,
+		target.watchdogDiffBaseline ?? ("recoveryDescriptor" in target ? target.recoveryDescriptor?.watchdogDiffBaseline : undefined),
+		true,
+	);
 	const scope: AgentScope = resolveExecutionAgentScope(input.params.agentScope);
 	const discovered = input.deps.discoverAgents(effectiveCwd, scope, input.parentModel?.provider);
 	const discoveredAgents = discovered.agents;
@@ -1907,6 +1936,7 @@ async function resumeAsyncRun(input: {
 			intercomBridge,
 			parentSessionFile,
 			absoluteDeadlineAt: input.absoluteDeadlineAt,
+			watchdogDiffBaseline: targetWatchdogDiffBaseline,
 		});
 	}
 
@@ -1974,6 +2004,7 @@ async function resumeAsyncRun(input: {
 				interactive: input.ctx.hasUI,
 		permissions: input.deps.config.permissions,
 		childRuntime: input.deps.childRuntime,
+		watchdogDiffBaseline: targetWatchdogDiffBaseline,
 			}),
 			availableModels,
 			cwd: effectiveCwd,
@@ -2084,6 +2115,7 @@ async function resumeAsyncRun(input: {
 			interactive: input.ctx.hasUI,
 		permissions: input.deps.config.permissions,
 		childRuntime: input.deps.childRuntime,
+		watchdogDiffBaseline: targetWatchdogDiffBaseline,
 		}),
 		cwd: effectiveCwd,
 		maxOutput: input.params.maxOutput ?? recoveryDescriptor?.maxOutput,
@@ -3230,6 +3262,7 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 		interactive: ctx.hasUI,
 		permissions: deps.config.permissions,
 		childRuntime: deps.childRuntime,
+		watchdogDiffBaseline: data.watchdogDiffBaseline,
 	});
 	const availableModels: ModelInfo[] = ctx.modelRegistry.getAvailable().map(toModelInfo);
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth, deps.childRuntime);
@@ -3893,6 +3926,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			permissions: deps.config.permissions,
 			runtimeSnapshotHost: deps.pi,
 			hostAvailableBuiltins: getHostBuiltinToolNames(deps.pi),
+			watchdogDiffBaseline: data.watchdogDiffBaseline,
 			parentSessionId: ctx.sessionManager.getSessionId() ?? undefined,
 			llmIntentArbiter: createTaskMutationArbiter({ model: ctx.model, modelRegistry: ctx.modelRegistry, sessionId: ctx.sessionManager.getSessionId() }),
 			childRuntime: deps.childRuntime,
@@ -4054,7 +4088,7 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		usageBudget: usageBudgetState(data.usageBudget, totalCost),
 		...(worktreeHandoff?.reference ? { parallelHandoff: worktreeHandoff.reference } : {}),
 	}));
-	rememberForegroundRun(deps.state, { modelResponseAliases, runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, results: details.results, params, effectiveOutput, effectiveOutputMode, extensionBindings: params.extensionBindings });
+	rememberForegroundRun(deps.state, { modelResponseAliases, runId, mode: "single", cwd: singleCwd, sessionId: data.parentSessionId, results: details.results, params, effectiveOutput, effectiveOutputMode, extensionBindings: params.extensionBindings, watchdogDiffBaseline: data.watchdogDiffBaseline });
 
 	const suppressRoutineResultIntercom = shouldSuppressRoutineResultIntercom({ suppressRoutineResultIntercom: params.suppressRoutineResultIntercom, results: [r] });
 	if (!r.detached && !r.interrupted && !suppressRoutineResultIntercom) {
@@ -4884,6 +4918,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		ctx: ExtensionContext,
 		preserveActiveSession = false,
 		parentModelOverride?: ParentModel | null,
+		runWatchdogDiffBaseline?: WatchdogDiffBaseline,
 	): Promise<AgentToolResult<Details>> => {
 		const workflowLaunchObserver = workflowLaunchObservers.get(params);
 		const inheritedUsageBudget = workflowOwnedUsageBudgets.get(params);
@@ -4895,6 +4930,9 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const workflowPermitContext = workflowPermitContexts.get(params);
 		const delegatedWorkflowPermit = workflowPermitContext && "root" in workflowPermitContext ? workflowPermitContext.root : undefined;
 		const workflowChildPermitLaunch = workflowPermitContext && "child" in workflowPermitContext ? workflowPermitContext.child : undefined;
+		const requestedRunCwd = resolveRequestedCwd(ctx.cwd, params.cwd);
+		const inheritedWatchdogDiffBaseline = runWatchdogDiffBaseline ?? deps.childRuntime?.watchdogDiffBaseline;
+		const watchdogDiffBaseline = resolveWatchdogDiffBaseline(requestedRunCwd, inheritedWatchdogDiffBaseline, preserveActiveSession);
 		if (!preserveActiveSession) deps.state.baseCwd = ctx.cwd;
 		deps.state.foregroundRuns ??= new Map();
 		deps.state.foregroundControls ??= new Map();
@@ -5109,6 +5147,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 					lastUpdate: startedAt,
 					...(timeout !== undefined ? { deadlineAt: startedAt + timeout, timeoutMs: timeout } : {}),
 					cwd: workflowCwd,
+					...(watchdogDiffBaseline ? { watchdogDiffBaseline } : {}),
 					...(workflowSessionRoot ? { sessionRoot: workflowSessionRoot } : {}),
 					...(requestParams.scheduleOrigin ? { scheduleOrigin: requestParams.scheduleOrigin } : {}),
 					pid: process.pid,
@@ -5674,7 +5713,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 											status: step.status,
 											heartbeat: { status: step.status, ...(childPhase ? { phase: childPhase } : {}) },
 										});
-									}, ctx, preserveActiveSession, workflowParentModel);
+									}, ctx, preserveActiveSession, workflowParentModel, watchdogDiffBaseline);
 								});
 								workflowResults.push(...result.details.results);
 								for (const childResult of result.details.results) {
@@ -5705,7 +5744,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 								}
 								return child;
 							},
-							status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel)),
+							status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel, watchdogDiffBaseline)),
 							resolveResume: (reference, _signal, index) => resolveWorkflowResume(reference, deps, ctx.sessionManager.getSessionFile() ?? null, index),
 							steer: (key, message, options, workflowSignal) => steerWorkflowChildByKey({ state: deps.state, workflowRunId, key, message, options, signal: workflowSignal, resolveRunId: () => workflowChildRunIds.get(key) }),
 						});
@@ -5934,7 +5973,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 									status: progressStatus,
 									heartbeat: { status: progressStatus, ...(childPhase ? { phase: childPhase } : {}) },
 								});
-							}, ctx, preserveActiveSession, workflowParentModel);
+							}, ctx, preserveActiveSession, workflowParentModel, watchdogDiffBaseline);
 						});
 						workflowResults.push(...result.details.results);
 						for (const childResult of result.details.results) {
@@ -5955,7 +5994,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 						});
 						return child;
 					},
-					status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel)),
+					status: async (keyOrRunId, workflowSignal) => workflowChildResult(keyOrRunId, await execute(randomUUID(), { action: "status", id: keyOrRunId }, workflowSignal, undefined, ctx, preserveActiveSession, workflowParentModel, watchdogDiffBaseline)),
 					resolveResume: (reference, _signal, index) => resolveWorkflowResume(reference, deps, ctx.sessionManager.getSessionFile() ?? null, index),
 					steer: (key, message, options, workflowSignal) => steerWorkflowChildByKey({ state: deps.state, workflowRunId: foregroundWorkflowRunId, key, message, options, signal: workflowSignal, resolveRunId: () => workflowChildRunIds.get(key) }),
 				});
@@ -7005,6 +7044,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			topLevelAsyncCapacityEligible,
 			activeAsyncCapacity,
 			workflowChildPermitLaunch,
+			watchdogDiffBaseline,
 		});
 
 		const foregroundDescription = selectedAgentNames.length === 1
@@ -7045,7 +7085,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				});
 				const redoParams = promptAuditRedoParams(audit.rerun.params, rewrittenTask);
 				const previousForegroundId = deps.state.lastForegroundControlId;
-				const launch = execute(randomUUID(), redoParams, signal, undefined, ctx, true);
+				const launch = execute(randomUUID(), redoParams, signal, undefined, ctx, true, undefined, watchdogDiffBaseline);
 				const newRunId = deps.state.lastForegroundControlId && deps.state.lastForegroundControlId !== previousForegroundId
 					? deps.state.lastForegroundControlId
 					: undefined;

--- a/src/runs/shared/child-launch.ts
+++ b/src/runs/shared/child-launch.ts
@@ -7,6 +7,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ChildWatchdogConfig, ChildWatchdogStatusEvent } from "../../watchdog/child-status.ts";
+import { resolveWatchdogDiffBaseline, type WatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 import type { ThinkingLevel } from "../../shared/model-info.ts";
 import { intersectThinkingCeilings } from "../../shared/thinking-ceiling.ts";
 import {
@@ -44,7 +45,7 @@ export const MCP_DIRECT_TOOLS_ENV = "MCP_DIRECT_TOOLS";
  * launches inherits. Serialized into the background runner config; the
  * foreground path passes the executor's full `ChildRuntimeConfig`.
  */
-export type InheritedChildRuntime = Pick<ChildRuntimeConfig, "depth" | "maxDepth" | "nestedRoute" | "nestedParent" | "capabilityCeiling" | "thinkingCeiling" | "runFanoutBudget">;
+export type InheritedChildRuntime = Pick<ChildRuntimeConfig, "depth" | "maxDepth" | "nestedRoute" | "nestedParent" | "capabilityCeiling" | "thinkingCeiling" | "runFanoutBudget" | "watchdogDiffBaseline">;
 
 export function inheritedChildRuntime(config: ChildRuntimeConfig | undefined): InheritedChildRuntime | undefined {
 	if (!config) return undefined;
@@ -56,6 +57,7 @@ export function inheritedChildRuntime(config: ChildRuntimeConfig | undefined): I
 		...(config.capabilityCeiling ? { capabilityCeiling: config.capabilityCeiling } : {}),
 		...(config.thinkingCeiling ? { thinkingCeiling: config.thinkingCeiling } : {}),
 		...(config.runFanoutBudget ? { runFanoutBudget: config.runFanoutBudget } : {}),
+		...(config.watchdogDiffBaseline ? { watchdogDiffBaseline: config.watchdogDiffBaseline } : {}),
 	};
 }
 
@@ -95,6 +97,8 @@ export interface BuildInProcessChildLaunchInput {
 	permissionRules?: PermissionRules;
 	permissionAuditPath?: string;
 	childWatchdog?: ChildWatchdogConfig;
+	/** Session-start repository baseline exposed to reviewer lanes through watchdog_diff. */
+	watchdogDiffBaseline?: WatchdogDiffBaseline;
 	watchdogStatus?: (event: ChildWatchdogStatusEvent) => void;
 	waitToolEnabled?: boolean;
 	waitToolDefaultTimeoutMs?: number;
@@ -182,8 +186,15 @@ function childStorage(input: BuildInProcessChildLaunchInput): ChildSessionStorag
 }
 
 export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput): InProcessChildLaunch {
+	const inherited = input.inherited;
+	const watchdogDiffBaseline = resolveWatchdogDiffBaseline(
+		input.cwd,
+		input.watchdogDiffBaseline ?? inherited?.watchdogDiffBaseline,
+		true,
+	);
 	const toolPlan = resolvePiLaunchToolPlan({
 		tools: input.tools,
+		watchdogDiffBaseline,
 		excludeTools: input.excludeTools,
 		allowNestedSubagents: input.allowNestedSubagents,
 		extensions: input.extensions,
@@ -203,7 +214,6 @@ export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput)
 		hostAvailableBuiltins: input.hostAvailableBuiltins,
 	});
 
-	const inherited = input.inherited;
 	const fanout = toolPlan.fanoutAuthorized;
 	const inheritedRoute = inherited?.nestedRoute;
 	const parentRunId = input.runId ?? inherited?.nestedParent?.parentRunId ?? "";
@@ -232,6 +242,7 @@ export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput)
 	let structuredAcceptanceProvided = false;
 
 	const config: ChildRuntimeConfig = {
+		cwd: input.cwd,
 		...(input.runId ? { runId: input.runId } : {}),
 		agent: input.childAgentName,
 		childIndex: input.childIndex,
@@ -255,6 +266,9 @@ export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput)
 		...(permissions ? { permissions } : {}),
 		...(input.toolBudget ? { toolBudget: input.toolBudget } : {}),
 		...(input.childWatchdog ? { childWatchdog: input.childWatchdog } : {}),
+		...(toolPlan.effectiveToolAllowlist.includes("watchdog_diff") && watchdogDiffBaseline
+			? { watchdogDiffBaseline }
+			: {}),
 		...(input.watchdogStatus ? { watchdogStatus: input.watchdogStatus } : {}),
 		waitTool: {
 			enabled: input.waitToolEnabled ?? true,

--- a/src/runs/shared/child-runtime-config.ts
+++ b/src/runs/shared/child-runtime-config.ts
@@ -3,6 +3,7 @@ import type { ThinkingLevel } from "../../shared/model-info.ts";
 import type { NestedPathEntry } from "./nested-path.ts";
 import type { PermissionRules } from "./permissions.ts";
 import type { ChildWatchdogConfig, ChildWatchdogStatusEvent } from "../../watchdog/child-status.ts";
+import type { WatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 import type { ResolvedWaitToolConfig } from "../background/wait-config.ts";
 import type { ChildToolDiagnostic } from "./tool-availability.ts";
 import type { ResolvedSubagentCapabilityCeiling } from "./capability-ceiling.ts";
@@ -57,6 +58,8 @@ export interface ChildSupervisorMetadata {
  * that hosts the child session builds it and passes it to the hooks directly.
  */
 export interface ChildRuntimeConfig {
+	/** Actual session working directory used to resolve tool paths. */
+	cwd?: string;
 	runId?: string;
 	agent?: string;
 	childIndex?: number;
@@ -83,6 +86,8 @@ export interface ChildRuntimeConfig {
 	permissions?: ChildPermissions;
 	toolBudget?: ResolvedToolBudget;
 	childWatchdog?: ChildWatchdogConfig;
+	/** Session-start repository baseline exposed to reviewer lanes through watchdog_diff. */
+	watchdogDiffBaseline?: WatchdogDiffBaseline;
 	/** Receives child watchdog status events. */
 	watchdogStatus?: (event: ChildWatchdogStatusEvent) => void;
 	waitTool: ResolvedWaitToolConfig;

--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -22,6 +22,7 @@ import {
 import { THINKING_LEVELS } from "../../shared/model-info.ts";
 import { getAgentDir } from "../../shared/utils.ts";
 import type { PermissionRules } from "./permissions.ts";
+import type { WatchdogDiffBaseline } from "../../watchdog/diff-tool.ts";
 import {
 	capabilityCeilingAgentRestrictionSources,
 	intersectSubagentCapabilityCeilings,
@@ -64,11 +65,17 @@ const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
 const PI_BUILTIN_TOOL_NAMES = new Set(["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"]);
 const REPOSITORY_INSPECTION_TOOLS = new Set(["read", "grep", "find", "ls", "bash", "powershell"]);
 const REVIEW_OR_SCOUT_AGENT_PATTERN = /\b(?:reviewer|scout)\b/i;
+const REVIEWER_AGENT_PATTERN = /\breviewer\b/i;
 // These providers come from child hooks, not the host's builtin tool registry.
 const NATIVE_COORDINATION_TOOL_NAMES = new Set(["subagent", "contact_supervisor", "subagent_supervisor"]);
+const RUNTIME_REGISTERED_TOOL_NAMES = new Set(["watchdog_diff"]);
 
 export function isReviewOrScoutLaneAgent(agentName: string | undefined): boolean {
 	return typeof agentName === "string" && REVIEW_OR_SCOUT_AGENT_PATTERN.test(agentName);
+}
+
+export function isReviewerLaneAgent(agentName: string | undefined): boolean {
+	return typeof agentName === "string" && REVIEWER_AGENT_PATTERN.test(agentName);
 }
 
 export function missingPermittedRepositoryInspectionTools(
@@ -165,6 +172,8 @@ function resolveFastModeExtension(input: Pick<ResolvePiLaunchToolPlanInput, "fas
 
 export interface ResolvePiLaunchToolPlanInput {
 	tools?: string[];
+	/** Session-start baseline enabling bounded reviewer diff evidence. */
+	watchdogDiffBaseline?: WatchdogDiffBaseline;
 	excludeTools?: string[];
 	allowNestedSubagents?: boolean;
 	extensions?: string[];
@@ -376,11 +385,17 @@ export function resolvePiLaunchToolPlan(
 		input.hostAvailableBuiltins === undefined
 			? undefined
 			: new Set(input.hostAvailableBuiltins);
-	const requestedBuiltinTools =
-		input.tools?.filter(
+	const reviewerLane = isReviewerLaneAgent(input.agentName);
+	const runtimeTools = input.watchdogDiffBaseline && reviewerLane ? ["watchdog_diff"] : [];
+	const requestedBuiltinTools = input.tools === undefined
+		? []
+		: [...new Set([
+			...input.tools,
+			...runtimeTools,
+		])].filter(
 			(tool) =>
 				!(tool.includes("/") || tool.endsWith(".ts") || tool.endsWith(".js")),
-		) ?? [];
+		);
 	if (input.requireReadTool && hostAvailableSet && !hostAvailableSet.has("read")) {
 		const agentLabel = input.agentName ? ` for agent '${input.agentName}'` : "";
 		throw new Error(
@@ -405,13 +420,16 @@ export function resolvePiLaunchToolPlan(
 					: requestedBuiltinTools
 				).filter((tool) => !allowedToolSet || allowedToolSet.has(tool));
 	const declaredBuiltinTools = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => hostAvailableSet.has(tool) || NATIVE_COORDINATION_TOOL_NAMES.has(tool))
+		? ceilingFilteredBuiltinTools.filter((tool) => hostAvailableSet.has(tool) || NATIVE_COORDINATION_TOOL_NAMES.has(tool) || RUNTIME_REGISTERED_TOOL_NAMES.has(tool))
 		: ceilingFilteredBuiltinTools;
 	const unavailableHostBuiltins = hostAvailableSet
-		? ceilingFilteredBuiltinTools.filter((tool) => !hostAvailableSet.has(tool) && !NATIVE_COORDINATION_TOOL_NAMES.has(tool))
+		? ceilingFilteredBuiltinTools.filter((tool) => !hostAvailableSet.has(tool) && !NATIVE_COORDINATION_TOOL_NAMES.has(tool) && !RUNTIME_REGISTERED_TOOL_NAMES.has(tool))
 		: [];
 	const excludeTools = [...new Set((input.excludeTools ?? []).map((tool) => tool.trim()).filter(Boolean))];
-	const excludedToolSet = new Set(excludeTools);
+	const excludedToolSet = new Set([
+		...excludeTools,
+		...(reviewerLane ? ["bash", "powershell"] : []),
+	]);
 	const effectiveDeclaredBuiltinTools = declaredBuiltinTools.filter((tool) => !excludedToolSet.has(tool));
 	const fanoutAuthorized = effectiveDeclaredBuiltinTools.includes("subagent") || (
 		input.allowNestedSubagents === true &&

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -14,6 +14,7 @@ import type { ResolvedToolBudget, SubagentState } from "../../shared/types.ts";
 import { resolveCurrentSessionId } from "../../shared/session-identity.ts";
 import { getAgentDir } from "../../shared/utils.ts";
 import { registerChildWatchdog } from "../../watchdog/register-child.ts";
+import { createWatchdogDiffTool } from "../../watchdog/diff-tool.ts";
 import type { ChildWatchdogConfig } from "../../watchdog/child-status.ts";
 import { requestWatchdogPermission, type WatchdogPermissionRequest, type WatchdogPermissionResult } from "../../watchdog/permission-arbiter.ts";
 import { SUBAGENT_WATCHDOG_WARNING_TYPE } from "../../watchdog/types.ts";
@@ -63,6 +64,7 @@ const PROJECT_CONTEXT_XML_HEADER = "\n\n<project_context>\n\n";
 const PROJECT_CONTEXT_LEGACY_HEADER = "\n\n# Project Context\n\nProject-specific instructions and guidelines:\n\n";
 const SKILLS_HEADER = "\n\nThe following skills provide specialized instructions for specific tasks.";
 const DATE_HEADER = "\nCurrent date:";
+const REVIEWER_DIFF_NO_BASELINE_GUIDANCE = "Reviewer current-change evidence is unavailable: request the exact diff or changed-file list from the parent; never probe Git internals or read .git paths.";
 
 function registerRuntimeExtensionAcknowledgements(pi: ExtensionAPI, sink: ((ids: string[]) => void) | undefined): void {
 	if (!sink) return;
@@ -401,6 +403,76 @@ function registerToolBudget(pi: ExtensionAPI, budget: ResolvedToolBudget | undef
 	});
 }
 
+function canonicalPathWithExistingAncestor(candidate: string, cwd: string): string {
+	const absolute = path.resolve(cwd, candidate);
+	const unresolved: string[] = [];
+	let current = absolute;
+	while (true) {
+		try {
+			return path.join(fs.realpathSync(current), ...unresolved.reverse());
+		} catch {
+			const parent = path.dirname(current);
+			if (parent === current) return absolute;
+			unresolved.push(path.basename(current));
+			current = parent;
+		}
+	}
+}
+
+function repositoryGitMetadataPath(cwd: string, baseline: ChildRuntimeConfig["watchdogDiffBaseline"]): string | undefined {
+	let root = canonicalPathWithExistingAncestor(baseline?.root ?? cwd, cwd);
+	if (!baseline) {
+		while (!fs.existsSync(path.join(root, ".git"))) {
+			const parent = path.dirname(root);
+			if (parent === root) return undefined;
+			root = parent;
+		}
+	}
+	const gitPath = path.join(root, ".git");
+	try {
+		if (fs.statSync(gitPath).isFile()) {
+			const gitFile = fs.readFileSync(gitPath, "utf8").match(/^gitdir:\\s*(.+?)\\s*$/im)?.[1];
+			if (gitFile) return canonicalPathWithExistingAncestor(gitFile, root);
+		}
+		return canonicalPathWithExistingAncestor(gitPath, root);
+	} catch {
+		return undefined;
+	}
+}
+
+function isWithinPath(candidate: string, parent: string): boolean {
+	const relative = path.relative(parent, candidate);
+	return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+function registerReviewerRepositoryGuard(pi: ExtensionAPI, config: ChildRuntimeConfig): void {
+	const cwd = config.cwd ?? process.cwd();
+	const metadataPath = repositoryGitMetadataPath(cwd, config.watchdogDiffBaseline);
+	// SAFETY: this narrows Pi's generic event API to the documented tool_call payload used by this handler.
+	const onToolCall = pi.on as unknown as (event: "tool_call", handler: (event: { toolName: string; input: Record<string, unknown> }) => unknown) => void;
+	onToolCall("tool_call", (event) => {
+		if (!["read", "grep", "find", "ls"].includes(event.toolName)) return undefined;
+		const candidate = event.input.path;
+		if (typeof candidate !== "string") return undefined;
+		const canonicalCandidate = canonicalPathWithExistingAncestor(candidate, cwd);
+		const lexicalGitPath = candidate.replaceAll("\\", "/").split("/").includes(".git");
+		if (!lexicalGitPath && (!metadataPath || !isWithinPath(canonicalCandidate, metadataPath))) return undefined;
+		const guidance = config.watchdogDiffBaseline
+			? "call watchdog_diff for changed-file evidence"
+			: "request the exact diff or changed-file list from the parent; do not probe Git internals";
+		return { block: true, reason: `Reviewer repository inspection cannot read .git internals; ${guidance}.` };
+	});
+}
+
+function registerReviewerDiffTool(pi: ExtensionAPI, config: ChildRuntimeConfig): void {
+	if (!/\breviewer\b/i.test(config.agent ?? "")) return;
+	registerReviewerRepositoryGuard(pi, config);
+	if (!config.watchdogDiffBaseline) return;
+	// SAFETY: watchdog_diff implements Pi's runtime tool contract; the package's AgentTool type omits extension-only metadata.
+	const registerTool = pi.registerTool as unknown as (tool: ReturnType<typeof createWatchdogDiffTool>) => void;
+	registerTool(createWatchdogDiffTool(config.watchdogDiffBaseline));
+}
+
 function registerStructuredOutputTool(pi: ExtensionAPI, structured: NonNullable<ChildRuntimeConfig["structuredOutput"]>): void {
 	const required = structured.acceptanceReport === "required";
 	const parameters = createStructuredOutputToolParameters(structured.schema, { acceptanceReport: structured.acceptanceReport });
@@ -451,6 +523,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI, config?:
 	registerPermissionGate(pi, config.permissions, config.childWatchdog);
 	registerToolBudget(pi, config.toolBudget);
 	registerChildWatchdog(pi, config.childWatchdog, config.watchdogStatus);
+	registerReviewerDiffTool(pi, config);
 	const waitState = config.runtimeState ?? {
 		baseCwd: "",
 		currentSessionId: null,
@@ -536,6 +609,9 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI, config?:
 				fanoutChild,
 				structuredOutput: Boolean(config.structuredOutput),
 			});
+		}
+		if (/\breviewer\b/i.test(config.agent ?? "") && !config.watchdogDiffBaseline) {
+			rewritten = `${rewritten}\n\n${REVIEWER_DIFF_NO_BASELINE_GUIDANCE}`;
 		}
 		if (rewritten === event.systemPrompt) return;
 		return { systemPrompt: rewritten };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -840,6 +840,8 @@ export interface SteeringRecoveryDescriptor {
 	controlConfig?: ResolvedControlConfig;
 	/** Resolved launch context for this async child. */
 	context?: "fresh" | "fork";
+	/** Stable repository baseline captured before this child run's writer stages. */
+	watchdogDiffBaseline?: import("../watchdog/diff-tool.ts").WatchdogDiffBaseline;
 	/** Raw per-run bridge override. Omitted descriptors continue to use global config. */
 	intercomBridge?: IntercomBridgeConfig;
 	lane?: WorkflowLaneMetadata;
@@ -1840,6 +1842,8 @@ export interface AsyncStatus {
 	cwd?: string;
 	/** Parent-resolved child session root retained for trusted restored transcript lookup. */
 	sessionRoot?: string;
+	/** Stable repository baseline captured before this run's writer stages. */
+	watchdogDiffBaseline?: import("../watchdog/diff-tool.ts").WatchdogDiffBaseline;
 	currentStep?: number;
 	chainStepCount?: number;
 	pendingAppends?: number;
@@ -2095,6 +2099,8 @@ export interface ForegroundResumeRun {
 	cwd: string;
 	/** Originating parent session. Detached exits can outlive the active session. */
 	sessionId?: string;
+	/** Stable repository baseline captured before this run's writer stages. */
+	watchdogDiffBaseline?: import("../watchdog/diff-tool.ts").WatchdogDiffBaseline;
 	updatedAt: number;
 	children: ForegroundResumeChild[];
 }
@@ -2443,6 +2449,8 @@ export interface RunSyncOptions {
 	runtimeSnapshotHost?: import("../runs/shared/mcp-direct-tool-allowlist.ts").McpRuntimeSnapshotHost;
 	/** Builtin tool names the host runtime provides; used to intersect agent-declared tools. */
 	hostAvailableBuiltins?: readonly string[];
+	/** Session-start repository baseline exposed to reviewer lanes through watchdog_diff. */
+	watchdogDiffBaseline?: import("../watchdog/diff-tool.ts").WatchdogDiffBaseline;
 	/** Optional subagent model-scope enforcement for fallback candidates */
 	modelScope?: ModelScopeRule | ModelScopeRule[];
 	/** Skills to make available (overrides agent default if provided) */

--- a/src/watchdog/diff-tool.ts
+++ b/src/watchdog/diff-tool.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type, type Static } from "typebox";
@@ -33,6 +34,22 @@ export function captureWatchdogDiffBaseline(cwd: string): WatchdogDiffBaseline |
 	const root = toplevel.stdout.trim();
 	const ref = head.stdout.trim();
 	return root && ref ? { root, ref } : undefined;
+}
+
+function baselineMatchesCwd(baseline: WatchdogDiffBaseline, cwd: string): boolean {
+	const toplevel = runGit(cwd, ["rev-parse", "--show-toplevel"]);
+	if (!toplevel.ok) return false;
+	let root = path.resolve(baseline.root);
+	let candidate = path.resolve(toplevel.stdout.trim());
+	try { root = fs.realpathSync(root); } catch { /* retain resolved path */ }
+	try { candidate = fs.realpathSync(candidate); } catch { /* retain resolved path */ }
+	return root === candidate;
+}
+
+/** Resolve one run's stable baseline; inherited baselines never cross repositories. */
+export function resolveWatchdogDiffBaseline(cwd: string, inherited: WatchdogDiffBaseline | undefined, preserveActiveSession: boolean): WatchdogDiffBaseline | undefined {
+	if (inherited) return baselineMatchesCwd(inherited, cwd) ? inherited : undefined;
+	return preserveActiveSession ? undefined : captureWatchdogDiffBaseline(cwd);
 }
 
 function validatePath(value: string | undefined): string | undefined {

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -34,6 +34,65 @@ describe("child tool plan", () => {
 });
 
 describe("child tool plan host builtin intersection", () => {
+	it("injects bounded diff evidence only for reviewers and keeps reviewer shells closed", () => {
+		const baseline = { root: process.cwd(), ref: "HEAD" };
+		const reviewer = resolvePiLaunchToolPlan({
+			agentName: "reviewer",
+			tools: ["read", "grep", "find", "ls", "bash", "powershell"],
+			watchdogDiffBaseline: baseline,
+			hostAvailableBuiltins: ["read", "grep", "find", "ls", "bash", "powershell"],
+		});
+		assert.deepEqual(reviewer.effectiveToolAllowlist, ["read", "grep", "find", "ls", "watchdog_diff"]);
+		const launch = buildInProcessChildLaunch({
+			host: "parent", cwd: process.cwd(), childAgentName: "reviewer", childIndex: 0,
+			sessionEnabled: false, tools: ["read", "grep", "find", "ls", "bash", "powershell"],
+			watchdogDiffBaseline: baseline, inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+		});
+		assert.deepEqual(launch.session.tools, reviewer.effectiveToolAllowlist);
+
+		const scout = resolvePiLaunchToolPlan({
+			agentName: "scout",
+			tools: ["read", "bash"],
+			watchdogDiffBaseline: baseline,
+			hostAvailableBuiltins: ["read", "bash"],
+		});
+		assert.deepEqual(scout.effectiveToolAllowlist, ["read", "bash"]);
+		assert.deepEqual(scout.excludeTools, []);
+
+		const noBaseline = resolvePiLaunchToolPlan({
+			agentName: "reviewer",
+			tools: ["read", "bash"],
+			hostAvailableBuiltins: ["read", "bash"],
+		});
+		assert.deepEqual(noBaseline.effectiveToolAllowlist, ["read"]);
+		assert.deepEqual(noBaseline.excludeTools, []);
+	});
+
+	it("does not propagate reviewer diff baseline when watchdog_diff is excluded by plan", () => {
+		const baseline = { root: process.cwd(), ref: "HEAD" };
+		for (const restriction of [
+			{ excludeTools: ["watchdog_diff"] },
+			{ capabilityCeiling: { version: 1 as const, allowedTools: ["read", "grep", "find", "ls"], denyExtensions: false, sources: ["test"] } },
+		]) {
+			const launch = buildInProcessChildLaunch({
+				host: "parent", cwd: process.cwd(), childAgentName: "reviewer", childIndex: 0,
+				sessionEnabled: false, tools: ["read", "grep", "find", "ls"], watchdogDiffBaseline: baseline,
+				...restriction, inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+			});
+			assert.equal(launch.toolPlan.effectiveToolAllowlist.includes("watchdog_diff"), false);
+			assert.equal(launch.config.watchdogDiffBaseline, undefined);
+			assert.equal(launch.session.tools?.includes("watchdog_diff"), false);
+		}
+		const inherited = buildInProcessChildLaunch({
+			host: "parent", cwd: process.cwd(), childAgentName: "reviewer", childIndex: 0,
+			sessionEnabled: false, tools: ["read", "grep", "find", "ls"],
+			inherited: { depth: 1, watchdogDiffBaseline: baseline },
+			inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+		});
+		assert.equal(inherited.toolPlan.effectiveToolAllowlist.includes("watchdog_diff"), true);
+		assert.deepEqual(inherited.config.watchdogDiffBaseline, baseline);
+	});
+
 	it("intersects declared tools with host-available builtins", () => {
 		const plan = resolvePiLaunchToolPlan({
 			tools: ["read", "grep", "find", "ls", "bash"],

--- a/test/unit/nested-control.test.ts
+++ b/test/unit/nested-control.test.ts
@@ -4,12 +4,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, it } from "node:test";
 import registerFanoutChildSubagentExtension from "../../src/extension/fanout-child.ts";
-import { createSubagentExecutor, readNestedRecoveryDescriptor } from "../../src/runs/foreground/subagent-executor.ts";
+import { createSubagentExecutor, readNestedRecoveryDescriptor, resolveNestedResumeTarget } from "../../src/runs/foreground/subagent-executor.ts";
 import { createNestedRoute, findNestedControlResult, projectNestedEvents, readNestedControlRequests, readNestedControlResults, snapshotNestedEventFiles, writeNestedControlRequest, writeNestedControlResult, writeNestedEvent } from "../../src/runs/shared/nested-events.ts";
 import type { ChildRuntimeConfig } from "../../src/runs/shared/child-runtime-config.ts";
-import { ASYNC_DIR, type SubagentState } from "../../src/shared/types.ts";
+import { ASYNC_DIR, TEMP_ROOT_DIR, type SubagentState } from "../../src/shared/types.ts";
 import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
 import { getArtifactPaths, getArtifactsDir } from "../../src/shared/artifacts.ts";
+import { resolveSubagentRunId } from "../../src/runs/background/run-id-resolver.ts";
+import { resolveWatchdogDiffBaseline } from "../../src/watchdog/diff-tool.ts";
 
 const routeRoots: string[] = [];
 const fanoutListenerCleanupKey = "__piSubagentFanoutChildNestedControlInboxCleanups";
@@ -381,6 +383,49 @@ describe("nested control routing", () => {
 			assert.equal(result.isError, true);
 			assert.match(text(result), /session file does not exist/);
 		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("uses persisted nested cwd so its watchdog baseline survives revival", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-nested-resume-cwd-"));
+		const runId = "nested-persisted-cwd";
+		const repoCwd = process.cwd();
+		const asyncDir = path.join(TEMP_ROOT_DIR, "nested-subagent-runs", "root-persisted-cwd", runId);
+		const sessionRoot = path.join(root, "parent");
+		const sessionFile = path.join(sessionRoot, runId, "run-0", "session.jsonl");
+		const baseline = { root: repoCwd, ref: "persisted-baseline" };
+		try {
+			const route = createNestedRoute("root-persisted-cwd");
+			routeRoots.push(path.dirname(route.eventSink));
+			fs.mkdirSync(asyncDir, { recursive: true });
+			fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+			fs.writeFileSync(sessionFile, "", "utf-8");
+			fs.writeFileSync(path.join(asyncDir, "status.json"), JSON.stringify({
+				runId,
+				mode: "single",
+				state: "complete",
+				startedAt: 1,
+				cwd: repoCwd,
+				watchdogDiffBaseline: baseline,
+			}), "utf-8");
+			writeNestedEvent(route, {
+				type: "subagent.nested.completed",
+				ts: 100,
+				parentRunId: route.rootRunId,
+				child: { id: runId, parentRunId: route.rootRunId, parentStepIndex: 0, depth: 1, path: [{ runId: route.rootRunId, stepIndex: 0 }], state: "complete", agent: "worker", ownerState: "gone", asyncDir, sessionFile },
+			});
+
+			const resolved = resolveSubagentRunId(runId, { nested: { routes: [route] } });
+			assert.equal(resolved?.kind, "nested");
+			if (!resolved || resolved.kind !== "nested") throw new Error("expected nested run resolution");
+			const target = resolveNestedResumeTarget(resolved, [sessionRoot]);
+			assert.equal(target.cwd, repoCwd);
+			assert.notEqual(target.cwd, path.dirname(asyncDir));
+			assert.deepEqual(target.watchdogDiffBaseline, baseline);
+			assert.deepEqual(resolveWatchdogDiffBaseline(target.cwd!, target.watchdogDiffBaseline, true), baseline);
+		} finally {
+			fs.rmSync(asyncDir, { recursive: true, force: true });
 			fs.rmSync(root, { recursive: true, force: true });
 		}
 	});

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import { RUNTIME_EXTENSION_ACK_EVENT } from "../../src/runs/shared/runtime-acknowledged-extensions.ts";
 import { clearStructuredOutputCaptures } from "../../src/runs/shared/structured-output.ts";
 import { getAgentDir } from "../../src/shared/utils.ts";
+import { buildInProcessChildLaunch } from "../../src/runs/shared/child-launch.ts";
 import { formatChildToolDiagnostic, type ChildToolDiagnostic } from "../../src/runs/shared/tool-availability.ts";
 import type { ChildRuntimeConfig } from "../../src/runs/shared/child-runtime-config.ts";
 import type { ChildWatchdogConfig } from "../../src/watchdog/child-status.ts";
@@ -105,6 +106,99 @@ const CONFIGURED_SKILLS_SECTION = "\n\nThe following configured skills are avail
 describe("subagent prompt runtime", () => {
 	it("ignores an unconfigured path-based load", () => {
 		assert.doesNotThrow(() => registerSubagentPromptRuntime({} as never));
+	});
+
+	it("registers bounded reviewer diff evidence and blocks .git access", () => {
+		const handlers: Array<(event: { toolName: string; input: Record<string, unknown> }) => unknown> = [];
+		const tools: Array<{ name: string }> = [];
+		registerSubagentPromptRuntime({
+			on(event: string, handler: (event: { toolName: string; input: Record<string, unknown> }) => unknown) { if (event === "tool_call") handlers.push(handler); },
+			registerTool(tool: { name: string }) { tools.push(tool); },
+		} as never, childConfig({ agent: "custom-reviewer", watchdogDiffBaseline: { root: process.cwd(), ref: "HEAD" } }));
+		assert.ok(tools.some((tool) => tool.name === "watchdog_diff"));
+		assert.deepEqual(handlers[0]?.({ toolName: "read", input: { path: ".git/HEAD" } }), {
+			block: true,
+			reason: "Reviewer repository inspection cannot read .git internals; call watchdog_diff for changed-file evidence.",
+		});
+		assert.equal(handlers[0]?.({ toolName: "read", input: { path: "src/index.ts" } }), undefined);
+	});
+
+	it("blocks symlinked Git metadata paths relative to child cwd", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-reviewer-git-"));
+		const childCwd = path.join(root, "child");
+		fs.mkdirSync(path.join(root, ".git"));
+		fs.mkdirSync(childCwd);
+		fs.symlinkSync(path.join(root, ".git"), path.join(childCwd, "metadata"), "dir");
+		const handlers: Array<(event: { toolName: string; input: Record<string, unknown> }) => unknown> = [];
+		try {
+			registerSubagentPromptRuntime({
+				on(event: string, handler: (event: { toolName: string; input: Record<string, unknown> }) => unknown) { if (event === "tool_call") handlers.push(handler); },
+				registerTool() {},
+			} as never, childConfig({ agent: "reviewer", cwd: childCwd, watchdogDiffBaseline: { root, ref: "HEAD" } }));
+			assert.deepEqual(handlers[0]?.({ toolName: "read", input: { path: "metadata/HEAD" } }), {
+				block: true,
+				reason: "Reviewer repository inspection cannot read .git internals; call watchdog_diff for changed-file evidence.",
+			});
+			const noBaselineHandlers: Array<(event: { toolName: string; input: Record<string, unknown> }) => unknown> = [];
+			registerSubagentPromptRuntime({
+				on(event: string, handler: (event: { toolName: string; input: Record<string, unknown> }) => unknown) { if (event === "tool_call") noBaselineHandlers.push(handler); },
+				registerTool() {},
+			} as never, childConfig({ agent: "reviewer", cwd: childCwd }));
+			assert.deepEqual(noBaselineHandlers[0]?.({ toolName: "read", input: { path: "metadata/HEAD" } }), {
+				block: true,
+				reason: "Reviewer repository inspection cannot read .git internals; request the exact diff or changed-file list from the parent; do not probe Git internals.",
+			});
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("omits watchdog_diff registration and gives no-baseline guidance after plan restrictions", async () => {
+		const baseline = { root: process.cwd(), ref: "HEAD" };
+		for (const restriction of [
+			{ excludeTools: ["watchdog_diff"] },
+			{ capabilityCeiling: { version: 1 as const, allowedTools: ["read", "grep", "find", "ls"], denyExtensions: false, sources: ["test"] } },
+		]) {
+			const launch = buildInProcessChildLaunch({
+				host: "parent", cwd: process.cwd(), childAgentName: "reviewer", childIndex: 0,
+				sessionEnabled: false, tools: ["read", "grep", "find", "ls"], watchdogDiffBaseline: baseline,
+				...restriction, inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+			});
+			const registered: string[] = [];
+			const beforeStart: Array<(event: { systemPrompt: string }) => unknown> = [];
+			registerSubagentPromptRuntime({
+				on(event: string, handler: (event: { systemPrompt: string }) => unknown) { if (event === "before_agent_start") beforeStart.push(handler); },
+				registerTool(tool: { name: string }) { registered.push(tool.name); },
+			} as never, launch.config);
+			assert.equal(launch.config.watchdogDiffBaseline, undefined);
+			assert.equal(registered.includes("watchdog_diff"), false);
+			assert.match(JSON.stringify(await beforeStart[0]?.({ systemPrompt: "base" }) ?? {}), /request the exact diff or changed-file list/);
+		}
+	});
+
+	it("fails closed for reviewer without a baseline and leaves scouts unchanged", async () => {
+		type RuntimeEvent = { toolName?: string; input?: Record<string, unknown>; systemPrompt?: string };
+		const handlers: Array<(event: RuntimeEvent) => unknown> = [];
+		const beforeStart: Array<(event: RuntimeEvent) => unknown> = [];
+		const tools: Array<{ name: string }> = [];
+		const register = (agent: string) => registerSubagentPromptRuntime({
+			on(event: string, handler: (event: RuntimeEvent) => unknown) {
+				if (event === "tool_call") handlers.push(handler);
+				if (event === "before_agent_start") beforeStart.push(handler);
+			},
+			registerTool(tool: { name: string }) { tools.push(tool); },
+		} as never, childConfig({ agent }));
+		register("reviewer");
+		assert.equal(tools.some((tool) => tool.name === "watchdog_diff"), false);
+		assert.deepEqual(handlers[0]?.({ toolName: "grep", input: { path: ".git/index" } }), {
+			block: true,
+			reason: "Reviewer repository inspection cannot read .git internals; request the exact diff or changed-file list from the parent; do not probe Git internals.",
+		});
+		assert.match(JSON.stringify(await beforeStart[0]?.({ systemPrompt: "base" }) ?? {}), /request the exact diff or changed-file list/);
+
+		const scoutHandlers = handlers.length;
+		register("scout");
+		assert.equal(handlers.length, scoutHandlers, "scouts must not receive reviewer .git guards");
 	});
 
 	it("registers no permission hook by default and routes ask only to the watchdog arbiter", async () => {

--- a/test/unit/watchdog-diff-tool.test.ts
+++ b/test/unit/watchdog-diff-tool.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { captureWatchdogDiffBaseline, createWatchdogDiffTool, WATCHDOG_DIFF_MAX_CHARS } from "../../src/watchdog/diff-tool.ts";
+import { captureWatchdogDiffBaseline, createWatchdogDiffTool, resolveWatchdogDiffBaseline, WATCHDOG_DIFF_MAX_CHARS } from "../../src/watchdog/diff-tool.ts";
 
 let repo = "";
 
@@ -41,6 +41,25 @@ describe("watchdog diff tool", () => {
 		assert.equal(baseline.ref, git("rev-parse", "HEAD").trim());
 		assert.match(await run(createWatchdogDiffTool(baseline)), /^No changes since baseline/);
 		assert.equal(captureWatchdogDiffBaseline(os.tmpdir()), undefined);
+	});
+
+	it("resolves explicit cross-repository cwd without leaking parent baseline", () => {
+		const otherRepo = fs.mkdtempSync(path.join(os.tmpdir(), "watchdog-diff-other-"));
+		try {
+			execFileSync("git", ["init", "-q"], { cwd: otherRepo });
+			execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: otherRepo });
+			execFileSync("git", ["config", "user.name", "Test User"], { cwd: otherRepo });
+			fs.writeFileSync(path.join(otherRepo, "other.txt"), "other\n", "utf-8");
+			execFileSync("git", ["add", "."], { cwd: otherRepo });
+			execFileSync("git", ["commit", "-q", "-m", "other base"], { cwd: otherRepo });
+			const parentBaseline = captureWatchdogDiffBaseline(repo)!;
+			const childBaseline = resolveWatchdogDiffBaseline(otherRepo, undefined, false);
+			assert.ok(childBaseline);
+			assert.notEqual(childBaseline.root, parentBaseline.root);
+			assert.equal(resolveWatchdogDiffBaseline(otherRepo, parentBaseline, true), undefined);
+		} finally {
+			fs.rmSync(otherRepo, { recursive: true, force: true });
+		}
 	});
 
 	it("shows tracked changes since the baseline, including later commits, and lists untracked paths", async () => {


### PR DESCRIPTION
## Summary
- inject the existing bounded `watchdog_diff` tool for reviewer agents instead of giving them shell access
- block direct and symlinked Git metadata reads while leaving scout and non-reviewer capabilities unchanged
- preserve a run-scoped repository baseline across foreground, background, workflow, and resume paths without leaking it across repositories
- add focused regressions for capability ceilings, exclusions, symlink access, cross-repository runs, and nested resume

## Validation
- `npm run typecheck`
- focused affected unit tests: 96 passed
- `npm run test:integration`: 1033 passed, 6 skipped
- `git diff --check`
- `npm test`: 3127 passed, 13 skipped; one unrelated macOS environment failure remains in `test/unit/owned-process-tree.test.ts:71` (`kill EPERM`)
