### PR TITLE
fix: ignore stale explicit model exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Allow an explicit model request when a cached unavailable-model exclusion is contradicted by the current model registry, while preserving live health, auth, quota, and rate-limit exclusions. Thanks to [@xz-dev](https://github.com/xz-dev) for identifying the stale explicit-request cache symptom in #2145.
 - Reject invalid global `checkpointBeforeDeadlineMs` values during config loading instead of silently disabling the requested checkpoint.
 - Preserve wrapped Pi core tools and explicitly requested non-core tools in child launches. Core slots still respect host availability; non-core tools are validated in the child's runtime after ceilings and exclusions (#2132, #2133, #2134, #2135, #2140). Thanks to [@carlesba](https://github.com/carlesba) for #2137 and [@clementprevot](https://github.com/clementprevot) for #2138.
 

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -333,8 +333,13 @@ function ignoreStaleModelUnavailableExclusion(candidate: string, exclusion: NonN
 	return MODEL_UNAVAILABLE_EXCLUSION_PATTERNS.some((pattern) => pattern.test(reason)) && isCurrentRegistryModel(candidate, availableModels);
 }
 
-function throwForExplicitModelExclusion(model: string): void {
-	const exclusion = findModelExclusion(model);
+function throwForExplicitModelExclusion(model: string, availableModels: AvailableModelInfo[] | undefined): void {
+	const blocked: { exclusion?: NonNullable<ReturnType<typeof findModelExclusion>> } = {};
+	filterFallbackCandidates([model], {
+		onExcluded: (_candidate, exclusion) => { blocked.exclusion = exclusion; },
+		ignoreExclusion: (candidate, exclusion) => ignoreStaleModelUnavailableExclusion(candidate, exclusion, availableModels),
+	});
+	const exclusion = blocked.exclusion;
 	if (!exclusion) return;
 	const reason = redactSecretValues((exclusion.reason ?? "runtime-failure").replace(/[\u0000-\u001f\u007f]+/g, " ")).slice(0, 240);
 	const expiry = Number.isFinite(exclusion.expiresAt) ? `; expires: ${new Date(exclusion.expiresAt).toISOString()}` : "";
@@ -377,7 +382,7 @@ export function resolveSubagentModelOverride(
 		const candidate = resolveSubagentModelCandidate(explicit, availableModels, preferredProvider);
 		if (options?.source === "explicit") {
 			resolved = candidate ?? resolveRequiredSubagentModelCandidate(explicit, availableModels, preferredProvider);
-			throwForExplicitModelExclusion(resolved);
+			throwForExplicitModelExclusion(resolved, availableModels);
 			resolvedFromRegistry = true;
 		} else if (candidate) {
 			resolved = candidate;
@@ -480,7 +485,7 @@ export function buildModelCandidates(
 	};
 	if (origin === "explicit" && primaryModel) {
 		const normalized = resolveRequiredSubagentModelCandidate(primaryModel.trim(), availableModels, preferredProvider);
-		throwForExplicitModelExclusion(normalized);
+		throwForExplicitModelExclusion(normalized, availableModels);
 		enforceModelScopes(normalized, scopes, "explicit", options?.onWarn);
 		primaryModel = normalized;
 	}

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -379,15 +379,14 @@ describe("model fallback helpers", () => {
 		);
 	});
 
-	it("keeps explicit stale model-not-found exclusions strict", () => {
-		recordModelFailure({
-			modelId: "gpt-5-mini",
-			provider: "openai",
-			reason: 'Model "openai/gpt-5-mini" not found. Use --list-models to see available models.',
-		});
-		assert.throws(
-			() => buildModelCandidates("openai/gpt-5-mini", ["anthropic/claude-sonnet-4"], availableModels, undefined, { origin: "explicit" }),
-			/Requested subagent model 'openai\/gpt-5-mini' is excluded and cannot be replaced by a fallback/,
+	it("ignores a stale explicit model-not-found exclusion when the base model is in the registry", () => {
+		recordRetryableModelFailure(
+			"openai/gpt-5-mini:high",
+			'Model "openai/gpt-5-mini:high" not found. Use --list-models to see available models.',
+		);
+		assert.deepEqual(
+			buildModelCandidates("openai/gpt-5-mini:high", ["anthropic/claude-sonnet-4"], availableModels, undefined, { origin: "explicit" }),
+			["openai/gpt-5-mini:high", "anthropic/claude-sonnet-4"],
 		);
 	});
 
@@ -610,6 +609,31 @@ describe("resolveSubagentModelOverride (cross-session inherit, issue #266)", () 
 				const message = String(error);
 				return message.includes("openai/gpt-5-mini") && message.includes("rate limit") && message.includes("expires:");
 			},
+		);
+	});
+
+	it("resolves an explicit model despite a stale unavailable exclusion contradicted by the registry", () => {
+		recordModelFailure({
+			modelId: "gpt-5-mini",
+			provider: "openai",
+			reason: "Model openai/gpt-5-mini is unavailable",
+		});
+		assert.equal(
+			resolveSubagentModelOverride("openai/gpt-5-mini:high", parentModel, availableModels, undefined, { source: "explicit" }),
+			"openai/gpt-5-mini:high",
+		);
+	});
+
+	it("keeps a provider-wide quota exclusion when ignoring a stale model-specific exclusion", () => {
+		recordModelFailure({ provider: "openai", reason: "quota exceeded" });
+		recordModelFailure({
+			modelId: "gpt-5-mini",
+			provider: "openai",
+			reason: "Model openai/gpt-5-mini not found",
+		});
+		assert.throws(
+			() => resolveSubagentModelOverride("openai/gpt-5-mini", parentModel, availableModels, undefined, { source: "explicit" }),
+			(error: unknown) => String(error).includes("quota exceeded") && !String(error).includes("not found"),
 		);
 	});
 


### PR DESCRIPTION
## Summary

- let explicit model requests ignore cached unavailable/not-found entries when the current registry proves the exact model exists
- continue enforcing concurrent provider/model quota, auth, rate-limit, and other live exclusions
- preserve Pi's supported `provider/model:thinking` resolution syntax and existing cache persistence/TTL

Closes #2145.

Thanks to [@xz-dev](https://github.com/xz-dev) for identifying the stale explicit-request exclusion symptom in #2145. Investigation found that Pi 0.85.1 already parses valid thinking suffixes correctly, so this intentionally fixes only the independently reproduced cache-policy inconsistency.

## Validation

- 136 focused model-fallback and model-exclusion tests
- `npm run typecheck`
- `git diff --check`
- fresh review plus targeted follow-up review: OK
