### PR TITLE
fix: avoid duplicate automatic compaction resumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Let Pi continue threshold and overflow compactions without an extra extension resume, while preserving manual re-drive for active async work. Thanks to [@mxp7064](https://github.com/mxp7064) for #2144.
 - Allow an explicit model request when a cached unavailable-model exclusion is contradicted by the current model registry, while preserving live health, auth, quota, and rate-limit exclusions. Thanks to [@xz-dev](https://github.com/xz-dev) for identifying the stale explicit-request cache symptom in #2145.
 - Preserve wrapped Pi core tools and explicitly requested non-core tools in child launches. Core slots still respect host availability; non-core tools are validated in the child's runtime after ceilings and exclusions (#2132, #2133, #2134, #2135, #2140). Thanks to [@carlesba](https://github.com/carlesba) for #2137 and [@clementprevot](https://github.com/clementprevot) for #2138.
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1136,7 +1136,8 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 		if (event.reason !== "manual") suspendWidgetsForCompaction();
 	});
 
-	pi.on("session_compact", () => {
+	pi.on("session_compact", (event) => {
+		if (event.reason !== "manual") return;
 		const hasActiveAsyncWork = [...state.asyncJobs.values()].some((job) => job.status === "queued" || job.status === "running");
 		if (!hasActiveAsyncWork || !withLastUiContext(() => true)) return;
 		pi.sendMessage(

--- a/test/unit/compaction-resume.test.ts
+++ b/test/unit/compaction-resume.test.ts
@@ -7,7 +7,7 @@ import { describe, it } from "node:test";
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 describe("async compaction resume", () => {
-	it("continues an interactive parent after compaction while async work is active", () => {
+	it("only re-drives manual compaction while async work is active", () => {
 		const script = String.raw`
 			import os from "node:os";
 			import path from "node:path";
@@ -42,25 +42,36 @@ describe("async compaction resume", () => {
 			for (const handler of handlers.get("agent_start")) await handler();
 			const restored = widgets.filter(([_, value]) => value !== undefined).map(([key]) => key).sort();
 			if (JSON.stringify(restored) !== JSON.stringify(["subagent-async", "subagent-fleet-status"])) throw new Error(JSON.stringify(widgets));
+			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("resumed after threshold compaction");
+
+			sent.length = 0;
+			widgets.length = 0;
+			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "manual", signal: new AbortController().signal });
+			if (widgets.length !== 0) throw new Error("manual compaction changed widget state");
+			for (const handler of handlers.get("session_compact")) await handler({ reason: "manual" });
 			if (sent.length !== 1 || sent[0].options?.triggerTurn !== true || sent[0].message?.customType !== "subagent-compaction-resume") throw new Error(JSON.stringify(sent));
 
 			sent.length = 0;
 			events.emit("subagent:async-complete", { id: "running-2", sessionId: "compact-session", agent: "worker", success: true, summary: "done" });
-			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "threshold", signal: new AbortController().signal });
-			for (const handler of handlers.get("session_compact")) await handler({ reason: "threshold" });
+			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "manual", signal: new AbortController().signal });
+			for (const handler of handlers.get("session_compact")) await handler({ reason: "manual" });
 			for (const handler of handlers.get("agent_settled")) await handler();
 			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("resumed without active work");
 
 			events.emit("subagent:async-started", { id: "running-3", pid: 3, sessionId: "compact-session", mode: "single", agent: "worker", asyncDir: path.join(os.tmpdir(), "pi-compaction-test-running-3") });
+			sent.length = 0;
+			widgets.length = 0;
+			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "overflow", signal: new AbortController().signal });
+			widgets.length = 0;
+			for (const handler of handlers.get("session_compact")) await handler({ reason: "overflow" });
+			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("resumed after overflow compaction");
+			for (const handler of handlers.get("agent_start")) await handler();
+
 			widgets.length = 0;
 			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "overflow", signal: new AbortController().signal });
 			widgets.length = 0;
 			for (const handler of handlers.get("agent_settled")) await handler();
 			if (!widgets.some(([_, value]) => value !== undefined)) throw new Error("widgets did not recover after compaction failure");
-
-			widgets.length = 0;
-			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "manual", signal: new AbortController().signal });
-			if (widgets.length !== 0) throw new Error("manual compaction changed widget state");
 			for (const handler of handlers.get("session_shutdown")) await handler();
 		`;
 		const env = { ...process.env };
@@ -74,19 +85,22 @@ describe("async compaction resume", () => {
 			import registerSubagentExtension from "./index.ts";
 			const handlers = new Map();
 			const events = { listeners: new Map(), on(name, handler) { this.listeners.set(name, handler); return () => this.listeners.delete(name); }, emit(name, payload) { this.listeners.get(name)?.(payload); } };
+			const sent = [];
 			const pi = new Proxy({
 				events,
 				on(name, handler) { handlers.set(name, [...(handlers.get(name) ?? []), handler]); },
 				registerTool() {}, registerCommand() {}, registerShortcut() {}, registerMessageRenderer() {},
-				sendMessage() {}, getSessionName() { return undefined; },
+				sendMessage(message, options) { sent.push({ message, options }); }, getSessionName() { return undefined; },
 			}, { get(target, prop) { return prop in target ? target[prop] : () => undefined; } });
 			let stale = false;
 			const ctx = { cwd: process.cwd(), get hasUI() { if (stale) throw new Error("This extension ctx is stale after session replacement or reload."); return true; }, ui: { setWidget() {}, requestRender() {}, onTerminalInput() { return () => {}; }, getEditorText() { return ""; }, notify() {}, theme: { fg(_name, text) { return text; }, bg(_name, text) { return text; }, bold(text) { return text; } } }, sessionManager: { getSessionId() { return "stale-context-session"; }, getSessionFile() { return null; }, getEntries() { return []; } }, modelRegistry: { getAvailable() { return []; } } };
 			registerSubagentExtension(pi);
 			for (const handler of handlers.get("session_start")) await handler({}, ctx);
+			sent.length = 0;
 			events.emit("subagent:async-started", { id: "running", sessionId: "stale-context-session", mode: "single", agent: "worker", asyncDir: "/tmp/pi-stale-context-running" });
 			stale = true;
-			for (const handler of handlers.get("session_compact")) await handler({ reason: "threshold" });
+			for (const handler of handlers.get("session_compact")) await handler({ reason: "manual" });
+			if (sent.some((entry) => entry.message?.customType === "subagent-compaction-resume")) throw new Error("resumed with stale UI context");
 			for (const handler of handlers.get("session_before_compact")) await handler({ reason: "threshold", signal: new AbortController().signal });
 			for (const handler of handlers.get("session_shutdown")) await handler();
 		`;


### PR DESCRIPTION
## Summary

- let Pi continue threshold compaction inline without an extra extension-triggered turn
- let Pi own overflow retry/continuation without an extra extension re-drive
- preserve the existing manual-compaction re-drive when async work and usable UI context remain

This is a narrower replacement for #2144. Pi 0.85.1 does not expose whether a manual compaction causally interrupted a parent run, so this change avoids that unsafe inference and does not claim to distinguish idle from interrupting manual compaction.

Thanks to [@mxp7064](https://github.com/mxp7064) for #2144 and for identifying the automatic-compaction behavior. The profile-linked credit is also retained in `CHANGELOG.md`.

## Validation

- focused compaction test fails against the previous automatic re-drive behavior
- `test/unit/compaction-resume.test.ts`: 2 passed
- `test/unit/extension-context.test.ts`: 2 passed
- `npm run typecheck`
- `git diff --check`
