### PR TITLE
fix: avoid caching transient empty model responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Keep canonical empty child responses eligible for same-launch model fallback without persisting them as 24-hour model exclusions. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #2154.
 - Let Pi continue threshold and overflow compactions without an extra extension resume, while preserving manual re-drive for active async work. Thanks to [@mxp7064](https://github.com/mxp7064) for #2144.
 - Allow an explicit model request when a cached unavailable-model exclusion is contradicted by the current model registry, while preserving live health, auth, quota, and rate-limit exclusions. Thanks to [@xz-dev](https://github.com/xz-dev) for identifying the stale explicit-request cache symptom in #2145.
 - Preserve wrapped Pi core tools and explicitly requested non-core tools in child launches. Core slots still respect host availability; non-core tools are validated in the child's runtime after ceilings and exclusions (#2132, #2133, #2134, #2135, #2140). Thanks to [@carlesba](https://github.com/carlesba) for #2137 and [@clementprevot](https://github.com/clementprevot) for #2138.

--- a/src/runs/shared/model-fallback.ts
+++ b/src/runs/shared/model-fallback.ts
@@ -589,10 +589,15 @@ function messageError(message: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
+function isTransientNoOutputFailure(error: string | undefined): boolean {
+	return error === "Subagent produced no output (possible model cold-start or empty response)."
+		|| /^Subagent produced no output after terminal assistant stopReason "[^"]+"\.$/.test(error ?? "");
+}
+
 export function isRetryableModelFailureAttempt(input: { error: string | undefined; messages?: readonly unknown[]; toolCount?: number }): boolean {
 	if (!isRetryableModelFailure(input.error)) return false;
 	if ((input.toolCount ?? 0) > 0) return false;
-	if (input.error === "Subagent produced no output (possible model cold-start or empty response)." || /^Subagent produced no output after terminal assistant stopReason "[^"]+"\.$/.test(input.error ?? "")) return true;
+	if (isTransientNoOutputFailure(input.error)) return true;
 	if ((input.toolCount ?? 0) === 0 && (input.messages?.length ?? 0) === 0) return true;
 	const error = input.error?.trim();
 	return Boolean(error && input.messages?.some((message) => messageError(message)?.trim() === error));
@@ -604,7 +609,7 @@ const REQUEST_SHAPE_FAILURE_PATTERN = /\b(?:bad[ _]request|invalid[ _]argument|i
 
 export function recordRetryableModelFailure(model: string | undefined, error: string | undefined): void {
 	if (!model || !error || !isRetryableModelFailure(error) || isContextOverflow(error)) return;
-	if (REQUEST_SHAPE_FAILURE_PATTERN.test(error)) return;
+	if (REQUEST_SHAPE_FAILURE_PATTERN.test(error) || isTransientNoOutputFailure(error)) return;
 	const { provider, modelId } = parseModelKey(model);
 	recordModelFailure({ modelId, reason: error, ...(provider ? { provider } : {}) });
 }

--- a/test/unit/model-fallback.test.ts
+++ b/test/unit/model-fallback.test.ts
@@ -218,6 +218,26 @@ describe("model fallback helpers", () => {
 		assert.equal(getExcludedCount(), 0);
 	});
 
+	it("retries canonical no-output failures without caching a model exclusion", () => {
+		const model = "openai/gpt-5-mini:high";
+		for (const error of [
+			"Subagent produced no output (possible model cold-start or empty response).",
+			'Subagent produced no output after terminal assistant stopReason "stop".',
+		]) {
+			assert.equal(isRetryableModelFailureAttempt({ error, messages: [{ role: "assistant" }], toolCount: 0 }), true, error);
+			recordRetryableModelFailure(model, error);
+			assert.equal(findModelExclusion(model), undefined, error);
+			assert.equal(getExcludedCount(), 0, error);
+			assert.deepEqual(buildModelCandidates(model, undefined, availableModels), [model], error);
+		}
+	});
+
+	it("does not suppress arbitrary no-output model failures from the exclusion cache", () => {
+		const error = "provider returned no output";
+		recordRetryableModelFailure("openai/gpt-5-mini", error);
+		assert.equal(findModelExclusion("openai/gpt-5-mini")?.reason, error);
+	});
+
 	it("does not cache the reported Databricks tool-message request error (issue #1955)", () => {
 		const model = "databricks/databricks-kimi-k3";
 		const error = 'Databricks error: {"error_code":"BAD_REQUEST","message":"{\\"error\\":\\"Upstream error: INVALID_ARGUMENT: Kimi K3 tool messages need a resolvable tool name: carry `tool`/`name`, or match a preceding assistant tool_call by order.\\"}"}';


### PR DESCRIPTION
## Summary
- keep canonical empty/no-output attempts eligible for same-launch fallback
- prevent those exact transient failures from creating durable 24-hour model exclusions
- preserve useful exclusion behavior for other provider/model failures

Closes #2154.

Thanks to [@rochecompaan](https://github.com/rochecompaan) for the detailed reproduction.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/model-fallback.test.ts` (109 passed)
- `npm run typecheck`
- `git diff --check`
- fresh independent review: no findings, merge verdict OK