### PR TITLE
fix: narrow acceptance string schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Reject unsupported bare acceptance strings at the provider schema boundary while preserving shorthand levels and JSON-encoded acceptance objects. Thanks to [@vrolok](https://github.com/vrolok) for #2152.
 - Keep canonical empty child responses eligible for same-launch model fallback without persisting them as 24-hour model exclusions. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #2154.
 - Let Pi continue threshold and overflow compactions without an extra extension resume, while preserving manual re-drive for active async work. Thanks to [@mxp7064](https://github.com/mxp7064) for #2144.
 - Allow an explicit model request when a cached unavailable-model exclusion is contradicted by the current model registry, while preserving live health, auth, quota, and rate-limit exclusions. Thanks to [@xz-dev](https://github.com/xz-dev) for identifying the stale explicit-request cache symptom in #2145.

--- a/src/extension/schemas.ts
+++ b/src/extension/schemas.ts
@@ -78,6 +78,7 @@ const AcceptanceOverride = Type.Unsafe({
 		},
 		{
 			type: "string",
+			pattern: "^\\s*\\{",
 		},
 		{ type: "boolean" },
 		{ type: "object", additionalProperties: true },

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -585,7 +585,8 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 		const reviewedRecoveryBranch = acceptanceStringBranches.find((branch) => Array.isArray(branch.enum) && branch.enum.includes("reviewed"));
 		assert.deepEqual(reviewedRecoveryBranch?.enum, ["reviewed"]);
 		assert.equal(reviewedRecoveryBranch?.deprecated, true);
-		assert.equal(acceptanceStringBranches.some((branch) => branch.enum === undefined), true, "acceptance should tolerate JSON-encoded object strings");
+		const acceptanceObjectStringBranch = acceptanceStringBranches.find((branch) => branch.enum === undefined);
+		assert.equal(acceptanceObjectStringBranch?.pattern, "^\\s*\\{", "acceptance should tolerate only object-shaped JSON strings");
 		assert.match(String(acceptanceSchema.description ?? ""), /omit for read-only\/review/i);
 		assert.match(String(acceptanceSchema.description ?? ""), /prefer object/i);
 		assert.match(String(acceptanceSchema.description ?? ""), /false disables; true invalid/i);
@@ -607,6 +608,12 @@ describe("SubagentParams schema", { skip: !schemasAvailable ? "typebox not avail
 			assert.equal(validator.Check({ [field]: false }), true);
 			assert.equal(validator.Check({ [field]: true }), true);
 			assert.equal(validator.Check({ [field]: 123 }), false);
+		}
+		for (const acceptance of ["auto", "attested", "checked", false, { level: "checked" }, '{"level":"checked"}', '  \n {"level":"checked"}']) {
+			assert.equal(validator.Check({ agent: "worker", task: "Fix", acceptance }), true, `${JSON.stringify(acceptance)} acceptance should validate`);
+		}
+		for (const acceptance of ["cheked", "none", "verified", "not-json", '[{"level":"checked"}]']) {
+			assert.equal(validator.Check({ agent: "worker", task: "Fix", acceptance }), false, `${JSON.stringify(acceptance)} acceptance should not validate`);
 		}
 		const validValues = [
 			{ skill: "review" },


### PR DESCRIPTION
## Summary
- keep the provider-compatible boolean over-approximation for false-only inputs
- narrow JSON-encoded acceptance strings to object-shaped values
- reject unsupported bare levels and encoded arrays at the provider schema boundary

Closes #2152.

Thanks to [@vrolok](https://github.com/vrolok) for identifying the independent acceptance-string issue.

## Validation
- `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/schemas.test.ts` (17 passed)
- `npm run typecheck`
- `git diff --check`
- fresh independent review: no findings, merge verdict OK