### PR TITLE
fix: clear terminal async widget jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Clear polled partial and rejected async jobs from the widget after terminal retention while preserving live nested descendants. Thanks to [@ashlineldridge](https://github.com/ashlineldridge) for #2159.
 - Reject unsupported bare acceptance strings at the provider schema boundary while preserving shorthand levels and JSON-encoded acceptance objects. Thanks to [@vrolok](https://github.com/vrolok) for #2152.
 - Keep canonical empty child responses eligible for same-launch model fallback without persisting them as 24-hour model exclusions. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #2154.
 - Let Pi continue threshold and overflow compactions without an extra extension resume, while preserving manual re-drive for active async work. Thanks to [@mxp7064](https://github.com/mxp7064) for #2144.

--- a/src/runs/background/async-job-tracker.ts
+++ b/src/runs/background/async-job-tracker.ts
@@ -52,11 +52,14 @@ const DEFAULT_LIVENESS_INTERVAL_MS = 5000;
 const EVENT_REFRESH_DEBOUNCE_MS = 25;
 const WATCH_ATTACHMENT_RETRY_MS = 100;
 
+const isTerminalJobStatus = (status: AsyncJobState["status"]): boolean =>
+	status === "complete" || status === "failed" || status === "partial" || status === "paused" || status === "rejected" || status === "stopped";
+
 function rememberFleetJob(state: SubagentState, job: AsyncJobState): void {
 	state.fleetJobs ??= new Map();
 	state.fleetJobs.set(job.asyncId, job);
 	const terminal = [...state.fleetJobs.values()]
-		.filter((candidate) => candidate.status === "complete" || candidate.status === "failed" || candidate.status === "paused" || candidate.status === "stopped")
+		.filter((candidate) => isTerminalJobStatus(candidate.status))
 		.sort((left, right) => (right.updatedAt ?? right.startedAt ?? 0) - (left.updatedAt ?? left.startedAt ?? 0));
 	for (const stale of terminal.slice(MAX_RECENT_FLEET_JOBS)) state.fleetJobs.delete(stale.asyncId);
 }
@@ -100,7 +103,6 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 	let nextWidgetAnimationAt = Date.now() + WIDGET_ANIMATION_INTERVAL_MS;
 	const watch = options.watch ?? fs.watch;
 	const useNativeWatcher = () => shouldUseNativeFsWatch("async-job-tracker", options.platform);
-	const terminalStatus = (status: string) => status === "complete" || status === "failed" || status === "paused" || status === "stopped";
 	const withLastUiContext = <T>(run: (ctx: ExtensionContext) => T): T | undefined => {
 		const cached = state.lastUiContext;
 		return withCachedUiContext(cached, () => {
@@ -445,10 +447,10 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 			if (status) {
 				const previousStatus = job.status;
 				job.status = status.state;
-				if (!terminalStatus(job.status)) terminalPublications.delete(job.asyncId);
+				if (!isTerminalJobStatus(job.status)) terminalPublications.delete(job.asyncId);
 				if (job.status === "running") runningJobIds.add(job.asyncId);
 				else runningJobIds.delete(job.asyncId);
-				if (job.status !== "complete" && job.status !== "failed" && job.status !== "paused" && job.status !== "stopped") cancelCleanup(job.asyncId);
+				if (!isTerminalJobStatus(job.status)) cancelCleanup(job.asyncId);
 				job.sessionId = status.sessionId ?? job.sessionId;
 				job.activityState = status.activityState;
 				job.lastActivityAt = status.lastActivityAt ?? job.lastActivityAt;
@@ -502,7 +504,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 				job.turnBudgetExceeded = status.turnBudgetExceeded ?? job.turnBudgetExceeded;
 				job.wrapUpRequested = status.wrapUpRequested ?? job.wrapUpRequested;
 				job.sessionFile = status.sessionFile ?? job.sessionFile;
-				if (terminalStatus(job.status)) {
+				if (isTerminalJobStatus(job.status)) {
 					let publication = terminalPublications.get(job.asyncId);
 					if (!publication && status.mode !== "workflow" && status.processTerminal?.state === "pending"
 						&& status.runId === job.asyncId && status.sessionId === state.currentSessionId
@@ -524,7 +526,7 @@ export function createAsyncJobTracker(pi: Pick<ExtensionAPI, "events">, state: S
 						} else cancelCleanup(job.asyncId);
 					}
 					// Scan on close too: publication may have raced the payload check.
-					if (!terminalStatus(previousStatus) || (wasPending && !publication?.pending)) options.onJobTerminal?.();
+					if (!isTerminalJobStatus(previousStatus) || (wasPending && !publication?.pending)) options.onJobTerminal?.();
 					rememberFleetJob(state, job);
 					if (!publication?.pending && !nestedRefreshFailed && !hasLiveNestedDescendants(job.nestedChildren) && (previousStatus !== job.status || !state.cleanupTimers.has(job.asyncId))) {
 						scheduleCleanup(job.asyncId);

--- a/test/integration/async-job-tracker.test.ts
+++ b/test/integration/async-job-tracker.test.ts
@@ -1252,35 +1252,40 @@ describe("async job tracker", { skip: !available ? "pi packages not available" :
 		}
 	});
 
-	it("schedules cleanup when polling observes a completed status without a completion event", async () => {
+	it("schedules cleanup when polling observes terminal statuses without completion events", async () => {
 		const asyncRoot = createTempDir("pi-async-job-tracker-");
 		try {
-			const runDir = path.join(asyncRoot, "run-2");
-			fs.mkdirSync(runDir, { recursive: true });
-			fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
-				runId: "run-2",
-				mode: "single",
-				state: "complete",
-				startedAt: Date.now() - 1000,
-				lastUpdate: Date.now(),
-				steps: [{ agent: "worker", status: "complete" }],
-			}), "utf-8");
-
 			const state = createState();
 			const ui = createUiContext();
-			const recorder = createEventRecorder();
-			const tracker = createTracker(recorder.pi, state as never, asyncRoot, {
+			const tracker = createTracker(createEventRecorder().pi, state as never, asyncRoot, {
 				completionRetentionMs: 5,
 				pollIntervalMs: 10,
 			});
 			tracker.resetJobs(ui.ctx as never);
-			tracker.handleStarted({ id: "run-2", asyncDir: runDir, agent: "worker" });
+			for (const terminalState of ["complete", "partial", "rejected"] as const) {
+				const runId = `run-${terminalState}`;
+				const runDir = path.join(asyncRoot, runId);
+				fs.mkdirSync(runDir, { recursive: true });
+				fs.writeFileSync(path.join(runDir, "status.json"), JSON.stringify({
+					runId,
+					mode: "single",
+					state: terminalState,
+					startedAt: Date.now() - 1000,
+					lastUpdate: Date.now(),
+					steps: [{ agent: "worker", status: terminalState }],
+				}), "utf-8");
+				tracker.handleStarted({ id: runId, asyncDir: runDir, agent: "worker" });
+			}
 
 			await new Promise((resolve) => setTimeout(resolve, 80));
 
 			assert.equal(state.asyncJobs.size, 0);
 			assert.ok(ui.renderRequests > 0, "expected polling cleanup to request a rerender");
 			assert.equal(ui.widgets.at(-1), undefined);
+			assert.equal(state.fleetJobs.get("run-complete")?.status, "complete");
+			assert.equal(state.fleetJobs.get("run-partial")?.status, "partial");
+			assert.equal(state.fleetJobs.get("run-rejected")?.status, "rejected");
+			tracker.resetJobs();
 		} finally {
 			removeTempDir(asyncRoot);
 		}


### PR DESCRIPTION
## Summary

- treat persisted `partial` and `rejected` async jobs as terminal in widget cleanup
- use one terminal-state invariant for widget cleanup and Fleet retention
- cover polled complete, partial, and rejected states in one integration regression

Closes #2159.

Thanks to @ashlineldridge for the detailed reproduction and root-cause analysis.

## Validation

- focused async job tracker integration tests
- `npm run typecheck`
- `git diff --check`