### PR TITLE
feat: run native Pi agents on saved machines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
         run: node test/smoke/npm-background.mjs "$RUNNER_TEMP/npm-background-sdk" "$RUNNER_TEMP/npm-background"
       - name: Require completed Linux smoke receipts
         run: |
-          node -e 'const a = require("node:assert/strict"); const r = require(process.env.RUNNER_TEMP + "/standalone-matrix/matrix.json"); a.equal(r.complete, true); a.equal(r.cases.length, 18); a.ok(r.cases.every(c => c.exitCode === 0 && !c.error));'
+          node -e 'const a = require("node:assert/strict"); const r = require(process.env.RUNNER_TEMP + "/standalone-matrix/matrix.json"); a.equal(r.complete, true); a.equal(r.cases.length, 19); a.ok(r.cases.every(c => c.exitCode === 0 && !c.error));'
           node -e 'const a = require("node:assert/strict"); const r = require(process.env.RUNNER_TEMP + "/npm-background/npm-launch.json"); a.equal(r.publicLaunch, true); a.equal(r.runtime, "Node"); a.equal(r.version, "0.85.1"); a.equal(r.network, "unshared");'
       - name: Collect bounded lifecycle evidence
         id: evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Added
 
 - Add a session-scoped public host API for required native-child extension module paths. Required extensions survive agent overrides and detached/nested launches, appear by safe host ID in launch evidence, and fail closed when denied or unable to load before model resolution. Thanks to [@gkoreli](https://github.com/gkoreli) for #2153.
-- Run the six code-owned external-cli profiles on Herdr saved machines via `machine` placement. The local parent uses `ssh -T`, records remote machine/git evidence, and rejects unsupported agents, commands, and worktrees.
+- Run Pi, Claude Code, Codex, and Cursor subagents on another computer by setting `machine` to a saved Herdr machine.
 - Add `checkpointBeforeDeadlineMs` for async single-agent runs (call param, with a global config default): the runner requests that the child "checkpoint and stop" that many milliseconds before its run deadline. This best-effort handoff request uses the normal steering lifecycle at the child's next tool boundary, so its receipt appears in status and events; the ordinary `timeoutMs` kill still applies. Absent option keeps the current behavior. Thanks to [@freezscholte](https://github.com/freezscholte) for #2141.
 - Add `subagents.agentExcludeDirs` to prune directory subtrees from agent discovery, including nested plugin sources, without disabling ordinary legacy agents. Exclusions respect symlink aliases and apply to explicit/package roots, diagnostics, and agent cache fingerprints. Thanks to [@xarillian](https://github.com/xarillian) for #2131.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -234,11 +234,13 @@ Disable and restore:
 
 `eject`, `disable`, `enable`, and `reset` accept `agentScope: "user" | "project"` and operate in one scope at a time. Project overrides still win over user ones, so a project-scope disable survives a user-scope `enable` until you target the project scope.
 
-## Running external CLI agents on a Herdr saved machine
+## Running agents on a Herdr saved machine
 
-The six code-owned external-cli profiles can run on a Herdr machine (`herdr machine add <target> --label <name>`). The local parent spawns `ssh -T <target>`, retaining prompt delivery, stream parsing, stop, and exit proof. Herdr's catalog is the host allowlist; raw ssh targets are rejected.
+Native Pi agents and the six code-owned external CLI profiles (`claude-code`, `claude-code-writer`, `codex-exec`, `codex-exec-writer`, `cursor-agent`, and `cursor-agent-writer`) can run on a Herdr saved machine. Add the machine with `herdr machine add <target> --label <name>`; Herdr's catalog is the host allowlist, and raw ssh targets are rejected. The local parent connects with `ssh -T`, retaining prompt delivery, stream parsing, stop, and exit proof.
 
-`machine` is a top-level frontmatter key, a settings override (`subagents.agentOverrides.<agent>.machine`, project beats user, `false` clears a pin), and a launch option on the `subagent` tool, workflow `runs.run`, chain, parallel, and dynamic-fanout steps. The launch option wins. Placement survives `subagent({ action: "disable" })`, `reset`, and model profile switches.
+For native agents, install the same pi-subagents version through Pi on the remote machine (for example, `pi install npm:pi-subagents@<same-version>`) and authenticate that Pi installation and its providers. For an external CLI profile, install and authenticate its CLI on the remote machine. The machine supplies its own Pi settings, provider credentials, model registry, and agent resources.
+
+`machine` is a top-level frontmatter key, a settings override (`subagents.agentOverrides.<agent>.machine`, project beats user, `false` clears a pin), and a launch option on direct calls, workflow `runs.run`, chain, parallel, and dynamic-fanout steps. The launch option wins. Placement survives `subagent({ action: "disable" })`, `reset`, and model profile switches.
 
 `cwd` means the directory on that machine when a machine is set. An absolute path or `~/...` is used as given; a relative path joins the repo's configured machine root; with no cwd the root is used; with no root the launch fails closed naming the setting:
 
@@ -251,11 +253,13 @@ The six code-owned external-cli profiles can run on a Herdr machine (`herdr mach
 }
 ```
 
-`machines.<label-or-id>.env` is optional and is exported in front of the remote command. Nothing else crosses: the local ssh process receives only `PATH`, `HOME`, `USER`, `LOGNAME`, `TMPDIR`, and `SSH_AUTH_SOCK`, and no local API key is copied. Remote runs use the machine's own credentials, so log in to the CLI on that machine once. Non-interactive ssh shells skip rc files, so `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` are prepended to the remote `PATH`; for anything else set the agent's `command` to the absolute path on the machine.
+For native runs, provider-qualified model choices and thinking levels are resolved by the remote Pi installation. The effective cwd, skills, memory, refinements, and other resources also come from that installation. Local credentials, absolute resource paths, and resource contents are not copied to the machine.
 
-Remote `--version` and `--help` probes use a ready marker to discard rc-file noise. Runs share one OpenSSH ControlMaster socket per machine (`~/.pi/agent/ssh-control/`, `ControlPersist=60`). Status, receipts, and FleetView carry the machine identity, remote cwd, and remote git state; writer results state that changes are remote.
+`machines.<label-or-id>.env` is optional and is exported in front of the remote command. For external CLI profiles, the local ssh process receives only `PATH`, `HOME`, `USER`, `LOGNAME`, `TMPDIR`, and `SSH_AUTH_SOCK`, and no local API key is copied. Non-interactive ssh shells skip rc files, so `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` are prepended to the remote `PATH`; for anything else set the profile's `command` to the absolute path on the machine.
 
-pi-subagents never clones, pulls, or checks out on the machine; a missing directory fails the remote `cd` with a hint. Native Pi agents, generic `external-cli` commands, managed worktrees, and Windows hosts are rejected before launch. Codex's final message and Cursor's handoff file use the ssh stream and remote temp files, not local paths.
+External CLI `--version` and `--help` probes use a ready marker to discard rc-file noise. Runs share one OpenSSH ControlMaster socket per machine (`~/.pi/agent/ssh-control/`, `ControlPersist=60`). Status, results, receipts, and FleetView carry the machine identity and remote cwd. Results include before/after remote Git evidence, and writer results state that changes are remote.
+
+pi-subagents never clones, pulls, or checks out on the machine; a missing directory fails the remote `cd` with a hint. Saved-machine launches require a POSIX host. Native remote runs use fresh context: an implicit fork falls back to fresh with a warning, while an explicit fork is rejected. This first slice does not support managed worktrees, transfer of local extensions/MCP selections/bindings, structured output or watchdog callbacks, nested remote fanout, local output paths, reconnect, or revival. Generic `external-cli` commands remain unsupported; only the six code-owned profiles are accepted. Codex's final message and Cursor's handoff file use the ssh stream and remote temp files, not local paths.
 
 ## Parent prompt discovery
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -119,7 +119,7 @@ The complete plain-JSON inventory is validated before the first launch (maximum 
 | `toolBudget` | object | none | Optional child tool-call budget `{ soft?, hard, block? }`. At `soft` the child is nudged to finalize. After `hard`, configured tools are blocked; `block` defaults to `read`, `grep`, `find`, and `ls`, while `"*"` blocks every tool call. Final assistant text is never blocked. |
 | `usageBudget` | object | none | Optional root-only reported-usage budget `{ tokens?: { soft?, hard }, costUsd?: { soft?, hard } }`. Soft limits are status-only. Hard limits prevent later child launches after reported usage is reconciled; already-running children are not stopped and no reservations are made. |
 | `cwd` | string | runtime cwd | Override working directory. With `machine`, the directory on that machine. |
-| `machine` | string | - | Herdr saved machine (label or profile id) for external-cli agents; see [agents.md](agents.md#running-external-cli-agents-on-a-herdr-saved-machine). |
+| `machine` | string | - | Herdr saved machine (label or profile id) for native Pi agents or the six code-owned external CLI profiles; see [agents.md](agents.md#running-agents-on-a-herdr-saved-machine). |
 | `maxOutput` | object | 200KB, 5000 lines | Final output truncation limits. |
 | `artifacts` | boolean | true | Write debug artifacts. |
 | `includeProgress` | boolean | false | Include full progress in result. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "yaml": "2.8.3"
       },
       "bin": {
-        "pi-subagents": "install.mjs"
+        "pi-subagents": "install.mjs",
+        "pi-subagents-remote-host": "remote-native-host.sh"
       },
       "devDependencies": {
         "@earendil-works/pi-agent-core": "0.81.0",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
     "cli"
   ],
   "bin": {
-    "pi-subagents": "install.mjs"
+    "pi-subagents": "install.mjs",
+    "pi-subagents-remote-host": "remote-native-host.sh"
   },
   "files": [
     "index.ts",
     "src/**/*.ts",
     "*.mjs",
+    "*.sh",
     "agents/",
     "skills/**/*",
     "prompts/**/*",

--- a/remote-native-host.sh
+++ b/remote-native-host.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+self=$0
+while [ -L "$self" ]; do
+	link=$(readlink "$self") || exit 126
+	case $link in
+		/*) self=$link ;;
+		*) self=$(dirname "$self")/$link ;;
+	esac
+done
+package_dir=$(CDPATH= cd -P -- "$(dirname -- "$self")" && pwd) || {
+	printf '%s\n' "Remote native Pi launcher could not resolve its installed package directory." >&2
+	exit 126
+}
+bootstrap=$package_dir/src/runs/shared/remote-native-bootstrap.ts
+
+case ${PI_SUBAGENT_PI_BINARY-} in
+	"") pi_command=pi ;;
+	/*) pi_command=$PI_SUBAGENT_PI_BINARY ;;
+	*)
+		printf '%s\n' "Remote native Pi launcher failed: PI_SUBAGENT_PI_BINARY must be an absolute path to the remote Pi executable." >&2
+		exit 126
+		;;
+esac
+
+exec "$pi_command" \
+	--no-extensions \
+	--no-skills \
+	--no-prompt-templates \
+	--no-context-files \
+	--no-session \
+	--mode rpc \
+	--extension "$bootstrap"

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -14,7 +14,7 @@ import { createAtomicJsonWriter, writePrivateAtomicJson } from "../../shared/ato
 import { buildEffectiveSystemPrompt } from "../shared/effective-system-prompt.ts";
 import { currentCompletionOwnerId } from "../../shared/completion-owner.ts";
 import { planChildLaunch, resolveStepBehavior, suppressProgressForReadOnlyTask, type ResolvedStepBehavior } from "../shared/child-launch-plan.ts";
-import { formatHerdrMachineRunnerUnsupported, resolveHerdrMachinePlacement } from "../shared/herdr-machine.ts";
+import { formatHerdrMachineRunnerUnsupported, isNativePiRunner, resolveHerdrMachinePlacement } from "../shared/herdr-machine.ts";
 import { applyThinkingSuffix, getHostBuiltinToolNames, projectLaunchResolvedChildExtensions, resolvePiLaunchToolPlan } from "../shared/child-tool-plan.ts";
 import { injectSingleOutputInstruction, normalizeSingleOutputOverride, resolveSingleOutputPath, validateFileOnlyOutputMode } from "../shared/single-output.ts";
 import { applyWatchdogLaunchRules, sendRuleViolationWarning } from "../../watchdog/rules.ts";
@@ -880,6 +880,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 				throw new AsyncStartValidationError(error instanceof Error ? error.message : String(error));
 			}
 		}
+		const nativeMachine = Boolean(machine && isNativePiRunner(a.runner));
 		if (externalRunner) {
 			const unsupported: string[] = [];
 			if (s.model !== undefined) unsupported.push("model override");
@@ -921,7 +922,8 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			resolvedBehavior,
 		});
 		const { stepCwd, instructionCwd, readExistenceCwd, behavior, namespaceOutputPath, outputPath, skillNames } = launchPlan;
-		const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+		if (nativeMachine && outputPath) throw new AsyncStartValidationError("Remote native Pi does not support child-written output paths; use inline output so the local runner captures the result.");
+		const { resolved: resolvedSkills, missing: missingSkills } = nativeMachine ? { resolved: [], missing: [] } : resolveSkillsWithFallback(
 			skillNames,
 			stepCwd,
 			ctx.cwd,
@@ -931,12 +933,12 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		if (missingSkills.includes("pi-subagents")) throw new UnavailableSubagentSkillError(UNAVAILABLE_SUBAGENT_SKILL_ERROR);
 
 		// A namespaced parallel output is injected by the runner, not the prompt.
-		const systemPrompt = buildEffectiveSystemPrompt({ agent: a, resolvedSkills, cwd: stepCwd, ...(!namespaceOutputPath && outputPath ? { outputPath } : {}) });
+		const systemPrompt = nativeMachine ? a.systemPrompt?.trim() ?? "" : buildEffectiveSystemPrompt({ agent: a, resolvedSkills, cwd: stepCwd, ...(!namespaceOutputPath && outputPath ? { outputPath } : {}) });
 
 		const readInstructions = buildChainInstructions({ ...behavior, output: false, progress: false }, instructionCwd, false, undefined, readExistenceCwd);
 		const isFirstProgressAgent = behavior.progress && !progressPrecreated && !progressInstructionCreated;
 		if (behavior.progress) progressInstructionCreated = true;
-		const progressInstructions = buildChainInstructions({ ...behavior, output: false, reads: false }, progressDir, isFirstProgressAgent);
+		const progressInstructions = nativeMachine ? { prefix: "", suffix: "" } : buildChainInstructions({ ...behavior, output: false, reads: false }, progressDir, isFirstProgressAgent);
 		const validationError = validateFileOnlyOutputMode(behavior.outputMode, outputPath, `Async step (${s.agent})`);
 		if (validationError) throw new AsyncStartValidationError(validationError);
 		let taskTemplate = s.task ?? "{previous}";
@@ -947,8 +949,10 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 
 		const modelScopes = resolveModelScopesForAgent(ctx.modelScope, a.name, ctx.currentModel);
 		const modelOrigin = resolveModelOrigin({ explicitModel: s.model, agentModel: a.model, parentModel: ctx.currentModel });
-		const primaryModelFromParent = modelOrigin === "inherited";
-		const primaryModel = externalRunner ? undefined : resolveEffectiveSubagentModel(
+		const remoteRequestedModel = s.model ?? a.model;
+		if (nativeMachine && remoteRequestedModel && !remoteRequestedModel.includes("/")) throw new AsyncStartValidationError("Remote native Pi model overrides must be provider-qualified (provider/model).");
+		const primaryModelFromParent = !nativeMachine && modelOrigin === "inherited";
+		const primaryModel = externalRunner ? undefined : nativeMachine ? remoteRequestedModel : resolveEffectiveSubagentModel(
 			s.model,
 			a.model,
 			ctx.currentModel,
@@ -977,11 +981,11 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 		let modelCandidates: string[] = [];
 		if (!externalRunner) {
 			try {
-				modelCandidates = buildModelCandidates(primaryModel, a.fallbackModels, availableModels, a.modelProvider ?? ctx.currentModelProvider, {
+				modelCandidates = (nativeMachine ? [primaryModel] : buildModelCandidates(primaryModel, a.fallbackModels, availableModels, a.modelProvider ?? ctx.currentModelProvider, {
 					scope: modelScopes,
 					primaryModelFromParent,
 					origin: modelOrigin,
-				}).flatMap((candidate) => {
+				})).flatMap((candidate) => {
 					const resolved = applyThinkingSuffix(candidate, effectiveThinking, thinkingOverride !== undefined);
 					return resolved ? [resolved] : [];
 				});
@@ -1004,7 +1008,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			requiredExtensions,
 			mcpDirectTools: a.mcpDirectTools,
 			cwd: stepCwd,
-			requireReadTool: Boolean(resolvedSkills.length),
+			requireReadTool: nativeMachine ? skillNames.length > 0 : Boolean(resolvedSkills.length),
 			structuredOutput: Boolean(s.outputSchema),
 			fast,
 			model,
@@ -1044,7 +1048,7 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			...(a.runner ? { runner: a.runner } : {}),
 			...(machine ? { machine } : {}),
 			...(machineEnv ? { machineEnv } : {}),
-			...(params.contextForAgent ? { context: params.contextForAgent(s.agent) } : {}),
+			...(params.contextForAgent ? { context: machine && isNativePiRunner(a.runner) ? "fresh" : params.contextForAgent(s.agent) } : {}),
 			...(agentContract ? { agentContract } : {}),
 			phase: s.phase,
 			label: s.label,
@@ -1076,11 +1080,12 @@ export function buildAsyncRunnerSteps(id: string, params: AsyncRunnerStepBuildPa
 			inheritProjectContext: a.inheritProjectContext,
 			inheritGlobalContext: a.inheritGlobalContext,
 			inheritSkills: a.inheritSkills,
-			skills: resolvedSkills.map((r) => r.name),
+			skills: nativeMachine ? skillNames : resolvedSkills.map((r) => r.name),
+			...(a.memory ? { memory: { ...a.memory } } : {}),
 			outputPath,
 			...(namespaceOutputPath ? { namespaceOutputPath: true } : {}),
 			outputMode: behavior.outputMode,
-			sessionFile,
+			...(nativeMachine ? {} : { sessionFile }),
 			maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, a.maxSubagentDepth),
 			timeoutMs: a.defaultTimeoutMs ?? DEFAULT_ASYNC_TIMEOUT_MS,
 			toolTimeoutMs: resolvedToolTimeout.toolTimeoutMs,
@@ -1654,6 +1659,7 @@ export function executeAsyncSingle(
 	const requestedMachine = params.machine ?? agentConfig.machine;
 	const machineUnsupported = formatHerdrMachineRunnerUnsupported({ machine: requestedMachine, agentName: agentConfig.name, runnerType: agentConfig.runner?.type, adapter: agentConfig.runner?.type === "external-cli" ? agentConfig.runner.adapter : undefined, worktree: params.worktree });
 	if (machineUnsupported) return formatAsyncStartError("single", machineUnsupported);
+	if (requestedMachine && isNativePiRunner(agentConfig.runner) && params.context === "fork") return formatAsyncStartError("single", `Agent '${agentConfig.name}' requested explicit context='fork' on machine '${requestedMachine}', but remote native Pi supports fresh context only.`);
 	let machine: HerdrMachineReference | undefined;
 	let machineEnv: Record<string, string> | undefined;
 	if (requestedMachine) {
@@ -1665,6 +1671,7 @@ export function executeAsyncSingle(
 			return formatAsyncStartError("single", error instanceof Error ? error.message : String(error));
 		}
 	}
+	const nativeMachine = Boolean(machine && isNativePiRunner(agentConfig.runner));
 	let managedWorktreeProvider: "native" | "worktrunk" | undefined;
 	if (params.worktree === true) {
 		try {
@@ -1682,7 +1689,7 @@ export function executeAsyncSingle(
 	const readExistenceCwd = params.worktree === true ? runnerCwd : instructionCwd;
 	const skillNames = params.skills ?? agentConfig.skills ?? [];
 	const availableModels = params.availableModels;
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+	const { resolved: resolvedSkills, missing: missingSkills } = nativeMachine ? { resolved: [], missing: [] } : resolveSkillsWithFallback(
 		skillNames,
 		runnerCwd,
 		ctx.cwd,
@@ -1711,8 +1718,9 @@ export function executeAsyncSingle(
 	}
 
 	const effectiveOutput = normalizeSingleOutputOverride(params.output, agentConfig.output);
-	const outputPath = resolveSingleOutputPath(effectiveOutput, ctx.cwd, instructionCwd, params.outputBaseDir ?? (artifactsDir ? path.join(artifactsDir, "outputs", id) : undefined));
-	const systemPrompt = buildEffectiveSystemPrompt({ agent: agentConfig, resolvedSkills, cwd: runnerCwd, ...(outputPath ? { outputPath } : {}) });
+	if (machine && isNativePiRunner(agentConfig.runner) && effectiveOutput) return formatAsyncStartError("single", "Remote native Pi does not support child-written output paths; use inline output so the local runner captures the result.");
+	const outputPath = machine && isNativePiRunner(agentConfig.runner) ? undefined : resolveSingleOutputPath(effectiveOutput, ctx.cwd, instructionCwd, params.outputBaseDir ?? (artifactsDir ? path.join(artifactsDir, "outputs", id) : undefined));
+	const systemPrompt = nativeMachine ? agentConfig.systemPrompt?.trim() ?? "" : buildEffectiveSystemPrompt({ agent: agentConfig, resolvedSkills, cwd: runnerCwd, ...(outputPath ? { outputPath } : {}) });
 	const outputMode = params.outputMode ?? agentConfig.outputMode ?? "inline";
 	const validationError = validateFileOnlyOutputMode(outputMode, outputPath, `Async single run (${agent})`);
 	if (validationError) return formatAsyncStartError("single", validationError);
@@ -1721,7 +1729,9 @@ export function executeAsyncSingle(
 	// absolute paths pass through; relative paths resolve against the child cwd.
 	const reads = params.reads !== undefined ? params.reads : agentConfig.defaultReads ?? false;
 	const readPaths = Array.isArray(reads)
-		? managedWorktreeProvider === "worktrunk"
+		? nativeMachine
+			? reads.map((value) => value.startsWith("/") || value === "~" || value.startsWith("~/") ? value : path.posix.join(instructionCwd, value))
+			: managedWorktreeProvider === "worktrunk"
 			? resolveExistingReadInstructionPaths(reads, instructionCwd, readExistenceCwd)
 			: resolveExistingReadPaths(reads, readExistenceCwd)
 		: [];
@@ -1737,9 +1747,11 @@ export function executeAsyncSingle(
 		agentModel: agentConfig.model,
 		parentModel: ctx.currentModel,
 	});
+	const remoteRequestedModel = params.modelOverrideFromParent ? agentConfig.model : params.modelOverride ?? agentConfig.model;
+	if (nativeMachine && remoteRequestedModel && !remoteRequestedModel.includes("/")) return formatAsyncStartError("single", "Remote native Pi model overrides must be provider-qualified (provider/model).");
 	let primaryModel: string | undefined;
 	try {
-		primaryModel = externalRunner ? undefined : modelOrigin === "inherited"
+		primaryModel = externalRunner ? undefined : nativeMachine ? remoteRequestedModel : modelOrigin === "inherited"
 			? params.modelOverride ?? (ctx.currentModel ? `${ctx.currentModel.provider}/${ctx.currentModel.id}` : undefined)
 			: resolveSubagentModelOverride(
 				params.modelOverride ?? agentConfig.model,
@@ -1790,11 +1802,11 @@ export function executeAsyncSingle(
 	let modelCandidates: string[] = [];
 	if (!externalRunner) {
 		try {
-			modelCandidates = buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, agentConfig.modelProvider ?? ctx.currentModelProvider, {
+			modelCandidates = (nativeMachine ? [primaryModel] : buildModelCandidates(primaryModel, agentConfig.fallbackModels, availableModels, agentConfig.modelProvider ?? ctx.currentModelProvider, {
 				scope: modelScopes,
 				primaryModelFromParent: modelOrigin === "inherited",
 				origin: modelOrigin,
-			}).flatMap((candidate) => {
+			})).flatMap((candidate) => {
 				const resolved = applyThinkingSuffix(candidate, effectiveThinking, params.thinkingOverride !== undefined);
 				return resolved ? [resolved] : [];
 			});
@@ -1814,7 +1826,7 @@ export function executeAsyncSingle(
 		requiredExtensions,
 		mcpDirectTools: agentConfig.mcpDirectTools,
 		cwd: runnerCwd,
-		requireReadTool: Boolean(resolvedSkills.length),
+		requireReadTool: nativeMachine ? skillNames.length > 0 : Boolean(resolvedSkills.length),
 		structuredOutput: Boolean(params.structuredOutputSchema),
 		fast: params.fast ?? agentConfig.fast,
 		model,
@@ -1850,7 +1862,7 @@ export function executeAsyncSingle(
 		...(fast !== undefined ? { fast } : {}),
 		...(launchThinking ? { thinking: launchThinking } : {}),
 		systemPrompt,
-		skills: resolvedSkills.map((skill) => skill.name),
+		skills: nativeMachine ? skillNames : resolvedSkills.map((skill) => skill.name),
 		toolPlan,
 		...(outputPath ? { outputPath } : {}),
 		outputMode,
@@ -1901,7 +1913,7 @@ export function executeAsyncSingle(
 		inheritProjectContext: recoveryAgentConfig.inheritProjectContext,
 		inheritGlobalContext: recoveryAgentConfig.inheritGlobalContext,
 		inheritSkills: recoveryAgentConfig.inheritSkills,
-		...(resolvedSkills.length ? { skills: resolvedSkills.map((skill) => skill.name) } : {}),
+		...((nativeMachine ? skillNames.length : resolvedSkills.length) ? { skills: nativeMachine ? skillNames : resolvedSkills.map((skill) => skill.name) } : {}),
 		...(recoveryAgentConfig.skillPath ? { skillPath: [...recoveryAgentConfig.skillPath] } : {}),
 		...(recoveryAgentConfig.filePath ? { agentFilePath: recoveryAgentConfig.filePath } : {}),
 		...(recoveryAgentConfig.completionGuard !== undefined ? { completionGuard: recoveryAgentConfig.completionGuard } : {}),
@@ -1924,7 +1936,7 @@ export function executeAsyncSingle(
 		artifactConfig,
 		...(capabilityCeiling ? { capabilityCeiling } : {}),
 	};
-	if (!externalRunner) {
+	if (!externalRunner && !nativeMachine) {
 		try {
 			writePrivateAtomicJson(path.join(asyncDir, "recovery-descriptor.json"), recoveryDescriptor);
 		} catch (error) {
@@ -1975,11 +1987,12 @@ export function executeAsyncSingle(
 						inheritProjectContext: agentConfig.inheritProjectContext,
 						inheritGlobalContext: agentConfig.inheritGlobalContext,
 						inheritSkills: agentConfig.inheritSkills,
-						skills: resolvedSkills.map((r) => r.name),
+						skills: nativeMachine ? skillNames : resolvedSkills.map((r) => r.name),
+						...(agentConfig.memory ? { memory: { ...agentConfig.memory } } : {}),
 						outputPath,
 						...(params.outputClaimPath ? { outputClaimPath: params.outputClaimPath } : {}),
 						outputMode,
-						...(!externalRunner && sessionFile ? { sessionFile } : {}),
+						...(!externalRunner && !nativeMachine && sessionFile ? { sessionFile } : {}),
 						maxSubagentDepth: resolveChildMaxSubagentDepth(maxSubagentDepth, agentConfig.maxSubagentDepth),
 						waitToolEnabled: params.waitToolEnabled,
 						waitToolDefaultTimeoutMs: params.waitToolDefaultTimeoutMs,

--- a/src/runs/background/run-child-session.ts
+++ b/src/runs/background/run-child-session.ts
@@ -24,6 +24,9 @@ import { isMutatingTool, resolveCurrentPath } from "../shared/long-running-guard
 import { effectiveToolTimeoutMs, formatToolTimeoutMessage, toolTimeoutCallKey } from "../shared/tool-timeout.ts";
 import { createReportedChildSessionInput, type InProcessChildLaunch } from "../shared/child-launch.ts";
 import { childSessionHasQueuedMessages, projectChildSessionEventForJson, type ChildSession, type ChildSessionEvent, type ChildSessionFactory } from "../shared/child-session.ts";
+import type { ExternalCliMachineStatus } from "../../shared/types.ts";
+import type { ChildToolDiagnostic } from "../shared/tool-availability.ts";
+import { projectNativeMachineEvidence } from "../shared/remote-native-session.ts";
 import { formatSteerMessage } from "../shared/subagent-prompt-runtime.ts";
 import { getReadonlySessionEvidence, requestReadonlySessionEvidence, type SettledReadonlyEvidence } from "../shared/readonly-session-evidence.ts";
 import type { SteerDeliveryStatus, SteerRequest } from "./control-channel.ts";
@@ -138,8 +141,10 @@ export interface RunChildSessionResult {
 	toolBudgetBlocked?: boolean;
 	structuredOutput?: unknown;
 	runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensions;
+	toolDiagnostic?: ChildToolDiagnostic;
 	abortRecoveryDiagnostic?: string;
 	effects?: EffectsProjection;
+	machine?: ExternalCliMachineStatus;
 }
 
 /** Events the child emits while the model streams; not persisted into the diagnostic log. */
@@ -607,6 +612,9 @@ export function runChildSession(input: RunChildSessionInput): Promise<RunChildSe
 					structuredOutputMessageStartIndex,
 					watchdog: childWatchdogState,
 					sessionFile: session?.sessionFile,
+					toolDiagnostic: session?.toolDiagnostic,
+					runtimeAcknowledgedExtensions: session?.runtimeAcknowledgedExtensions,
+					...(input.launch.session.machine ? { machine: projectNativeMachineEvidence(input.launch.session.machine, session?.machineEvidence) } : {}),
 					currentTool,
 					currentToolArgs,
 					currentPath,

--- a/src/runs/background/runner-child-launch.ts
+++ b/src/runs/background/runner-child-launch.ts
@@ -6,6 +6,7 @@ import { normalizeExtensionBindings } from "../shared/extension-bindings.ts";
 import type { RunnerSubagentStep } from "../shared/parallel-utils.ts";
 import { formatAcceptancePrompt } from "../shared/acceptance.ts";
 import { isAgentContract } from "../shared/agent-contract.ts";
+import { agentHasWriteTools } from "../../agents/agent-memory.ts";
 
 export interface RunnerChildLaunchContext {
 	cwd: string;
@@ -34,7 +35,7 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 	const acceptancePrompt = step.effectiveAcceptance
 		? formatAcceptancePrompt(step.effectiveAcceptance, { reportOptional: isAgentContract(step.agentContract), structuredOutput: Boolean(step.structuredOutput?.acceptanceReportPath) })
 		: "";
-	return buildInProcessChildLaunch({
+	const launch = buildInProcessChildLaunch({
 		parentSessionId: step.parentSessionId,
 		forkCacheKey: step.context === "fork" ? deriveForkPromptCacheKey(step.parentSessionId) : undefined,
 		sessionEnabled: attempt.sessionEnabled,
@@ -54,6 +55,7 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 		fast: step.fast,
 		modelCandidates: step.modelCandidates,
 		systemPrompt: acceptancePrompt ? `${step.systemPrompt ?? ""}\n${acceptancePrompt}` : step.systemPrompt ?? "",
+		skillNames: step.machine ? step.skills : undefined,
 		systemPromptMode: step.systemPromptMode,
 		mcpDirectTools: step.mcpDirectTools,
 		extensionBindings: normalizeExtensionBindings(step.extensionBindings)?.value,
@@ -86,4 +88,17 @@ export function buildRunnerChildLaunch(step: RunnerSubagentStep, ctx: RunnerChil
 		hostAvailableBuiltins: ctx.hostAvailableBuiltins,
 		host: "runner",
 	});
+	if (step.machine) {
+		const mode = launch.session.systemPrompt !== undefined ? "replace" : "append";
+		launch.session.remotePromptSpec = {
+			agentName: step.agent, baseSystemPrompt: launch.session.systemPrompt ?? launch.session.appendSystemPrompt ?? "", mode,
+			...(step.skills?.length ? { skillNames: step.skills } : {}),
+			...(step.memory ? { memory: { ...step.memory, writable: agentHasWriteTools({ tools: step.tools }) } } : {}),
+		};
+		delete launch.session.systemPrompt; delete launch.session.appendSystemPrompt; delete launch.session.skillNames;
+		launch.session.machine = step.machine;
+		launch.session.machineEnv = step.machineEnv;
+		if (step.thinking) launch.session.thinking = step.thinking as NonNullable<typeof launch.session.thinking>;
+	}
+	return launch;
 }

--- a/src/runs/background/runner-child-sessions.ts
+++ b/src/runs/background/runner-child-sessions.ts
@@ -11,6 +11,7 @@
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createDefaultChildSessionFactory, type ChildSessionFactory, type DefaultChildSessionFactoryOptions } from "../shared/child-session.ts";
+import { createPlacementAwareChildSessionFactory } from "../shared/remote-native-session.ts";
 
 export interface RunnerChildSessionConfig {
 	/** Test seam: module whose default export is a `ChildSessionFactory`, or a function returning one. */
@@ -22,7 +23,7 @@ function isChildSessionFactory(value: unknown): value is ChildSessionFactory {
 }
 
 export async function loadRunnerChildSessionFactory(config: RunnerChildSessionConfig, options?: DefaultChildSessionFactoryOptions): Promise<ChildSessionFactory> {
-	if (!config.childSessionFactoryModule) return createDefaultChildSessionFactory(options);
+	if (!config.childSessionFactoryModule) return createPlacementAwareChildSessionFactory(createDefaultChildSessionFactory(options));
 	const loaded = await import(pathToFileURL(path.resolve(config.childSessionFactoryModule)).href) as { default?: unknown };
 	const candidate = typeof loaded.default === "function" ? (loaded.default as () => unknown)() : loaded.default;
 	if (!isChildSessionFactory(candidate)) {

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -68,6 +68,7 @@ import {
 	type SubagentChildStatusEvent,
 	type WorkflowLaneMetadata,
 	type HerdrMachineReference,
+	type ExternalCliMachineStatus,
 	DEFAULT_MAX_OUTPUT,
 	type MaxOutputConfig,
 	SUBAGENT_LIFECYCLE_ARTIFACT_VERSION,
@@ -254,6 +255,7 @@ interface StepResult {
 	/** Human-readable display name for the child session, when derived at launch. */
 	sessionName?: string;
 	context?: "fresh" | "fork";
+	machine?: ExternalCliMachineStatus;
 	capabilityCeiling?: ResolvedSubagentCapabilityCeiling;
 	capabilityAudit?: import("../shared/capability-ceiling.ts").SubagentCapabilityAudit;
 	launchResolvedExtensions?: LaunchResolvedChildExtensions;
@@ -1043,7 +1045,7 @@ export async function runSingleStepInner(
 	}
 
 	const effectiveCwd = step.cwd ?? ctx.cwd;
-	const cwdError = preflightLaunchCwd(step.requestedCwd ?? effectiveCwd, effectiveCwd);
+	const cwdError = step.machine ? undefined : preflightLaunchCwd(step.requestedCwd ?? effectiveCwd, effectiveCwd);
 	if (cwdError) return { agent: step.agent, output: cwdError, error: cwdError, exitCode: 1, context: step.context };
 	if (step.context === "fork" && step.sessionFile && fs.existsSync(step.sessionFile)) {
 		alignForkedSessionCwd(step.sessionFile, effectiveCwd);
@@ -1069,8 +1071,8 @@ export async function runSingleStepInner(
 	let toolBudget = step.toolBudget ? initialToolBudgetState(step.toolBudget) : undefined;
 	let toolBudgetBlocked = false;
 	let actualLaunchContractDigest = step.launchContractDigest;
-	const mutationSnapshot = snapshotTrackedMutations(step.cwd ?? ctx.cwd);
-	let finalMutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.cwd ?? ctx.cwd);
+	const mutationSnapshot = snapshotTrackedMutations(step.machine ? ctx.cwd : step.cwd ?? ctx.cwd);
+	let finalMutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.machine ? ctx.cwd : step.cwd ?? ctx.cwd);
 
 	let modelIndex = 0;
 	let contextOverflow = false;
@@ -1243,9 +1245,9 @@ export async function runSingleStepInner(
 		// A parked run still owes completion evidence when it actually finishes.
 		// Stopped/timedOut runs already have terminal failures; checking completion evidence there is meaningless.
 		const completionDiagnosticsEligible = !run.interrupted && !run.stopped && !run.timedOut;
-		const toolDiagnostic = run.exitCode === 0 && !run.error ? launch.capture.toolDiagnostic() : undefined;
+		const toolDiagnostic = run.exitCode === 0 && !run.error ? run.toolDiagnostic ?? launch.capture.toolDiagnostic() : undefined;
 		const toolAvailabilityError = toolDiagnostic ? formatChildToolDiagnostic(toolDiagnostic) : undefined;
-		const runtimeAcknowledgedExtensions = launch.capture.runtimeAcknowledgedExtensions();
+		const runtimeAcknowledgedExtensions = run.runtimeAcknowledgedExtensions ?? launch.capture.runtimeAcknowledgedExtensions();
 		const midToolExitError = run.currentTool
 			&& isOrdinaryToolForMidToolExit(run.currentTool)
 			&& !run.interrupted
@@ -1298,7 +1300,7 @@ export async function runSingleStepInner(
 		const completionGuardEnabled = isAgentContract(step.agentContract) ? step.completionGuard === true : step.completionGuard !== false;
 		const completionToolPlan = resolvedTaskToolPlan;
 		const completionTools = completionToolPlan ? (completionToolPlan.explicitToolAllowlist ? completionToolPlan.effectiveToolAllowlist : undefined) : step.tools;
-		const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.cwd ?? ctx.cwd);
+		const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, step.machine ? ctx.cwd : step.cwd ?? ctx.cwd);
 		finalMutationEvidence = mutationEvidence;
 		const completionMutationEvidence = ctx.trackedMutationEvidenceForCompletionGuard === false ? undefined : mutationEvidence;
 		const completionGuard = completionDiagnosticsEligible && run.exitCode === 0 && !run.error && !structuredError && !hiddenError?.hasError && !midToolExitError && !emptyOutputError && completionGuardEnabled
@@ -1389,7 +1391,7 @@ export async function runSingleStepInner(
 			afterCompactionSettlement: run.afterCompactionSettlement === true,
 		});
 		const fileMutationEffect = completionEvidence.fileMutation ?? (missingRequiredOutputAfterMutation ? { status: "observed" as const, expected: completionEvidence.mutationExpected, attempted: true, evidence: mutationEvidence } : undefined);
-		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect || settlementDiagnostic ? { effects: { ...(fileMutationEffect ? { fileMutation: fileMutationEffect } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunChildSessionResult;
+		finalResult = { ...run, exitCode: effectiveExitCode, model: candidate ?? run.model, error, structuredOutput, runtimeAcknowledgedExtensions, ...(run.machine ?? step.machine ? { machine: run.machine ?? step.machine } : {}), ...(step.agentContract ? { agentContract: step.agentContract } : {}), ...(fileMutationEffect || settlementDiagnostic ? { effects: { ...(fileMutationEffect ? { fileMutation: fileMutationEffect } : {}), ...(settlementDiagnostic ? { settlementDiagnostic } : {}) } } : {}) } as RunChildSessionResult;
 		const abortRecovery = !attempt.success ? planAbortRecovery({
 			messages: run.messages,
 			error,
@@ -1598,6 +1600,7 @@ export async function runSingleStepInner(
 				task: PROMPT_REDACTED,
 				exitCode: effectiveFinalExitCode,
 				model: finalResult?.model,
+				machine: finalResult?.machine,
 				attemptedModels: attemptedModels.length > 0 ? attemptedModels : undefined,
 				modelAttempts,
 				usage,
@@ -1619,6 +1622,7 @@ export async function runSingleStepInner(
 		agent: step.agent,
 		...(childSessionName ? { sessionName: childSessionName } : {}),
 		context: step.context,
+		machine: finalResult?.machine,
 		...(step.agentContract ? { agentContract: step.agentContract } : {}),
 		launchContractDigest: actualLaunchContractDigest,
 		output: outputForSummary,
@@ -4966,6 +4970,7 @@ export async function runSubagent(
 				agent: r.agent,
 				...(r.sessionName ? { sessionName: r.sessionName } : {}),
 				context: r.context,
+				machine: r.machine,
 				output: r.output,
 				outputState: r.outputState,
 				error: r.error,

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -8,6 +8,7 @@ import type { Message } from "@earendil-works/pi-ai";
 import { discoverAgents, formatUnknownAgentError, unknownAgentDiagnosticContext, type AgentConfig } from "../../agents/agents.ts";
 import { alignForkedSessionCwd } from "../../shared/fork-session-cwd.ts";
 import { buildEffectiveSystemPrompt } from "../shared/effective-system-prompt.ts";
+import { agentHasWriteTools } from "../../agents/agent-memory.ts";
 import {
 	ensureArtifactsDir,
 	formatOutputArtifactContent,
@@ -113,6 +114,7 @@ import {
 } from "../../watchdog/child-status.ts";
 import { buildInProcessChildLaunch, createReportedChildSessionInput } from "../shared/child-launch.ts";
 import { childSessionFactory, childSessionHasQueuedMessages, projectChildSessionEventForJson, type ChildSession, type ChildSessionEvent } from "../shared/child-session.ts";
+import { createPlacementAwareChildSessionFactory, projectNativeMachineEvidence } from "../shared/remote-native-session.ts";
 
 const artifactOutputByResult = new WeakMap<SingleResult, string>();
 const acceptanceOutputByResult = new WeakMap<SingleResult, string>();
@@ -358,6 +360,7 @@ async function runSingleAttempt(
 		systemPrompt: string;
 		acceptancePrompt: string;
 		resolvedSkillNames?: string[];
+		remoteSkillNames?: string[];
 		modelCandidates?: string[];
 		skillsWarning?: string;
 		jsonlPath?: string;
@@ -383,7 +386,7 @@ async function runSingleAttempt(
 	// runtime config and echoed back on the result payload so hosts can label
 	// this run without reading the child's session file.
 	const childSessionName = deriveChildSessionName({ agent: agent.name, task: shared.originalTask ?? task });
-	const watchdogConfig = resolveWatchdogConfig(options.cwd ?? runtimeCwd);
+	const watchdogConfig = resolveWatchdogConfig(options.machine ? runtimeCwd : options.cwd ?? runtimeCwd);
 	const childWatchdog = watchdogConfig.ok
 		? resolveChildWatchdogConfig({
 			config: watchdogConfig.config,
@@ -409,6 +412,7 @@ async function runSingleAttempt(
 		inheritGlobalContext: agent.inheritGlobalContext,
 		inheritSkills: agent.inheritSkills,
 		requireReadTool: Boolean(shared.resolvedSkillNames?.length),
+		skillNames: shared.remoteSkillNames,
 		tools: agent.tools,
 		excludeTools: agent.excludeTools,
 		allowNestedSubagents: agent.allowNestedSubagents,
@@ -447,6 +451,22 @@ async function runSingleAttempt(
 		inherited: options.childRuntime,
 		host: "parent",
 	});
+	if (options.machine) {
+		const mode = launch.session.systemPrompt !== undefined ? "replace" : "append";
+		launch.session.remotePromptSpec = {
+			agentName: agent.name,
+			baseSystemPrompt: launch.session.systemPrompt ?? launch.session.appendSystemPrompt ?? "",
+			mode,
+			...(shared.remoteSkillNames?.length ? { skillNames: shared.remoteSkillNames } : {}),
+			...(agent.memory ? { memory: { ...agent.memory, writable: agentHasWriteTools(agent) } } : {}),
+		};
+		delete launch.session.systemPrompt; delete launch.session.appendSystemPrompt; delete launch.session.skillNames;
+	}
+	if (options.machine) {
+		launch.session.machine = options.machine;
+		launch.session.machineEnv = options.machineEnv;
+		if (effectiveThinking) launch.session.thinking = effectiveThinking as NonNullable<typeof launch.session.thinking>;
+	}
 	const { toolPlan, capabilityAudit, warnings, launchResolvedExtensions, capture } = launch;
 	if (!shared.launchWarnings.emitted && warnings.length > 0) {
 		for (const warning of warnings) console.warn(`[pi-subagents] ${warning}`);
@@ -504,6 +524,7 @@ async function runSingleAttempt(
 		agent: agent.name,
 		task: shared.originalTask ?? task,
 		...(childSessionName ? { sessionName: childSessionName } : {}),
+		...(options.machine ? { machine: options.machine } : {}),
 		...(options.agentContract ? { agentContract: options.agentContract } : {}),
 		launchContractDigest,
 		launchResolvedExtensions,
@@ -569,7 +590,7 @@ async function runSingleAttempt(
 		};
 		return result;
 	}
-	const mutationSnapshot = snapshotTrackedMutations(options.cwd ?? runtimeCwd);
+	const mutationSnapshot = snapshotTrackedMutations(options.machine ? runtimeCwd : options.cwd ?? runtimeCwd);
 	let observedMutationAttempt = false;
 	let structuredOutputToolInvoked = false;
 	let structuredOutputMessageStartIndex: number | undefined;
@@ -594,7 +615,8 @@ async function runSingleAttempt(
 			return result;
 		}
 	}
-	const childSessions = options.childSessionFactory ?? childSessionFactory();
+	const baseChildSessions = options.childSessionFactory ?? childSessionFactory();
+	const childSessions = options.machine ? createPlacementAwareChildSessionFactory(baseChildSessions) : baseChildSessions;
 	let afterCompactionSettlement = false;
 	const exitCode = await new Promise<number>((resolve) => {
 		const jsonlWriter = createJsonlWriter(shared.jsonlPath, { pause() {}, resume() {} });
@@ -1011,7 +1033,7 @@ async function runSingleAttempt(
 				afterCompactionSettlement = false;
 			}
 			if (evt.type === "agent_start") {
-				const diagnostic = capture.toolDiagnostic();
+				const diagnostic = session?.toolDiagnostic ?? capture.toolDiagnostic();
 				if (diagnostic) {
 					const message = formatChildToolDiagnostic(diagnostic, { host: "parent" });
 					toolAvailabilityError = message;
@@ -1305,10 +1327,10 @@ async function runSingleAttempt(
 			if (lifecycleFinished || sessionSettled) return;
 			sessionSettled = true;
 			clearFinalDrainTimers();
-			const diagnostic = capture.toolDiagnostic();
+			const diagnostic = session?.toolDiagnostic ?? capture.toolDiagnostic();
 			const toolDiagnosticError = diagnostic ? formatChildToolDiagnostic(diagnostic, { host: "parent" }) : undefined;
 			toolAvailabilityError = toolDiagnosticError;
-			result.runtimeAcknowledgedExtensions = capture.runtimeAcknowledgedExtensions();
+			result.runtimeAcknowledgedExtensions = session?.runtimeAcknowledgedExtensions ?? capture.runtimeAcknowledgedExtensions();
 			let closeError = result.error ?? toolDiagnosticError ?? assistantError;
 			if (!closeError && promptError !== undefined) {
 				closeError = promptError instanceof Error ? promptError.message : String(promptError);
@@ -1392,6 +1414,7 @@ async function runSingleAttempt(
 					return;
 				}
 				session = created;
+				if (options.machine) result.machine = projectNativeMachineEvidence(options.machine, created.machineEvidence);
 				const steer = created.steer.bind(created);
 				const followUp = created.followUp.bind(created);
 				created.steer = async (text) => {
@@ -1413,8 +1436,10 @@ async function runSingleAttempt(
 					|| actualReadonlyModel.api !== shared.readonlyExpected.api || created.modelId !== shared.readonlyModel || abortedBySignal || interruptedByControl || result.timedOut
 					|| !shared.readonlyHandoffAllowed?.())) throw new Error("Read-only continuation handoff vetoed.");
 				await created.prompt(`Task: ${task}`);
+				if (options.machine) result.machine = projectNativeMachineEvidence(options.machine, created.machineEvidence);
 				settle(undefined);
 			} catch (error) {
+				if (options.machine) result.machine = projectNativeMachineEvidence(options.machine, session?.machineEvidence);
 				settle(error ?? new Error("Child session failed."));
 			}
 		})();
@@ -1510,7 +1535,7 @@ async function runSingleAttempt(
 		tokens: progress.tokens,
 		durationMs: progress.durationMs,
 	};
-	const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, options.cwd ?? runtimeCwd);
+	const mutationEvidence = collectTrackedMutationEvidence(mutationSnapshot, options.machine ? runtimeCwd : options.cwd ?? runtimeCwd);
 
 	const acceptanceOutput = getFinalOutput(result.messages ?? []);
 	let fullOutput = stripAcceptanceReport(acceptanceOutput);
@@ -1667,7 +1692,7 @@ async function runSyncCompletionInner(
 	options: RunSyncOptions,
 ): Promise<SingleResult> {
 	const effectiveCwd = options.cwd ?? runtimeCwd;
-	const cwdError = preflightLaunchCwd(options.requestedCwd ?? effectiveCwd, effectiveCwd);
+	const cwdError = options.machine ? undefined : preflightLaunchCwd(options.requestedCwd ?? effectiveCwd, effectiveCwd);
 	if (cwdError) {
 		return redactResultPrompt(withRunContext({
 			index: options.index ?? 0,
@@ -1785,7 +1810,7 @@ async function runSyncCompletionInner(
 	}
 	const skillNames = options.skills ?? agent.skills ?? [];
 	const skillCwd = options.cwd ?? runtimeCwd;
-	const { resolved: resolvedSkills, missing: missingSkills } = resolveSkillsWithFallback(
+	const { resolved: resolvedSkills, missing: missingSkills } = options.machine ? { resolved: [], missing: [] } : resolveSkillsWithFallback(
 		skillNames,
 		skillCwd,
 		runtimeCwd,
@@ -1803,9 +1828,9 @@ async function runSyncCompletionInner(
 			error: "Skills not found: pi-subagents",
 		}, options.context));
 	}
-	const systemPrompt = buildEffectiveSystemPrompt({ agent, resolvedSkills, cwd: skillCwd, ...(options.outputPath ? { outputPath: options.outputPath } : {}) });
+	const systemPrompt = options.machine ? agent.systemPrompt?.trim() ?? "" : buildEffectiveSystemPrompt({ agent, resolvedSkills, cwd: skillCwd, ...(options.outputPath ? { outputPath: options.outputPath } : {}) });
 
-	const candidates = buildModelCandidates(
+	const candidates = options.machine ? [options.modelOverride] : buildModelCandidates(
 		options.modelOverride ?? agent.model,
 		agent.fallbackModels,
 		options.availableModels,
@@ -1944,7 +1969,8 @@ async function runSyncCompletionInner(
 				sessionEnabled,
 				systemPrompt,
 				acceptancePrompt,
-				resolvedSkillNames: resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
+				resolvedSkillNames: options.machine ? skillNames : resolvedSkills.length > 0 ? resolvedSkills.map((skill) => skill.name) : undefined,
+				remoteSkillNames: options.machine && skillNames.length > 0 ? skillNames : undefined,
 				skillsWarning: missingSkills.length > 0 ? `Skills not found: ${missingSkills.join(", ")}` : undefined,
 				jsonlPath,
 				artifactPaths: artifactPathsResult,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -107,7 +107,7 @@ import { inspectSubagentStatus } from "../background/run-status.ts";
 import { getExternalJobProvider } from "../../api/external-job-provider.ts";
 import { externalJobFollowUpRequestDigest, externalJobFollowUpRequestId, externalJobFollowUpRunId, externalJobPromptDigest, externalJobStableJson } from "../shared/external-job-runner.ts";
 import { externalCliReceiptMetadata, normalizeExternalCliRunnerStatus } from "../shared/external-cli-contract.ts";
-import { formatHerdrMachineRunnerUnsupported } from "../shared/herdr-machine.ts";
+import { formatHerdrMachineRunnerUnsupported, isNativePiRunner, resolveHerdrMachinePlacement } from "../shared/herdr-machine.ts";
 import { applyForceTopLevelAsyncOverride } from "../background/top-level-async.ts";
 import { handleMissionAction, MISSION_ACTIONS } from "../../missions/actions.ts";
 import { attachMissionToLaunchResult, prepareMissionLaunch, writeMissionAsyncBinding, type MissionLaunchBinding } from "../../missions/lifecycle.ts";
@@ -2421,6 +2421,7 @@ function canonicalizeExecutionParams(params: SubagentParamsLike, agents: AgentCo
 		if (params.extensionBindings !== undefined && (agent?.runner?.type === "external-cli" || agent?.runner?.type === "external-job")) return { error: `extensionBindings is not supported for runner.type='${agent.runner.type}'.` };
 		const machineError = agent ? formatHerdrMachineRunnerUnsupported({ machine: params.machine ?? agent.machine, agentName: agent.name, runnerType: agent.runner?.type, adapter: agent.runner?.type === "external-cli" ? agent.runner.adapter : undefined, worktree: params.worktree }) : undefined;
 		if (machineError) return { error: machineError };
+		if ((params.machine ?? agent?.machine) && isNativePiRunner(agent?.runner) && params.context === "fork") return { error: `Agent '${agent?.name ?? params.agent}' requested explicit context='fork' on machine '${params.machine ?? agent?.machine}', but remote native Pi supports fresh context only.` };
 	}
 	if (params.extensionBindings !== undefined) {
 		try {
@@ -2628,14 +2629,46 @@ interface AgentDefaultContextPolicy {
 
 type AgentDefaultContextPolicyResult = AgentDefaultContextPolicy | { error: string };
 
-function resolveAgentDefaultContextPolicy(
+export function resolveAgentDefaultContextPolicy(
 	params: SubagentParamsLike,
 	agents: AgentConfig[],
 	defaultSubagentContext: ExtensionConfig["defaultSubagentContext"],
 	canUseDefaultFork = false,
 ): AgentDefaultContextPolicyResult {
+	const byName = new Map(agents.map((agent) => [agent.name, agent]));
+	const hasStepRemoteNative = (agentName: string, machine: string | undefined) => Boolean(machine ?? byName.get(agentName)?.machine) && isNativePiRunner(byName.get(agentName)?.runner);
+	const remoteNative = (agentName: string) => hasStepRemoteNative(agentName, params.machine);
+	const explicitRemoteFork = params.tasks?.some((task) => hasStepRemoteNative(task.agent, task.machine))
+		|| params.chain?.some((step) => isParallelStep(step)
+			? step.parallel.some((task) => hasStepRemoteNative(task.agent, task.machine ?? step.machine))
+			: isDynamicParallelStep(step)
+				? hasStepRemoteNative(step.parallel.agent, step.parallel.machine)
+				: hasStepRemoteNative(step.agent, step.machine));
+	const warnedRemoteFork = new Set<string>();
+	const forceRemoteFresh = (agentName: string, preferred: ContextMode): ContextMode => {
+		if (preferred !== "fork") return preferred;
+		if (!warnedRemoteFork.has(agentName)) {
+			warnedRemoteFork.add(agentName);
+			console.warn(`[pi-subagents] Agent '${agentName}' prefers fork context, but native machine placement starts fresh because parent history is not transferred.`);
+		}
+		return "fresh";
+	};
+	const remoteFresh = (agentName: string, preferred: ContextMode): ContextMode => remoteNative(agentName) ? forceRemoteFresh(agentName, preferred) : preferred;
+	const summarizeEffectiveOccurrences = (contextForAgent: (agentName: string) => ContextMode): ContextSummary | undefined => {
+		const effective = (agentName: string, machine?: string) => {
+			const preferred = contextForAgent(agentName);
+			return hasStepRemoteNative(agentName, machine) ? forceRemoteFresh(agentName, preferred) : preferred;
+		};
+		const modes: ContextMode[] = [];
+		if (params.tasks) for (const task of params.tasks) modes.push(effective(task.agent, task.machine));
+		else if (params.chain) for (const step of params.chain) {
+			if (isParallelStep(step)) for (const task of step.parallel) modes.push(effective(task.agent, task.machine ?? step.machine));
+			else if (isDynamicParallelStep(step)) modes.push(effective(step.parallel.agent, step.parallel.machine));
+			else modes.push(effective(step.agent, step.machine));
+		} else for (const agentName of collectRequestedAgentNames(params)) modes.push(effective(agentName, params.machine));
+		return summarizeContextModes(modes);
+	};
 	if (params.context === "profile") {
-		const byName = new Map(agents.map((agent) => [agent.name, agent]));
 		for (const agentName of collectRequestedAgentNames(params)) {
 			const agent = byName.get(agentName);
 			if (agent && agent.defaultContext === undefined) {
@@ -2645,9 +2678,9 @@ function resolveAgentDefaultContextPolicy(
 		const contextForAgent = (agentName: string): ContextMode => {
 			const context = byName.get(agentName)?.defaultContext;
 			if (context === undefined) throw new Error(`context: "profile" requires agent '${agentName}' to declare defaultContext.`);
-			return context;
+			return remoteFresh(agentName, context);
 		};
-		const contextSummary = summarizeContextModes(collectRequestedAgentNames(params).map(contextForAgent));
+		const contextSummary = summarizeEffectiveOccurrences(contextForAgent);
 		return {
 			params,
 			contextForAgent,
@@ -2655,17 +2688,19 @@ function resolveAgentDefaultContextPolicy(
 			usesFork: contextSummary === "fork" || contextSummary === "mixed",
 		};
 	}
+	if (params.context === "fork" && (collectRequestedAgentNames(params).some(remoteNative) || explicitRemoteFork)) {
+		return { error: "Explicit context='fork' cannot be used with native saved-machine placement; remote Pi children start with fresh context." };
+	}
 	if (params.context === "fresh" || params.context === "fork") return resolveExplicitContextPolicy(params);
-	const byName = new Map(agents.map((agent) => [agent.name, agent]));
 	const contextForAgent = (agentName: string): ContextMode =>
-		resolveSubagentLaunchContext({
+		remoteFresh(agentName, resolveSubagentLaunchContext({
 			explicitContext: undefined,
 			agentDefaultContext: byName.get(agentName)?.defaultContext,
 			defaultSubagentContext,
 			canUseImplicitFork: canUseDefaultFork,
-		});
+		}));
 	const requestedAgentNames = collectRequestedAgentNames(params);
-	const contextSummary = summarizeContextModes(requestedAgentNames.map((name) => contextForAgent(name)));
+	const contextSummary = summarizeEffectiveOccurrences(contextForAgent);
 	const usesFork = contextSummary === "fork" || contextSummary === "mixed";
 	return omitUndefinedProperties({
 		params,
@@ -3280,13 +3315,16 @@ async function runAsyncPath(data: ExecutionContextData, deps: ExecutorDeps): Pro
 			agentModel: a.model,
 			parentModel,
 		});
+		const nativeMachineRequested = Boolean(params.machine ?? a.machine) && isNativePiRunner(a.runner);
+		const remoteRequestedModel = (params.model as string | undefined) ?? a.model;
 		const modelOverride = a.runner?.type === "external-cli" || a.runner?.type === "external-job"
 			? params.model ?? (externalRunnerWithoutExplicitModel ? undefined : a.model)
+			: nativeMachineRequested ? remoteRequestedModel
 			: resolveEffectiveSubagentModel(params.model as string | undefined, a.model, parentModel, availableModels, a.modelProvider ?? currentProvider, {
 				...(modelScopes.length === 0 ? {} : { scope: modelScopes }),
 				source: modelOrigin === "explicit" ? "explicit" : "inherited",
 			});
-		const modelOverrideFromParent = modelOrigin === "inherited";
+		const modelOverrideFromParent = nativeMachineRequested ? false : modelOrigin === "inherited";
 		const launchRuleError = applyWatchdogLaunchRules({ cwd: effectiveCwd, agent: a.name, model: modelOverride ?? (parentModel && `${parentModel.provider}/${parentModel.id}`), warn: (violation) => deps.watchdog?.displayRuleWarning(violation) });
 		if (launchRuleError) return toExecutionErrorResult(params, new Error(launchRuleError), data.contextPolicy.contextSummary);
 		const asyncResult = executeAsyncSingle(id, compactOptional<Parameters<typeof executeAsyncSingle>[1]>({
@@ -3740,6 +3778,12 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			details: { mode: "single", results: [] },
 		};
 	}
+	let nativePlacement: ReturnType<typeof resolveHerdrMachinePlacement> | undefined;
+	const requestedMachine = params.machine ?? agentConfig.machine;
+	if (requestedMachine && isNativePiRunner(agentConfig.runner)) {
+		try { nativePlacement = resolveHerdrMachinePlacement({ machine: requestedMachine, cwd: ctx.cwd, stepCwd: params.machineCwd }); }
+		catch (error) { return toExecutionErrorResult(params, error instanceof Error ? error : new Error(String(error)), data.contextPolicy.contextSummary); }
+	}
 	const effectiveToolBudget = resolveEffectiveToolBudget(omitUndefinedProperties({ runBudget: data.toolBudget, agentBudget: agentConfig.toolBudget, configBudget: data.configToolBudget }));
 	if (effectiveToolBudget.error) return toExecutionErrorResult(params, new Error(effectiveToolBudget.error), data.contextPolicy.contextSummary);
 
@@ -3754,30 +3798,26 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 		agentModel: agentConfig.model,
 		parentModel,
 	});
-	let modelOverride: string | undefined = resolveEffectiveSubagentModel(
-		params.model as string | undefined,
-		agentConfig.model,
-		parentModel,
-		availableModels,
-		agentConfig.modelProvider ?? currentProvider,
-		{
-			...(modelScopes.length === 0 ? {} : { scope: modelScopes }),
-			source: modelOrigin === "explicit" ? "explicit" : "inherited",
-		},
+	const remoteRequestedModel = (params.model as string | undefined) ?? agentConfig.model;
+	if (nativePlacement && remoteRequestedModel && !remoteRequestedModel.includes("/")) return toExecutionErrorResult(params, new Error("Remote native Pi model overrides must be provider-qualified (provider/model)."), data.contextPolicy.contextSummary);
+	let modelOverride: string | undefined = nativePlacement ? remoteRequestedModel : resolveEffectiveSubagentModel(
+		params.model as string | undefined, agentConfig.model, parentModel, availableModels, agentConfig.modelProvider ?? currentProvider,
+		{ ...(modelScopes.length === 0 ? {} : { scope: modelScopes }), source: modelOrigin === "explicit" ? "explicit" : "inherited" },
 	);
-	const modelOverrideFromParent = modelOrigin === "inherited";
+	const modelOverrideFromParent = nativePlacement ? false : modelOrigin === "inherited";
 	const launchRuleError = applyWatchdogLaunchRules({ cwd: effectiveCwd, agent: agentConfig.name, model: modelOverride ?? (parentModel && `${parentModel.provider}/${parentModel.id}`), warn: (violation) => deps.watchdog?.displayRuleWarning(violation) });
 	if (launchRuleError) return toExecutionErrorResult(params, new Error(launchRuleError), data.contextPolicy.contextSummary);
 	let skillOverride: string[] | false | undefined = normalizeSkillInput(params.skill);
 	let readsOverride: string[] | false | undefined = params.reads;
 	const rawOutput = params.output !== undefined ? params.output : agentConfig.output;
 	let effectiveOutput = normalizeSingleOutputOverride(rawOutput, agentConfig.output);
+	if (nativePlacement && effectiveOutput) return toExecutionErrorResult(params, new Error("Remote native Pi does not support child-written output paths; use inline output so the local host captures the result."), data.contextPolicy.contextSummary);
 	const effectiveOutputMode = params.outputMode ?? agentConfig.outputMode ?? "inline";
 	const currentMaxSubagentDepth = resolveCurrentMaxSubagentDepth(deps.config.maxSubagentDepth, deps.childRuntime);
 	const maxSubagentDepth = resolveChildMaxSubagentDepth(currentMaxSubagentDepth, agentConfig.maxSubagentDepth);
 
 
-	const sourceCwd = effectiveCwd;
+	const sourceCwd = nativePlacement?.machine.cwd ?? effectiveCwd;
 	let pendingHandoff: Details["parallelHandoff"];
 	const { setup: worktreeSetup, errorResult: worktreeSetupError } = params.worktree ? await createSingleWorktreeSetup(
 		sourceCwd,
@@ -3854,7 +3894,11 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 	// Reads: caller override > agent defaultReads > none. `~`/`~/` expand to home;
 	// absolute paths pass through; relative paths resolve against the child cwd.
 	const reads = readsOverride !== undefined ? readsOverride : agentConfig.defaultReads ?? false;
-	const readPaths = Array.isArray(reads) ? resolveExistingReadPaths(reads, singleCwd) : [];
+	const readPaths = Array.isArray(reads)
+		? nativePlacement
+			? reads.map((value) => value.startsWith("/") || value === "~" || value.startsWith("~/") ? value : path.posix.join(singleCwd, value))
+			: resolveExistingReadPaths(reads, singleCwd)
+		: [];
 	const readsInstruction = readPaths.length > 0
 		? `[Read from: ${readPaths.join(", ")}]\n\n`
 		: "";
@@ -3938,6 +3982,8 @@ async function runSinglePath(data: ExecutionContextData, deps: ExecutorDeps): Pr
 			runFanoutBudget: params.runFanoutAdmitted ? data.runFanoutBudget : { ...data.runFanoutBudget, parentPath: `${data.runFanoutBudget.parentPath ? `${data.runFanoutBudget.parentPath}/` : ""}single` },
 			cwd: singleCwd,
 			requestedCwd: data.requestedCwd,
+			machine: nativePlacement?.machine,
+			machineEnv: nativePlacement?.env,
 			signal,
 			interruptSignal: interruptController.signal,
 			allowIntercomDetach: agentConfig.systemPrompt?.includes(INTERCOM_BRIDGE_MARKER) === true,

--- a/src/runs/shared/child-launch.ts
+++ b/src/runs/shared/child-launch.ts
@@ -81,6 +81,7 @@ export interface BuildInProcessChildLaunchInput {
 	/** Serialized launch snapshot; omitted only for a top-level parent-process lookup. */
 	requiredExtensions?: RequiredChildExtensionSnapshot;
 	systemPrompt?: string | null;
+	skillNames?: string[];
 	mcpDirectTools?: string[];
 	extensionBindings?: ExtensionBindings;
 	cwd: string;
@@ -225,7 +226,7 @@ export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput)
 		? { rules: input.permissionRules, ...(input.permissionAuditPath ? { auditPath: input.permissionAuditPath } : {}) }
 		: undefined;
 	let supervisorDir: string | undefined;
-	if (input.orchestratorIntercomTarget && input.parentSessionId && input.runId) {
+	if (input.parentSessionId && input.runId && (input.orchestratorIntercomTarget || toolPlan.effectiveToolAllowlist.includes("contact_supervisor"))) {
 		supervisorDir = supervisorChannelDir(input.runId, input.childAgentName, input.childIndex);
 		fs.mkdirSync(path.join(supervisorDir, "requests"), { recursive: true });
 		fs.mkdirSync(path.join(supervisorDir, "replies"), { recursive: true });
@@ -318,6 +319,7 @@ export function buildInProcessChildLaunch(input: BuildInProcessChildLaunchInput)
 		...(taggedPrompt !== undefined
 			? input.systemPromptMode === "replace" ? { systemPrompt: taggedPrompt } : { appendSystemPrompt: taggedPrompt }
 			: {}),
+		...(input.skillNames?.length ? { skillNames: [...input.skillNames] } : {}),
 	};
 
 	return {

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -9,12 +9,17 @@
  * across every child it creates.
  */
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ThinkingLevel } from "../../shared/model-info.ts";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getAgentDir } from "../../shared/utils.ts";
 import type { ChildRuntimeConfig } from "./child-runtime-config.ts";
 import { prepareReadonlySessionEvidence } from "./readonly-session-evidence.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import type { RequiredChildExtensionSnapshot } from "../../shared/required-child-extensions.ts";
+import type { HerdrMachineReference } from "../../shared/types.ts";
+import type { HerdrRemoteGitStatus } from "../../shared/types.ts";
+import type { ChildToolDiagnostic } from "./tool-availability.ts";
+import type { RuntimeAcknowledgedChildExtensions } from "../../shared/types.ts";
 
 // Private runtime authority for host continuation planning; injected factories have none.
 const readonlyModels = new WeakMap<ChildSession, { current: ModelInfo; resolve(reference: string): ModelInfo | undefined; requestBytes: number }>();
@@ -55,9 +60,14 @@ export type ChildSessionStorage =
 
 export interface ChildSessionLaunch {
 	cwd: string;
+	/** Native remote placement; absent means the owning process hosts the SDK session. */
+	machine?: HerdrMachineReference;
+	machineEnv?: Record<string, string>;
 	storage: ChildSessionStorage;
 	/** Model reference as the agent config names it (`provider/id`, optionally `:thinking`). */
 	model?: string;
+	/** Explicit thinking for a remotely resolved default model. */
+	thinking?: ThinkingLevel;
 	/** Explicit tool allowlist; undefined keeps pi's defaults. */
 	tools?: string[];
 	excludeTools?: string[];
@@ -75,6 +85,16 @@ export interface ChildSessionLaunch {
 	noContextFiles: boolean;
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
+	/** Logical skill names resolved only by the process that owns the Pi installation. */
+	skillNames?: string[];
+	/** Data-only recipe for constructing path-bearing prompt resources on the remote host. */
+	remotePromptSpec?: {
+		agentName: string;
+		baseSystemPrompt: string;
+		mode: "append" | "replace";
+		skillNames?: string[];
+		memory?: { scope: "user" | "project"; path: string; writable: boolean };
+	};
 	/**
 	 * Environment values that extensions loaded into the child read from
 	 * `process.env`. Applied to the hosting process while the session is created
@@ -102,6 +122,9 @@ export interface ChildSession {
 	readonly sessionFile: string | undefined;
 	readonly sessionId: string;
 	readonly modelId: string | undefined;
+	readonly machineEvidence?: { initial?: HerdrRemoteGitStatus; final?: HerdrRemoteGitStatus };
+	readonly toolDiagnostic?: ChildToolDiagnostic;
+	readonly runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensions;
 	/** Set by the foreground host once the run detached; `factory.dispose()` leaves such children running. */
 	detached?: boolean;
 	/** Set by `factory.dispose()` before it aborts the child, so the host can report the stop truthfully. */
@@ -278,7 +301,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 					agentDir,
 					modelRuntime,
 					...(resolvedModel?.model ? { model: resolvedModel.model } : {}),
-					...(resolvedModel?.thinkingLevel ? { thinkingLevel: resolvedModel.thinkingLevel } : {}),
+					...(resolvedModel?.thinkingLevel ?? launch.thinking ? { thinkingLevel: resolvedModel?.thinkingLevel ?? launch.thinking } : {}),
 					...(launch.tools ? { tools: launch.tools } : {}),
 					...(launch.excludeTools?.length ? { excludeTools: launch.excludeTools } : {}),
 					resourceLoader: loader,

--- a/src/runs/shared/herdr-machine.ts
+++ b/src/runs/shared/herdr-machine.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExternalProcessStatus, HerdrMachineReference, HerdrRemoteGitStatus } from "../../shared/types.ts";
+import type { AgentRunnerConfig, ExternalProcessStatus, HerdrMachineReference, HerdrRemoteGitStatus } from "../../shared/types.ts";
 import { getAgentDir, getProjectConfigDir } from "../../shared/utils.ts";
 import { CODE_OWNED_EXTERNAL_CLI_ADAPTER_IDS, type CodeOwnedExternalCliAdapterId } from "./external-cli-contract.ts";
 import { type ExternalCliPreflightResult, type ExternalCliPreflightSpec } from "./external-cli-preflight.ts";
@@ -32,6 +32,10 @@ const READY_MARKER = `__pi_subagents_ready_${RUN_TOKEN}__`;
 const FINAL_BEGIN_MARKER = `__pi_subagents_final_begin_${RUN_TOKEN}__`;
 const FINAL_END_MARKER = `__pi_subagents_final_end_${RUN_TOKEN}__`;
 const GIT_MARKER = `__pi_subagents_git_${RUN_TOKEN}__`;
+
+export function isNativePiRunner(runner: AgentRunnerConfig | undefined): boolean {
+	return runner === undefined || runner.type === "pi";
+}
 
 type RunExternalCliInput = Parameters<typeof runExternalCli>[0];
 
@@ -234,7 +238,11 @@ export function resolveHerdrMachinePlacement(input: ResolveHerdrMachinePlacement
 	const stepCwd = input.stepCwd?.trim();
 	let cwd: string;
 	if (stepCwd && isRemoteAbsolute(stepCwd)) cwd = stepCwd;
-	else if (settings?.cwd) cwd = stepCwd ? path.posix.join(settings.cwd, stepCwd) : settings.cwd;
+	else if (settings?.cwd) {
+		const root = validateRemoteCwd(settings.cwd, requested);
+		cwd = stepCwd ? path.posix.normalize(path.posix.join(root, stepCwd)) : root;
+		if (cwd !== root && !(root === "/" ? cwd.startsWith("/") : cwd.startsWith(`${root}/`))) throw new Error(`Herdr machine '${requested}' relative cwd escapes configured root ${root}: ${JSON.stringify(stepCwd)}.`);
+	}
 	else throw new Error(`No root for ${name} in this repo. Set subagents.machines.${name}.cwd in .pi/settings.json or pass an absolute cwd on that machine.`);
 	return {
 		machine: {
@@ -257,14 +265,18 @@ export function formatHerdrMachineRunnerUnsupported(input: {
 	worktree?: boolean;
 }): string | undefined {
 	if (input.machine === undefined) return undefined;
+	if (input.runnerType !== "external-cli" && input.runnerType !== undefined && input.runnerType !== "pi") {
+		return `Agent '${input.agentName}' requested machine '${input.machine}', but runner.type='${input.runnerType}' does not support Herdr saved-machine placement.`;
+	}
+	if (input.worktree === true) return `Agent '${input.agentName}' requested machine '${input.machine}', but managed worktrees are local git operations and cannot be combined with a Herdr saved machine.`;
+	if (process.platform === "win32") return "Herdr saved-machine launches use OpenSSH and a POSIX remote shell, which is not supported from a Windows host yet.";
+	if (input.runnerType === undefined || input.runnerType === "pi") return undefined;
 	if (input.runnerType !== "external-cli") {
 		return `Agent '${input.agentName}' requested machine '${input.machine}', but only external-cli agents can run on a Herdr saved machine. Use claude-code, codex-exec, or cursor-agent profiles, or open a Herdr pane on that machine and run Pi there.`;
 	}
 	if (input.adapter === undefined || !SUPPORTED_MACHINE_ADAPTERS.has(input.adapter)) {
 		return `Agent '${input.agentName}' requested machine '${input.machine}', but generic external-cli commands cannot be remote-wrapped safely. Use claude-code, claude-code-writer, codex-exec, codex-exec-writer, cursor-agent, or cursor-agent-writer.`;
 	}
-	if (input.worktree === true) return `Agent '${input.agentName}' requested machine '${input.machine}', but managed worktrees are local git operations and cannot be combined with a Herdr saved machine.`;
-	if (process.platform === "win32") return "Herdr saved-machine launches wrap the child with OpenSSH ControlMaster and a POSIX shell script, which is not supported from a Windows host yet.";
 	return undefined;
 }
 
@@ -276,7 +288,7 @@ function sshControlPath(): string {
 }
 
 /** Herdr's saved-machine ssh option block (src/remote/attach.rs), plus pi-subagents' own ControlMaster entries. */
-function sshArgs(machine: HerdrMachineReference, controlPath: string): string[] {
+export function herdrSshArgs(machine: HerdrMachineReference, controlPath = sshControlPath()): string[] {
 	return [
 		"-T",
 		"-o", "BatchMode=yes",
@@ -297,7 +309,7 @@ function sshArgs(machine: HerdrMachineReference, controlPath: string): string[] 
  * The remote login shell receives one argument, `sh -c '<script>'`, so fish or a noisy rc file cannot change
  * how the script is parsed. The script prints the ready marker only after `cd` succeeded.
  */
-function remoteCommand(machine: HerdrMachineReference, env: Record<string, string> | undefined, body: string): string {
+export function herdrRemoteCommand(machine: HerdrMachineReference, env: Record<string, string> | undefined, body: string): string {
 	const exports = Object.entries(env ?? {}).map(([key, value]) => `export ${key}=${shellQuote(value)}`);
 	const script = [
 		`export PATH=${REMOTE_PATH_PREFIX}`,
@@ -309,6 +321,36 @@ function remoteCommand(machine: HerdrMachineReference, env: Record<string, strin
 	return `sh -c ${shellQuote(script)}`;
 }
 
+/** Native RPC owns stdout framing, so unlike adapter commands it emits no shell readiness marker. */
+export function herdrNativeRemoteCommand(machine: HerdrMachineReference, env: Record<string, string> | undefined, body: string): string {
+	const exports = Object.entries(env ?? {}).map(([key, value]) => `export ${key}=${shellQuote(value)}`);
+	const script = [
+		`export PATH=${REMOTE_PATH_PREFIX}`,
+		...exports,
+		`cd ${remotePathExpr(machine.cwd)} || exit 125`,
+		body,
+	].join("; ");
+	return `sh -c ${shellQuote(script)}`;
+}
+
+/** Resolve the packaged native host using Pi's documented managed npm roots without interpolating remote values into shell syntax. */
+export function nativeRemoteHostDiscoveryBody(): string {
+	const executable = "pi-subagents-remote-host";
+	return [
+		`host=$(command -v ${executable} 2>/dev/null || :)`,
+		`if [ -n "$host" ] && [ -x "$host" ]; then exec "$host"; fi`,
+		`project_host=$PWD/.pi/npm/node_modules/.bin/${executable}`,
+		`if [ -x "$project_host" ]; then exec "$project_host"; fi`,
+		`agent_dir=\${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}`,
+		`case "$agent_dir" in '~') agent_dir=$HOME;; '~/'*) agent_dir=$HOME/\${agent_dir#??};; esac`,
+		`case "$agent_dir" in /*) ;; *) printf '%s\\n' 'Remote native Pi host configuration error: PI_CODING_AGENT_DIR must be an absolute remote path.' >&2; exit 126;; esac`,
+		`user_host=$agent_dir/npm/node_modules/.bin/${executable}`,
+		`if [ -x "$user_host" ]; then exec "$user_host"; fi`,
+		`printf '%s\\n' 'Remote native Pi host executable not found. Run: pi install npm:pi-subagents (user scope), or pi install -l npm:pi-subagents (project scope), or add pi-subagents-remote-host to PATH.' >&2`,
+		`exit 127`,
+	].join("; ");
+}
+
 function stripThroughMarker(text: string): string {
 	const index = text.indexOf(READY_MARKER);
 	return index < 0 ? text : text.slice(index + READY_MARKER.length).trim();
@@ -317,7 +359,7 @@ function stripThroughMarker(text: string): string {
 function remotePreflight(input: RunExternalCliInput, machine: HerdrMachineReference, env: Record<string, string> | undefined, controlPath: string): ExternalCliPreflightSpec | undefined {
 	const spec = input.preflight;
 	if (!spec) return undefined;
-	const probe = (args: readonly string[]) => [...sshArgs(machine, controlPath), remoteCommand(machine, env, `exec ${shellQuote(input.command)} ${args.map(shellQuote).join(" ")}`)];
+	const probe = (args: readonly string[]) => [...herdrSshArgs(machine, controlPath), herdrRemoteCommand(machine, env, `exec ${shellQuote(input.command)} ${args.map(shellQuote).join(" ")}`)];
 	const { probeTimeoutMs: _probeTimeoutMs, ...rest } = spec;
 	return {
 		...rest,
@@ -443,7 +485,7 @@ export function prepareHerdrMachineExternalCliRun(input: RunExternalCliInput, pl
 	const prepared: RunExternalCliInput = {
 		...rest,
 		command: "ssh",
-		args: [...sshArgs(machine, controlPath), remoteCommand(machine, env, body)],
+		args: [...herdrSshArgs(machine, controlPath), herdrRemoteCommand(machine, env, body)],
 		cwd: options.localCwd,
 		environment: { allowlist: HERDR_SSH_ENV_ALLOWLIST },
 		parser: wrapped.parser,

--- a/src/runs/shared/native-remote-rpc.ts
+++ b/src/runs/shared/native-remote-rpc.ts
@@ -1,0 +1,143 @@
+import * as fs from "node:fs";
+import { StringDecoder } from "node:string_decoder";
+
+/** Protocol limits are deliberately independent from transcript/output limits. */
+export const NATIVE_REMOTE_RPC_MAX_FRAME_BYTES = 1024 * 1024;
+export const NATIVE_REMOTE_RPC_PROTOCOL_VERSION = 1;
+export const NATIVE_REMOTE_MIN_PI_VERSION = "0.81.0";
+
+export interface NativeRemoteRpcHandshake {
+	type: "pi-subagents-ready";
+	protocol: number;
+	packageVersion: string;
+	piVersion: string;
+	capabilities: readonly string[];
+	cwd: string;
+	model?: string;
+	tools: readonly string[];
+	initialGit?: { head?: string; branch?: string; dirty?: boolean; probeError?: string };
+}
+
+/**
+ * Strict LF-only JSONL decoder for Pi RPC stdout.
+ *
+ * Node's readline is intentionally not used because it treats U+2028/U+2029 as
+ * record separators. StringDecoder preserves fragmented UTF-8 sequences. A CR
+ * is accepted only immediately before LF, matching Pi's RPC contract.
+ */
+export class NativeRemoteJsonlDecoder {
+	readonly #decoder = new StringDecoder("utf8");
+	readonly #maxFrameBytes: number;
+	#text = "";
+	#bytes = 0;
+	#ended = false;
+
+	constructor(maxFrameBytes = NATIVE_REMOTE_RPC_MAX_FRAME_BYTES) {
+		if (!Number.isSafeInteger(maxFrameBytes) || maxFrameBytes < 1) throw new Error("Native remote RPC frame limit must be a positive integer.");
+		this.#maxFrameBytes = maxFrameBytes;
+	}
+
+	push(chunk: Uint8Array): unknown[] {
+		if (this.#ended) throw new Error("Native remote RPC received bytes after EOF.");
+		const records: unknown[] = [];
+		let start = 0;
+		for (let index = 0; index < chunk.length; index++) {
+			if (chunk[index] !== 0x0a) continue;
+			const fragment = chunk.subarray(start, index);
+			this.#bytes += fragment.byteLength;
+			this.#assertBounded();
+			this.#text += this.#decoder.write(fragment);
+			records.push(this.#parseFrame(this.#text.endsWith("\r") ? this.#text.slice(0, -1) : this.#text));
+			this.#text = "";
+			this.#bytes = 0;
+			start = index + 1;
+		}
+		const remainder = chunk.subarray(start);
+		this.#bytes += remainder.byteLength;
+		this.#assertBounded();
+		this.#text += this.#decoder.write(remainder);
+		return records;
+	}
+
+	end(): void {
+		if (this.#ended) return;
+		this.#ended = true;
+		this.#text += this.#decoder.end();
+		if (this.#bytes !== 0 || this.#text.length !== 0) throw new Error("Native remote RPC stream ended with a truncated JSONL frame.");
+	}
+
+	#assertBounded(): void {
+		if (this.#bytes > this.#maxFrameBytes) throw new Error(`Native remote RPC frame exceeded ${this.#maxFrameBytes} bytes.`);
+	}
+
+	#parseFrame(frame: string): unknown {
+		if (!frame) throw new Error("Native remote RPC emitted an empty JSONL frame.");
+		try {
+			return JSON.parse(frame) as unknown;
+		} catch (error) {
+			throw new Error(`Native remote RPC emitted malformed JSON: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+}
+
+export function validateNativeRemoteHandshake(value: unknown, expected: {
+	packageVersion: string;
+	requiredCapabilities: readonly string[];
+	requiredTools?: readonly string[];
+}): NativeRemoteRpcHandshake {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Native remote Pi host did not return a handshake object.");
+	const record = value as Record<string, unknown>;
+	if (record.type !== "pi-subagents-ready" || record.protocol !== NATIVE_REMOTE_RPC_PROTOCOL_VERSION) {
+		throw new Error(`Incompatible remote native protocol; expected ${NATIVE_REMOTE_RPC_PROTOCOL_VERSION}, received ${String(record.protocol ?? "none")}.`);
+	}
+	if (record.packageVersion !== expected.packageVersion) {
+		throw new Error(`Incompatible remote pi-subagents version; expected ${expected.packageVersion}, received ${String(record.packageVersion ?? "unknown")}.`);
+	}
+	if (typeof record.piVersion !== "string" || !record.piVersion || typeof record.cwd !== "string" || !record.cwd
+		|| !Array.isArray(record.capabilities) || record.capabilities.some((item) => typeof item !== "string")
+		|| !Array.isArray(record.tools) || record.tools.some((item) => typeof item !== "string")) {
+		throw new Error("Remote native Pi handshake is incomplete.");
+	}
+	const version = /^(\d+)\.(\d+)\.(\d+)/u.exec(record.piVersion);
+	const minimum = NATIVE_REMOTE_MIN_PI_VERSION.split(".").map(Number);
+	if (!version || [Number(version[1]), Number(version[2]), Number(version[3])].some((part, index) => part < minimum[index]! && version.slice(1, index + 1).every((prior, priorIndex) => Number(prior) === minimum[priorIndex]))) {
+		throw new Error(`Incompatible remote Pi runtime '${record.piVersion}'; native transport requires Pi >= ${NATIVE_REMOTE_MIN_PI_VERSION}.`);
+	}
+	const capabilities = record.capabilities as string[];
+	const missing = expected.requiredCapabilities.filter((capability) => !capabilities.includes(capability));
+	if (missing.length) throw new Error(`Remote native Pi host lacks required capabilities: ${missing.join(", ")}.`);
+	const tools = record.tools as string[];
+	const missingTools = expected.requiredTools?.filter((tool) => !tools.includes(tool)) ?? [];
+	if (missingTools.length) throw new Error(`Remote native Pi runtime lacks required tools: ${missingTools.join(", ")}.`);
+	return value as NativeRemoteRpcHandshake;
+}
+
+export function encodeNativeRemoteRpcRecord(value: unknown): Buffer {
+	const json = JSON.stringify(value);
+	if (Buffer.byteLength(json) > NATIVE_REMOTE_RPC_MAX_FRAME_BYTES) throw new Error(`Native remote RPC frame exceeded ${NATIVE_REMOTE_RPC_MAX_FRAME_BYTES} bytes.`);
+	return Buffer.from(`${json}\n`, "utf8");
+}
+
+export type NativeRemoteRawWriter = (fd: number, buffer: Uint8Array, offset: number, length: number) => number;
+
+/** Writes one bounded frame directly to an fd, bypassing Pi's redirected stdout stream. */
+export function writeNativeRemoteRpcRecordSync(value: unknown, writer: NativeRemoteRawWriter = fs.writeSync, fd = 1): void {
+	const frame = encodeNativeRemoteRpcRecord(value);
+	let offset = 0;
+	let attempts = 0;
+	const maxAttempts = frame.byteLength + 128;
+	while (offset < frame.byteLength) {
+		if (++attempts > maxAttempts) throw new Error("Native remote RPC raw writer made too many interrupted attempts.");
+		let written: number;
+		try {
+			written = writer(fd, frame, offset, frame.byteLength - offset);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException)?.code === "EINTR") continue;
+			throw error;
+		}
+		if (!Number.isSafeInteger(written) || written <= 0 || written > frame.byteLength - offset) {
+			throw new Error(`Native remote RPC raw writer made invalid progress (${String(written)} bytes).`);
+		}
+		offset += written;
+	}
+}

--- a/src/runs/shared/parallel-utils.ts
+++ b/src/runs/shared/parallel-utils.ts
@@ -61,6 +61,7 @@ export interface RunnerSubagentStep {
 	inheritGlobalContext: boolean;
 	inheritSkills: boolean;
 	skills?: string[];
+	memory?: import("../../agents/agents.ts").AgentMemoryConfig;
 	outputPath?: string;
 	outputClaimPath?: string;
 	/** Defer the authoritative output instruction until a dynamic fanout item is materialized. */

--- a/src/runs/shared/remote-native-bootstrap.ts
+++ b/src/runs/shared/remote-native-bootstrap.ts
@@ -1,0 +1,23 @@
+import * as sdk from "@earendil-works/pi-coding-agent";
+import { createDefaultChildSessionFactory } from "./child-session.ts";
+import { writeNativeRemoteRpcRecordSync } from "./native-remote-rpc.ts";
+import { runRemoteNativeHost } from "./remote-native-host.ts";
+
+/**
+ * Runs inside Pi's extension loader so Pi's embedded/npm SDK and peer aliases own
+ * every SDK import. Awaiting the host here and exiting prevents the outer Pi RPC
+ * loop from competing for stdin or writing its own protocol records.
+ */
+export default async function runRemoteNativeBootstrap(): Promise<never> {
+	try {
+		await runRemoteNativeHost({
+			factory: createDefaultChildSessionFactory({ loadPiCodingAgent: async () => sdk }),
+			piVersion: sdk.VERSION,
+			sendRecord: writeNativeRemoteRpcRecordSync,
+		});
+		process.exit(0);
+	} catch (error) {
+		process.stderr.write(`Remote native Pi host failed: ${error instanceof Error ? error.message : String(error)}\n`);
+		process.exit(1);
+	}
+}

--- a/src/runs/shared/remote-native-host.ts
+++ b/src/runs/shared/remote-native-host.ts
@@ -1,0 +1,158 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import packageJson from "../../../package.json" with { type: "json" };
+import { createCapturedChildHooks } from "./child-hooks.ts";
+import { createDefaultChildSessionFactory, type ChildSession, type ChildSessionFactory, type ChildSessionLaunch } from "./child-session.ts";
+import { NATIVE_REMOTE_RPC_PROTOCOL_VERSION, NativeRemoteJsonlDecoder, encodeNativeRemoteRpcRecord } from "./native-remote-rpc.ts";
+import type { ChildRuntimeConfig } from "./child-runtime-config.ts";
+import { buildSkillInjection, resolveSkills } from "../../agents/skills.ts";
+import { buildEffectiveSystemPrompt } from "./effective-system-prompt.ts";
+
+interface RemoteLaunchRecord {
+	type: "launch";
+	protocol: number;
+	packageVersion: string;
+	launch: Omit<ChildSessionLaunch, "hooks" | "onExtensionError" | "processEnv" | "requiredExtensions"> & { runtime: ChildRuntimeConfig; remoteSupervision?: boolean };
+}
+
+function send(value: unknown): void {
+	process.stdout.write(encodeNativeRemoteRpcRecord(value));
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export function collectRemoteGitEvidence(cwd: string): Record<string, unknown> {
+	const evidence: Record<string, unknown> = {};
+	try { evidence.head = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 }).trim(); } catch (error) { evidence.probeError = errorMessage(error); }
+	try { const branch = execFileSync("git", ["symbolic-ref", "--quiet", "--short", "HEAD"], { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 }).trim(); if (branch) evidence.branch = branch; } catch { /* detached HEAD is valid */ }
+	try { evidence.dirty = Boolean(execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 }).trim()); } catch (error) { evidence.probeError ??= errorMessage(error); }
+	return evidence;
+}
+
+function requireLaunch(value: unknown): RemoteLaunchRecord {
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Expected a native launch record.");
+	const record = value as Partial<RemoteLaunchRecord>;
+	if (record.type !== "launch" || record.protocol !== NATIVE_REMOTE_RPC_PROTOCOL_VERSION || record.packageVersion !== packageJson.version || !record.launch) {
+		throw new Error(`Incompatible native launch (local=${String(record.packageVersion)}, remote=${packageJson.version}, protocol=${String(record.protocol)}).`);
+	}
+	if (record.launch.storage.kind === "file" || record.launch.storage.kind === "dir") throw new Error("Remote native Pi does not accept local session storage paths; use a fresh remote session.");
+	if (record.launch.extensionPaths.length > 0) throw new Error("Remote native Pi cannot transfer extension paths. Configure required extensions on the saved machine.");
+	return record as RemoteLaunchRecord;
+}
+
+export function resolveRemoteNativeSkillLaunch<T extends Pick<ChildSessionLaunch, "cwd" | "skillNames" | "systemPrompt" | "appendSystemPrompt">>(launch: T): T {
+	if (!launch.skillNames?.length) return launch;
+	const skills = resolveSkills(launch.skillNames, launch.cwd);
+	if (skills.missing.length) throw new Error(`Remote native Pi skills not found: ${skills.missing.join(", ")}.`);
+	const injection = buildSkillInjection(skills.resolved);
+	if (!injection) return launch;
+	if (launch.systemPrompt !== undefined) return { ...launch, systemPrompt: `${launch.systemPrompt}\n\n${injection}` };
+	return { ...launch, appendSystemPrompt: launch.appendSystemPrompt ? `${launch.appendSystemPrompt}\n\n${injection}` : injection };
+}
+
+export function resolveRemoteNativePromptLaunch(launch: ChildSessionLaunch): ChildSessionLaunch {
+	const spec = launch.remotePromptSpec;
+	if (!spec) return resolveRemoteNativeSkillLaunch(launch);
+	const skills = resolveSkills(spec.skillNames ?? [], launch.cwd);
+	if (skills.missing.length) throw new Error(`Remote native Pi skills not found: ${skills.missing.join(", ")}.`);
+	const systemPrompt = buildEffectiveSystemPrompt({
+		agent: {
+			name: spec.agentName, description: "Remote native Pi child", source: "runtime", filePath: "<remote-native>", systemPrompt: spec.baseSystemPrompt,
+			systemPromptMode: spec.mode, inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false,
+			...(spec.memory ? { memory: { scope: spec.memory.scope, path: spec.memory.path }, tools: spec.memory.writable ? undefined : [] } : {}),
+		},
+		resolvedSkills: skills.resolved,
+		cwd: launch.cwd,
+	});
+	return { ...launch, skillNames: undefined, remotePromptSpec: undefined, systemPrompt: spec.mode === "replace" ? systemPrompt : undefined, appendSystemPrompt: spec.mode === "append" ? systemPrompt : undefined };
+}
+
+export async function teardownRemoteNativeChild(child: ChildSession | undefined, factory: Pick<ChildSessionFactory, "dispose">, timeoutMs = 1_000): Promise<void> {
+	const bounded = async (operation: Promise<unknown>) => { await Promise.race([operation.catch(() => {}), new Promise<void>((resolve) => { setTimeout(resolve, timeoutMs); })]); };
+	if (child) {
+		await bounded(child.abort());
+		await bounded(child.dispose());
+	}
+	await bounded(factory.dispose());
+}
+
+export async function runRemoteNativeHost(options: { piVersion: string; input?: AsyncIterable<Uint8Array>; factory?: ChildSessionFactory; sendRecord?: (value: unknown) => void; teardownTimeoutMs?: number }): Promise<void> {
+	const input = options.input ?? process.stdin;
+	const sendRecord = options.sendRecord ?? send;
+	const piVersion = options.piVersion;
+	if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u.test(piVersion)) throw new Error(`Remote native Pi host received an invalid Pi SDK version '${piVersion}'.`);
+	const records = async function* () {
+		const decoder = new NativeRemoteJsonlDecoder();
+		for await (const chunk of input) for (const value of decoder.push(chunk)) yield value;
+		decoder.end();
+	};
+	const iterator = records()[Symbol.asyncIterator]();
+	const first = await iterator.next();
+	if (first.done) throw new Error("Input ended before launch.");
+	const record = requireLaunch(first.value);
+	const supervisorRoot = record.launch.remoteSupervision
+		? fs.mkdtempSync(path.join(os.tmpdir(), "pi-subagents-supervisor-")) : undefined;
+	if (supervisorRoot) {
+		fs.mkdirSync(path.join(supervisorRoot, "requests"), { recursive: true });
+		fs.mkdirSync(path.join(supervisorRoot, "replies"), { recursive: true });
+	}
+	const runtime: ChildRuntimeConfig = { ...record.launch.runtime, ...(supervisorRoot ? { supervisorChannelDir: supervisorRoot } : {}) };
+	const captured = createCapturedChildHooks(runtime, true);
+	let observedTools: string[] = [];
+	const toolObserver = { name: "pi-subagents-remote-tool-observer", factory: (pi: Parameters<ChildSessionLaunch["hooks"][number]["factory"]>[0]) => {
+		pi.on("session_start", () => { observedTools = pi.getAllTools().map((tool) => tool.name); });
+	} };
+	const factory = options.factory ?? createDefaultChildSessionFactory();
+	let child: ChildSession | undefined;
+	let requestTimer: NodeJS.Timeout | undefined;
+	let disposing = false;
+	const seenRequests = new Set<string>();
+	try {
+		const remoteLaunch = resolveRemoteNativePromptLaunch({ ...record.launch, runtime, hooks: [...captured.hooks, toolObserver] });
+		child = await factory.create(remoteLaunch);
+		child.subscribe((event) => sendRecord({ type: "event", event }));
+		if (supervisorRoot) {
+			requestTimer = setInterval(() => {
+				for (const name of fs.readdirSync(path.join(supervisorRoot, "requests"))) {
+					if (seenRequests.has(name) || !name.endsWith(".json")) continue;
+					seenRequests.add(name);
+					try { sendRecord({ type: "supervisor-request", name, value: JSON.parse(fs.readFileSync(path.join(supervisorRoot, "requests", name), "utf8")) }); } catch { /* writer may still be replacing */ }
+				}
+			}, 25);
+			requestTimer.unref?.();
+		}
+		const supervisionReady = Boolean(supervisorRoot && runtime.runId && runtime.agent && runtime.orchestratorSessionId && runtime.childIndex !== undefined);
+		const initialGit = collectRemoteGitEvidence(record.launch.cwd);
+		sendRecord({ type: "pi-subagents-ready", protocol: NATIVE_REMOTE_RPC_PROTOCOL_VERSION, packageVersion: packageJson.version, piVersion, capabilities: ["settlement", "steer", "follow-up", "abort", ...(supervisionReady ? ["supervision"] : [])], cwd: record.launch.cwd, model: child.modelId, tools: observedTools, initialGit });
+		const active = new Set<Promise<void>>();
+		const handle = async (command: Record<string, unknown>): Promise<void> => {
+			const id = typeof command.id === "string" ? command.id : undefined;
+			try {
+				let data: unknown;
+				if (command.type === "prompt") { await child!.prompt(String(command.message ?? "")); data = { finalGit: collectRemoteGitEvidence(record.launch.cwd), toolDiagnostic: captured.toolDiagnostic(), runtimeAcknowledgedExtensions: captured.runtimeAcknowledgedExtensions() }; }
+				else if (command.type === "steer") await child!.steer(String(command.message ?? ""));
+				else if (command.type === "follow_up") await child!.followUp(String(command.message ?? ""));
+				else if (command.type === "abort") await child!.abort();
+				else if (command.type === "dispose") { await child!.abort().catch(() => {}); await child!.dispose(); disposing = true; data = { finalGit: collectRemoteGitEvidence(record.launch.cwd) }; }
+				else if (command.type === "supervisor-reply" && supervisorRoot && typeof command.name === "string") fs.writeFileSync(path.join(supervisorRoot, "replies", path.basename(command.name)), JSON.stringify(command.value), { mode: 0o600 });
+				else throw new Error(`Unsupported native control '${String(command.type)}'.`);
+				sendRecord({ type: "response", id, command: command.type, success: true, ...(data !== undefined ? { data } : {}) });
+			} catch (error) { sendRecord({ type: "response", id, command: command.type, success: false, error: errorMessage(error), ...(command.type === "prompt" ? { data: { finalGit: collectRemoteGitEvidence(record.launch.cwd), toolDiagnostic: captured.toolDiagnostic(), runtimeAcknowledgedExtensions: captured.runtimeAcknowledgedExtensions() } } : {}) }); }
+		};
+		for await (const value of { [Symbol.asyncIterator]: () => iterator }) {
+			if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Control record must be an object.");
+			const command = value as Record<string, unknown>;
+			const pending = handle(command).finally(() => active.delete(pending));
+			active.add(pending);
+			if (command.type === "dispose") { await pending; break; }
+		}
+	} finally {
+		if (requestTimer) clearInterval(requestTimer);
+		await teardownRemoteNativeChild(disposing ? undefined : child, factory, options.teardownTimeoutMs);
+		if (supervisorRoot) fs.rmSync(supervisorRoot, { recursive: true, force: true });
+	}
+}

--- a/src/runs/shared/remote-native-session.ts
+++ b/src/runs/shared/remote-native-session.ts
@@ -1,0 +1,263 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import packageJson from "../../../package.json" with { type: "json" };
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { herdrNativeRemoteCommand, herdrSshArgs, nativeRemoteHostDiscoveryBody } from "./herdr-machine.ts";
+import { NativeRemoteJsonlDecoder, encodeNativeRemoteRpcRecord, validateNativeRemoteHandshake } from "./native-remote-rpc.ts";
+import type { ChildSession, ChildSessionEvent, ChildSessionFactory, ChildSessionLaunch } from "./child-session.ts";
+import { MCP_DIRECT_TOOLS_ENV } from "./child-launch.ts";
+import { PI_SUBAGENT_EXTENSION_BINDINGS_ENV } from "./extension-bindings.ts";
+import type { ChildRuntimeConfig } from "./child-runtime-config.ts";
+import type { ChildToolDiagnostic } from "./tool-availability.ts";
+import { sanitizeRuntimeAcknowledgedExtensions } from "./runtime-acknowledged-extensions.ts";
+import type { ExternalCliMachineStatus, HerdrMachineReference, HerdrRemoteGitStatus, RuntimeAcknowledgedChildExtensions } from "../../shared/types.ts";
+
+interface Pending { resolve(value: unknown): void; reject(error: Error): void; timer?: NodeJS.Timeout }
+const COMMAND_TIMEOUT_MS = 15_000;
+export const NATIVE_REMOTE_MAX_TRANSPORT_BYTES = 32 * 1024 * 1024;
+
+type RemoteChildRuntime = Pick<ChildRuntimeConfig,
+	"runId" | "agent" | "childIndex" | "fanoutChild" | "sessionName" | "intercomSessionName" |
+	"orchestratorTarget" | "orchestratorSessionId" | "parentSessionId" | "depth" | "maxDepth" |
+	"capabilityCeiling" | "thinkingCeiling" | "inheritProjectContext" | "inheritGlobalContext" |
+	"inheritSkills" | "permissions" | "toolBudget" | "waitTool" | "requiredTools" | "fast"
+>;
+
+export function serializeNativeRemoteLaunch(launch: ChildSessionLaunch): Record<string, unknown> {
+	if (!launch.machine) throw new Error("Remote native launch requires a saved machine.");
+	if (launch.storage.kind === "file") throw new Error("Remote native Pi does not support forked, resumed, or revived session files; use fresh context.");
+	if (launch.requiredExtensions?.length || launch.extensionPaths.length) throw new Error("Remote native Pi cannot transfer local extension resources. Configure extensions on the saved machine and omit local required paths.");
+	if (launch.runtime.structuredOutput || launch.runtime.childWatchdog) throw new Error("Remote native Pi does not support structured output or child watchdog callbacks in this version.");
+	if (launch.runtime.nestedRoute) throw new Error("Remote native Pi does not transfer nested-route paths or capability tokens; nested remote fanout requires a scoped relay.");
+	if (launch.runtime.mcpDirectTools?.length || (launch.processEnv?.[MCP_DIRECT_TOOLS_ENV] && launch.processEnv[MCP_DIRECT_TOOLS_ENV] !== "__none__")) throw new Error("Remote native Pi does not transfer local MCP selections.");
+	if (launch.processEnv?.[PI_SUBAGENT_EXTENSION_BINDINGS_ENV]) throw new Error("Remote native Pi does not transfer local extension bindings.");
+	if (launch.skillNames?.some((name) => !name.trim() || path.isAbsolute(name) || name.startsWith("~") || name.includes("/") || name.includes("\\"))) throw new Error("Remote native Pi skill requests must use logical names, not local paths.");
+	const promptSpec = launch.remotePromptSpec;
+	if (promptSpec?.skillNames?.some((name) => !name.trim() || path.isAbsolute(name) || name.startsWith("~") || name.includes("/") || name.includes("\\"))) throw new Error("Remote native Pi skill requests must use logical names, not local paths.");
+	if (promptSpec?.memory && (path.isAbsolute(promptSpec.memory.path) || path.win32.isAbsolute(promptSpec.memory.path) || promptSpec.memory.path.startsWith("~") || promptSpec.memory.path.split(/[/\\]/u).some((segment) => !segment || segment === "." || segment === ".." || segment.includes(":")))) throw new Error("Remote native Pi memory configuration must use a safe relative logical path.");
+	const source = launch.runtime;
+	const runtime: RemoteChildRuntime = {
+		...(source.runId ? { runId: source.runId } : {}), ...(source.agent ? { agent: source.agent } : {}),
+		...(source.childIndex !== undefined ? { childIndex: source.childIndex } : {}), fanoutChild: source.fanoutChild,
+		...(source.sessionName ? { sessionName: source.sessionName } : {}), ...(source.intercomSessionName ? { intercomSessionName: source.intercomSessionName } : {}),
+		...(source.orchestratorTarget ? { orchestratorTarget: source.orchestratorTarget } : {}), ...(source.orchestratorSessionId ? { orchestratorSessionId: source.orchestratorSessionId } : {}),
+		...(source.parentSessionId ? { parentSessionId: source.parentSessionId } : {}), depth: source.depth, ...(source.maxDepth !== undefined ? { maxDepth: source.maxDepth } : {}),
+		...(source.capabilityCeiling ? { capabilityCeiling: source.capabilityCeiling } : {}), ...(source.thinkingCeiling ? { thinkingCeiling: source.thinkingCeiling } : {}),
+		...(source.inheritProjectContext !== undefined ? { inheritProjectContext: source.inheritProjectContext } : {}), ...(source.inheritGlobalContext !== undefined ? { inheritGlobalContext: source.inheritGlobalContext } : {}),
+		...(source.inheritSkills !== undefined ? { inheritSkills: source.inheritSkills } : {}), ...(source.permissions ? { permissions: { rules: source.permissions.rules } } : {}),
+		...(source.toolBudget ? { toolBudget: source.toolBudget } : {}), waitTool: source.waitTool, ...(source.requiredTools ? { requiredTools: source.requiredTools } : {}), fast: source.fast,
+	};
+	const remoteSupervision = Boolean(source.supervisorChannelDir);
+	return {
+		cwd: launch.machine.cwd,
+		storage: { kind: "memory" },
+		...(launch.model ? { model: launch.model } : {}),
+		...(launch.thinking ? { thinking: launch.thinking } : {}),
+		...(launch.tools ? { tools: launch.tools } : {}),
+		...(launch.excludeTools ? { excludeTools: launch.excludeTools } : {}),
+		extensionPaths: [],
+		ambientExtensions: true,
+		noSkills: launch.noSkills,
+		noContextFiles: launch.noContextFiles,
+		...(promptSpec ? { remotePromptSpec: promptSpec } : {
+			...(launch.systemPrompt ? { systemPrompt: launch.systemPrompt } : {}),
+			...(launch.appendSystemPrompt ? { appendSystemPrompt: launch.appendSystemPrompt } : {}),
+			...(launch.skillNames?.length ? { skillNames: [...launch.skillNames] } : {}),
+		}),
+		runtime,
+		remoteSupervision,
+	};
+}
+
+export function projectNativeMachineEvidence(machine: HerdrMachineReference, evidence: ChildSession["machineEvidence"]): ExternalCliMachineStatus {
+	if (!evidence?.initial) return machine;
+	return { ...machine, remoteGit: evidence.final ?? evidence.initial, nativeGit: { initial: evidence.initial, ...(evidence.final ? { final: evidence.final } : {}) } };
+}
+
+class RemoteNativeSession implements ChildSession {
+	readonly #process: ChildProcessWithoutNullStreams;
+	readonly #decoder = new NativeRemoteJsonlDecoder();
+	readonly #listeners = new Set<(event: ChildSessionEvent) => void>();
+	readonly #pending = new Map<string, Pending>();
+	readonly #supervisorDir?: string;
+	#replyTimer?: NodeJS.Timeout;
+	#sequence = 0;
+	#messages: AgentMessage[] = [];
+	#sessionId = "remote-pending";
+	#modelId?: string;
+	#closedError?: Error;
+	#disposed = false;
+	#disposeAcknowledged = false;
+	#transportBytes = 0;
+	#exitOutcome?: { code: number | null; signal: NodeJS.Signals | null };
+	#initialGit?: HerdrRemoteGitStatus;
+	#finalGit?: HerdrRemoteGitStatus;
+	#toolDiagnostic?: ChildToolDiagnostic;
+	#runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensions;
+	#requiredTools: readonly string[] = [];
+	readonly #commandTimeoutMs: number;
+	readonly #closed: Promise<void>;
+	#resolveClosed!: () => void;
+
+	private constructor(process: ChildProcessWithoutNullStreams, supervisorDir?: string, commandTimeoutMs = COMMAND_TIMEOUT_MS) {
+		this.#process = process;
+		this.#supervisorDir = supervisorDir;
+		this.#commandTimeoutMs = commandTimeoutMs;
+		this.#closed = new Promise((resolve) => { this.#resolveClosed = resolve; });
+		process.stdout.on("data", (chunk: Buffer) => {
+			this.#transportBytes += chunk.byteLength;
+			if (this.#transportBytes > NATIVE_REMOTE_MAX_TRANSPORT_BYTES) { this.#fail(new Error(`Remote native Pi transport exceeded ${NATIVE_REMOTE_MAX_TRANSPORT_BYTES} aggregate bytes.`)); return; }
+			try { for (const record of this.#decoder.push(chunk)) this.#record(record); }
+			catch (error) { this.#fail(error instanceof Error ? error : new Error(String(error))); }
+		});
+		process.on("error", (error) => this.#fail(error));
+		process.stdin.on("error", (error) => this.#fail(new Error(`Remote native Pi stdin failed: ${error.message}`)));
+		process.on("exit", (code, signal) => {
+			this.#exitOutcome = { code, signal };
+		});
+		process.on("close", (code, signal) => {
+			try { this.#decoder.end(); } catch (error) { this.#fail(error instanceof Error ? error : new Error(String(error))); this.#resolveClosed(); return; }
+			const outcome = this.#exitOutcome ?? { code, signal };
+			if (!this.#disposeAcknowledged) this.#fail(new Error(`Remote native Pi transport exited prematurely with code ${String(outcome.code)}${outcome.signal ? ` (${outcome.signal})` : ""}; remote termination is unknown and the run will not be resumed automatically.`));
+			this.#resolveClosed();
+		});
+		if (supervisorDir) {
+			const replies = path.join(supervisorDir, "replies");
+			this.#replyTimer = setInterval(() => {
+				for (const name of fs.existsSync(replies) ? fs.readdirSync(replies) : []) {
+					try {
+						const file = path.join(replies, name);
+						const value = JSON.parse(fs.readFileSync(file, "utf8")) as unknown;
+						void this.#command("supervisor-reply", { name, value }).then(() => fs.rmSync(file, { force: true }));
+					} catch { /* bounded polling retries incomplete writes */ }
+				}
+			}, 25);
+			this.#replyTimer.unref?.();
+		}
+	}
+
+	static async create(launch: ChildSessionLaunch, options: { commandTimeoutMs?: number } = {}): Promise<RemoteNativeSession> {
+		const machine = launch.machine!;
+		const launchFrame = encodeNativeRemoteRpcRecord({ type: "launch", protocol: 1, packageVersion: packageJson.version, launch: serializeNativeRemoteLaunch(launch) });
+		const child = spawn("ssh", [...herdrSshArgs(machine), herdrNativeRemoteCommand(machine, launch.machineEnv, nativeRemoteHostDiscoveryBody())], {
+			env: Object.fromEntries(["PATH", "HOME", "USER", "LOGNAME", "TMPDIR", "SSH_AUTH_SOCK"].flatMap((name) => process.env[name] === undefined ? [] : [[name, process.env[name]!]])),
+			stdio: ["pipe", "pipe", "pipe"], windowsHide: true,
+		});
+		let stderr = "";
+		child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString("utf8")}`.slice(-8192); });
+		const session = new RemoteNativeSession(child, launch.runtime.supervisorChannelDir, options.commandTimeoutMs);
+		session.#requiredTools = launch.runtime.requiredTools ?? [];
+		const handshakePending = session.#waitHandshake();
+		child.stdin.write(launchFrame);
+		const handshake = await handshakePending.catch((error) => { session.#fail(error instanceof Error ? error : new Error(String(error))); throw new Error(`${error instanceof Error ? error.message : String(error)}${stderr.trim() ? ` Remote stderr: ${stderr.trim()}` : ""}`); });
+		session.#sessionId = `remote:${machine.id}:${Date.now()}`;
+		session.#modelId = handshake.model;
+		return session;
+	}
+
+	#handshakeResolve?: (value: ReturnType<typeof validateNativeRemoteHandshake>) => void;
+	#handshakeReject?: (error: Error) => void;
+	#waitHandshake(): Promise<ReturnType<typeof validateNativeRemoteHandshake>> {
+		return new Promise((resolve, reject) => {
+			this.#handshakeResolve = resolve; this.#handshakeReject = reject;
+			const timer = setTimeout(() => reject(new Error("Remote native Pi handshake timed out.")), COMMAND_TIMEOUT_MS); timer.unref?.();
+		});
+	}
+	#record(value: unknown): void {
+		if (this.#handshakeResolve) {
+			const resolve = this.#handshakeResolve; this.#handshakeResolve = undefined;
+			const handshake = validateNativeRemoteHandshake(value, { packageVersion: packageJson.version, requiredCapabilities: ["settlement", "steer", "follow-up", "abort", ...(this.#supervisorDir ? ["supervision"] : [])], requiredTools: this.#requiredTools });
+			this.#initialGit = handshake.initialGit;
+			resolve(handshake); return;
+		}
+		if (!value || typeof value !== "object") throw new Error("Remote native Pi emitted a non-object record.");
+		const record = value as Record<string, unknown>;
+		if (record.type === "event" && record.event && typeof record.event === "object") {
+			const event = record.event as ChildSessionEvent;
+			if (event.type === "message_end" && event.message && typeof event.message === "object") this.#messages.push(event.message as AgentMessage);
+			if (event.type === "agent_end" && Array.isArray(event.messages)) this.#messages = event.messages as AgentMessage[];
+			for (const listener of this.#listeners) listener(event); return;
+		}
+		if (record.type === "supervisor-request" && this.#supervisorDir && typeof record.name === "string") {
+			fs.writeFileSync(path.join(this.#supervisorDir, "requests", path.basename(record.name)), JSON.stringify(record.value), { mode: 0o600 }); return;
+		}
+		if (record.type === "response" && typeof record.id === "string") {
+			const pending = this.#pending.get(record.id); if (!pending) throw new Error(`Remote native Pi returned unknown response '${record.id}'.`);
+			const data = record.data as { finalGit?: HerdrRemoteGitStatus; toolDiagnostic?: ChildToolDiagnostic; runtimeAcknowledgedExtensions?: RuntimeAcknowledgedChildExtensions } | undefined;
+			if (data?.finalGit) this.#finalGit = data.finalGit;
+			if (data?.toolDiagnostic && (![data.toolDiagnostic.required, data.toolDiagnostic.available, data.toolDiagnostic.missing].every((items) => Array.isArray(items) && items.every((item) => typeof item === "string")))) throw new Error("Remote native Pi returned a malformed tool diagnostic.");
+			this.#toolDiagnostic = data?.toolDiagnostic;
+			if (data?.runtimeAcknowledgedExtensions) {
+				const acknowledged = sanitizeRuntimeAcknowledgedExtensions(data.runtimeAcknowledgedExtensions);
+				if (!acknowledged) throw new Error("Remote native Pi returned malformed extension acknowledgements.");
+				this.#runtimeAcknowledgedExtensions = acknowledged;
+			}
+			if (pending.timer) clearTimeout(pending.timer); this.#pending.delete(record.id);
+			if (record.success === true) {
+				if (record.command === "dispose") this.#disposeAcknowledged = true;
+				pending.resolve(record.data);
+			} else pending.reject(new Error(String(record.error ?? "Remote command failed."))); return;
+		}
+		throw new Error(`Unexpected remote native Pi record '${String(record.type)}'.`);
+	}
+	#fail(error: Error): void {
+		if (this.#closedError) return;
+		this.#closedError = error; this.#handshakeReject?.(error);
+		for (const pending of this.#pending.values()) { if (pending.timer) clearTimeout(pending.timer); pending.reject(error); }
+		this.#pending.clear(); this.#process.stdin.destroy();
+		if (this.#process.exitCode === null && this.#process.signalCode === null) {
+			this.#process.kill("SIGTERM");
+			const timer = setTimeout(() => { if (this.#process.exitCode === null && this.#process.signalCode === null) this.#process.kill("SIGKILL"); }, 1_000); timer.unref?.();
+		}
+	}
+	#command(type: string, extra: Record<string, unknown> = {}, timeout = true): Promise<unknown> {
+		if (this.#closedError) return Promise.reject(this.#closedError);
+		const id = String(++this.#sequence);
+		return new Promise((resolve, reject) => {
+			const timer = timeout ? setTimeout(() => { const error = new Error(`Remote native Pi command '${type}' timed out.`); reject(error); this.#fail(error); }, this.#commandTimeoutMs) : undefined; timer?.unref?.();
+			this.#pending.set(id, { resolve, reject, timer });
+			this.#process.stdin.write(encodeNativeRemoteRpcRecord({ type, id, ...extra }), (error) => { if (error) this.#fail(new Error(`Remote native Pi command '${type}' write failed: ${error.message}`)); });
+		});
+	}
+	subscribe(listener: (event: ChildSessionEvent) => void): () => void { this.#listeners.add(listener); return () => this.#listeners.delete(listener); }
+	async prompt(text: string): Promise<void> { await this.#command("prompt", { message: text }, false); }
+	async steer(text: string): Promise<void> { await this.#command("steer", { message: text }); }
+	async followUp(text: string): Promise<void> { await this.#command("follow_up", { message: text }); }
+	async abort(): Promise<void> { if (!this.#disposed) await this.#command("abort"); }
+	async dispose(): Promise<void> {
+		if (this.#disposed) return;
+		if (this.#replyTimer) clearInterval(this.#replyTimer);
+		if (!this.#closedError) await this.#command("dispose").catch(() => {});
+		this.#disposed = true;
+		this.#process.stdin.end();
+		const wait = (ms: number) => Promise.race([this.#closed.then(() => true), new Promise<false>((resolve) => { const timer = setTimeout(() => resolve(false), ms); timer.unref?.(); })]);
+		if (!await wait(500) && this.#process.exitCode === null && this.#process.signalCode === null) this.#process.kill("SIGTERM");
+		if (!await wait(1_000) && this.#process.exitCode === null && this.#process.signalCode === null) this.#process.kill("SIGKILL");
+		await this.#closed;
+	}
+	get messages(): readonly AgentMessage[] { return this.#messages; }
+	get sessionFile(): undefined { return undefined; }
+	get sessionId(): string { return this.#sessionId; }
+	get modelId(): string | undefined { return this.#modelId; }
+	get machineEvidence() { return { ...(this.#initialGit ? { initial: this.#initialGit } : {}), ...(this.#finalGit ? { final: this.#finalGit } : {}) }; }
+	get toolDiagnostic() { return this.#toolDiagnostic; }
+	get runtimeAcknowledgedExtensions() { return this.#runtimeAcknowledgedExtensions; }
+}
+
+export function createPlacementAwareChildSessionFactory(local: ChildSessionFactory, options: {
+	/** Test seam for the SSH-backed constructor. */
+	createRemote?: (launch: ChildSessionLaunch) => Promise<ChildSession>;
+	remoteCommandTimeoutMs?: number;
+} = {}): ChildSessionFactory {
+	const remote = new Set<RemoteNativeSession>();
+	return {
+		async create(launch) {
+			if (!launch.machine) return local.create(launch);
+			const child = await (options.createRemote ?? ((input) => RemoteNativeSession.create(input, { commandTimeoutMs: options.remoteCommandTimeoutMs })))(launch);
+			if (child instanceof RemoteNativeSession) remote.add(child);
+			return child;
+		},
+		async dispose() { await Promise.allSettled([...remote].map(async (child) => { try { await child.abort(); } finally { await child.dispose(); } })); remote.clear(); await local.dispose(); },
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1250,6 +1250,8 @@ export interface SingleResult {
 	sessionName?: string;
 	/** Resolved launch context for this child. */
 	context?: "fresh" | "fork";
+	/** Native saved-machine execution evidence. */
+	machine?: ExternalCliMachineStatus;
 	exitCode: number;
 	processSignal?: string | null;
 	timeoutRecovery?: TimeoutRecoverySummary;
@@ -1718,6 +1720,11 @@ export interface HerdrRemoteGitStatus {
 	dirty?: boolean;
 }
 
+export interface RemoteNativeGitEvidence {
+	initial: HerdrRemoteGitStatus;
+	final?: HerdrRemoteGitStatus;
+}
+
 /** A Herdr saved SSH machine resolved for one launch. `cwd` is the directory on that machine. */
 export interface HerdrMachineReference {
 	provider: "herdr";
@@ -1730,6 +1737,8 @@ export interface HerdrMachineReference {
 
 export interface ExternalCliMachineStatus extends HerdrMachineReference {
 	remoteGit?: HerdrRemoteGitStatus;
+	/** Explicit before/after evidence for native Pi saved-machine runs. */
+	nativeGit?: RemoteNativeGitEvidence;
 }
 
 export interface ExternalCliCapabilities {
@@ -2402,6 +2411,9 @@ export interface RunSyncOptions {
 	cwd?: string;
 	/** Original cwd input retained for launch diagnostics. */
 	requestedCwd?: string;
+	/** Resolved native saved-machine placement. */
+	machine?: HerdrMachineReference;
+	machineEnv?: Record<string, string>;
 	signal?: AbortSignal;
 	interruptSignal?: AbortSignal;
 	timeoutMs?: number;

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -26,9 +26,49 @@ import {
 	readLastMockPiArgs, readMockPiArgs, readMockPiArgsMatching, tempDir, mockPi,
 	makeAsyncExecutor, readAsyncPayload, observeSharedCwdRunner,
 } from "../support/async-execution-fixture.ts";
+import { resolveAgentDefaultContextPolicy } from "../../src/runs/foreground/subagent-executor.ts";
 
 describe("async execution utilities", { skip: !available ? "pi packages not available" : undefined }, () => {
 	installAsyncExecutionHooks();
+
+	it("plans an async native machine model against the remote registry instead of local authentication", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		mockPi.onCall({ output: "remote done" });
+		const bin = fs.mkdtempSync(path.join(tempDir, "remote-bin-"));
+		const herdr = path.join(bin, "herdr");
+		fs.writeFileSync(herdr, `#!/usr/bin/env node\nconsole.log(JSON.stringify([{id:'saved',label:'workmac',target:'remote.example',enabled:true}]));`, { mode: 0o755 });
+		const oldHerdr = process.env.HERDR_BIN; process.env.HERDR_BIN = herdr;
+		try {
+			const ctx = { ...makeMinimalCtx(tempDir), modelRegistry: { getAvailable: () => [] }, sessionManager: { ...makeMinimalCtx(tempDir).sessionManager, getSessionId: () => "remote-parent" } };
+			const launch = await makeAsyncExecutor([makeAgent("worker", { runner: { type: "pi" } as never, thinking: "high" })]).execute(`remote-model-${Date.now().toString(36)}`, { agent: "worker", machine: "workmac", cwd: tempDir, model: "remote-only/model-x", task: "remote", async: true, acceptance: false }, new AbortController().signal, undefined, ctx) as AsyncExecutionResult;
+			assert.ok(!launch.isError, launch.content[0]?.text); const payload = await readAsyncPayload(launch.details.asyncId!); assert.equal(payload.results[0]?.model, "remote-only/model-x:high");
+			assert.equal(payload.results[0]?.thinking, "high");
+		} finally { if (oldHerdr === undefined) delete process.env.HERDR_BIN; else process.env.HERDR_BIN = oldHerdr; fs.rmSync(bin, { recursive: true, force: true }); }
+	});
+
+	it("records fresh aggregate context for step-only native placement in parallel, chain, and dynamic fanout", () => {
+		const agent = makeAgent("worker", { runner: { type: "pi" } as never, defaultContext: "fork" });
+		const warnings: string[] = []; const originalWarn = console.warn; console.warn = (value?: unknown) => { warnings.push(String(value)); };
+		const cases = [
+			{ tasks: [{ agent: "worker", task: "parallel", machine: "workmac" }] },
+			{ chain: [{ agent: "worker", task: "chain", machine: "workmac" }] },
+			{ chain: [{ expand: { from: { output: "seed", path: "/items" }, item: "item" }, parallel: { agent: "worker", machine: "workmac", task: "dynamic" }, collect: { as: "items" } }] },
+		];
+		try { for (const params of cases) {
+			const policy = resolveAgentDefaultContextPolicy(params as never, [agent], undefined, true); assert.equal("error" in policy, false); if ("error" in policy) continue;
+			assert.equal(policy.contextForAgent("worker"), "fork"); assert.equal(policy.contextSummary, "fresh"); assert.equal(policy.usesFork, false);
+		} } finally { console.warn = originalWarn; }
+		assert.equal(warnings.length, 3); assert.ok(warnings.every((warning) => warning.includes("native machine placement starts fresh")));
+	});
+
+	it("keeps local same-agent occurrences forked while mixed remote occurrences report mixed", () => {
+		const agent = makeAgent("worker", { runner: { type: "pi" } as never, defaultContext: "fork" });
+		const cases = [
+			{ chain: [{ agent: "worker", task: "local" }, { agent: "worker", task: "remote", machine: "workmac" }] },
+			{ chain: [{ parallel: [{ agent: "worker", task: "local" }, { agent: "worker", task: "remote", machine: "workmac" }] }] },
+			{ chain: [{ agent: "worker", task: "local" }, { expand: { from: { output: "seed", path: "/items" } }, parallel: { agent: "worker", task: "remote", machine: "workmac" }, collect: { as: "items" } }] },
+		];
+		for (const params of cases) { const policy = resolveAgentDefaultContextPolicy(params as never, [agent], undefined, true); assert.equal("error" in policy, false); if ("error" in policy) continue; assert.equal(policy.contextForAgent("worker"), "fork"); assert.equal(policy.contextSummary, "mixed"); assert.equal(policy.usesFork, true); }
+	});
 
 	it("background does not use compaction recovery after compaction_end willRetry false and a continued agent turn", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
 		const sessionFile = path.join(tempDir, "async-generic-empty-after-successful-compaction-session.jsonl");

--- a/test/integration/remote-native-packed-host.test.ts
+++ b/test/integration/remote-native-packed-host.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import { spawn, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { nativeRemoteHostDiscoveryBody } from "../../src/runs/shared/herdr-machine.ts";
+
+const supportsPosixPackedHost = process.platform !== "win32";
+const pi = supportsPosixPackedHost ? spawnSync("/bin/sh", ["-c", "command -v pi"], { encoding: "utf8" }).stdout?.trim() ?? "" : "";
+const npm = supportsPosixPackedHost ? spawnSync("/bin/sh", ["-c", "command -v npm"], { encoding: "utf8" }).stdout?.trim() ?? "" : "";
+
+it("fresh packed user and project Pi installs run the complete raw-fd protocol", { timeout: 120_000, skip: !supportsPosixPackedHost || !pi || !npm ? "POSIX shell, Pi, or npm executable unavailable" : undefined }, async () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-remote-packed-host-"));
+	try {
+		const packed = spawnSync(npm, ["pack", "--pack-destination", root, "--silent"], { cwd: process.cwd(), encoding: "utf8" }); assert.equal(packed.status, 0, packed.stderr);
+		const tarball = path.join(root, packed.stdout.trim().split(/\r?\n/u).at(-1)!);
+		const project = path.join(root, "project"); const home = path.join(root, "home"); const projectRoot = path.join(project, ".pi", "npm"); const userRoot = path.join(home, ".pi", "agent", "npm");
+		fs.mkdirSync(projectRoot, { recursive: true }); fs.mkdirSync(userRoot, { recursive: true });
+		for (const prefix of [projectRoot, userRoot]) {
+			const installed = spawnSync(npm, ["install", "--prefix", prefix, "--legacy-peer-deps", "--ignore-scripts", "--package-lock=false", tarball], { encoding: "utf8" }); assert.equal(installed.status, 0, installed.stderr);
+			assert.equal(fs.existsSync(path.join(prefix, "node_modules", "@earendil-works", "pi-tui")), false);
+			const executable = path.join(prefix, "node_modules", ".bin", "pi-subagents-remote-host"); assert.equal(fs.realpathSync(executable), fs.realpathSync(path.join(prefix, "node_modules", "pi-subagents", "remote-native-host.sh"))); assert.match(fs.readFileSync(executable, "utf8"), /^#!\/bin\/sh\n/u);
+		}
+		const isolatedBin = path.join(root, "bin"); fs.mkdirSync(isolatedBin); fs.symlinkSync(process.execPath, path.join(isolatedBin, "node"));
+		for (const tool of ["dirname", "readlink"]) {
+			const executable = spawnSync("/bin/sh", ["-c", `command -v ${tool}`], { encoding: "utf8" }).stdout.trim(); fs.symlinkSync(executable, path.join(isolatedBin, tool));
+		}
+		const packageVersion = (JSON.parse(fs.readFileSync(path.resolve("package.json"), "utf8")) as { version: string }).version;
+		const piVersion = spawnSync(pi, ["--version"], { encoding: "utf8" }).stdout.trim();
+		const run = (cwd: string) => new Promise<{ status: number | null; records: Record<string, unknown>[]; stderr: string }>((resolve, reject) => {
+			const child = spawn("/bin/sh", ["-c", nativeRemoteHostDiscoveryBody()], { cwd, env: { HOME: home, PATH: isolatedBin, PI_SUBAGENT_PI_BINARY: pi }, stdio: ["pipe", "pipe", "pipe"] });
+			const records: Record<string, unknown>[] = []; let stdout = ""; let stderr = ""; let disposed = false;
+			const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error(`packed host protocol timed out: ${stderr}`)); }, 30_000);
+			child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+			child.stdout.on("data", (chunk) => {
+				stdout += String(chunk); let newline: number;
+				while ((newline = stdout.indexOf("\n")) >= 0) {
+					const line = stdout.slice(0, newline); stdout = stdout.slice(newline + 1); const record = JSON.parse(line) as Record<string, unknown>; records.push(record);
+					if (record.type === "pi-subagents-ready" && !disposed) { disposed = true; child.stdin.write(`${JSON.stringify({ type: "dispose", id: "dispose-1" })}\n`); }
+					if (record.type === "response" && record.command === "dispose" && record.id === "dispose-1") child.stdin.end();
+				}
+			});
+			child.once("error", reject); child.once("close", (status) => { clearTimeout(timer); if (stdout) reject(new Error(`truncated stdout frame: ${stdout}`)); else resolve({ status, records, stderr }); });
+			child.stdin.write(`${JSON.stringify({ type: "launch", protocol: 1, packageVersion, launch: {
+				cwd, storage: { kind: "memory" }, extensionPaths: [], ambientExtensions: false, noSkills: true, noContextFiles: true,
+				runtime: { agent: "worker", childIndex: 0, fanoutChild: false, inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false, fast: false, depth: 1, maxDepth: 2, waitTool: { enabled: false } },
+			} })}\n`);
+		});
+		for (const [scope, cwd] of [["project", project], ["user", path.join(root, "other-project")]] as const) {
+			fs.mkdirSync(cwd, { recursive: true }); const result = await run(cwd);
+			assert.equal(result.status, 0, `${scope}: ${result.stderr}`); assert.doesNotMatch(result.stderr, /MODULE_NOT_FOUND|pi-tui|"type":"(?:pi-subagents-ready|event|supervisor-request|response)"/u);
+			const ready = result.records.find((record) => record.type === "pi-subagents-ready"); assert.equal(ready?.piVersion, piVersion); assert.equal(ready?.packageVersion, packageVersion);
+			assert.ok(result.records.some((record) => record.type === "response" && record.command === "dispose" && record.id === "dispose-1" && record.success === true));
+			assert.ok(result.records.every((record) => record.type === "pi-subagents-ready" || record.type === "event" || (record.type === "response" && record.command === "dispose")), `${scope}: unexpected outer Pi frame ${JSON.stringify(result.records)}`);
+		}
+	} finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/test/smoke/standalone-background.mjs
+++ b/test/smoke/standalone-background.mjs
@@ -16,7 +16,7 @@ if (process.platform !== "linux" || process.arch !== "x64") {
 const source = fileURLToPath(new URL("../../", import.meta.url));
 const binary = process.argv[2];
 const mode = process.argv[4] ?? "single";
-assert.ok(["single", "workflow", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout", "tool-timeout", "sdk-init-failure", "persistence-failure", "authorization-failure", "missing-bootstrap", "revival", "shared-run", "parallel-stop", "bootstrap-errors"].includes(mode), "unknown standalone smoke mode");
+assert.ok(["single", "workflow", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout", "tool-timeout", "sdk-init-failure", "persistence-failure", "authorization-failure", "missing-bootstrap", "revival", "shared-run", "parallel-stop", "bootstrap-errors", "remote-host"].includes(mode), "unknown standalone smoke mode");
 assert.ok(binary && path.isAbsolute(binary) && fs.existsSync(binary), "an existing absolute Pi binary path is required on Linux x64");
 const release = JSON.parse(fs.readFileSync(new URL("standalone-release.json", import.meta.url), "utf8"));
 assert.equal(process.platform, release.platform, "requires Linux/bubblewrap");
@@ -26,8 +26,8 @@ const root = process.argv[3] ? path.resolve(process.argv[3]) : fs.mkdtempSync(pa
 fs.mkdirSync(root, { recursive: true });
 assert.deepEqual(fs.readdirSync(root), [], "requires an empty artifact directory");
 const coreSdk = /(?:^|\/)@earendil-works\/(?:pi-coding-agent|pi-agent-core|pi-ai|pi-tui)(?:\/|$)/;
-function run(name, command, args) {
-	const result = spawnSync(command, args, { cwd: source, encoding: "utf8", timeout: 90_000, maxBuffer: 10 * 1024 * 1024 });
+function run(name, command, args, options = {}) {
+	const result = spawnSync(command, args, { cwd: source, encoding: "utf8", timeout: 90_000, maxBuffer: 10 * 1024 * 1024, ...options });
 	fs.writeFileSync(path.join(root, `${name}.log`), `${result.stdout ?? ""}${result.stderr ?? ""}`);
 	assert.ifError(result.error);
 	return result;
@@ -71,7 +71,21 @@ const bootstrap = "/stage/package/src/runs/background/binary-bootstrap.ts";
 if (mode === "missing-bootstrap") fs.renameSync(path.join(root, "package/src/runs/background/binary-bootstrap.ts"), path.join(root, "withheld-binary-bootstrap.ts"));
 const hostArgs = ["/stage/pi-native", "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-session", "--mode", "rpc"];
 console.log(`Artifacts: ${root}`);
-if (mode === "bootstrap-errors") {
+if (mode === "remote-host") {
+	const launch = { type: "launch", protocol: 1, packageVersion: JSON.parse(fs.readFileSync(path.join(root, "package/package.json"), "utf8")).version, launch: {
+		cwd: "/stage/work", storage: { kind: "memory" }, extensionPaths: [], ambientExtensions: false, noSkills: true, noContextFiles: true,
+		runtime: { agent: "worker", childIndex: 0, fanoutChild: false, inheritProjectContext: false, inheritGlobalContext: false, inheritSkills: false, fast: false, depth: 1, maxDepth: 2, waitTool: { enabled: false } },
+	} };
+	const input = `${JSON.stringify(launch)}\n${JSON.stringify({ type: "dispose", id: "dispose-1" })}\n`;
+	const invocation = run("remote-host", "bwrap", [...sandbox, "--setenv", "PI_SUBAGENT_PI_BINARY", "/stage/pi-native", "--", "/stage/package/remote-native-host.sh"], { input });
+	assert.equal(invocation.status, 0, invocation.stdout + invocation.stderr);
+	assert.doesNotMatch(invocation.stderr, /MODULE_NOT_FOUND|pi-tui|"type":"(?:pi-subagents-ready|event|supervisor-request|response)"/);
+	const records = invocation.stdout.trim().split("\n").map((line) => JSON.parse(line));
+	assert.deepEqual(records.map((record) => record.type), ["pi-subagents-ready", "response"], "outer Pi RPC must never start");
+	assert.equal(records[0].piVersion, version.stdout.trim());
+	assert.deepEqual({ command: records[1].command, id: records[1].id, success: records[1].success }, { command: "dispose", id: "dispose-1", success: true });
+	console.log("PASS standalone native remote host: raw launch/ready/dispose protocol");
+} else if (mode === "bootstrap-errors") {
 	const nativeStep = {
 		agent: "binary-smoke", task: "Return the scripted response.", context: "fresh", model: "standalone-smoke/local", modelCandidates: ["standalone-smoke/local"],
 		tools: [], extensions: ["/stage/package/test/smoke/standalone-provider.ts"], completionGuard: false,

--- a/test/smoke/standalone-matrix.mjs
+++ b/test/smoke/standalone-matrix.mjs
@@ -30,7 +30,7 @@ const inputs = ["index.ts", "package.json", "package-lock.json",
 ].filter((file) => fs.statSync(path.join(source, file)).isFile()).sort();
 const frozen = Object.fromEntries(inputs.map((file) => [file, sha(path.join(source, file))]));
 fs.writeFileSync(path.join(root, "inputs.json"), JSON.stringify(frozen, null, 2));
-const modes = ["single", "workflow", "shared-run", "parallel-stop", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout", "tool-timeout", "missing-bootstrap", "persistence-failure", "authorization-failure", "sdk-init-failure", "bootstrap-errors", "revival"];
+const modes = ["single", "workflow", "shared-run", "parallel-stop", "targeted-controls", "steer", "interrupt", "stop", "child-stop", "child-timeout", "run-timeout", "tool-timeout", "missing-bootstrap", "persistence-failure", "authorization-failure", "sdk-init-failure", "bootstrap-errors", "revival", "remote-host"];
 const receipt = { release, complete: false, cases: [] };
 let packageSha;
 for (const mode of modes) {

--- a/test/unit/herdr-machine.test.ts
+++ b/test/unit/herdr-machine.test.ts
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { spawnSync } from "node:child_process";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import {
 	formatHerdrMachineHint,
 	formatHerdrMachineRunnerUnsupported,
+	herdrNativeRemoteCommand,
 	HERDR_SSH_ENV_ALLOWLIST,
 	prepareHerdrMachineExternalCliRun,
+	nativeRemoteHostDiscoveryBody,
 	resolveHerdrMachinePlacement,
 	shellQuote,
 } from "../../src/runs/shared/herdr-machine.ts";
@@ -28,6 +31,15 @@ let tempProject = "";
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+function writeHostExecutable(file: string, marker: string): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, `#!/bin/sh\nprintf '%s\\n' ${shellQuote(marker)}\n`, { mode: 0o755 });
+}
+
+function runHostDiscovery(cwd: string, env: NodeJS.ProcessEnv) {
+	return spawnSync("/bin/sh", ["-c", nativeRemoteHostDiscoveryBody()], { cwd, env: { HOME: tempHome, PATH: "/usr/bin:/bin", ...env }, encoding: "utf8" });
+}
 
 function writeJson(filePath: string, value: unknown): void {
 	fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -101,6 +113,11 @@ describe("Herdr machine placement", () => {
 			);
 		});
 
+		it("contains relative cwd beneath the configured root while preserving explicit absolute cwd", () => {
+			assert.throws(() => resolveHerdrMachinePlacement({ machine: "workmac", cwd: tempProject, stepCwd: "../../etc", catalogJson: catalog, settings: { cwd: "/srv/repo" } }), /relative cwd escapes configured root/u);
+			assert.equal(resolveHerdrMachinePlacement({ machine: "workmac", cwd: tempProject, stepCwd: "/etc", catalogJson: catalog, settings: { cwd: "/srv/repo" } }).machine.cwd, "/etc");
+		});
+
 		it("reads machine roots from project settings over user settings, keyed by label or id, with opt-in env", () => {
 			writeJson(path.join(tempHome, ".pi", "agent", "settings.json"), { subagents: { machines: { workmac: { cwd: "/user/root", env: { FOO: "user" } } } } });
 			writeJson(path.join(tempProject, ".pi", "settings.json"), { subagents: { machines: { [machine.id]: { cwd: "/project/root" } } } });
@@ -119,17 +136,55 @@ describe("Herdr machine placement", () => {
 		});
 	});
 
+	describe("native host discovery", () => {
+		it("embeds discovery after quoted machine environment and remote cwd setup", () => {
+			const command = herdrNativeRemoteCommand(machine, { PATH: "/custom remote/bin", PI_CODING_AGENT_DIR: "/remote agent" }, nativeRemoteHostDiscoveryBody()); const script = remoteScript([command]);
+			assert.match(script, /export PATH='\/custom remote\/bin'/u); assert.match(script, /cd '\/home\/nico\/proj' \|\| exit 125/u); assert.match(script, /project_host=\$PWD\/\.pi\/npm\/node_modules\/\.bin/u);
+			assert.equal(script.includes("100.82.67.118"), false);
+		});
+
+		it("prefers a PATH override over managed Pi package installs", { skip: process.platform === "win32" ? "POSIX remote shell discovery" : false }, () => {
+			const bin = path.join(tempProject, "path-bin"); writeHostExecutable(path.join(bin, "pi-subagents-remote-host"), "path");
+			writeHostExecutable(path.join(tempProject, ".pi", "npm", "node_modules", ".bin", "pi-subagents-remote-host"), "project");
+			const result = runHostDiscovery(tempProject, { PATH: `${bin}:/usr/bin:/bin` }); assert.equal(result.status, 0); assert.equal(result.stdout.trim(), "path");
+		});
+
+		it("finds the documented project-local Pi npm bin", { skip: process.platform === "win32" ? "POSIX remote shell discovery" : false }, () => {
+			writeHostExecutable(path.join(tempProject, ".pi", "npm", "node_modules", ".bin", "pi-subagents-remote-host"), "project");
+			const result = runHostDiscovery(tempProject, {}); assert.equal(result.status, 0); assert.equal(result.stdout.trim(), "project");
+		});
+
+		it("finds user-scope installs in the default and configured Pi agent directories", { skip: process.platform === "win32" ? "POSIX remote shell discovery" : false }, () => {
+			writeHostExecutable(path.join(tempHome, ".pi", "agent", "npm", "node_modules", ".bin", "pi-subagents-remote-host"), "default-user");
+			let result = runHostDiscovery(tempProject, {}); assert.equal(result.status, 0); assert.equal(result.stdout.trim(), "default-user");
+			fs.rmSync(path.join(tempHome, ".pi"), { recursive: true, force: true }); const configured = path.join(tempHome, "configured agent");
+			writeHostExecutable(path.join(configured, "npm", "node_modules", ".bin", "pi-subagents-remote-host"), "configured-user");
+			result = runHostDiscovery(tempProject, { PI_CODING_AGENT_DIR: configured }); assert.equal(result.status, 0); assert.equal(result.stdout.trim(), "configured-user");
+			result = runHostDiscovery(tempProject, { PI_CODING_AGENT_DIR: `~/${path.basename(configured)}` }); assert.equal(result.status, 0); assert.equal(result.stdout.trim(), "configured-user");
+		});
+
+		it("does not execute unsafe agent-dir shell text and fails clearly when missing", { skip: process.platform === "win32" ? "POSIX remote shell discovery" : false }, () => {
+			const marker = path.join(tempProject, "injected");
+			let result = runHostDiscovery(tempProject, { PI_CODING_AGENT_DIR: `relative; touch ${marker}` }); assert.equal(result.status, 126); assert.match(result.stderr, /must be an absolute remote path/u); assert.equal(fs.existsSync(marker), false);
+			result = runHostDiscovery(tempProject, { PI_CODING_AGENT_DIR: path.join(tempHome, `missing; touch ${marker}`) }); assert.equal(result.status, 127); assert.match(result.stderr, /Run: pi install npm:pi-subagents/u); assert.equal(fs.existsSync(marker), false);
+		});
+	});
+
 	describe("launch gating", () => {
-		it("rejects native agents, generic adapters, and worktrees with a pointer", () => {
-			assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "reviewer", runnerType: "pi" }) ?? "", /only external-cli agents can run on a Herdr saved machine/u);
-			assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "generic", runnerType: "external-cli" }) ?? "", /generic external-cli commands cannot be remote-wrapped/u);
-			assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "worker", runnerType: "external-cli", adapter: "claude-code", worktree: true }) ?? "", /managed worktrees are local git operations/u);
+		it("admits native agents on supported hosts and rejects saved machines from Windows", () => {
+			if (process.platform === "win32") assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "reviewer", runnerType: "pi" }) ?? "", /Windows host/u);
+			else assert.equal(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "reviewer", runnerType: "pi" }), undefined);
 			assert.equal(formatHerdrMachineRunnerUnsupported({ agentName: "reviewer", runnerType: "pi" }), undefined);
 			if (process.platform === "win32") {
 				assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "worker", runnerType: "external-cli", adapter: "claude-code" }) ?? "", /Windows host/u);
 			} else {
 				assert.equal(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "worker", runnerType: "external-cli", adapter: "claude-code-writer" }), undefined);
 			}
+		});
+
+		it("preserves generic adapter and worktree restrictions", { skip: process.platform === "win32" ? "POSIX saved-machine restrictions" : false }, () => {
+			assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "generic", runnerType: "external-cli" }) ?? "", /generic external-cli commands cannot be remote-wrapped/u);
+			assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "worker", runnerType: "external-cli", adapter: "claude-code", worktree: true }) ?? "", /managed worktrees are local git operations/u);
 		});
 	});
 

--- a/test/unit/native-remote-rpc.test.ts
+++ b/test/unit/native-remote-rpc.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	NativeRemoteJsonlDecoder,
+	encodeNativeRemoteRpcRecord,
+	validateNativeRemoteHandshake,
+	writeNativeRemoteRpcRecordSync,
+} from "../../src/runs/shared/native-remote-rpc.ts";
+import { collectRemoteGitEvidence } from "../../src/runs/shared/remote-native-host.ts";
+
+describe("native remote Pi RPC framing", () => {
+	it("decodes fragmented UTF-8 and preserves Unicode separators inside JSON strings", () => {
+		const decoder = new NativeRemoteJsonlDecoder();
+		const bytes = Buffer.from('{"type":"event","text":"a b c 😀"}\n', "utf8");
+		const split = bytes.indexOf(Buffer.from("😀")) + 2;
+		assert.deepEqual(decoder.push(bytes.subarray(0, split)), []);
+		assert.deepEqual(decoder.push(bytes.subarray(split)), [{ type: "event", text: "a b c 😀" }]);
+		decoder.end();
+	});
+
+	it("accepts CRLF but rejects malformed, empty, oversized, and truncated frames", () => {
+		const crlf = new NativeRemoteJsonlDecoder();
+		assert.deepEqual(crlf.push(Buffer.from('{"ok":true}\r\n')), [{ ok: true }]);
+		crlf.end();
+		assert.throws(() => new NativeRemoteJsonlDecoder().push(Buffer.from("\n")), /empty JSONL frame/u);
+		assert.throws(() => new NativeRemoteJsonlDecoder().push(Buffer.from("nope\n")), /malformed JSON/u);
+		assert.throws(() => new NativeRemoteJsonlDecoder(3).push(Buffer.from("1234")), /exceeded 3 bytes/u);
+		const truncated = new NativeRemoteJsonlDecoder();
+		truncated.push(Buffer.from('{"ok":'));
+		assert.throws(() => truncated.end(), /truncated JSONL frame/u);
+	});
+
+	it("bounds outbound records and emits exactly one LF", () => {
+		assert.equal(encodeNativeRemoteRpcRecord({ type: "abort", id: "1" }).toString(), '{"type":"abort","id":"1"}\n');
+	});
+
+	it("completes raw fd-1 records across EINTR and partial writes", () => {
+		const chunks: Buffer[] = []; let calls = 0;
+		writeNativeRemoteRpcRecordSync({ type: "response", id: "x" }, (fd, buffer, offset, length) => {
+			assert.equal(fd, 1); calls++;
+			if (calls === 1) throw Object.assign(new Error("interrupted"), { code: "EINTR" });
+			const written = Math.min(3, length); chunks.push(Buffer.from(buffer.subarray(offset, offset + written))); return written;
+		});
+		assert.equal(Buffer.concat(chunks).toString(), '{"type":"response","id":"x"}\n'); assert.ok(calls > chunks.length);
+	});
+
+	it("rejects zero or invalid raw-writer progress instead of truncating a frame", () => {
+		assert.throws(() => writeNativeRemoteRpcRecordSync({ ok: true }, () => 0), /invalid progress \(0 bytes\)/u);
+		assert.throws(() => writeNativeRemoteRpcRecordSync({ ok: true }, (_fd, _buffer, _offset, length) => length + 1), /invalid progress/u);
+	});
+});
+
+describe("native remote Pi handshake", () => {
+	const ready = {
+		type: "pi-subagents-ready" as const,
+		protocol: 1,
+		packageVersion: "0.67.0",
+		piVersion: "0.85.0",
+		capabilities: ["settlement", "steer", "follow-up", "abort", "supervision"],
+		cwd: "/srv/project",
+		model: "anthropic/claude",
+		tools: ["read", "grep"],
+	};
+
+	it("requires exact package/protocol compatibility and requested capabilities", () => {
+		assert.equal(validateNativeRemoteHandshake(ready, { packageVersion: "0.67.0", requiredCapabilities: ["supervision"] }).cwd, "/srv/project");
+		assert.throws(() => validateNativeRemoteHandshake({ ...ready, protocol: 2 }, { packageVersion: "0.67.0", requiredCapabilities: [] }), /Incompatible remote native protocol/u);
+		assert.throws(() => validateNativeRemoteHandshake({ ...ready, packageVersion: "0.66.0" }, { packageVersion: "0.67.0", requiredCapabilities: [] }), /Incompatible remote pi-subagents version/u);
+		assert.throws(() => validateNativeRemoteHandshake({ ...ready, piVersion: "0.80.9" }, { packageVersion: "0.67.0", requiredCapabilities: [] }), /requires Pi >= 0.81.0/u);
+		assert.throws(() => validateNativeRemoteHandshake(ready, { packageVersion: "0.67.0", requiredCapabilities: ["structured-output"] }), /lacks required capabilities: structured-output/u);
+	});
+});
+
+describe("remote Git evidence", () => {
+	it("retains full head and dirty state on a detached HEAD", () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-remote-git-"));
+		try {
+			execFileSync("git", ["init", "-q"], { cwd }); execFileSync("git", ["config", "user.email", "test@example.com"], { cwd }); execFileSync("git", ["config", "user.name", "Test"], { cwd });
+			fs.writeFileSync(path.join(cwd, "file.txt"), "one"); execFileSync("git", ["add", "file.txt"], { cwd }); execFileSync("git", ["commit", "-qm", "one"], { cwd }); execFileSync("git", ["checkout", "--detach", "-q"], { cwd });
+			fs.writeFileSync(path.join(cwd, "file.txt"), "two");
+			const evidence = collectRemoteGitEvidence(cwd);
+			assert.match(String(evidence.head), /^[0-9a-f]{40}$/u); assert.equal(evidence.branch, undefined); assert.equal(evidence.dirty, true);
+		} finally { fs.rmSync(cwd, { recursive: true, force: true }); }
+	});
+});

--- a/test/unit/remote-native-launcher.test.ts
+++ b/test/unit/remote-native-launcher.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const launcherSource = path.resolve("remote-native-host.sh");
+
+function runLauncher(launcher: string, env: NodeJS.ProcessEnv, input = ""): Promise<{ code: number | null; stdout: string; stderr: string }> {
+	return new Promise((resolve) => {
+		const child = spawn(launcher, [], { env, stdio: ["pipe", "pipe", "pipe"] }); let stdout = ""; let stderr = "";
+		child.stdout.on("data", (chunk) => { stdout += String(chunk); }); child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+		child.on("close", (code) => resolve({ code, stdout, stderr })); child.stdin.end(input);
+	});
+}
+
+describe("remote native POSIX launcher", { skip: process.platform === "win32" ? "POSIX shell launcher" : false }, () => {
+	it("resolves an npm-style symlink and execs an absolute Pi with exact argv and streams", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi remote launcher ")); const packageDir = path.join(root, "node_modules", "pi-subagents"); const binDir = path.join(root, "node_modules", ".bin"); const fakePi = path.join(root, "fake pi"); const argvFile = path.join(root, "argv");
+		fs.mkdirSync(path.join(packageDir, "src", "runs", "shared"), { recursive: true }); fs.mkdirSync(binDir, { recursive: true });
+		fs.copyFileSync(launcherSource, path.join(packageDir, "remote-native-host.sh")); fs.chmodSync(path.join(packageDir, "remote-native-host.sh"), 0o755); fs.writeFileSync(path.join(packageDir, "src", "runs", "shared", "remote-native-bootstrap.ts"), "");
+		fs.symlinkSync(path.join("..", "pi-subagents", "remote-native-host.sh"), path.join(binDir, "pi-subagents-remote-host"));
+		fs.writeFileSync(fakePi, `#!/bin/sh\nprintf '%s\\n' "$@" >${JSON.stringify(argvFile)}\ncat\nprintf 'fake-pi-stderr\\n' >&2\nexit 23\n`, { mode: 0o755 });
+		try {
+			const result = await runLauncher(path.join(binDir, "pi-subagents-remote-host"), { ...process.env, PI_SUBAGENT_PI_BINARY: fakePi }, "rpc-input\n");
+			assert.equal(result.code, 23); assert.equal(result.stdout, "rpc-input\n"); assert.equal(result.stderr, "fake-pi-stderr\n");
+			assert.deepEqual(fs.readFileSync(argvFile, "utf8").trim().split("\n"), ["--no-extensions", "--no-skills", "--no-prompt-templates", "--no-context-files", "--no-session", "--mode", "rpc", "--extension", path.join(fs.realpathSync(packageDir), "src", "runs", "shared", "remote-native-bootstrap.ts")]);
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+
+	it("rejects a relative override and reports a missing PATH Pi", async () => {
+		let result = await runLauncher(launcherSource, { ...process.env, PI_SUBAGENT_PI_BINARY: "relative/pi" }); assert.equal(result.code, 126); assert.match(result.stderr, /must be an absolute path/u);
+		result = await runLauncher(launcherSource, { ...process.env, PATH: "/usr/bin:/bin", PI_SUBAGENT_PI_BINARY: "" }); assert.equal(result.code, 127); assert.match(result.stderr, /pi.*not found|not found.*pi/ui);
+	});
+
+	it("transfers process ownership and termination directly to Pi", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-remote-signal-")); const fakePi = path.join(dir, "pi"); const ready = path.join(dir, "ready"); const terminated = path.join(dir, "terminated");
+		fs.writeFileSync(fakePi, `#!/bin/sh\ntrap 'printf done >${JSON.stringify(terminated)}; exit 42' TERM\nprintf ready >${JSON.stringify(ready)}\nwhile :; do sleep 1; done\n`, { mode: 0o755 });
+		try {
+			const child = spawn(launcherSource, [], { env: { ...process.env, PI_SUBAGENT_PI_BINARY: fakePi }, stdio: "ignore" });
+			for (let i = 0; i < 100 && !fs.existsSync(ready); i++) await new Promise((resolve) => setTimeout(resolve, 10));
+			assert.equal(fs.existsSync(ready), true); child.kill("SIGTERM");
+			const code = await new Promise<number | null>((resolve) => child.on("close", resolve)); assert.equal(code, 42); assert.equal(fs.readFileSync(terminated, "utf8"), "done");
+		} finally { fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+});

--- a/test/unit/remote-native-placement.test.ts
+++ b/test/unit/remote-native-placement.test.ts
@@ -1,0 +1,269 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ChildSession, ChildSessionFactory, ChildSessionLaunch } from "../../src/runs/shared/child-session.ts";
+import { createPlacementAwareChildSessionFactory, projectNativeMachineEvidence, serializeNativeRemoteLaunch } from "../../src/runs/shared/remote-native-session.ts";
+import { formatHerdrMachineRunnerUnsupported, isNativePiRunner } from "../../src/runs/shared/herdr-machine.ts";
+import { buildRunnerChildLaunch } from "../../src/runs/background/runner-child-launch.ts";
+import { resolveRemoteNativePromptLaunch, resolveRemoteNativeSkillLaunch, runRemoteNativeHost, teardownRemoteNativeChild } from "../../src/runs/shared/remote-native-host.ts";
+import { encodeNativeRemoteRpcRecord } from "../../src/runs/shared/native-remote-rpc.ts";
+
+const child: ChildSession = {
+	subscribe: () => () => {}, prompt: async () => {}, steer: async () => {}, followUp: async () => {}, abort: async () => {}, dispose: async () => {},
+	messages: [], sessionFile: undefined, sessionId: "remote", modelId: "test/model",
+};
+
+function launch(machine = true): ChildSessionLaunch {
+	return {
+		cwd: "/remote/project", storage: { kind: "memory" }, extensionPaths: [], ambientExtensions: true, hooks: [], noSkills: true, noContextFiles: false,
+		runtime: { agent: "worker", childIndex: 0, fanoutChild: false, inheritProjectContext: true, inheritGlobalContext: true, inheritSkills: false, fast: false, depth: 1, maxDepth: 2, waitTool: { enabled: true } },
+		...(machine ? { machine: { provider: "herdr" as const, id: "saved", label: "workmac", target: "remote.example", cwd: "/remote/project" } } : {}),
+	};
+}
+
+describe("native saved-machine placement", () => {
+	it("routes a bare worker machine launch to the native remote session rather than the local factory", async () => {
+		let localCreates = 0;
+		let remoteLaunch: ChildSessionLaunch | undefined;
+		const local: ChildSessionFactory = { create: async () => { localCreates++; return child; }, dispose: async () => {} };
+		const factory = createPlacementAwareChildSessionFactory(local, { createRemote: async (input) => { remoteLaunch = input; return child; } });
+		assert.equal(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "worker" }), process.platform === "win32" ? "Herdr saved-machine launches use OpenSSH and a POSIX remote shell, which is not supported from a Windows host yet." : undefined);
+		await factory.create(launch());
+		assert.equal(localCreates, 0);
+		assert.equal(remoteLaunch?.machine?.label, "workmac");
+		assert.equal(remoteLaunch?.runtime.agent, "worker");
+	});
+
+	it("leaves local native launches and external-cli restrictions unchanged", async () => {
+		let localCreates = 0;
+		const local: ChildSessionFactory = { create: async () => { localCreates++; return child; }, dispose: async () => {} };
+		await createPlacementAwareChildSessionFactory(local).create(launch(false));
+		assert.equal(localCreates, 1);
+		if (process.platform !== "win32") assert.match(formatHerdrMachineRunnerUnsupported({ machine: "workmac", agentName: "custom", runnerType: "external-cli" }) ?? "", /generic external-cli commands/u);
+		assert.equal(isNativePiRunner({ type: "pi" }), true);
+	});
+
+	it("preserves read-only versus writer tool policy and rejects local resource transfer", () => {
+		const readonly = { ...launch(), tools: ["read", "grep", "find", "ls"] };
+		const writer = { ...launch(), tools: ["read", "bash", "edit", "write", "contact_supervisor"] };
+		assert.deepEqual(serializeNativeRemoteLaunch(readonly).tools, readonly.tools);
+		assert.deepEqual(serializeNativeRemoteLaunch(writer).tools, writer.tools);
+		assert.throws(() => serializeNativeRemoteLaunch({ ...writer, extensionPaths: ["/local/extension.ts"] }), /cannot transfer local extension resources/u);
+		assert.throws(() => serializeNativeRemoteLaunch({ ...writer, storage: { kind: "file", sessionFile: "/local/fork.jsonl" } }), /does not support forked, resumed, or revived/u);
+		const runnerBaseline = { ...writer, processEnv: { PI_SUBAGENT_EXTENSION_BINDINGS: undefined, MCP_DIRECT_TOOLS: "__none__" } };
+		assert.doesNotThrow(() => serializeNativeRemoteLaunch(runnerBaseline));
+		assert.throws(() => serializeNativeRemoteLaunch({ ...writer, runtime: { ...writer.runtime, nestedRoute: { rootRunId: "r", eventSink: "/Users/alice/events", controlInbox: "/Users/alice/control", capabilityToken: "SECRET" } } }), /does not transfer nested-route paths or capability tokens/u);
+		assert.doesNotMatch(JSON.stringify(serializeNativeRemoteLaunch(runnerBaseline)), /Users|SECRET|PI_SUBAGENT_EXTENSION_BINDINGS|MCP_DIRECT_TOOLS/u);
+	});
+
+	it("serializes the production async buildRunnerChildLaunch path without local process environment", () => {
+		const machine = launch().machine!;
+		const localSessions = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-sessions-"));
+		const built = buildRunnerChildLaunch({ agent: "worker", task: "edit", machine, machineEnv: {}, tools: ["read", "edit", "write"], skills: ["remote-review"], memory: { scope: "project", path: "worker" }, systemPrompt: "BASE_REMOTE_PROMPT", systemPromptMode: "replace", inheritProjectContext: true, inheritGlobalContext: false, inheritSkills: false }, { cwd: "/local/project", id: "run", flatIndex: 0 }, { sessionEnabled: true, sessionDir: localSessions, thinking: undefined, watchdogStatus() {} } as never);
+		const serialized = serializeNativeRemoteLaunch(built.session);
+		assert.equal(serialized.cwd, "/remote/project");
+		assert.ok(!JSON.stringify(serialized).includes(localSessions));
+		assert.deepEqual((serialized.remotePromptSpec as { skillNames?: string[] }).skillNames, ["remote-review"]);
+		assert.equal((serialized.remotePromptSpec as { memory?: { path: string } }).memory?.path, "worker");
+		assert.doesNotMatch(JSON.stringify(serialized), /PI_SUBAGENT_CHILD|MCP_DIRECT_TOOLS/u);
+		fs.rmSync(localSessions, { recursive: true, force: true });
+	});
+
+	it("preserves remote-only provider models and thinking while leaving omitted defaults omitted", () => {
+		const selected = serializeNativeRemoteLaunch({ ...launch(), model: "remote-provider/model-x:high" });
+		assert.equal(selected.model, "remote-provider/model-x:high");
+		const defaulted = serializeNativeRemoteLaunch({ ...launch(), thinking: "high" });
+		assert.equal(defaulted.model, undefined);
+		assert.equal(defaulted.thinking, "high");
+	});
+
+	it("serializes only logical skill names and resolves their locations from the remote cwd", () => {
+		const remote = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-remote-skills-"));
+		const skillFile = path.join(remote, ".pi", "skills", "remote-review", "SKILL.md"); fs.mkdirSync(path.dirname(skillFile), { recursive: true }); fs.writeFileSync(skillFile, "---\ndescription: Remote review\n---\n\nUse remote resources.\n");
+		try {
+			const localSecret = "/Users/local/private/skills/remote-review/SKILL.md";
+			const frame = serializeNativeRemoteLaunch({ ...launch(), skillNames: ["remote-review"], appendSystemPrompt: "base" });
+			assert.deepEqual(frame.skillNames, ["remote-review"]); assert.equal(JSON.stringify(frame).includes(localSecret), false);
+			assert.throws(() => serializeNativeRemoteLaunch({ ...launch(), skillNames: [localSecret] }), /must use logical names/u);
+			const resolved = resolveRemoteNativeSkillLaunch({ cwd: remote, skillNames: ["remote-review"], appendSystemPrompt: "base" });
+			assert.match(resolved.appendSystemPrompt ?? "", new RegExp(skillFile.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+			assert.throws(() => resolveRemoteNativeSkillLaunch({ cwd: remote, skillNames: ["local-only"] }), /Remote native Pi skills not found: local-only/u);
+		} finally { fs.rmSync(remote, { recursive: true, force: true }); }
+	});
+
+	it("builds memory and refinement prompt resources only from the remote cwd", () => {
+		const remote = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-remote-prompt-")); fs.mkdirSync(path.join(remote, ".git"));
+		const memoryFile = path.join(remote, ".pi", "agent-memory", "worker", "MEMORY.md"); fs.mkdirSync(path.dirname(memoryFile), { recursive: true }); fs.writeFileSync(memoryFile, "REMOTE_MEMORY_CONTENT\n");
+		const refinementFile = path.join(remote, ".pi", "subagents", "refinements", "worker.md"); fs.mkdirSync(path.dirname(refinementFile), { recursive: true });
+		fs.writeFileSync(refinementFile, `<!-- pi-subagents-refinement:v1\n${JSON.stringify({ agent: "worker", revision: 1, updatedAt: new Date().toISOString(), base: { source: "project", filePath: "agents/worker.md", systemPromptSha256: "abc" }, evidence: {} })}\n-->\n\n\`\`\`pi-subagents-refinement-current\nREMOTE_REFINEMENT_CONTENT\n\`\`\`\n\n\`\`\`pi-subagents-refinement-snapshots-json\n[]\n\`\`\`\n`);
+		try {
+			const localPath = "/Users/local/.pi/agent/agent-memory/worker/MEMORY.md"; const localContent = "LOCAL_MEMORY_CONTENT";
+			const remotePromptSpec = { agentName: "worker", baseSystemPrompt: "BASE", mode: "replace" as const, memory: { scope: "project" as const, path: "worker", writable: true } };
+			const frame = serializeNativeRemoteLaunch({ ...launch(), remotePromptSpec }); const json = JSON.stringify(frame); assert.equal(json.includes(localPath), false); assert.equal(json.includes(localContent), false);
+			const resolved = resolveRemoteNativePromptLaunch({ ...launch(), cwd: remote, remotePromptSpec }); const prompt = resolved.systemPrompt ?? "";
+			assert.match(prompt, /REMOTE_MEMORY_CONTENT/u); assert.match(prompt, /REMOTE_REFINEMENT_CONTENT/u); assert.match(prompt, new RegExp(memoryFile.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+			assert.throws(() => serializeNativeRemoteLaunch({ ...launch(), remotePromptSpec: { ...remotePromptSpec, memory: { ...remotePromptSpec.memory, path: "/Users/local/secret" } } }), /safe relative logical path/u);
+		} finally { fs.rmSync(remote, { recursive: true, force: true }); }
+	});
+
+	it("does not apply the short control acknowledgement timeout to prompt settlement", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-prompt-timeout-")); const ssh = path.join(dir, "ssh");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node
+const readline=require('readline');let first=true;const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');readline.createInterface({input:process.stdin}).on('line',line=>{const c=JSON.parse(line);if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',tools:[]});return;}if(c.type==='prompt'){setTimeout(()=>send({type:'response',id:c.id,command:'prompt',success:true}),80);return;}send({type:'response',id:c.id,command:c.type,success:true});if(c.type==='dispose')process.exit(0);});`, { mode: 0o755 });
+		const oldPath = process.env.PATH; process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try { const local: ChildSessionFactory = { create: async () => child, dispose: async () => {} }; const session = await createPlacementAwareChildSessionFactory(local, { remoteCommandTimeoutMs: 10 }).create({ ...launch(), tools: [] }); await session.prompt("long turn"); await session.dispose(); }
+		finally { process.env.PATH = oldPath; fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+
+	it("fails the runtime-observed handshake when a required remote tool is missing", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-tools-")); const ssh = path.join(dir, "ssh");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node
+const readline=require('readline');let first=true;const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');readline.createInterface({input:process.stdin}).on('line',line=>{const c=JSON.parse(line);if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',tools:['read']});return;}if(c.type==='prompt'){send({type:'response',id:c.id,command:'prompt',success:false,error:'required tool missing',data:{toolDiagnostic:{required:['contact_supervisor'],available:['read'],missing:['contact_supervisor']}}});return;}send({type:'response',id:c.id,command:c.type,success:true});if(c.type==='dispose')process.exit(0);});`, { mode: 0o755 });
+		const oldPath = process.env.PATH; process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try { const local: ChildSessionFactory = { create: async () => child, dispose: async () => {} }; await assert.rejects(createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: ["read", "contact_supervisor"], runtime: { ...launch().runtime, requiredTools: ["contact_supervisor"] } }), /runtime lacks required tools: contact_supervisor/u); }
+		finally { process.env.PATH = oldPath; fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+
+	it("aborts and boundedly disposes the remote child when control input reaches EOF during a hung prompt", async () => {
+		let aborted = 0; let disposed = 0; let factoryDisposed = 0;
+		const hung: ChildSession = { ...child, prompt: () => new Promise(() => {}), abort: async () => { aborted++; }, dispose: async () => { disposed++; await new Promise(() => {}); } };
+		void hung.prompt("never settles");
+		await teardownRemoteNativeChild(hung, { dispose: async () => { factoryDisposed++; } }, 10);
+		assert.equal(aborted, 1); assert.equal(disposed, 1); assert.equal(factoryDisposed, 1);
+	});
+
+	it("exits the production host loop after EOF while a prompt never settles", async () => {
+		let aborted = 0; let disposed = 0; let factoryDisposed = 0; const sent: unknown[] = [];
+		const hung: ChildSession = { ...child, prompt: () => new Promise(() => {}), abort: async () => { aborted++; }, dispose: async () => { disposed++; } };
+		const factory: ChildSessionFactory = { create: async () => hung, dispose: async () => { factoryDisposed++; } };
+		const version = (JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8")) as { version: string }).version;
+		const input = async function* () { yield encodeNativeRemoteRpcRecord({ type: "launch", protocol: 1, packageVersion: version, launch: serializeNativeRemoteLaunch(launch()) }); yield encodeNativeRemoteRpcRecord({ type: "prompt", id: "1", message: "never" }); };
+		await runRemoteNativeHost({ input: input(), factory, sendRecord: (value) => sent.push(value), teardownTimeoutMs: 10, piVersion: "9.8.7" });
+		assert.equal((sent.find((value) => (value as { type?: string }).type === "pi-subagents-ready") as { piVersion?: string }).piVersion, "9.8.7"); assert.equal(aborted, 1); assert.equal(disposed, 1); assert.equal(factoryDisposed, 1);
+		await assert.rejects(runRemoteNativeHost({ input: input(), factory, piVersion: "unknown" }), /invalid Pi SDK version/u);
+	});
+
+	it("projects explicit typed before/after Git evidence for public machine results", () => {
+		assert.deepEqual(projectNativeMachineEvidence(launch().machine!, { initial: { head: "before", dirty: false }, final: { head: "after", dirty: true } }), {
+			...launch().machine, remoteGit: { head: "after", dirty: true }, nativeGit: { initial: { head: "before", dirty: false }, final: { head: "after", dirty: true } },
+		});
+	});
+
+	it("drives prompt, steering, follow-up, abort, settlement messages, and dispose over the SSH protocol", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-ssh-"));
+		const log = path.join(dir, "commands.log");
+		const ssh = path.join(dir, "ssh");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node
+const fs=require('fs'); const readline=require('readline'); const log=${JSON.stringify(log)};
+let first=true; const rl=readline.createInterface({input:process.stdin});
+const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');
+rl.on('line',line=>{const c=JSON.parse(line); fs.appendFileSync(log,c.type+'\\n');
+if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',model:'test/model',tools:['read'],initialGit:{head:'abc',dirty:false}});return;}
+if(c.type==='prompt') send({type:'event',event:{type:'agent_end',messages:[]}});
+send({type:'response',id:c.id,command:c.type,success:true,...(c.type==='prompt'?{data:{finalGit:{head:'def',dirty:true}}}:{})});
+if(c.type==='dispose') process.exit(0);
+});`, { mode: 0o755 });
+		const oldPath = process.env.PATH;
+		process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try {
+			const local: ChildSessionFactory = { create: async () => { throw new Error("local factory used"); }, dispose: async () => {} };
+			const session = await createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: ["read"] });
+			await session.prompt("task");
+			assert.deepEqual(session.machineEvidence, { initial: { head: "abc", dirty: false }, final: { head: "def", dirty: true } });
+			await session.steer("guidance");
+			await session.followUp("continue");
+			await session.abort();
+			await session.dispose();
+			assert.deepEqual(fs.readFileSync(log, "utf8").trim().split("\n"), ["launch", "prompt", "steer", "follow_up", "abort", "dispose"]);
+		} finally {
+			process.env.PATH = oldPath;
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("delivers abort while a prompt is active and fails immediately on clean premature exit", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-active-"));
+		const ssh = path.join(dir, "ssh");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node
+const readline=require('readline');let first=true,prompt;
+const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');
+readline.createInterface({input:process.stdin}).on('line',line=>{const c=JSON.parse(line);
+if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',tools:[],initialGit:{head:'before',dirty:false}});return;}
+if(c.type==='prompt'){prompt=c;return;} if(c.type==='abort'){send({type:'response',id:c.id,command:'abort',success:true});send({type:'response',id:prompt.id,command:'prompt',success:false,error:'aborted',data:{finalGit:{head:'after',dirty:true}}});return;}
+send({type:'response',id:c.id,command:c.type,success:true}); if(c.type==='dispose')process.exit(0);
+});`, { mode: 0o755 });
+		const oldPath = process.env.PATH; process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try {
+			const local: ChildSessionFactory = { create: async () => child, dispose: async () => {} };
+			const session = await createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: [] });
+			const prompting = session.prompt("hang");
+			await session.abort();
+			await assert.rejects(prompting, /aborted/u);
+			assert.deepEqual(session.machineEvidence, { initial: { head: "before", dirty: false }, final: { head: "after", dirty: true } });
+			await session.dispose();
+
+			fs.writeFileSync(ssh, `#!/usr/bin/env node
+const readline=require('readline');let first=true;const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');readline.createInterface({input:process.stdin}).on('line',line=>{const c=JSON.parse(line);if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',tools:[]});}else if(c.type==='prompt')process.exit(0);});`, { mode: 0o755 });
+			const exited = await createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: [] });
+			await assert.rejects(Promise.race([exited.prompt("exit"), new Promise((_, reject) => setTimeout(() => reject(new Error("too slow")), 2_000))]), /exited prematurely/u);
+
+			const pidFile = path.join(dir, "bad.pid");
+			fs.writeFileSync(ssh, `#!/usr/bin/env node
+const fs=require('fs'),readline=require('readline');fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));readline.createInterface({input:process.stdin}).once('line',()=>{process.stdout.write(JSON.stringify({type:'pi-subagents-ready',protocol:99,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:[],cwd:'/remote/project',tools:[]})+'\\n');setInterval(()=>{},1000);});`, { mode: 0o755 });
+			await assert.rejects(createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: [] }), /Incompatible remote native protocol/u);
+			const pid = Number(fs.readFileSync(pidFile, "utf8"));
+			for (let attempt = 0; attempt < 20; attempt++) {
+				try { process.kill(pid, 0); await new Promise((resolve) => setTimeout(resolve, 25)); } catch { break; }
+			}
+			assert.throws(() => process.kill(pid, 0));
+		} finally { process.env.PATH = oldPath; fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+
+	it("terminates the owned transport when aggregate event output exceeds its bound", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-bound-")); const ssh = path.join(dir, "ssh");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node
+const readline=require('readline');let first=true;const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');readline.createInterface({input:process.stdin}).on('line',line=>{const c=JSON.parse(line);if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',tools:[]});return;}if(c.type==='prompt'){const text='x'.repeat(900000);for(let i=0;i<40;i++)send({type:'event',event:{type:'noise',text}});}});`, { mode: 0o755 });
+		const oldPath = process.env.PATH; process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try {
+			const local: ChildSessionFactory = { create: async () => child, dispose: async () => {} };
+			const session = await createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: [] });
+			await assert.rejects(session.prompt("flood"), /aggregate bytes/u);
+		} finally { process.env.PATH = oldPath; fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+
+	it("does not resolve acknowledged disposal until the owned SSH process is reaped", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-dispose-")); const ssh = path.join(dir, "ssh"); const pidFile = path.join(dir, "pid");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node
+const fs=require('fs'),readline=require('readline');fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));let first=true;const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');readline.createInterface({input:process.stdin}).on('line',line=>{const c=JSON.parse(line);if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',tools:[]});return;}send({type:'response',id:c.id,command:c.type,success:true});if(c.type==='dispose')setInterval(()=>{},1000);});`, { mode: 0o755 });
+		const oldPath = process.env.PATH; process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try {
+			const local: ChildSessionFactory = { create: async () => child, dispose: async () => {} };
+			const session = await createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: [] }); const pid = Number(fs.readFileSync(pidFile, "utf8"));
+			await session.dispose(); assert.throws(() => process.kill(pid, 0));
+		} finally { process.env.PATH = oldPath; fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+
+	it("rejects invalid launch DTOs before spawning SSH", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-prespawn-")); const ssh = path.join(dir, "ssh"); const marker = path.join(dir, "spawned");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node\nrequire('fs').writeFileSync(${JSON.stringify(marker)},String(process.pid));setInterval(()=>{},1000);`, { mode: 0o755 });
+		const oldPath = process.env.PATH; process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try {
+			const local: ChildSessionFactory = { create: async () => child, dispose: async () => {} };
+			await assert.rejects(createPlacementAwareChildSessionFactory(local).create({ ...launch(), extensionPaths: ["/local/secret.ts"] }), /cannot transfer local extension resources/u);
+			assert.equal(fs.existsSync(marker), false);
+		} finally { process.env.PATH = oldPath; fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+
+	it("drains the final stdout response before classifying an immediate SSH exit", { skip: process.platform === "win32" }, async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-native-drain-")); const ssh = path.join(dir, "ssh");
+		fs.writeFileSync(ssh, `#!/usr/bin/env node
+const readline=require('readline');let first=true;const send=v=>process.stdout.write(JSON.stringify(v)+'\\n');readline.createInterface({input:process.stdin}).on('line',line=>{const c=JSON.parse(line);if(first){first=false;send({type:'pi-subagents-ready',protocol:1,packageVersion:'0.67.0',piVersion:'0.85.0',capabilities:['settlement','steer','follow-up','abort'],cwd:'/remote/project',tools:[],initialGit:{head:'before',dirty:false}});return;}if(c.type==='prompt'){send({type:'response',id:c.id,command:'prompt',success:true,data:{finalGit:{head:'after',dirty:false}}});process.exit(0);}});`, { mode: 0o755 });
+		const oldPath = process.env.PATH; process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ""}`;
+		try {
+			const local: ChildSessionFactory = { create: async () => child, dispose: async () => {} }; const session = await createPlacementAwareChildSessionFactory(local).create({ ...launch(), tools: [] });
+			await session.prompt("finish and exit"); assert.equal(session.machineEvidence?.final?.head, "after");
+		} finally { process.env.PATH = oldPath; fs.rmSync(dir, { recursive: true, force: true }); }
+	});
+});


### PR DESCRIPTION
## Summary

- run native Pi subagents on saved Herdr SSH machines through a first-class Pi SDK/RPC host
- resolve provider-qualified models, thinking levels, credentials, skills, memory, refinements, and other resources on the remote Pi installation
- preserve machine placement across direct, foreground, background, workflow, chain, parallel, and dynamic-fanout launches
- report machine, cwd, tool/extension diagnostics, and before/after remote Git evidence while keeping local paths and credentials off the wire
- package and discover the remote host in Pi-managed user and project installs, including npm Pi and official standalone Pi

## First-slice limits

Remote native runs use fresh context and POSIX hosts. Explicit remote fork, managed worktrees, local extension/MCP/binding transfer, structured-output/watchdog callbacks, nested remote fanout, local output paths, reconnect, and revival fail closed.

Existing Claude Code, Codex, and Cursor saved-machine behavior remains unchanged.

## Validation

- `npm run typecheck`
- 29 focused native RPC, launcher, placement, and Herdr unit tests
- 59 packed-host and async integration tests
- fresh peer-free tarball installs in both Pi-managed package roots: launch → ready → dispose, exact Pi version, clean stdout/stderr and exit
- checksum-pinned official standalone remote-host CI matrix mode
- fresh lifecycle, security, resource/context, discovery, SDK-host, and raw-protocol reviews
- `git diff --check`
