### PR TITLE
fix(watchdog): surface provider error text in failed-review lastError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Surface the provider error text of a failed watchdog review in `/subagents-watchdog status` `Last error` (bounded to 600 chars). Previously only `stop reason 'error'` was recorded, so a watchdog failing every review (rate limit, rejected model, auth) was indistinguishable from a clean one.
 - Reject invalid global `checkpointBeforeDeadlineMs` values during config loading instead of silently disabling the requested checkpoint.
 
 ### Added

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -373,7 +373,7 @@ async function runWatchdogAttempt(ctx: ExtensionContext, request: WatchdogReview
 	const stopReason = reason === "error" || reason === "aborted" || reason === "length" ? reason : "stop";
 	const error = terminal && "errorMessage" in terminal && typeof terminal.errorMessage === "string" ? terminal.errorMessage : undefined;
 	return {
-		result: clarification ? { clarification } : { stopReason },
+		result: clarification ? { clarification } : { stopReason, ...(error ? { errorMessage: error } : {}) },
 		retryable: !clarification && stopReason === "error" && !isContextOverflow(error) && isRetryableModelFailureAttempt({ error, messages: agent.state.messages, toolCount }),
 	};
 }

--- a/src/watchdog/runtime.ts
+++ b/src/watchdog/runtime.ts
@@ -31,6 +31,8 @@ type ReviewStopReason = "stop" | "error" | "aborted" | "length";
 export interface WatchdogReviewResult {
 	warnings?: WatchdogWarning[];
 	stopReason?: ReviewStopReason;
+	/** Provider error text for a failed review, surfaced in status `Last error`. */
+	errorMessage?: string;
 	clarification?: { question: string; evidence: string };
 }
 
@@ -658,7 +660,8 @@ export class MainWatchdogRuntime {
 			}
 			for (const warning of result.warnings ?? []) this.acceptWarning(reviewEpoch, reviewId, warning);
 			if (result.stopReason && result.stopReason !== "stop") {
-				this.fail(`Watchdog review ended with stop reason '${result.stopReason}'.`);
+				const detail = result.errorMessage?.trim() ? ` ${boundWatchdogReviewText(result.errorMessage.trim(), 600)}` : "";
+				this.fail(`Watchdog review ended with stop reason '${result.stopReason}'.${detail}`);
 				return "completed";
 			}
 			this.displayAcceptedReviewWarning(options.correction);

--- a/test/unit/watchdog-review.test.ts
+++ b/test/unit/watchdog-review.test.ts
@@ -217,6 +217,7 @@ describe("main watchdog review adapter", () => {
 		const result = await createMainWatchdogReview(createCtx({ current: a, models: [a, b] }), { streamFn })(request(enabledConfig({ fallbackModels: ["mock/b"] }), []));
 		assert.deepEqual(calls.map((call) => call.model.id), ["a"]);
 		assert.equal(result?.stopReason, "error");
+		assert.equal(result?.errorMessage, "upstream: maximum context length exceeded");
 	});
 
 	it("does not retry normal, length, aborted, or unclassified error outcomes", async () => {

--- a/test/unit/watchdog-runtime.test.ts
+++ b/test/unit/watchdog-runtime.test.ts
@@ -431,6 +431,20 @@ describe("main watchdog runtime", () => {
 		assert.equal(snapshot.failedReviews, 1);
 	});
 
+	it("surfaces the provider error text of a failed review in lastError", async () => {
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig()),
+			review: () => ({ stopReason: "error", errorMessage: '429: {"message":"rate limit exceeded"}' }),
+		});
+
+		runtime.enqueueDelta("Assistant:\nWorking");
+		await runtime.handleAgentEnd({ type: "agent_end", messages: [] }, { cwd: "/tmp/project" });
+
+		const snapshot = runtime.getSnapshot();
+		assert.equal(snapshot.status, "failed");
+		assert.match(snapshot.lastError ?? "", /stop reason 'error'\. 429: .*rate limit exceeded/);
+	});
+
 	it("marks unresolved agent-end review work stale on timeout", async () => {
 		let started!: () => void;
 		const reviewStarted = new Promise<void>((resolve) => { started = resolve; });


### PR DESCRIPTION
## Problem

`runWatchdogReview` already reads `terminal.errorMessage` from the failed assistant message to decide whether the review is retryable, but drops it from the returned result. `MainWatchdogRuntime` can therefore only record:

```
Last error: Watchdog review ended with stop reason 'error'.
```

In practice this made a dead watchdog invisible. Observed on a project with `watchdog.enabled: true`, cadence every 10 tools, boundary reviews on: a ~14 h session accumulated `Failed reviews: 5` and produced **zero** findings across the whole project history, and there was no way to tell rate limit from rejected model id from auth from payload size — or from "every review was clean". Only after a `/reload` (fresh runtime) did reviews start passing, which points at a long-lived-runtime issue I can now only diagnose once the error text is visible.

## Change

- `review.ts`: return `errorMessage` next to `stopReason` when the terminal message carried one.
- `runtime.ts`: optional `errorMessage` on `WatchdogReviewResult`; `fail()` message appends a bounded (600 char, `boundWatchdogReviewText`) copy, so `/subagents-watchdog status` → `Last error:` shows the cause.
- Tests: runtime test asserts the text reaches `lastError`; review test asserts the context-overflow case returns it.
- CHANGELOG entry under Unreleased/Fixed.

No change to review, retry or fallback behaviour; this is observability only. `tsc --noEmit` clean; `watchdog-runtime` 41/41 and `watchdog-review` 22/22 pass.

## Follow-up (not in this PR)

Unclassified `error` outcomes are deliberately not retried on `fallbackModels` (per the existing "does not retry … unclassified error outcomes" test), so a configured fallback never engaged during the 5 failures above. That may be the right policy, but with the error text now visible I'd like to gather a few real failures before proposing anything there.
