### PR TITLE
fix(slash): include runtime-registered agents in /subagents admin panel

### DIFF
--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -11,6 +11,7 @@ import {
 	type BuiltinAgentOverrideBase,
 } from "../agents/agents.ts";
 import { serializeAgent } from "../agents/agent-serializer.ts";
+import { mergeRuntimeAgents, type RuntimeAgentOwner } from "../agents/runtime-agent-registry.ts";
 import { editableAgentConfig, preservedAgentFrontmatterFields } from "../agents/agent-management.ts";
 import { findModelInfo, getSupportedThinkingLevels, toModelInfo } from "../shared/model-info.ts";
 import { SelectorComponent, type SelectorItem, type SelectorResult } from "./selector.ts";
@@ -28,11 +29,14 @@ function sourceRank(source: AgentConfig["source"]): number {
 	return 3;
 }
 
-function allVisibleAgents(cwd: string): AgentConfig[] {
+function allVisibleAgents(pi: RuntimeAgentOwner | null, cwd: string): AgentConfig[] {
 	const d = discoverAgentsAll(cwd);
-	return [...d.project, ...d.user, ...d.package, ...d.builtin]
-		.filter((agent) => !agent.disabled)
-		.sort((a, b) => a.name.localeCompare(b.name) || sourceRank(a.source) - sourceRank(b.source));
+	const configured = [...d.project, ...d.user, ...d.package, ...d.builtin]
+		.filter((agent) => !agent.disabled);
+	// Runtime-registered agents (pi-subagents:runtime-agent-register:v1) participate in every
+	// delegation and listing path through mergeRuntimeAgents; the admin panel must list them too.
+	const agents = pi ? mergeRuntimeAgents(pi, { agents: configured }, configured).agents : configured;
+	return agents.sort((a, b) => a.name.localeCompare(b.name) || sourceRank(a.source) - sourceRank(b.source));
 }
 
 function agentLabel(agent: AgentConfig): string {
@@ -146,6 +150,9 @@ function isReadOnlyExtraAgent(agent: AgentConfig): boolean {
 }
 
 function readOnlyAgentMessage(agent: AgentConfig, field: EditableOverrideField): string | undefined {
+	if (agent.source === "runtime") {
+		return `Cannot update '${agent.name}' ${field} because that agent is runtime-registered by an extension; edit its source definition instead.`;
+	}
 	if (agent.source === "package") {
 		return `Cannot update '${agent.name}' ${field} because that field is owned by its read-only package definition.`;
 	}
@@ -154,8 +161,8 @@ function readOnlyAgentMessage(agent: AgentConfig, field: EditableOverrideField):
 		: undefined;
 }
 
-async function selectAgent(ctx: ExtensionContext, args: string): Promise<AgentSelection> {
-	const agents = allVisibleAgents(ctx.cwd);
+async function selectAgent(pi: RuntimeAgentOwner, ctx: ExtensionContext, args: string): Promise<AgentSelection> {
+	const agents = allVisibleAgents(pi, ctx.cwd);
 	const requestedName = args.trim().split(/\s+/)[0] ?? "";
 	if (agents.length === 0) return { kind: "not-found", agents, requestedName: requestedName || undefined };
 
@@ -390,7 +397,7 @@ async function editSystemPrompt(ctx: ExtensionContext, agent: AgentConfig): Prom
 }
 
 export async function openSubagentsAdmin(pi: ExtensionAPI, ctx: ExtensionContext, args = ""): Promise<void> {
-	const selection = await selectAgent(ctx, args);
+	const selection = await selectAgent(pi, ctx, args);
 	if (selection.kind === "cancelled") return;
 	if (selection.kind === "ambiguous") {
 		sendAdminMessage(pi, `Subagent '${selection.requestedName}' is ambiguous. Choose a scope in interactive mode:\n${selection.matches.map((agent) => `- ${agent.source}: ${agent.filePath}`).join("\n")}`);


### PR DESCRIPTION
## Problem

The `/subagents` admin panel only lists statically discovered agents. `allVisibleAgents()` (`src/slash/subagents-admin.ts`) builds its list from `discoverAgentsAll()` (project / user / package / builtin) and never consults the runtime agent registry.

Runtime agents registered through the `pi-subagents:runtime-agent-register:v1` event are invisible there, even though every other path merges them via `mergeRuntimeAgents()`:

- delegation resolution (`effectiveAgentsForScope`, `agent-management.ts`)
- the `subagent` tool list action
- `/run` (`discoverSlashAgents`)

### Reproduction

Any extension that registers a runtime agent — for example [pi-flow-composer](https://github.com/mystery4f/pi-flow-composer), which auto-injects `templates/flow/*/agents/*.md` as runtime agents on session start. The agents are delegable (`subagent({ agent: "sdd-explore", ... })` works) but absent from `/subagents`.

## Fix

- `allVisibleAgents(pi, cwd)` merges the runtime registry after static discovery — same pattern as `effectiveAgentsForScope()` in `agent-management.ts`.
- `pi` is threaded through `selectAgent()` from `openSubagentsAdmin()`.
- `readOnlyAgentMessage()` treats `runtime` source as read-only: these agents are owned by the registering extension, and a settings override written by the panel would never apply to them. The message points the user to the source definition instead.

## Verification

- Live pi install with 6 runtime-registered agents (`sdd-*`): after the patch they appear in the `/subagents` selector labeled `[runtime]`, and attempting to edit one shows the read-only message.
- Delegation, `subagent` list, and `/run` behavior unchanged (runtime merge was already active on those paths).
- `mergeRuntimeAgents` collision semantics are preserved: a runtime name colliding with a configured name still surfaces the existing hard error, consistent with the other merge call sites.
