### PR TITLE
fix: include runtime agents in /subagents admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.
 - Clear polled partial and rejected async jobs from the widget after terminal retention while preserving live nested descendants. Thanks to [@ashlineldridge](https://github.com/ashlineldridge) for #2159.
 - Reject unsupported bare acceptance strings at the provider schema boundary while preserving shorthand levels and JSON-encoded acceptance objects. Thanks to [@vrolok](https://github.com/vrolok) for #2152.
 - Keep canonical empty child responses eligible for same-launch model fallback without persisting them as 24-hour model exclusions. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #2154.

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -11,6 +11,7 @@ import {
 	type BuiltinAgentOverrideBase,
 } from "../agents/agents.ts";
 import { serializeAgent } from "../agents/agent-serializer.ts";
+import { mergeRuntimeAgents, type RuntimeAgentOwner } from "../agents/runtime-agent-registry.ts";
 import { editableAgentConfig, preservedAgentFrontmatterFields } from "../agents/agent-management.ts";
 import { findModelInfo, getSupportedThinkingLevels, toModelInfo } from "../shared/model-info.ts";
 import { SelectorComponent, type SelectorItem, type SelectorResult } from "./selector.ts";
@@ -28,11 +29,14 @@ function sourceRank(source: AgentConfig["source"]): number {
 	return 3;
 }
 
-function allVisibleAgents(cwd: string): AgentConfig[] {
+function allVisibleAgents(pi: RuntimeAgentOwner | null, cwd: string): AgentConfig[] {
 	const d = discoverAgentsAll(cwd);
-	return [...d.project, ...d.user, ...d.package, ...d.builtin]
-		.filter((agent) => !agent.disabled)
-		.sort((a, b) => a.name.localeCompare(b.name) || sourceRank(a.source) - sourceRank(b.source));
+	const configured = [...d.project, ...d.user, ...d.package, ...d.builtin]
+		.filter((agent) => !agent.disabled);
+	// Runtime-registered agents (pi-subagents:runtime-agent-register:v1) participate in every
+	// delegation and listing path through mergeRuntimeAgents; the admin panel must list them too.
+	const agents = pi ? mergeRuntimeAgents(pi, { agents: configured }, configured).agents : configured;
+	return agents.sort((a, b) => a.name.localeCompare(b.name) || sourceRank(a.source) - sourceRank(b.source));
 }
 
 function agentLabel(agent: AgentConfig): string {
@@ -146,6 +150,9 @@ function isReadOnlyExtraAgent(agent: AgentConfig): boolean {
 }
 
 function readOnlyAgentMessage(agent: AgentConfig, field: EditableOverrideField): string | undefined {
+	if (agent.source === "runtime") {
+		return `Cannot update '${agent.name}' ${field} because that agent is runtime-registered by an extension; edit its source definition instead.`;
+	}
 	if (agent.source === "package") {
 		return `Cannot update '${agent.name}' ${field} because that field is owned by its read-only package definition.`;
 	}
@@ -154,8 +161,8 @@ function readOnlyAgentMessage(agent: AgentConfig, field: EditableOverrideField):
 		: undefined;
 }
 
-async function selectAgent(ctx: ExtensionContext, args: string): Promise<AgentSelection> {
-	const agents = allVisibleAgents(ctx.cwd);
+async function selectAgent(pi: RuntimeAgentOwner, ctx: ExtensionContext, args: string): Promise<AgentSelection> {
+	const agents = allVisibleAgents(pi, ctx.cwd);
 	const requestedName = args.trim().split(/\s+/)[0] ?? "";
 	if (agents.length === 0) return { kind: "not-found", agents, requestedName: requestedName || undefined };
 
@@ -390,7 +397,7 @@ async function editSystemPrompt(ctx: ExtensionContext, agent: AgentConfig): Prom
 }
 
 export async function openSubagentsAdmin(pi: ExtensionAPI, ctx: ExtensionContext, args = ""): Promise<void> {
-	const selection = await selectAgent(ctx, args);
+	const selection = await selectAgent(pi, ctx, args);
 	if (selection.kind === "cancelled") return;
 	if (selection.kind === "ambiguous") {
 		sendAdminMessage(pi, `Subagent '${selection.requestedName}' is ambiguous. Choose a scope in interactive mode:\n${selection.matches.map((agent) => `- ${agent.source}: ${agent.filePath}`).join("\n")}`);

--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -31,11 +31,11 @@ function sourceRank(source: AgentConfig["source"]): number {
 
 function allVisibleAgents(pi: RuntimeAgentOwner | null, cwd: string): AgentConfig[] {
 	const d = discoverAgentsAll(cwd);
-	const configured = [...d.project, ...d.user, ...d.package, ...d.builtin]
-		.filter((agent) => !agent.disabled);
+	const allConfigured = [...d.project, ...d.user, ...d.package, ...d.builtin];
+	const visibleConfigured = allConfigured.filter((agent) => !agent.disabled);
 	// Runtime-registered agents (pi-subagents:runtime-agent-register:v1) participate in every
 	// delegation and listing path through mergeRuntimeAgents; the admin panel must list them too.
-	const agents = pi ? mergeRuntimeAgents(pi, { agents: configured }, configured).agents : configured;
+	const agents = pi ? mergeRuntimeAgents(pi, { agents: visibleConfigured }, allConfigured).agents : visibleConfigured;
 	return agents.sort((a, b) => a.name.localeCompare(b.name) || sourceRank(a.source) - sourceRank(b.source));
 }
 

--- a/test/unit/agent-management.test.ts
+++ b/test/unit/agent-management.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { editableAgentConfig, handleCreate, handleList, handleManagementAction, handleUpdate } from "../../src/agents/agent-management.ts";
 import { EXTRA_AGENT_DIRS_ENV } from "../../src/agents/agents.ts";
+import { registerAgent } from "../../src/api/agents.ts";
 import { EXTERNAL_JOB_PROVIDER_REGISTRY_KEY, registerExternalJobProvider } from "../../src/api/external-job-provider.ts";
 import { clearSkillCache } from "../../src/agents/skills.ts";
 import { PI_CODING_AGENT_PACKAGE_ROOT_ENV } from "../../src/shared/utils.ts";
@@ -1125,6 +1126,70 @@ Drive the failing test first.
 			assert.deepEqual(warnings, []);
 		});
 	}
+
+	it("shows runtime agents but refuses edits without writing configuration", async () => {
+		const sent: Array<{ content?: string }> = [];
+		const notified: string[] = [];
+		const pi = {
+			on() {}, registerTool() {},
+			sendMessage: (message: { content?: string }) => sent.push(message),
+		} as never;
+		const registration = registerAgent({
+			pi,
+			name: "runtime-admin-helper",
+			definition: { description: "Runtime admin helper", systemPrompt: "Help at runtime." },
+		});
+		try {
+			await openSubagentsAdmin(pi, {
+				cwd: tempDir, hasUI: false,
+				modelRegistry: { getAvailable: () => [] },
+			} as never, "runtime-admin-helper");
+			assert.match(sent.at(-1)?.content ?? "", /Agent: runtime-admin-helper \(runtime\)/);
+
+			await openSubagentsAdmin(pi, {
+				cwd: tempDir, hasUI: true,
+				modelRegistry: { getAvailable: () => [{ provider: "custom", id: "new-model" }] },
+				ui: {
+					select: async () => "custom/new-model",
+					notify: (message: string) => notified.push(message),
+				},
+			} as never, "runtime-admin-helper model");
+
+			const refusal = "runtime-registered by an extension; edit its source definition instead";
+			assert.match(notified.at(-1) ?? "", new RegExp(refusal));
+			assert.match(sent.at(-1)?.content ?? "", new RegExp(refusal));
+			assert.equal(fs.existsSync(path.join(tempDir, ".pi", "settings.json")), false);
+			assert.equal(fs.existsSync(path.join(tempDir, "agent-home", "settings.json")), false);
+		} finally {
+			registration.dispose();
+		}
+	});
+
+	it("fails closed when a runtime agent collides with a disabled configured definition", async () => {
+		const agentPath = path.join(tempDir, ".pi", "agents", "disabled-runtime-name.md");
+		fs.mkdirSync(path.dirname(agentPath), { recursive: true });
+		fs.writeFileSync(agentPath, "---\nname: disabled-runtime-name\ndescription: Hidden configured agent\ndisabled: true\n---\nHidden.\n");
+		const pi = {
+			on() {}, registerTool() {},
+			sendMessage: () => assert.fail("a colliding runtime agent must not be listed"),
+		} as never;
+		const registration = registerAgent({
+			pi,
+			name: "disabled-runtime-name",
+			definition: { description: "Colliding runtime agent", systemPrompt: "Runtime." },
+		});
+		try {
+			await assert.rejects(
+				openSubagentsAdmin(pi, {
+					cwd: tempDir, hasUI: false,
+					modelRegistry: { getAvailable: () => [] },
+				} as never, "disabled-runtime-name"),
+				/collides with configured agent 'disabled-runtime-name'/,
+			);
+		} finally {
+			registration.dispose();
+		}
+	});
 
 	for (const outcome of ["returned error", "aborted", "rejected"]) {
 		it(`warns and keeps registry choices when refresh ${outcome}`, async () => {


### PR DESCRIPTION
## Summary

- include runtime-registered agents in the `/subagents` admin panel
- keep runtime-owned definitions read-only
- preserve collision checks against disabled configured definitions
- add focused visibility, refusal, and collision tests

This is the maintainer-owned corrected replacement for #2169. It preserves the original contributor commit by @mystery4f and adds visible changelog credit.

## Validation

- 73 focused unit tests passed
- `npm run typecheck`
- `git diff --check`
