### PR TITLE
fix: surface watchdog provider errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.
 - Persist pretty JSON to explicitly bound background output artifacts when a successful child returns structured output without final prose. Thanks to [@rtbe](https://github.com/rtbe) for #2163.
+- Surface the provider error text of a failed watchdog review in `/subagents-watchdog status` `Last error` (bounded to 600 chars). Previously only `stop reason 'error'` was recorded, so a watchdog failing every review (rate limit, rejected model, auth) was indistinguishable from a clean one. Thanks to [@freezscholte](https://github.com/freezscholte) for #2166.
 - Clear polled partial and rejected async jobs from the widget after terminal retention while preserving live nested descendants. Thanks to [@ashlineldridge](https://github.com/ashlineldridge) for #2159.
 - Reject unsupported bare acceptance strings at the provider schema boundary while preserving shorthand levels and JSON-encoded acceptance objects. Thanks to [@vrolok](https://github.com/vrolok) for #2152.
 - Keep canonical empty child responses eligible for same-launch model fallback without persisting them as 24-hour model exclusions. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #2154.

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -373,7 +373,7 @@ async function runWatchdogAttempt(ctx: ExtensionContext, request: WatchdogReview
 	const stopReason = reason === "error" || reason === "aborted" || reason === "length" ? reason : "stop";
 	const error = terminal && "errorMessage" in terminal && typeof terminal.errorMessage === "string" ? terminal.errorMessage : undefined;
 	return {
-		result: clarification ? { clarification } : { stopReason },
+		result: clarification ? { clarification } : { stopReason, ...(error ? { errorMessage: error } : {}) },
 		retryable: !clarification && stopReason === "error" && !isContextOverflow(error) && isRetryableModelFailureAttempt({ error, messages: agent.state.messages, toolCount }),
 	};
 }

--- a/src/watchdog/runtime.ts
+++ b/src/watchdog/runtime.ts
@@ -31,6 +31,8 @@ type ReviewStopReason = "stop" | "error" | "aborted" | "length";
 export interface WatchdogReviewResult {
 	warnings?: WatchdogWarning[];
 	stopReason?: ReviewStopReason;
+	/** Provider error text for a failed review, surfaced in status `Last error`. */
+	errorMessage?: string;
 	clarification?: { question: string; evidence: string };
 }
 
@@ -658,7 +660,8 @@ export class MainWatchdogRuntime {
 			}
 			for (const warning of result.warnings ?? []) this.acceptWarning(reviewEpoch, reviewId, warning);
 			if (result.stopReason && result.stopReason !== "stop") {
-				this.fail(`Watchdog review ended with stop reason '${result.stopReason}'.`);
+				const detail = result.errorMessage?.trim() ? ` ${boundWatchdogReviewText(result.errorMessage.trim(), 600)}` : "";
+				this.fail(`Watchdog review ended with stop reason '${result.stopReason}'.${detail}`);
 				return "completed";
 			}
 			this.displayAcceptedReviewWarning(options.correction);

--- a/test/unit/watchdog-review.test.ts
+++ b/test/unit/watchdog-review.test.ts
@@ -217,6 +217,7 @@ describe("main watchdog review adapter", () => {
 		const result = await createMainWatchdogReview(createCtx({ current: a, models: [a, b] }), { streamFn })(request(enabledConfig({ fallbackModels: ["mock/b"] }), []));
 		assert.deepEqual(calls.map((call) => call.model.id), ["a"]);
 		assert.equal(result?.stopReason, "error");
+		assert.equal(result?.errorMessage, "upstream: maximum context length exceeded");
 	});
 
 	it("does not retry normal, length, aborted, or unclassified error outcomes", async () => {

--- a/test/unit/watchdog-runtime.test.ts
+++ b/test/unit/watchdog-runtime.test.ts
@@ -431,6 +431,25 @@ describe("main watchdog runtime", () => {
 		assert.equal(snapshot.failedReviews, 1);
 	});
 
+	it("surfaces the provider error text of a failed review in lastError", async () => {
+		const diagnostic = `provider-head-${"H".repeat(400)}-middle-${"M".repeat(400)}-provider-tail`;
+		const runtime = new MainWatchdogRuntime({
+			resolveConfig: () => configResult(enabledConfig()),
+			review: () => ({ stopReason: "error", errorMessage: diagnostic }),
+		});
+
+		runtime.enqueueDelta("Assistant:\nWorking");
+		await runtime.handleAgentEnd({ type: "agent_end", messages: [] }, { cwd: "/tmp/project" });
+
+		const snapshot = runtime.getSnapshot();
+		assert.equal(snapshot.status, "failed");
+		const lastError = snapshot.lastError ?? "";
+		assert.ok(lastError.includes(diagnostic.slice(0, 150)));
+		assert.ok(lastError.includes(`[... about ${diagnostic.length - 600} characters omitted ...]`));
+		assert.ok(lastError.endsWith(diagnostic.slice(-100)));
+		assert.ok(!lastError.includes(diagnostic));
+	});
+
 	it("marks unresolved agent-end review work stale on timeout", async () => {
 		let started!: () => void;
 		const reviewStarted = new Promise<void>((resolve) => { started = resolve; });


### PR DESCRIPTION
## Summary

- surface the provider error text in failed watchdog review status
- keep the diagnostic bounded before storing it in `lastError`
- preserve the contributor's focused review and runtime tests

This is a mechanical promotion of #2166 onto current `main`. The code/test patch is byte-identical to @freezscholte's contribution; the changelog conflict was resolved with visible contributor credit.

## Validation

- 63 focused watchdog tests passed
- `npm run typecheck`
- `git diff --check`
- promoted tree independently verified against the mechanical composition
