### PR TITLE
fix: persist structured-only bound outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.
+- Persist pretty JSON to explicitly bound background output artifacts when a successful child returns structured output without final prose. Thanks to [@rtbe](https://github.com/rtbe) for #2163.
 - Clear polled partial and rejected async jobs from the widget after terminal retention while preserving live nested descendants. Thanks to [@ashlineldridge](https://github.com/ashlineldridge) for #2159.
 - Reject unsupported bare acceptance strings at the provider schema boundary while preserving shorthand levels and JSON-encoded acceptance objects. Thanks to [@vrolok](https://github.com/vrolok) for #2152.
 - Keep canonical empty child responses eligible for same-launch model fallback without persisting them as 24-hour model exclusions. Thanks to [@rochecompaan](https://github.com/rochecompaan) for #2154.

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -1480,7 +1480,9 @@ export async function runSingleStepInner(
 	}
 
 	const rawOutput = finalResult?.finalOutput ?? "";
-	const outputForPersistence = stripAcceptanceReport(rawOutput);
+	let outputForPersistence = stripAcceptanceReport(rawOutput);
+	if (!outputForPersistence.trim() && finalResult?.structuredOutput !== undefined)
+		outputForPersistence = JSON.stringify(finalResult.structuredOutput, null, 2);
 	const resolvedOutput = step.outputPath && finalResult?.exitCode === 0
 		? resolveSingleOutput(step.outputPath, outputForPersistence, finalOutputSnapshot, step.outputClaimPath)
 		: { fullOutput: outputForPersistence };

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -1074,8 +1074,10 @@ export default function() {
 	});
 
 	it("background single runs support outputSchema", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {
-		mockPi.onCall({ output: "structured", structuredOutput: { ok: true, note: "async" } });
+		const expectedStructuredOutput = { ok: true, note: "async" };
+		mockPi.onCall({ output: "", structuredOutput: expectedStructuredOutput });
 		const id = `async-single-schema-${Date.now().toString(36)}`;
+		const outputPath = path.join(tempDir, `${id}.json`);
 
 		executeAsyncSingle(id, {
 			agent: "worker",
@@ -1094,12 +1096,17 @@ export default function() {
 			sessionRoot: path.join(tempDir, "sessions"),
 			maxSubagentDepth: 2,
 			acceptance: false,
+			output: outputPath,
 			structuredOutputSchema: { type: "object", required: ["ok"], properties: { ok: { type: "boolean" }, note: { type: "string" } } },
 		});
 
 		const payload = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(id, 10_000), "utf-8")) as AsyncResultPayload;
 		assert.equal(payload.success, true);
-		assert.deepEqual(payload.results[0]?.structuredOutput, { ok: true, note: "async" });
+		assert.deepEqual(payload.results[0]?.structuredOutput, expectedStructuredOutput);
+		assert.equal(payload.results[0]?.savedOutputPath, outputPath);
+		const savedOutput = fs.readFileSync(outputPath, "utf-8");
+		assert.equal(savedOutput, JSON.stringify(expectedStructuredOutput, null, 2));
+		assert.deepEqual(JSON.parse(savedOutput), expectedStructuredOutput);
 	});
 
 	it("background outputSchema runs fail closed when required acceptanceReport is missing", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {


### PR DESCRIPTION
## Summary

- persist pretty JSON to an explicit bound output when a successful background child returns structured output without prose
- preserve separate text and structured result channels when prose exists
- add a focused detached-run regression covering the exact artifact text and parsed value

Closes #2163.

Thanks to [@rtbe](https://github.com/rtbe) for the detailed reproduction and source analysis.

## Validation

- focused background output-schema integration test
- `npm run typecheck`
- `git diff --check`
