### PR TITLE
fix: group materialized workflow children in the async status snapshot

### DIFF
--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -362,11 +362,51 @@ function groupMaterializedChildren(jobs: readonly AsyncJobState[]) {
 	return { roots, childrenByParent };
 }
 
-/** The child job executing a workflow step, matched by workflow key or by run id. */
-function materializedChildForStep(step: AsyncJobStep, children: readonly AsyncJobState[]): AsyncJobState | undefined {
-	return children.find((child) =>
-		(step.workflowKey !== undefined && child.workflowKey === step.workflowKey)
-		|| (step.runId !== undefined && child.asyncId === step.runId));
+/**
+ * Assigns the child job executing each workflow lane, one child per lane at most.
+ * Run ids are matched across every lane before any workflow key, because a declared
+ * key may legitimately be reused: a lane naming its exact child must keep that child
+ * rather than lose it to whichever sibling lane the scan reaches first.
+ */
+function assignMaterializedChildren(lanes: readonly AsyncJobStep[], children: readonly AsyncJobState[]) {
+	const childByLane = new Map<AsyncJobStep, AsyncJobState>();
+	const claimed = new Set<AsyncJobState>();
+	const claim = (lane: AsyncJobStep, child: AsyncJobState | undefined): void => {
+		if (!child || claimed.has(child)) return;
+		childByLane.set(lane, child);
+		claimed.add(child);
+	};
+	for (const lane of lanes) {
+		if (lane.runId !== undefined) claim(lane, children.find((child) => child.asyncId === lane.runId));
+	}
+	for (const lane of lanes) {
+		if (childByLane.has(lane) || lane.workflowKey === undefined) continue;
+		claim(lane, children.find((child) => child.workflowKey === lane.workflowKey && !claimed.has(child)));
+	}
+	return childByLane;
+}
+
+/**
+ * The freshest activity of a grouped tree. A workflow must not rank behind its own
+ * live children: a finished or paused parent keeps a frozen `updatedAt` while a
+ * detached child still works — cleanup is held back for exactly that case — and the
+ * root cap would otherwise drop the parent and hide the child with it.
+ */
+function treeUpdatedAt(job: AsyncJobState, childrenByParent: MaterializedChildren, seen = new Set<string>()): number {
+	let freshest = job.updatedAt ?? job.startedAt ?? 0;
+	if (seen.has(job.asyncId)) return freshest;
+	seen.add(job.asyncId);
+	for (const child of childrenByParent.get(job.asyncId) ?? []) freshest = Math.max(freshest, treeUpdatedAt(child, childrenByParent, seen));
+	return freshest;
+}
+
+/** Runs grouped under a run: dropped with it, so counted with it. */
+function groupedRunCount(job: AsyncJobState, childrenByParent: MaterializedChildren, seen = new Set<string>()): number {
+	if (seen.has(job.asyncId)) return 0;
+	seen.add(job.asyncId);
+	let total = 0;
+	for (const child of childrenByParent.get(job.asyncId) ?? []) total += 1 + groupedRunCount(child, childrenByParent, seen);
+	return total;
 }
 
 /**
@@ -413,19 +453,22 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext, depth = 0, child
 	const nestedSummaries = (job.nestedChildren ?? []).filter((child) => !materialized.some((live) => live.asyncId === child.id));
 	const loadedKeys = new Set(steps.flatMap((step) => step.workflowKey ? [step.workflowKey] : []));
 	const graphStages = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph).filter((graphNode) => !loadedKeys.has(graphNode.id)) : [];
+	// One lane object per planned stage, built once: the assignment below is keyed by identity.
+	const graphLanes = graphStages.map((graphNode, index) => ({ step: workflowGraphStep(graphNode), index: graphNode.flatIndex ?? index }));
+	const childByLane = assignMaterializedChildren([...steps, ...graphLanes.map((lane) => lane.step)], materialized);
 	if (depth < ctx.caps.maxDepth) {
 		const childDepth = depth + 1;
-		const claimed = new Set<AsyncJobState>();
 		const projectLane = (step: AsyncJobStep, index: number): AsyncStatusSnapshotNode => {
-			const child = materializedChildForStep(step, materialized);
-			if (!child) return projectStep(step, index, childDepth, ctx);
-			claimed.add(child);
-			return projectMaterializedStep(step, index, child, childDepth, ctx, childrenByParent);
+			const child = childByLane.get(step);
+			return child
+				? projectMaterializedStep(step, index, child, childDepth, ctx, childrenByParent)
+				: projectStep(step, index, childDepth, ctx);
 		};
 		const stepChildren = steps.map((step, index) => projectLane(step, step.index ?? index));
-		const graphChildren = graphStages.map((graphNode, index) => projectLane(workflowGraphStep(graphNode), graphNode.flatIndex ?? index));
+		const graphChildren = graphLanes.map((lane) => projectLane(lane.step, lane.index));
 		const nestedChildren = nestedSummaries.map((child, index) => projectNestedRun(child, index, childDepth, ctx));
-		const unclaimedChildren = materialized.filter((child) => !claimed.has(child)).map((child) => projectRun(child, ctx, childDepth, childrenByParent));
+		const claimedChildren = new Set(childByLane.values());
+		const unclaimedChildren = materialized.filter((child) => !claimedChildren.has(child)).map((child) => projectRun(child, ctx, childDepth, childrenByParent));
 		const hostStepChildren = validHostStepList(job.hostSteps).map((hostStep) => projectHostStep(hostStep, ctx));
 		const ordinaryChildren = [...stepChildren, ...graphChildren, ...nestedChildren, ...unclaimedChildren];
 		const retainedHostSteps = hostStepChildren.slice(0, ctx.caps.maxChildrenPerNode);
@@ -435,8 +478,7 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext, depth = 0, child
 		ctx.omitted.children += ordinaryChildren.length - retainedOrdinaryChildren.length + hostStepChildren.length - retainedHostSteps.length;
 		if (bounded.length) node.children = bounded;
 	} else {
-		const claimedCount = [...steps, ...graphStages.map(workflowGraphStep)].filter((step) => materializedChildForStep(step, materialized) !== undefined).length;
-		ctx.omitted.children += steps.length + graphStages.length + nestedSummaries.length + (materialized.length - claimedCount) + validHostStepList(job.hostSteps).length;
+		ctx.omitted.children += steps.length + graphStages.length + nestedSummaries.length + (materialized.length - childByLane.size) + validHostStepList(job.hostSteps).length;
 	}
 	return node;
 }
@@ -445,7 +487,14 @@ function snapshotBytes(snapshot: AsyncStatusSnapshot): number {
 	return Buffer.byteLength(JSON.stringify(snapshot), "utf8");
 }
 
-function enforceByteLimit(snapshot: AsyncStatusSnapshot): void {
+/** Runs hidden from `index` onward: each trimmed root, plus the runs grouped under it. */
+function trimmedRunCount(groupedRuns: readonly number[], index: number): number {
+	let total = 0;
+	for (const grouped of groupedRuns.slice(index)) total += 1 + grouped;
+	return total;
+}
+
+function enforceByteLimit(snapshot: AsyncStatusSnapshot, groupedRuns: readonly number[]): void {
 	if (snapshotBytes(snapshot) <= snapshot.caps.maxSerializedBytes) return;
 	snapshot.omitted.byteLimitExceeded = true;
 	const runs = snapshot.runs;
@@ -455,12 +504,12 @@ function enforceByteLimit(snapshot: AsyncStatusSnapshot): void {
 	while (lower < upper) {
 		const retained = Math.ceil((lower + upper) / 2);
 		snapshot.runs = runs.slice(0, retained);
-		snapshot.omitted.runs = initialOmittedRuns + runs.length - retained;
+		snapshot.omitted.runs = initialOmittedRuns + trimmedRunCount(groupedRuns, retained);
 		if (snapshotBytes(snapshot) <= snapshot.caps.maxSerializedBytes) lower = retained;
 		else upper = retained - 1;
 	}
 	snapshot.runs = runs.slice(0, lower);
-	snapshot.omitted.runs = initialOmittedRuns + runs.length - lower;
+	snapshot.omitted.runs = initialOmittedRuns + trimmedRunCount(groupedRuns, lower);
 }
 
 function workflowStepActivity(step: AsyncJobStep): string | undefined {
@@ -628,20 +677,18 @@ export function projectAsyncStatusSnapshot(jobs: Iterable<AsyncJobState>, option
 	const caps = resolveCaps(options);
 	const ctx: ProjectionContext = { caps, omitted: { runs: 0, children: 0, byteLimitExceeded: false } };
 	const { roots, childrenByParent } = groupMaterializedChildren([...jobs]);
-	const sorted = roots.sort((left, right) => {
-		const leftUpdated = left.updatedAt ?? left.startedAt ?? 0;
-		const rightUpdated = right.updatedAt ?? right.startedAt ?? 0;
-		return rightUpdated - leftUpdated || left.asyncId.localeCompare(right.asyncId);
-	});
-	ctx.omitted.runs += Math.max(0, sorted.length - caps.maxRuns);
+	const ranked = roots.map((job) => ({ job, updatedAt: treeUpdatedAt(job, childrenByParent), groupedRuns: groupedRunCount(job, childrenByParent) }));
+	ranked.sort((left, right) => right.updatedAt - left.updatedAt || left.job.asyncId.localeCompare(right.job.asyncId));
+	const retained = ranked.slice(0, caps.maxRuns);
+	for (const entry of ranked.slice(caps.maxRuns)) ctx.omitted.runs += 1 + entry.groupedRuns;
 	const snapshot: AsyncStatusSnapshot = {
 		kind: ASYNC_STATUS_SNAPSHOT_KIND,
 		version: ASYNC_STATUS_SNAPSHOT_VERSION,
 		generatedAt: options.generatedAt ?? Date.now(),
 		caps,
 		omitted: ctx.omitted,
-		runs: sorted.slice(0, caps.maxRuns).map((job) => projectRun(job, ctx, 0, childrenByParent)),
+		runs: retained.map((entry) => projectRun(entry.job, ctx, 0, childrenByParent)),
 	};
-	enforceByteLimit(snapshot);
+	enforceByteLimit(snapshot, retained.map((entry) => entry.groupedRuns));
 	return snapshot;
 }

--- a/src/runs/shared/async-status-projection.ts
+++ b/src/runs/shared/async-status-projection.ts
@@ -224,16 +224,28 @@ function appendBoundedChildren(children: AsyncStatusSnapshotNode[], source: read
 	ctx.omitted.children += Math.max(0, source.length - remaining);
 }
 
+/** A step's public identity: its workflow key, else its run id, else its position. */
+function stepIdentity(step: AsyncJobStep | NestedStepSummary, index: number, ctx: ProjectionContext) {
+	return {
+		id: publicText("workflowKey" in step && step.workflowKey ? step.workflowKey : "runId" in step && step.runId ? step.runId : `step:${index}`, `step:${index}`, ctx.caps.maxStringLength),
+		label: publicText("label" in step && step.label ? step.label : step.agent, "step", ctx.caps.maxStringLength),
+	};
+}
+
 function projectStep(step: AsyncJobStep | NestedStepSummary, index: number, depth: number, ctx: ProjectionContext): AsyncStatusSnapshotNode {
 	const state = normalizeState(step.status);
 	const startedAt = publicTime(step.startedAt);
-	const endedAt = publicTime(step.endedAt);
+	// A finished workflow step records how long it ran, not when it ended;
+	// without an end, hosts would keep counting its time on every snapshot.
+	const durationMs = "durationMs" in step ? publicTime(step.durationMs) : undefined;
+	const endedAt = publicTime(step.endedAt) ?? (startedAt !== undefined && durationMs !== undefined ? startedAt + durationMs : undefined);
 	const updatedAt = endedAt ?? publicTime(step.lastActivityAt) ?? startedAt;
 	const activity = activityFor(step, ctx);
+	const { id, label } = stepIdentity(step, index, ctx);
 	const node: AsyncStatusSnapshotNode = {
-		id: publicText("workflowKey" in step && step.workflowKey ? step.workflowKey : "runId" in step && step.runId ? step.runId : `step:${index}`, `step:${index}`, ctx.caps.maxStringLength),
+		id,
 		kind: "step",
-		label: publicText("label" in step && step.label ? step.label : step.agent, "step", ctx.caps.maxStringLength),
+		label,
 		state,
 		...(startedAt !== undefined ? { startedAt } : {}),
 		...(updatedAt !== undefined ? { updatedAt } : {}),
@@ -251,14 +263,14 @@ function projectStep(step: AsyncJobStep | NestedStepSummary, index: number, dept
 	return node;
 }
 
-function projectWorkflowGraphNode(node: WorkflowGraphSnapshot["nodes"][number], index: number, depth: number, ctx: ProjectionContext): AsyncStatusSnapshotNode {
-	const step: AsyncJobStep = {
+/** A planned graph stage, as the step it becomes once loaded. */
+function workflowGraphStep(node: WorkflowGraphSnapshot["nodes"][number]): AsyncJobStep {
+	return {
 		agent: node.agent ?? node.label,
 		status: workflowGraphStepStatus(node.status),
 		workflowKey: node.id,
 		label: node.label,
 	};
-	return projectStep(step, node.flatIndex ?? index, depth, ctx);
 }
 
 function projectNestedRun(child: NestedRunSummary, index: number, depth: number, ctx: ProjectionContext): AsyncStatusSnapshotNode {
@@ -324,7 +336,63 @@ function projectHostStep(hostStep: HostStepNode, ctx: ProjectionContext): AsyncS
 	};
 }
 
-function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnapshotNode {
+/** Child jobs of each workflow, keyed by the parent's async id — see {@link groupMaterializedChildren}. */
+type MaterializedChildren = Map<string, AsyncJobState[]>;
+
+/**
+ * Workflow children run as tracked jobs of their own, carrying `parentWorkflowRunId`
+ * and `workflowKey`. Group them under their parent workflow, as the TUI widget does,
+ * so a lane is never listed twice: once as the parent's step and once as a root run.
+ * A child whose parent is not part of the snapshot stays a root, unchanged.
+ */
+function groupMaterializedChildren(jobs: readonly AsyncJobState[]) {
+	const parents = new Map(jobs.filter((job) => job.mode === "workflow").map((job) => [job.asyncId, job]));
+	const childrenByParent: MaterializedChildren = new Map();
+	const roots: AsyncJobState[] = [];
+	for (const job of jobs) {
+		const parent = job.parentWorkflowRunId ? parents.get(job.parentWorkflowRunId) : undefined;
+		if (parent && parent.asyncId !== job.asyncId) {
+			const siblings = childrenByParent.get(parent.asyncId) ?? [];
+			siblings.push(job);
+			childrenByParent.set(parent.asyncId, siblings);
+		} else {
+			roots.push(job);
+		}
+	}
+	return { roots, childrenByParent };
+}
+
+/** The child job executing a workflow step, matched by workflow key or by run id. */
+function materializedChildForStep(step: AsyncJobStep, children: readonly AsyncJobState[]): AsyncJobState | undefined {
+	return children.find((child) =>
+		(step.workflowKey !== undefined && child.workflowKey === step.workflowKey)
+		|| (step.runId !== undefined && child.asyncId === step.runId));
+}
+
+/**
+ * A workflow step executed by a materialized child job, as one node: the lane
+ * keeps its identity (key and label), the child supplies the live facts (state,
+ * timing, activity) and its own descendants. A single-mode child's lone step
+ * describes the child itself and is not repeated underneath — it is this node.
+ */
+function projectMaterializedStep(step: AsyncJobStep, index: number, child: AsyncJobState, depth: number, ctx: ProjectionContext, childrenByParent: MaterializedChildren): AsyncStatusSnapshotNode {
+	const { id, label } = stepIdentity(step, index, ctx);
+	const selfStep = child.mode === undefined || child.mode === "single" ? child.steps?.[0] : undefined;
+	const live = projectRun(child, ctx, depth, childrenByParent, { omitSteps: selfStep !== undefined });
+	const laneActivity = activityFor(step, ctx);
+	const selfActivity = selfStep ? activityFor(selfStep, ctx) : undefined;
+	const activity = laneActivity || selfActivity || live.activity ? { ...laneActivity, ...selfActivity, ...live.activity } : undefined;
+	const node: AsyncStatusSnapshotNode = { ...live, id, kind: "step", label };
+	if (activity) node.activity = activity;
+	return node;
+}
+
+interface ProjectRunOptions {
+	/** Leave the job's steps out (a materialized single-mode child: its lone step is the lane node itself). */
+	omitSteps?: boolean;
+}
+
+function projectRun(job: AsyncJobState, ctx: ProjectionContext, depth = 0, childrenByParent: MaterializedChildren = new Map(), options: ProjectRunOptions = {}): AsyncStatusSnapshotNode {
 	const state = normalizeState(job.status);
 	const startedAt = publicTime(job.startedAt);
 	const updatedAt = publicTime(job.updatedAt) ?? startedAt;
@@ -339,16 +407,27 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnap
 		...(terminalState(state) && updatedAt !== undefined ? { endedAt: updatedAt } : {}),
 		...(activity ? { activity } : {}),
 	};
-	if (ctx.caps.maxDepth > 0) {
-		const stepChildren = job.steps?.map((step, index) => projectStep(step, step.index ?? index, 1, ctx)) ?? [];
-		const loadedKeys = new Set(job.steps?.flatMap((step) => step.workflowKey ? [step.workflowKey] : []) ?? []);
-		const graphStages = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph) : [];
-		const graphChildren = graphStages
-			.filter((graphNode) => !loadedKeys.has(graphNode.id))
-			.map((graphNode, index) => projectWorkflowGraphNode(graphNode, index, 1, ctx));
-		const nestedChildren = job.nestedChildren?.map((child, index) => projectNestedRun(child, index, 1, ctx)) ?? [];
+	const steps = options.omitSteps ? [] : job.steps ?? [];
+	const materialized = childrenByParent.get(job.asyncId) ?? [];
+	// Nested summaries of the same children are the registry's view of them — one row each.
+	const nestedSummaries = (job.nestedChildren ?? []).filter((child) => !materialized.some((live) => live.asyncId === child.id));
+	const loadedKeys = new Set(steps.flatMap((step) => step.workflowKey ? [step.workflowKey] : []));
+	const graphStages = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph).filter((graphNode) => !loadedKeys.has(graphNode.id)) : [];
+	if (depth < ctx.caps.maxDepth) {
+		const childDepth = depth + 1;
+		const claimed = new Set<AsyncJobState>();
+		const projectLane = (step: AsyncJobStep, index: number): AsyncStatusSnapshotNode => {
+			const child = materializedChildForStep(step, materialized);
+			if (!child) return projectStep(step, index, childDepth, ctx);
+			claimed.add(child);
+			return projectMaterializedStep(step, index, child, childDepth, ctx, childrenByParent);
+		};
+		const stepChildren = steps.map((step, index) => projectLane(step, step.index ?? index));
+		const graphChildren = graphStages.map((graphNode, index) => projectLane(workflowGraphStep(graphNode), graphNode.flatIndex ?? index));
+		const nestedChildren = nestedSummaries.map((child, index) => projectNestedRun(child, index, childDepth, ctx));
+		const unclaimedChildren = materialized.filter((child) => !claimed.has(child)).map((child) => projectRun(child, ctx, childDepth, childrenByParent));
 		const hostStepChildren = validHostStepList(job.hostSteps).map((hostStep) => projectHostStep(hostStep, ctx));
-		const ordinaryChildren = [...stepChildren, ...graphChildren, ...nestedChildren];
+		const ordinaryChildren = [...stepChildren, ...graphChildren, ...nestedChildren, ...unclaimedChildren];
 		const retainedHostSteps = hostStepChildren.slice(0, ctx.caps.maxChildrenPerNode);
 		const retainedOrdinaryChildren = ordinaryChildren.slice(0, ctx.caps.maxChildrenPerNode - retainedHostSteps.length);
 		const bounded: AsyncStatusSnapshotNode[] = [];
@@ -356,10 +435,8 @@ function projectRun(job: AsyncJobState, ctx: ProjectionContext): AsyncStatusSnap
 		ctx.omitted.children += ordinaryChildren.length - retainedOrdinaryChildren.length + hostStepChildren.length - retainedHostSteps.length;
 		if (bounded.length) node.children = bounded;
 	} else {
-		const loadedKeys = new Set(job.steps?.flatMap((step) => step.workflowKey ? [step.workflowKey] : []) ?? []);
-		const graphStages = job.mode === "workflow" ? workflowGraphStageNodes(job.workflowGraph) : [];
-		const graphCount = graphStages.filter((graphNode) => !loadedKeys.has(graphNode.id)).length;
-		ctx.omitted.children += (job.steps?.length ?? 0) + graphCount + (job.nestedChildren?.length ?? 0) + validHostStepList(job.hostSteps).length;
+		const claimedCount = [...steps, ...graphStages.map(workflowGraphStep)].filter((step) => materializedChildForStep(step, materialized) !== undefined).length;
+		ctx.omitted.children += steps.length + graphStages.length + nestedSummaries.length + (materialized.length - claimedCount) + validHostStepList(job.hostSteps).length;
 	}
 	return node;
 }
@@ -550,7 +627,8 @@ function projectLoadedWorkflowRow(step: AsyncJobStep, index: number, preflight?:
 export function projectAsyncStatusSnapshot(jobs: Iterable<AsyncJobState>, options: AsyncStatusSnapshotOptions = {}): AsyncStatusSnapshot {
 	const caps = resolveCaps(options);
 	const ctx: ProjectionContext = { caps, omitted: { runs: 0, children: 0, byteLimitExceeded: false } };
-	const sorted = [...jobs].sort((left, right) => {
+	const { roots, childrenByParent } = groupMaterializedChildren([...jobs]);
+	const sorted = roots.sort((left, right) => {
 		const leftUpdated = left.updatedAt ?? left.startedAt ?? 0;
 		const rightUpdated = right.updatedAt ?? right.startedAt ?? 0;
 		return rightUpdated - leftUpdated || left.asyncId.localeCompare(right.asyncId);
@@ -562,7 +640,7 @@ export function projectAsyncStatusSnapshot(jobs: Iterable<AsyncJobState>, option
 		generatedAt: options.generatedAt ?? Date.now(),
 		caps,
 		omitted: ctx.omitted,
-		runs: sorted.slice(0, caps.maxRuns).map((job) => projectRun(job, ctx)),
+		runs: sorted.slice(0, caps.maxRuns).map((job) => projectRun(job, ctx, 0, childrenByParent)),
 	};
 	enforceByteLimit(snapshot);
 	return snapshot;

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -51,6 +51,61 @@ function stagedLaneGraph(statuses: WorkflowNodeStatus[] = stagedLaneKeys.map((_,
 	};
 }
 
+/** A workflow of three lanes: one finished, one running, one still planned. */
+const materializedWorkflow = job({
+	asyncId: "wf-1",
+	status: "running",
+	mode: "workflow",
+	agents: ["reviewer"],
+	startedAt: 1_000,
+	updatedAt: 5_000,
+	steps: [
+		// A finished step records how long it ran, never when it ended.
+		{ workflowKey: "rev-core", label: "rev-core", agent: "reviewer", status: "completed", runId: "child-core", startedAt: 1_500, durationMs: 2_500 },
+		{ workflowKey: "rev-r", label: "rev-r", agent: "reviewer", status: "running", runId: "child-r", startedAt: 1_500 },
+		{ workflowKey: "rev-parity", label: "rev-parity", agent: "reviewer", status: "pending" },
+	],
+});
+
+/** The tracked job executing the running lane, carrying the live facts of that work. */
+const materializedRunningChild = job({
+	asyncId: "child-r",
+	status: "running",
+	mode: "single",
+	parentWorkflowRunId: "wf-1",
+	workflowKey: "rev-r",
+	agents: ["reviewer"],
+	startedAt: 1_700,
+	updatedAt: 4_900,
+	currentTool: "read",
+	toolCount: 3,
+	turnCount: 1,
+	steps: [{ agent: "reviewer", status: "running" }],
+});
+
+/** A child of the workflow matching no lane: real extra work, kept under its parent. */
+const unmatchedChild = job({
+	asyncId: "child-extra",
+	status: "running",
+	mode: "single",
+	parentWorkflowRunId: "wf-1",
+	agents: ["helper"],
+	startedAt: 2_000,
+	steps: [{ agent: "helper", status: "running" }],
+});
+
+/** A child whose parent is absent from the snapshot: stays a root run, unchanged. */
+const orphanedChild = job({
+	asyncId: "child-orphan",
+	status: "running",
+	mode: "single",
+	parentWorkflowRunId: "wf-gone",
+	workflowKey: "lane",
+	agents: ["scout"],
+	startedAt: 3_000,
+	steps: [{ agent: "scout", status: "running" }],
+});
+
 describe("async status projection", () => {
 	it("projects already-loaded jobs in deterministic newest-first order", () => {
 		const snapshot = projectAsyncStatusSnapshot([
@@ -256,5 +311,59 @@ describe("async status projection", () => {
 			{ name: "writer · First (worker)", state: "complete" },
 			{ name: "writer · Second (worker)", state: "running" },
 		]);
+	});
+
+	it("projects a materialized workflow child once, as its lane, with the child's live facts", () => {
+		const snapshot = projectAsyncStatusSnapshot([materializedWorkflow, materializedRunningChild], { generatedAt: 5_000 });
+
+		assert.deepEqual(snapshot.runs.map((run) => run.id), ["wf-1"]);
+		assert.deepEqual(snapshot.runs[0]?.children?.map(({ id, kind, label, state }) => ({ id, kind, label, state })), [
+			{ id: "rev-core", kind: "step", label: "rev-core", state: "complete" },
+			{ id: "rev-r", kind: "step", label: "rev-r", state: "running" },
+			{ id: "rev-parity", kind: "step", label: "rev-parity", state: "queued" },
+		]);
+		const running = snapshot.runs[0]?.children?.[1];
+		assert.equal(running?.startedAt, 1_700);
+		assert.deepEqual(running?.activity, { currentTool: "read", toolCount: 3, turnCount: 1 });
+		// The child's lone self-describing step is this very node, not a row under it.
+		assert.equal(running?.children, undefined);
+		assert.deepEqual(snapshot.omitted, { runs: 0, children: 0, byteLimitExceeded: false });
+	});
+
+	it("keeps children matching no lane under their parent and orphaned children at the root", () => {
+		const snapshot = projectAsyncStatusSnapshot([materializedWorkflow, materializedRunningChild, unmatchedChild, orphanedChild], { generatedAt: 5_000 });
+
+		assert.deepEqual(snapshot.runs.map((run) => run.id), ["wf-1", "child-orphan"]);
+		assert.deepEqual(snapshot.runs[0]?.children?.map(({ id, kind, label }) => ({ id, kind, label })), [
+			{ id: "rev-core", kind: "step", label: "rev-core" },
+			{ id: "rev-r", kind: "step", label: "rev-r" },
+			{ id: "rev-parity", kind: "step", label: "rev-parity" },
+			{ id: "child-extra", kind: "subagent", label: "helper" },
+		]);
+		// The orphan keeps the shape of a root run: its lone step underneath.
+		assert.deepEqual(snapshot.runs[1]?.children?.map(({ kind, label }) => ({ kind, label })), [{ kind: "step", label: "scout" }]);
+	});
+
+	it("counts a lane and its materialized child once when the depth cap hides them", () => {
+		const snapshot = projectAsyncStatusSnapshot([materializedWorkflow, materializedRunningChild, unmatchedChild], { generatedAt: 5_000, maxDepth: 0 });
+
+		assert.equal(snapshot.runs[0]?.children, undefined);
+		// Three lanes plus the unmatched child: the running lane's child is not counted twice.
+		assert.equal(snapshot.omitted.children, 4);
+	});
+
+	it("derives a finished step's end from its duration when the tracker recorded none", () => {
+		const snapshot = projectAsyncStatusSnapshot([job({
+			asyncId: "ended-run",
+			status: "complete",
+			agents: ["reviewer"],
+			startedAt: 1_000,
+			updatedAt: 4_000,
+			steps: [{ agent: "reviewer", status: "completed", startedAt: 1_500, durationMs: 2_500 }],
+		})], { generatedAt: 9_000 });
+
+		const step = snapshot.runs[0]?.children?.[0];
+		assert.equal(step?.endedAt, 4_000);
+		assert.equal(step?.updatedAt, 4_000);
 	});
 });

--- a/test/unit/async-status-projection.test.ts
+++ b/test/unit/async-status-projection.test.ts
@@ -366,4 +366,61 @@ describe("async status projection", () => {
 		assert.equal(step?.endedAt, 4_000);
 		assert.equal(step?.updatedAt, 4_000);
 	});
+
+	it("matches each lane to the child its run id names when a declared lane key is reused", () => {
+		const workflow = job({
+			asyncId: "wf-dup",
+			status: "running",
+			mode: "workflow",
+			agents: ["worker"],
+			updatedAt: 9_000,
+			steps: [
+				{ workflowKey: "writer", label: "First", agent: "worker", status: "running", runId: "child-1", startedAt: 1_000 },
+				{ workflowKey: "writer", label: "Second", agent: "worker", status: "running", runId: "child-2", startedAt: 2_000 },
+			],
+		});
+		const firstChild = job({ asyncId: "child-1", status: "running", mode: "single", parentWorkflowRunId: "wf-dup", workflowKey: "writer", agents: ["worker"], startedAt: 1_100, updatedAt: 8_000, currentTool: "read", steps: [{ agent: "worker", status: "running" }] });
+		const secondChild = job({ asyncId: "child-2", status: "running", mode: "single", parentWorkflowRunId: "wf-dup", workflowKey: "writer", agents: ["worker"], startedAt: 2_100, updatedAt: 8_500, currentTool: "bash", steps: [{ agent: "worker", status: "running" }] });
+
+		const snapshot = projectAsyncStatusSnapshot([workflow, firstChild, secondChild], { generatedAt: 9_999 });
+
+		// Each lane takes its own child: neither child is projected twice, nor left over as a row of its own.
+		assert.deepEqual(snapshot.runs[0]?.children?.map(({ id, label, startedAt, activity }) => ({ id, label, startedAt, tool: activity?.currentTool })), [
+			{ id: "writer", label: "First", startedAt: 1_100, tool: "read" },
+			{ id: "writer", label: "Second", startedAt: 2_100, tool: "bash" },
+		]);
+	});
+
+	it("ranks a workflow by its live children so the root cap cannot hide them", () => {
+		const finished = job({
+			asyncId: "wf-frozen",
+			status: "complete",
+			mode: "workflow",
+			agents: ["worker"],
+			startedAt: 1,
+			updatedAt: 1,
+			steps: [{ workflowKey: "lane", label: "lane", agent: "worker", status: "running", runId: "live-child", startedAt: 1 }],
+		});
+		const liveChild = job({ asyncId: "live-child", status: "running", mode: "single", parentWorkflowRunId: "wf-frozen", workflowKey: "lane", agents: ["worker"], startedAt: 2, updatedAt: 9_999, currentTool: "bash", steps: [{ agent: "worker", status: "running" }] });
+		const fresherRuns = Array.from({ length: 20 }, (_, index) => job({ asyncId: `other-${index}`, status: "running", agents: ["worker"], updatedAt: 5_000 + index }));
+
+		const snapshot = projectAsyncStatusSnapshot([finished, liveChild, ...fresherRuns], { generatedAt: 10_000, maxRuns: 20 });
+
+		// The parent's own updatedAt froze when it ended; its running child keeps the tree at the front.
+		assert.equal(snapshot.runs[0]?.id, "wf-frozen");
+		assert.equal(snapshot.runs[0]?.children?.[0]?.activity?.currentTool, "bash");
+		assert.equal(snapshot.omitted.runs, 1);
+	});
+
+	it("counts a dropped run together with the runs grouped under it", () => {
+		const snapshot = projectAsyncStatusSnapshot([
+			materializedWorkflow,
+			materializedRunningChild,
+			job({ asyncId: "fresher", status: "running", agents: ["worker"], updatedAt: 99_000 }),
+		], { generatedAt: 99_999, maxRuns: 1 });
+
+		assert.deepEqual(snapshot.runs.map((run) => run.id), ["fresher"]);
+		// The workflow and the child grouped under it are both runs the host cannot see.
+		assert.equal(snapshot.omitted.runs, 2);
+	});
 });


### PR DESCRIPTION
Fixes both defects reported in #2168. Projection-only: nothing changes in what the tracker persists.

## Workflow children listed twice

Since 0.66 (#1964) a workflow's children run as tracked jobs of their own, carrying `parentWorkflowRunId` and `workflowKey`. The RPC async-status projection walked every tracked job as a root run, so each live child appeared twice — as a `step` under the workflow node, and as a root `subagent` run named after its agent, with one `step` child repeating the agent name. The projected nodes carried nothing to join on, so an RPC host could not de-duplicate the way `widgetJobTree` does for the TUI.

`groupMaterializedChildren` now groups jobs by `parentWorkflowRunId` when that parent is a `workflow` job present in the snapshot — the same rule the widget applies — and `projectMaterializedStep` projects a lane and its child as a single node:

- the lane keeps its identity: `kind: "step"`, its workflow key as `id`, its label;
- the child supplies the live facts — state, timing, activity — and its own descendants;
- a single-mode child's lone self-describing step is not repeated underneath, since it *is* that node;
- a child matching no lane is appended to its parent's children, unchanged;
- a child whose parent is absent from the snapshot stays a root run, unchanged;
- the `omitted` counters count a lane and its child once.

Two supporting changes fell out of this:

- `projectWorkflowGraphNode` becomes `workflowGraphStep`, returning the `AsyncJobStep` a planned stage stands for, so graph stages take the same lane-matching path as loaded steps.
- `projectRun` now carries `depth` explicitly and bounds children with `depth < maxDepth` instead of the former `maxDepth > 0`, so a materialized child's own subtree is bounded like any other child. `stepIdentity` factors out the identity both paths derive.

## Finished steps had no end time

A completed step is persisted with `startedAt` and `durationMs` but neither `endedAt` nor `lastActivityAt`, so a terminal lane's node had a start and no end. A host computing time worked from the node kept counting it on every republish — visible as four finished lanes out of five showing ✓ with their time still growing alongside the running one. `projectStep` now derives `endedAt = startedAt + durationMs` when the tracker recorded no end; `updatedAt` follows it as it already did.

## Tests

Four cases added to `test/unit/async-status-projection.test.ts`, on a workflow of three lanes (one finished, one running, one still planned):

- a matched lane: listed once, lane identity kept, live facts and activity taken from the child, no repeated self-step, and the finished lane's end derived from its duration;
- a child matching no lane kept under its parent, and a child whose parent is absent kept at the root with its pre-existing shape;
- omission accounting at `maxDepth: 0` — a lane and its child counted once;
- the derived end time on a plain step with no materialized child.

## Verification

`npm run typecheck` is clean and the full unit suite passes (3202 of 3206). The four failures are the `control-channel` inbox-diagnostics timing cases, which fail identically on a clean checkout of `main` in my environment. No integration test touches this projection. `npx oxlint` on both changed files reports the same 61 pre-existing findings as `main` — the change adds none.
