### PR TITLE
fix: stop paused async runs

### DIFF
--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -3302,8 +3302,9 @@ export async function runSubagent(
 		interruptActiveChildren();
 	};
 	const stopRunner = () => {
-		if (stopped || timedOut || interrupted || statusPayload.state !== "running") return;
+		if (stopped || timedOut || (statusPayload.state !== "running" && statusPayload.state !== "paused")) return;
 		stopped = true;
+		interrupted = false;
 		const now = Date.now();
 		statusPayload.stopped = true;
 		statusPayload.error = stopMessage;
@@ -3311,7 +3312,7 @@ export async function runSubagent(
 		delete statusPayload.activityState;
 		statusPayload.lastUpdate = now;
 		for (const step of statusPayload.steps) {
-			if (step.status !== "running" && step.status !== "pending") continue;
+			if (step.status !== "running" && step.status !== "pending" && step.status !== "paused") continue;
 			step.status = "stopped";
 			step.error = stopMessage;
 			step.exitCode = 1;

--- a/src/runs/foreground/async-stop-action.ts
+++ b/src/runs/foreground/async-stop-action.ts
@@ -27,7 +27,18 @@ function getAsyncStopTarget(
 	return direct ? { asyncId: direct.asyncId, asyncDir: direct.asyncDir } : undefined;
 }
 
-function sealPausedRunStopped(state: SubagentState, status: AsyncStatus, asyncDir: string, existingResultPath?: string): boolean {
+function readExistingResult(existingResultPath?: string): Record<string, unknown> {
+	if (!existingResultPath) return {};
+	try {
+		const parsed: unknown = JSON.parse(fs.readFileSync(existingResultPath, "utf-8"));
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+		throw error;
+	}
+}
+
+function sealPausedRunStopped(state: SubagentState, status: AsyncStatus, asyncDir: string, existing: Record<string, unknown>, sessionId: string): boolean {
 	const proof = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId });
 	if (proof?.state !== "observed") return false;
 	const now = Date.now();
@@ -50,6 +61,7 @@ function sealPausedRunStopped(state: SubagentState, status: AsyncStatus, asyncDi
 	});
 	const stoppedStatus: AsyncStatus = {
 		...status,
+		sessionId,
 		state: "stopped",
 		stopped: true,
 		error: stopMessage,
@@ -59,15 +71,6 @@ function sealPausedRunStopped(state: SubagentState, status: AsyncStatus, asyncDi
 		processTerminal: stoppedProof,
 		steps: stoppedSteps,
 	};
-	let existing: Record<string, unknown> = {};
-	if (existingResultPath) {
-		try {
-			const parsed: unknown = JSON.parse(fs.readFileSync(existingResultPath, "utf-8"));
-			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) existing = parsed as Record<string, unknown>;
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-		}
-	}
 	const priorResults = Array.isArray(existing.results) ? existing.results : [];
 	const results = stoppedSteps.map((step, index) => {
 		const prior = priorResults[index];
@@ -98,7 +101,7 @@ function sealPausedRunStopped(state: SubagentState, status: AsyncStatus, asyncDi
 		durationMs: Math.max(0, now - status.startedAt),
 		asyncDir,
 		cwd: status.cwd,
-		sessionId: status.sessionId,
+		sessionId,
 		completionOwnerId: status.completionOwnerId,
 		sessionFile: status.sessionFile,
 	});
@@ -107,9 +110,7 @@ function sealPausedRunStopped(state: SubagentState, status: AsyncStatus, asyncDi
 	updateActiveRunIndex(asyncDir, "stopped", status.toolCallId);
 	const tracked = state.asyncJobs.get(status.runId);
 	if (tracked) Object.assign(tracked, { status: "stopped", stopped: true, activityState: undefined, updatedAt: now, steps: stoppedSteps.map((step, index) => ({ ...step, index })) });
-	if (status.sessionId) {
-		state.activeAsyncCapacity = getActiveAsyncCapacitySnapshot(status.sessionId, state.activeAsyncCapacity?.limit || undefined, { liveWorkflowRunIds: new Set(state.workflowControllers?.keys() ?? []) });
-	}
+	state.activeAsyncCapacity = getActiveAsyncCapacitySnapshot(sessionId, state.activeAsyncCapacity?.limit || undefined, { liveWorkflowRunIds: new Set(state.workflowControllers?.keys() ?? []) });
 	return true;
 }
 
@@ -122,8 +123,11 @@ export function stopAsyncRun(
 ): AgentToolResult<Details> | null {
 	const target = getAsyncStopTarget(state, runId, location);
 	if (!target) return null;
-	const status = reconcileAsyncRun(target.asyncDir, { kill }).status;
-	if (state.currentSessionId && status?.sessionId !== state.currentSessionId) {
+	const reconciliation = reconcileAsyncRun(target.asyncDir, { kill });
+	const status = reconciliation.status;
+	const existingResult = readExistingResult(reconciliation.resultPath);
+	const sessionId = status?.sessionId ?? (typeof existingResult.sessionId === "string" && existingResult.sessionId ? existingResult.sessionId : undefined);
+	if (state.currentSessionId && sessionId !== state.currentSessionId) {
 		return {
 			content: [{ type: "text", text: `Async run '${target.asyncId}' was not found in the active session.` }],
 			isError: true,
@@ -158,8 +162,8 @@ export function stopAsyncRun(
 	}
 	try {
 		deliverStopRequest({ asyncDir: target.asyncDir, pid: typeof status.pid === "number" ? status.pid : undefined, kill, source: "stop-action", targetIndex: child?.index, childId: child?.id ?? childId });
-		const sealedPaused = status.state === "paused" && childId === undefined
-			? sealPausedRunStopped(state, status, target.asyncDir, reconcileAsyncRun(target.asyncDir, { kill }).resultPath)
+		const sealedPaused = status.state === "paused" && childId === undefined && sessionId !== undefined
+			? sealPausedRunStopped(state, status, target.asyncDir, existingResult, sessionId)
 			: false;
 		if (status.state === "paused" && childId === undefined && !sealedPaused) {
 			return {

--- a/src/runs/foreground/async-stop-action.ts
+++ b/src/runs/foreground/async-stop-action.ts
@@ -1,7 +1,13 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
-import type { Details, SubagentState } from "../../shared/types.ts";
-import { deliverStopRequest } from "../background/control-channel.ts";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import { DIRS, type AsyncStatus, type Details, type SubagentState } from "../../shared/types.ts";
+import { getActiveAsyncCapacitySnapshot } from "../background/active-async-capacity.ts";
+import { updateActiveRunIndex } from "../background/active-run-index.ts";
+import { closeSteerInbox, deliverStopRequest } from "../background/control-channel.ts";
+import { readProcessTerminal, processTerminalPath } from "../background/process-terminal.ts";
+import { resultFilePath, writeAsyncResultFile } from "../background/result-files.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
 import { isStoppableAsyncStatusStep, resolveAsyncStatusChild, type ResolvedAsyncStatusChild } from "../shared/child-identity.ts";
 
@@ -21,6 +27,92 @@ function getAsyncStopTarget(
 	return direct ? { asyncId: direct.asyncId, asyncDir: direct.asyncDir } : undefined;
 }
 
+function sealPausedRunStopped(state: SubagentState, status: AsyncStatus, asyncDir: string, existingResultPath?: string): boolean {
+	const proof = readProcessTerminal(asyncDir, { runId: status.runId, runnerProcessInstanceId: status.processTerminal?.runnerProcessInstanceId });
+	if (proof?.state !== "observed") return false;
+	const now = Date.now();
+	const stopMessage = "Subagent stopped by user.";
+	const stoppedProof = { ...proof, resumeDisposition: "non-resumable" as const };
+	const stoppedSteps = (status.steps ?? []).map((step) => {
+		if (step.status !== "pending" && step.status !== "running" && step.status !== "paused") return step;
+		return {
+			...step,
+			status: "stopped" as const,
+			error: stopMessage,
+			exitCode: 1,
+			stopped: true,
+			activityState: undefined,
+			endedAt: step.endedAt ?? now,
+			durationMs: step.durationMs ?? (step.startedAt === undefined ? 0 : Math.max(0, now - step.startedAt)),
+			lastActivityAt: now,
+			...(step.processTerminal ? { processTerminal: { ...step.processTerminal, resumeDisposition: "non-resumable" as const } } : {}),
+		};
+	});
+	const stoppedStatus: AsyncStatus = {
+		...status,
+		state: "stopped",
+		stopped: true,
+		error: stopMessage,
+		activityState: undefined,
+		lastUpdate: now,
+		endedAt: status.endedAt ?? now,
+		processTerminal: stoppedProof,
+		steps: stoppedSteps,
+	};
+	let existing: Record<string, unknown> = {};
+	if (existingResultPath) {
+		try {
+			const parsed: unknown = JSON.parse(fs.readFileSync(existingResultPath, "utf-8"));
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) existing = parsed as Record<string, unknown>;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
+	const priorResults = Array.isArray(existing.results) ? existing.results : [];
+	const results = stoppedSteps.map((step, index) => {
+		const prior = priorResults[index];
+		const base = prior && typeof prior === "object" && !Array.isArray(prior) ? prior as Record<string, unknown> : {};
+		if (step.status === "complete" || step.status === "completed") {
+			return { ...base, agent: step.agent, success: true, exitCode: typeof base.exitCode === "number" ? base.exitCode : 0 };
+		}
+		if (step.status !== "stopped") {
+			return { ...base, agent: step.agent, success: false, exitCode: typeof base.exitCode === "number" ? base.exitCode : 1, error: typeof base.error === "string" ? base.error : step.error };
+		}
+		return { ...base, agent: step.agent, success: false, stopped: true, interrupted: false, exitCode: 1, error: stopMessage, output: typeof base.output === "string" && base.output ? base.output : stopMessage };
+	});
+	writeAtomicJson(processTerminalPath(asyncDir), stoppedProof);
+	writeAsyncResultFile(resultFilePath(DIRS.results, status.runId), {
+		...existing,
+		id: status.runId,
+		runId: status.runId,
+		agent: stoppedSteps.length === 1 ? stoppedSteps[0]!.agent : status.mode === "parallel" ? "parallel" : status.mode === "workflow" ? "workflow" : "chain",
+		mode: status.mode,
+		success: false,
+		state: "stopped",
+		summary: stopMessage,
+		error: stopMessage,
+		stopped: true,
+		results,
+		exitCode: 1,
+		timestamp: now,
+		durationMs: Math.max(0, now - status.startedAt),
+		asyncDir,
+		cwd: status.cwd,
+		sessionId: status.sessionId,
+		completionOwnerId: status.completionOwnerId,
+		sessionFile: status.sessionFile,
+	});
+	writeAtomicJson(path.join(asyncDir, "status.json"), stoppedStatus);
+	closeSteerInbox(asyncDir, "stopped");
+	updateActiveRunIndex(asyncDir, "stopped", status.toolCallId);
+	const tracked = state.asyncJobs.get(status.runId);
+	if (tracked) Object.assign(tracked, { status: "stopped", stopped: true, activityState: undefined, updatedAt: now, steps: stoppedSteps.map((step, index) => ({ ...step, index })) });
+	if (status.sessionId) {
+		state.activeAsyncCapacity = getActiveAsyncCapacitySnapshot(status.sessionId, state.activeAsyncCapacity?.limit || undefined, { liveWorkflowRunIds: new Set(state.workflowControllers?.keys() ?? []) });
+	}
+	return true;
+}
+
 export function stopAsyncRun(
 	state: SubagentState,
 	runId: string | undefined,
@@ -38,9 +130,9 @@ export function stopAsyncRun(
 			details: { mode: "management", results: [] },
 		};
 	}
-	if (!status || (status.state !== "running" && status.state !== "queued")) {
+	if (!status || (status.state !== "running" && status.state !== "queued" && status.state !== "paused")) {
 		return {
-			content: [{ type: "text", text: `No running or queued async run was found for '${runId ?? "current"}'.` }],
+			content: [{ type: "text", text: `No running, queued, or paused async run was found for '${runId ?? "current"}'.` }],
 			isError: true,
 			details: { mode: "management", results: [] },
 		};
@@ -66,13 +158,23 @@ export function stopAsyncRun(
 	}
 	try {
 		deliverStopRequest({ asyncDir: target.asyncDir, pid: typeof status.pid === "number" ? status.pid : undefined, kill, source: "stop-action", targetIndex: child?.index, childId: child?.id ?? childId });
+		const sealedPaused = status.state === "paused" && childId === undefined
+			? sealPausedRunStopped(state, status, target.asyncDir, reconcileAsyncRun(target.asyncDir, { kill }).resultPath)
+			: false;
+		if (status.state === "paused" && childId === undefined && !sealedPaused) {
+			return {
+				content: [{ type: "text", text: `Stop request stored for paused async run ${target.asyncId}, but matching process-terminal proof is not observed yet. Retry stop after terminal proof is available.` }],
+				isError: true,
+				details: { mode: "management", results: [] },
+			};
+		}
 		const tracked = state.asyncJobs.get(target.asyncId);
 		if (tracked) {
 			tracked.activityState = undefined;
 			tracked.updatedAt = Date.now();
 		}
 		return {
-			content: [{ type: "text", text: child ? `Stop requested for child ${child.id} in async run ${target.asyncId}.` : `Stop requested for async run ${target.asyncId}.` }],
+			content: [{ type: "text", text: sealedPaused ? `Stopped paused async run ${target.asyncId}.` : child ? `Stop requested for child ${child.id} in async run ${target.asyncId}.` : `Stop requested for async run ${target.asyncId}.` }],
 			details: { mode: "management", results: [] },
 		};
 	} catch (error) {

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -795,8 +795,10 @@ describe("async interrupt action", () => {
 		};
 		writeJson(path.join(asyncDir, "process-terminal.json"), proof);
 		const statusPath = path.join(asyncDir, "status.json");
+		const pausedStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+		delete pausedStatus.sessionId;
 		writeJson(statusPath, {
-			...JSON.parse(fs.readFileSync(statusPath, "utf-8")),
+			...pausedStatus,
 			mode: "parallel",
 			state: "paused",
 			endedAt: 200,
@@ -824,6 +826,7 @@ describe("async interrupt action", () => {
 			assert.equal(text(result), `Stopped paused async run ${runId}.`);
 			const stoppedStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
 			assert.equal(stoppedStatus.state, "stopped");
+			assert.equal(stoppedStatus.sessionId, "session");
 			assert.deepEqual(stoppedStatus.steps.map((step: { status: string }) => step.status), ["stopped", "failed"]);
 			assert.equal(stoppedStatus.processTerminal.resumeDisposition, "non-resumable");
 			const stoppedResult = JSON.parse(fs.readFileSync(path.join(RESULTS_DIR, `${runId}.json`), "utf-8"));

--- a/test/unit/async-interrupt-action.test.ts
+++ b/test/unit/async-interrupt-action.test.ts
@@ -776,6 +776,96 @@ describe("async interrupt action", () => {
 		}
 	});
 
+	it("seals a paused run and releases capacity after observed process-terminal proof", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		state.activeAsyncCapacity = { used: 1, limit: 1 };
+		const runId = `stop-paused-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { sessionId: "session" });
+		const capacity = acquireActiveAsyncCapacity({ sessionId: "session", limit: 1, runId, kind: "runner", asyncDir });
+		assert.ok(capacity);
+		capacity.markStarted("runner-paused");
+		const proof = {
+			version: 1,
+			state: "observed",
+			runId,
+			runnerProcessInstanceId: "runner-paused",
+			observedAt: 200,
+			instances: [{ kind: "runner", processInstanceId: "runner-paused", closeObservedAt: 200, exitCode: 0, signal: null }],
+		};
+		writeJson(path.join(asyncDir, "process-terminal.json"), proof);
+		const statusPath = path.join(asyncDir, "status.json");
+		writeJson(statusPath, {
+			...JSON.parse(fs.readFileSync(statusPath, "utf-8")),
+			mode: "parallel",
+			state: "paused",
+			endedAt: 200,
+			processTerminal: proof,
+			steps: [
+				{ agent: "worker", status: "paused", startedAt: 100, endedAt: 200, sessionFile: path.join(asyncDir, "session.jsonl") },
+				{ agent: "reviewer", status: "failed", startedAt: 100, endedAt: 190, exitCode: 1, error: "review failed" },
+			],
+		});
+		writeJson(path.join(RESULTS_DIR, `${runId}.json`), {
+			id: runId,
+			runId,
+			sessionId: "session",
+			state: "paused",
+			results: [
+				{ agent: "worker", success: false, interrupted: true, output: "paused" },
+				{ agent: "reviewer", success: false, exitCode: 1, error: "review failed", output: "review output" },
+			],
+		});
+		try {
+			const result = await executorWithKill(state, () => { throw new Error("paused terminal runner must not be signalled"); })
+				.execute("stop-paused", { action: "stop", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, undefined);
+			assert.equal(text(result), `Stopped paused async run ${runId}.`);
+			const stoppedStatus = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+			assert.equal(stoppedStatus.state, "stopped");
+			assert.deepEqual(stoppedStatus.steps.map((step: { status: string }) => step.status), ["stopped", "failed"]);
+			assert.equal(stoppedStatus.processTerminal.resumeDisposition, "non-resumable");
+			const stoppedResult = JSON.parse(fs.readFileSync(path.join(RESULTS_DIR, `${runId}.json`), "utf-8"));
+			assert.equal(stoppedResult.state, "stopped");
+			assert.equal(stoppedResult.results[0].stopped, true);
+			assert.equal(stoppedResult.results[1].error, "review failed");
+			assert.equal(stoppedResult.results[1].stopped, undefined);
+			assert.deepEqual(state.activeAsyncCapacity, { used: 0, limit: 1 });
+			const next = acquireActiveAsyncCapacity({ sessionId: "session", limit: 1, runId: `${runId}-next`, kind: "runner", asyncDir: `${asyncDir}-next` });
+			assert.ok(next);
+			assert.equal(next.rollback(), true);
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
+	it("stores a paused-run stop request while process-terminal proof is pending", async () => {
+		const state = createState();
+		state.currentSessionId = "session";
+		const runId = `stop-paused-pending-${Date.now().toString(36)}`;
+		const asyncDir = createRunningAsync(state, runId, { track: false, sessionId: "session" });
+		const statusPath = path.join(asyncDir, "status.json");
+		writeJson(statusPath, {
+			...JSON.parse(fs.readFileSync(statusPath, "utf-8")),
+			state: "paused",
+			processTerminal: { version: 1, state: "pending", runId, runnerProcessInstanceId: "runner-pending" },
+			steps: [{ agent: "worker", status: "paused", startedAt: 100 }],
+		});
+		writeJson(path.join(asyncDir, "process-terminal.json"), { version: 1, state: "pending", runId, runnerProcessInstanceId: "runner-pending" });
+		try {
+			const result = await executorWithKill(state, () => true)
+				.execute("stop-paused-pending", { action: "stop", id: runId }, new AbortController().signal, undefined, ctx());
+
+			assert.equal(result.isError, true);
+			assert.match(text(result), /Stop request stored.*proof is not observed yet/);
+			assert.equal(consumeStopRequestPayload(asyncDir)?.type, "stop");
+			assert.equal(JSON.parse(fs.readFileSync(statusPath, "utf-8")).state, "paused");
+		} finally {
+			cleanup(runId, asyncDir);
+		}
+	});
+
 	it("stops a reload-recovered workflow through the durable control channel", async () => {
 		const state = createState();
 		state.currentSessionId = "session";


### PR DESCRIPTION
## Summary

- Accept whole-run stop requests for paused async runs.
- Seal a paused run only after matching process-terminal proof is observed.
- Mark stopped proof as non-resumable and release active async capacity.
- Keep a durable stop request and return a retryable error while proof is pending.
- Preserve terminal child failures when the run result changes to stopped.

## Validation

- Reproduced on unpatched `origin/main`: stop rejected the paused run and capacity remained `1/1 used`.
- Ran the same regression on this branch: stop sealed the run and the next capacity acquisition succeeded.
- `npm run test:unit` — 3,188 passed, 0 failed, 14 skipped.
- `npm run typecheck`
- `git diff --check`

Closes #2170
