### PR TITLE
test: retry Windows external cleanup

### DIFF
--- a/test/integration/external-cli-runner.test.ts
+++ b/test/integration/external-cli-runner.test.ts
@@ -12,7 +12,7 @@ import { writeNodeCommand } from "../support/node-command.ts";
 
 const tempDirs: string[] = [];
 afterEach(() => {
-	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 	const progressDir = path.join(TEMP_ROOT_DIR, "orca-progress");
 	if (fs.existsSync(progressDir)) {
 		for (const name of fs.readdirSync(progressDir)) {


### PR DESCRIPTION
Follow-up to #2178.

The exact post-merge Windows run completed the external baseline cancellation assertions, then hit a transient `EPERM` while recursively deleting its temporary Git repository. Use Node’s bounded recursive removal retries at that test I/O boundary, matching existing repository practice.

Production behavior and semantic test assertions are unchanged.