### PR TITLE
refactor: simplify recent backlog changes

### DIFF
--- a/src/slash/subagents-admin.ts
+++ b/src/slash/subagents-admin.ts
@@ -29,13 +29,12 @@ function sourceRank(source: AgentConfig["source"]): number {
 	return 3;
 }
 
-function allVisibleAgents(pi: RuntimeAgentOwner | null, cwd: string): AgentConfig[] {
+function allVisibleAgents(pi: RuntimeAgentOwner, cwd: string): AgentConfig[] {
 	const d = discoverAgentsAll(cwd);
 	const allConfigured = [...d.project, ...d.user, ...d.package, ...d.builtin];
 	const visibleConfigured = allConfigured.filter((agent) => !agent.disabled);
-	// Runtime-registered agents (pi-subagents:runtime-agent-register:v1) participate in every
-	// delegation and listing path through mergeRuntimeAgents; the admin panel must list them too.
-	const agents = pi ? mergeRuntimeAgents(pi, { agents: visibleConfigured }, allConfigured).agents : visibleConfigured;
+	// Disabled definitions remain in collision checks even though the panel hides them.
+	const agents = mergeRuntimeAgents(pi, { agents: visibleConfigured }, allConfigured).agents;
 	return agents.sort((a, b) => a.name.localeCompare(b.name) || sourceRank(a.source) - sourceRank(b.source));
 }
 

--- a/src/watchdog/review.ts
+++ b/src/watchdog/review.ts
@@ -373,7 +373,7 @@ async function runWatchdogAttempt(ctx: ExtensionContext, request: WatchdogReview
 	const stopReason = reason === "error" || reason === "aborted" || reason === "length" ? reason : "stop";
 	const error = terminal && "errorMessage" in terminal && typeof terminal.errorMessage === "string" ? terminal.errorMessage : undefined;
 	return {
-		result: clarification ? { clarification } : { stopReason, ...(error ? { errorMessage: error } : {}) },
+		result: clarification ? { clarification } : error ? { stopReason, errorMessage: error } : { stopReason },
 		retryable: !clarification && stopReason === "error" && !isContextOverflow(error) && isRetryableModelFailureAttempt({ error, messages: agent.state.messages, toolCount }),
 	};
 }

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -1106,7 +1106,6 @@ export default function() {
 		assert.equal(payload.results[0]?.savedOutputPath, outputPath);
 		const savedOutput = fs.readFileSync(outputPath, "utf-8");
 		assert.equal(savedOutput, JSON.stringify(expectedStructuredOutput, null, 2));
-		assert.deepEqual(JSON.parse(savedOutput), expectedStructuredOutput);
 	});
 
 	it("background outputSchema runs fail closed when required acceptanceReport is missing", { skip: !isAsyncAvailable() ? "jiti not available" : undefined }, async () => {


### PR DESCRIPTION
## Summary

- remove an unreachable runtime-agent fallback while retaining disabled-definition collision checks
- represent watchdog clarification, error, and stop results without a conditional empty-object spread
- remove a duplicate structured-output JSON assertion

This is the combined behavior-preserving cleanup from a seven-category deslop pass over `6d371748..2a8b23c1`, with one feature review per merged backlog change. Net change: 4 insertions, 6 deletions.

## Validation

- `npm run typecheck`
- focused structured-output integration test: 1/1
- focused runtime-agent admin tests: 2/2
- watchdog review/runtime tests: 63/63
- fresh final review: no findings

`npm run test:all` reached 3,206 passing and 13 skipped tests, with one unrelated local `kill EPERM` failure in `test/unit/owned-process-tree.test.ts`; the failure reproduced in isolation and none of this PR’s three files are involved. Exact-head CI remains authoritative.