### PR TITLE
fix: remove consumed workflow result indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Remove workflow-owned one-shot result payloads together with their child-local result indexes after successful consumption. Thanks to [@peedrr](https://github.com/peedrr) for #2182.
 - Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.
 - Persist pretty JSON to explicitly bound background output artifacts when a successful child returns structured output without final prose. Thanks to [@rtbe](https://github.com/rtbe) for #2163.
 - Surface the provider error text of a failed watchdog review in `/subagents-watchdog status` `Last error` (bounded to 600 chars). Previously only `stop reason 'error'` was recorded, so a watchdog failing every review (rate limit, rejected model, auth) was indistinguishable from a clean one. Thanks to [@freezscholte](https://github.com/freezscholte) for #2166.

--- a/src/runs/background/chain-root-attachment.ts
+++ b/src/runs/background/chain-root-attachment.ts
@@ -13,6 +13,7 @@ export interface ImportedAsyncRoot {
 
 export interface ImportedAsyncRootResult {
 	agent: string;
+	importedPublication?: { sessionId?: string; toolCallId?: string };
 	/** Human-readable display name for the child session, when derived at launch. */
 	sessionName?: string;
 	output: string;
@@ -43,6 +44,8 @@ export interface ImportedAsyncRootResult {
 }
 
 interface AsyncResultFile {
+	sessionId?: string;
+	toolCallId?: string;
 	state?: string;
 	success?: boolean;
 	summary?: string;
@@ -216,6 +219,10 @@ function buildImportedResult(root: ImportedAsyncRoot, status: AsyncStatus | null
 	const usage = child?.usage ?? usageFromAttempts(step?.modelAttempts);
 	return {
 		agent,
+		importedPublication: {
+			...(typeof result.sessionId === "string" ? { sessionId: result.sessionId } : {}),
+			...(typeof result.toolCallId === "string" ? { toolCallId: result.toolCallId } : {}),
+		},
 		output: success ? output : (output || error || ""),
 		success,
 		exitCode: success ? 0 : 1,

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -97,7 +97,7 @@ import { dismissRecoveredWorkflow } from "./async-dismiss-action.ts";
 import { promotePausedWorkflowIfSettled, reconcileDetachedWorkflowChildCompletion } from "./workflow-detach-reconcile.ts";
 import { reconcileAsyncRun } from "../background/stale-run-reconciler.ts";
 import { resolveAsyncRootResultPath, waitForImportedAsyncRoot } from "../background/chain-root-attachment.ts";
-import { resultFilePath, writeAsyncResultFile } from "../background/result-files.ts";
+import { removeResultIndex, resultFilePath, writeAsyncResultFile } from "../background/result-files.ts";
 import { attachRootChildrenToSteps, createNestedRoute, findNestedControlResult, inheritedNestedParentAddressOf, inheritedNestedRouteOf, resolveNestedAsyncDir, snapshotNestedEventFiles, updateForegroundNestedProjection, writeNestedControlRequest, writeNestedEvent, type NestedParentAddress, type NestedRoute, type NestedRunResolutionScope } from "../shared/nested-events.ts";
 import type { ChildRuntimeConfig } from "../shared/child-runtime-config.ts";
 import { resolveSubagentRunId, type ResolvedSubagentRunId } from "../background/run-id-resolver.ts";
@@ -2193,7 +2193,7 @@ async function resumeAsyncRun(input: {
 		} finally {
 			input.signal?.removeEventListener("abort", stopOnAbort);
 		}
-		fs.rmSync(resultPath, { force: true });
+		if (completed.importedPublication) removeWorkflowAwaitedResult(asyncDir, resultPath, revivedId, completed.importedPublication);
 		const usage = importedAsyncRootUsage(completed);
 		const childResult: SingleResult = {
 			index: 0,
@@ -3138,6 +3138,15 @@ function importedAsyncRootUsage(completed: Awaited<ReturnType<typeof waitForImpo
 	};
 }
 
+function removeWorkflowAwaitedResult(asyncDir: string, resultPath: string, runId: string, publication: NonNullable<Awaited<ReturnType<typeof waitForImportedAsyncRoot>>["importedPublication"]>): void {
+	try {
+		fs.rmSync(resultPath, { force: true });
+	} catch {
+		// Payload cleanup must not replace an already imported delivery.
+	}
+	removeResultIndex(asyncDir, publication.sessionId, runId, publication.toolCallId);
+}
+
 async function waitForWorkflowAsyncSingleResult(
 	params: SubagentParamsLike,
 	launchResult: AgentToolResult<Details>,
@@ -3158,7 +3167,7 @@ async function waitForWorkflowAsyncSingleResult(
 	} finally {
 		options.signal?.removeEventListener("abort", stopOnAbort);
 	}
-	fs.rmSync(resultPath, { force: true });
+	if (completed.importedPublication) removeWorkflowAwaitedResult(asyncDir, resultPath, options.runId, completed.importedPublication);
 	const usage = importedAsyncRootUsage(completed);
 	const childResult: SingleResult = omitUndefinedProperties({
 		index: 0,

--- a/test/integration/single-execution.part-1.test.ts
+++ b/test/integration/single-execution.part-1.test.ts
@@ -17,7 +17,8 @@ import {
 	installSingleExecutionHooks,
 } from "../support/single-execution-fixture.ts";
 import assert from "node:assert/strict";
-import * as fs from "node:fs";
+import fsDefault, * as fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
 import {
@@ -41,9 +42,10 @@ import {
 	type SubagentDelegationResponse,
 	type SubagentDelegationStarted,
 } from "../../src/api/delegation.ts";
-import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, SUBAGENT_CONTROL_EVENT, TEMP_ARTIFACTS_DIR, type AsyncStatus, type ChildWatchdogProgress, type ControlEvent, type SubagentState } from "../../src/shared/types.ts";
+import { CHAIN_RUNS_DIR, DIRS, INTERCOM_DETACH_REQUEST_EVENT, INTERCOM_DETACH_RESPONSE_EVENT, SUBAGENT_CONTROL_EVENT, SUBAGENT_PROCESS_TERMINAL_EVENT, TEMP_ARTIFACTS_DIR, type AsyncStatus, type ChildWatchdogProgress, type ControlEvent, type SubagentState } from "../../src/shared/types.ts";
 import { ACTIVE_RUN_INDEX_DIR } from "../../src/runs/background/active-run-index.ts";
 import { encodeIndexSegment } from "../../src/runs/background/index-segment.ts";
+import { removeResultIndex, writeAsyncResultFile, writePendingAsyncResultFile } from "../../src/runs/background/result-files.ts";
 import { listAsyncRuns } from "../../src/runs/background/async-status.ts";
 import { CHILD_WATCHDOG_STATUS_EVENT } from "../../src/watchdog/child-status.ts";
 import { createRunFanoutBudget } from "../../src/runs/shared/run-fanout-budget.ts";
@@ -2183,9 +2185,130 @@ Answer only from the supplied synthetic text.
 		assert.equal(child?.output, "default async child done");
 		assert.ok(child?.runId);
 		assert.equal(result.details.results[0]?.finalOutput, "default async child done");
-		assert.equal(fs.existsSync(path.join(DIRS.async, child.runId)), true);
-		fs.rmSync(path.join(DIRS.async, child.runId), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+		const childDir = path.join(DIRS.async, child.runId);
+		assert.equal(fs.existsSync(childDir), true);
+		assert.equal(fs.existsSync(path.join(childDir, "workflow-result.json")), false);
+		for (const localResultDir of ["result-pending", "result-index"]) {
+			const localPath = path.join(childDir, localResultDir);
+			const jsonFiles = fs.existsSync(localPath)
+				? fs.readdirSync(localPath, { recursive: true }).filter((entry) => String(entry).endsWith(".json"))
+				: [];
+			assert.deepEqual(jsonFiles, [], `${localResultDir} retained result metadata: ${jsonFiles.join(", ")}`);
+		}
+		fs.rmSync(childDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 		fs.rmSync(path.join(DIRS.results, `${child.runId}.json`), { force: true });
+	});
+
+	it("retains workflow publication recovery files when the executor await is already aborted", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {
+		const runId = `abort-await-${Date.now()}`;
+		const sessionId = "abort-session";
+		const toolCallId = "abort-call";
+		const childDir = path.join(DIRS.async, runId);
+		const resultPath = path.join(childDir, "workflow-result.json");
+		fs.mkdirSync(childDir, { recursive: true });
+		fs.writeFileSync(path.join(childDir, "mission.json"), "{}", "utf-8");
+		const payload = { id: runId, runId, sessionId, toolCallId, asyncDir: childDir, state: "complete", success: true, results: [{ agent: "echo", output: "recoverable publication—not imported", success: true }] };
+		assert.deepEqual(writeAsyncResultFile(resultPath, payload), { state: "public" });
+		writePendingAsyncResultFile(resultPath, payload);
+		const encodedRun = encodeIndexSegment(runId);
+		const seededPaths = [
+			resultPath,
+			path.join(childDir, "result-pending", encodeIndexSegment(sessionId), `${encodedRun}.json`),
+			path.join(childDir, "result-index", "sessions", encodeIndexSegment(sessionId), `${encodedRun}.json`),
+			path.join(childDir, "result-index", "runs", `${encodedRun}.json`),
+			path.join(childDir, "result-index", "tool-calls", encodeIndexSegment(toolCallId), `${encodedRun}.json`),
+			path.join(childDir, "result-index", "observers", "mission", `${encodedRun}.json`),
+		];
+		for (const file of seededPaths) assert.equal(fs.statSync(file).isFile(), true, file);
+		const before = seededPaths.map((file) => fs.readFileSync(file));
+		const piEvents = createEventBus();
+		let unsubscribe = () => {};
+		const terminal = new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(() => reject(new Error(`runner ${runId} did not terminate`)), 5_000);
+			unsubscribe = piEvents.on(SUBAGENT_PROCESS_TERMINAL_EVENT, (value) => {
+				if ((value as { runId?: string }).runId !== runId) return;
+				clearTimeout(timer);
+				resolve();
+			});
+		});
+		mockPi.onCall({ output: "runner output" });
+		const controller = new AbortController();
+		controller.abort();
+		try {
+			const result = await makeExecutor([makeAgent("echo")], {}, false, undefined, true, new Map(), undefined, undefined, piEvents).execute(
+				"abort-workflow-await",
+				{ agent: "echo", task: "Do not import the seeded result", async: true, workflowAwaitAsync: true, workflowChildAsyncId: runId },
+				controller.signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+			assert.equal(result.isError, true);
+			assert.equal(result.details.runId, runId);
+			assert.equal(result.details.asyncDir, childDir);
+			assert.equal(result.details.results.length, 1);
+			assert.equal(result.details.results[0]?.exitCode, 1);
+			assert.equal(result.details.results[0]?.timedOut, true);
+			assert.equal(result.details.results[0]?.error, "Workflow stopped before async child completed.");
+			assert.equal(result.details.results[0]?.finalOutput, "Workflow stopped before async child completed.");
+			assert.doesNotMatch(result.content[0]?.text ?? "", /recoverable publication—not imported/);
+			seededPaths.forEach((file, index) => assert.deepEqual(fs.readFileSync(file), before[index], file));
+			await terminal;
+		} finally {
+			unsubscribe();
+			fs.rmSync(childDir, { recursive: true, force: true });
+			fs.rmSync(path.join(DIRS.results, `${runId}.json`), { force: true });
+			removeResultIndex(DIRS.results, sessionId, runId, toolCallId);
+		}
+	});
+
+	it("preserves imported workflow delivery when payload cleanup fails", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async (t) => {
+		const runId = `cleanup-failure-${Date.now()}`;
+		const sessionId = "cleanup-session";
+		const toolCallId = "cleanup-call";
+		const childDir = path.join(DIRS.async, runId);
+		const resultPath = path.join(childDir, "workflow-result.json");
+		fs.mkdirSync(childDir, { recursive: true });
+		fs.writeFileSync(path.join(childDir, "mission.json"), "{}", "utf-8");
+		const payload = { id: runId, runId, sessionId, toolCallId, asyncDir: childDir, state: "complete", success: true, results: [{ agent: "echo", output: "imported despite cleanup failure", success: true, usage: { input: 3, output: 2, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 } }] };
+		writeAsyncResultFile(resultPath, payload);
+		writePendingAsyncResultFile(resultPath, payload);
+		const originalRmSync = fsDefault.rmSync;
+		let attempted = false;
+		t.mock.method(fsDefault, "rmSync", ((target: fs.PathLike, options?: fs.RmDirOptions) => {
+			if (path.resolve(String(target)) === path.resolve(resultPath)) {
+				attempted = true;
+				const error = new Error("denied") as NodeJS.ErrnoException;
+				error.code = "EACCES";
+				throw error;
+			}
+			return originalRmSync(target, options);
+		}) as typeof fsDefault.rmSync);
+		syncBuiltinESMExports();
+		mockPi.onCall({ output: "runner output" });
+		try {
+			const result = await makeExecutor([makeAgent("echo")]).execute(
+				"cleanup-failure-await",
+				{ agent: "echo", task: "Import seeded result", async: true, workflowAwaitAsync: true, workflowChildAsyncId: runId },
+				new AbortController().signal,
+				undefined,
+				makeMinimalCtx(tempDir),
+			);
+			assert.equal(attempted, true);
+			assert.equal(result.isError, undefined, result.content[0]?.text);
+			assert.equal(result.details.results[0]?.finalOutput, "imported despite cleanup failure");
+			assert.equal(result.details.results[0]?.exitCode, 0);
+			assert.deepEqual(result.details.results[0]?.usage, payload.results[0].usage);
+			assert.equal(fs.existsSync(resultPath), true);
+			for (const localResultDir of ["result-pending", "result-index"]) {
+				const localPath = path.join(childDir, localResultDir);
+				assert.deepEqual(fs.existsSync(localPath) ? fs.readdirSync(localPath, { recursive: true }).filter((entry) => String(entry).endsWith(".json")) : [], []);
+			}
+		} finally {
+			t.mock.restoreAll();
+			syncBuiltinESMExports();
+			fs.rmSync(childDir, { recursive: true, force: true });
+			fs.rmSync(path.join(DIRS.results, `${runId}.json`), { force: true });
+		}
 	});
 
 	it("keeps ordinary async workflow child results in the watcher-owned path", { skip: !createSubagentExecutor ? "executor not importable" : undefined }, async () => {

--- a/test/unit/chain-root-attachment.test.ts
+++ b/test/unit/chain-root-attachment.test.ts
@@ -43,21 +43,26 @@ describe("async chain root attachment", () => {
 			steps: [{ agent: "worker", status: "complete", sessionFile }],
 		});
 		writeJson(importedRoot.resultPath, {
+			sessionId: "publication-session",
+			toolCallId: "publication-tool-call",
 			state: "complete",
 			success: true,
 		results: [{ agent: "worker", output: "root output", success: true, sessionFile, usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.001, turns: 1 } }],
 		});
 
 		const result = await waitForImportedAsyncRoot(importedRoot, { pollIntervalMs: 1 });
+		fs.writeFileSync(path.join(importedRoot.asyncDir, "status.json"), "{malformed", "utf-8");
 
 		assert.deepEqual({
 			agent: result.agent,
+			importedPublication: result.importedPublication,
 			output: result.output,
 			exitCode: result.exitCode,
 			sessionFile: result.sessionFile,
 			usage: result.usage,
 		}, {
 			agent: "worker",
+			importedPublication: { sessionId: "publication-session", toolCallId: "publication-tool-call" },
 			output: "root output",
 			exitCode: 0,
 			sessionFile,
@@ -171,6 +176,7 @@ describe("async chain root attachment", () => {
 		assert.equal(result.exitCode, 1);
 		assert.equal(result.error, "root failed");
 		assert.equal(result.output, "root failed");
+		assert.deepEqual(result.importedPublication, {});
 	});
 
 	it("imports a partial root without collapsing it to failed", async () => {
@@ -247,6 +253,7 @@ describe("async chain root attachment", () => {
 		assert.equal(result.agent, "worker");
 		assert.equal(result.exitCode, 1);
 		assert.match(result.error ?? "", /ended without a result file/);
+		assert.equal(result.importedPublication, undefined);
 	});
 
 	it("stops waiting when the parent timeout aborts an attached root", async () => {
@@ -274,5 +281,6 @@ describe("async chain root attachment", () => {
 		assert.equal(result.timedOut, true);
 		assert.equal(result.error, "parent timed out");
 		assert.equal(result.output, "parent timed out");
+		assert.equal(result.importedPublication, undefined);
 	});
 });


### PR DESCRIPTION
## Summary

- retire child-local result indexes and pending copies with consumed one-shot workflow results
- preserve recoverable publication when import fails or is aborted
- add focused coverage and credit [@peedrr](https://github.com/peedrr)

Closes #2182

## Validation

- `npm run typecheck`
- focused awaited-workflow integration test: 1/1
- result-file index unit tests: 23/23
- `git diff --check`
- fresh review: no P0/P1/P2 findings