### PR TITLE
fix: preserve read-only acceptance for risky review topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Let headless parent and nested coordinator sessions answer blocking child supervisor requests without deadlocking their final background-work drain. Thanks to [@ProDrifterDK](https://github.com/ProDrifterDK) for #2185.
-- Keep inferred read-only reviews free of implementation acceptance requirements when their topic includes release, migration, or security; explicit acceptance and actual write tasks retain their gates.
+- Keep inferred read-only reviews free of implementation acceptance requirements when their topic includes release, migration, or security; explicit acceptance and actual write tasks retain their gates. Thanks to [@qsgy-edge](https://github.com/qsgy-edge) for #2191.
 - Include retention-managed async, output-artifact, and structured-output retrieval paths in native completion notices. Thanks to [@peedrr](https://github.com/peedrr) for #2181.
 - Remove workflow-owned one-shot result payloads together with their child-local result indexes after successful consumption. Thanks to [@peedrr](https://github.com/peedrr) for #2182.
 - Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Let headless parent and nested coordinator sessions answer blocking child supervisor requests without deadlocking their final background-work drain. Thanks to [@ProDrifterDK](https://github.com/ProDrifterDK) for #2185.
+- Keep inferred read-only reviews free of implementation acceptance requirements when their topic includes release, migration, or security; explicit acceptance and actual write tasks retain their gates.
 - Include retention-managed async, output-artifact, and structured-output retrieval paths in native completion notices. Thanks to [@peedrr](https://github.com/peedrr) for #2181.
 - Remove workflow-owned one-shot result payloads together with their child-local result indexes after successful consumption. Thanks to [@peedrr](https://github.com/peedrr) for #2182.
 - Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -412,7 +412,7 @@ Acceptance evidence levels are `auto`, `none`, `attested`, `checked`, and `verif
 Review is a separate gate configured with `acceptance.review`:
 
 - Async, risky, and dynamic writer contexts infer checked evidence plus `review: { agent: "reviewer", required: true }`.
-- Reviewer/read-only calls infer no acceptance by default, including reviews of release, migration, or security work; those topics do not turn a read-only task into implementation. Explicit acceptance requests still apply.
+- Tasks classified as read-only infer no acceptance by default, including reviews of release, migration, or security work; those topics do not turn a read-only task into implementation. With role metadata omitted, unknown risk-topic tasks retain their gate even when the agent name suggests a reviewer. Explicit acceptance requests still apply.
 - Normal writer tasks infer checked evidence without review.
 
 Agent frontmatter or `subagents.agentOverrides` may set `acceptanceRole: "read-only" | "writer"` for ambiguous tasks. Explicit task mutation or no-edit intent wins over that role, while omitted metadata preserves the existing reviewer/scout/worker name heuristics. The role affects acceptance inference only and does not change tool access.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -412,7 +412,7 @@ Acceptance evidence levels are `auto`, `none`, `attested`, `checked`, and `verif
 Review is a separate gate configured with `acceptance.review`:
 
 - Async, risky, and dynamic writer contexts infer checked evidence plus `review: { agent: "reviewer", required: true }`.
-- Reviewer/read-only calls infer no acceptance by default; explicit acceptance requests still apply.
+- Reviewer/read-only calls infer no acceptance by default, including reviews of release, migration, or security work; those topics do not turn a read-only task into implementation. Explicit acceptance requests still apply.
 - Normal writer tasks infer checked evidence without review.
 
 Agent frontmatter or `subagents.agentOverrides` may set `acceptanceRole: "read-only" | "writer"` for ambiguous tasks. Explicit task mutation or no-edit intent wins over that role, while omitted metadata preserves the existing reviewer/scout/worker name heuristics. The role affects acceptance inference only and does not change tool access.

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -106,11 +106,14 @@ function inferLevel(input: {
 	const roleResolvesReadOnly = input.acceptanceRole !== undefined && inferredReadOnly;
 	const dynamicResolvesReadOnly = inferredReadOnly && !writeTask;
 	const riskyKeywordPattern = /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/;
-	// A review topic does not turn resolved read-only work into an implementation task.
+	// Topic keywords cannot override classified read-only intent; unknown tasks keep their risk gate.
+	const keywordRiskReadOnly = input.acceptanceRole === undefined
+		? intent.kind === "read-only"
+		: inferredReadOnly;
 	const risky = Boolean(input.async && writeTask)
 		|| (Boolean(input.dynamic) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
 		|| (Boolean(input.dynamicGroup) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
-		|| (!inferredReadOnly && riskyKeywordPattern.test(task));
+		|| (!keywordRiskReadOnly && riskyKeywordPattern.test(task));
 
 	if (risky) {
 		reasons.push(input.async ? "async write-capable or risky run" : "risky write-capable run");

--- a/src/runs/shared/acceptance.ts
+++ b/src/runs/shared/acceptance.ts
@@ -106,13 +106,11 @@ function inferLevel(input: {
 	const roleResolvesReadOnly = input.acceptanceRole !== undefined && inferredReadOnly;
 	const dynamicResolvesReadOnly = inferredReadOnly && !writeTask;
 	const riskyKeywordPattern = /\b(?:release|migration|migrate|security|data[- ]loss|destructive|post-review|fix pass)\b/;
-	const keywordRiskReadOnly = input.acceptanceRole === undefined
-		? intent.kind === "read-only" && !riskyKeywordPattern.test(task)
-		: inferredReadOnly;
+	// A review topic does not turn resolved read-only work into an implementation task.
 	const risky = Boolean(input.async && writeTask)
 		|| (Boolean(input.dynamic) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
 		|| (Boolean(input.dynamicGroup) && !roleResolvesReadOnly && !dynamicResolvesReadOnly)
-		|| (!keywordRiskReadOnly && riskyKeywordPattern.test(task));
+		|| (!inferredReadOnly && riskyKeywordPattern.test(task));
 
 	if (risky) {
 		reasons.push(input.async ? "async write-capable or risky run" : "risky write-capable run");

--- a/test/integration/single-execution.part-2.test.ts
+++ b/test/integration/single-execution.part-2.test.ts
@@ -1555,13 +1555,18 @@ if (!fs.existsSync(${JSON.stringify(holdPath)})) { console.log('{}'); } else {
 	});
 
 	it("does not inject inferred acceptance into reviewer prompts", async () => {
-		mockPi.onCall({ output: "VERDICT: PASS" });
-		const result = await runSync(tempDir, [makeAgent("reviewer", { tools: ["read"], completionGuard: false })], "reviewer", "Review the diff and return findings only.", {
-			runId: "reviewer-inferred-acceptance",
-		});
+		for (const [index, task] of [
+			"Review the diff and return findings only.",
+			"Read-only review. Verify release recovery and security; do not edit files.",
+		].entries()) {
+			mockPi.onCall({ output: "VERDICT: PASS" });
+			const result = await runSync(tempDir, [makeAgent("reviewer", { tools: ["read"], completionGuard: false })], "reviewer", task, {
+				runId: `reviewer-inferred-acceptance-${index}`,
+			});
 
-		assert.equal(result.exitCode, 0);
-		assert.doesNotMatch(readCall().args.join("\n"), /## Acceptance Contract/);
+			assert.equal(result.exitCode, 0);
+			assert.doesNotMatch(readCall().args.join("\n"), /## Acceptance Contract/);
+		}
 	});
 
 	it("agent contract keeps acceptance rejection out of execution status", async () => {

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -173,12 +173,29 @@ describe("acceptance gates", () => {
 
 	it("keeps read-only tasks out of writer acceptance despite risk keywords", () => {
 		for (const agentName of ["worker", "read-only-reviewer"]) {
-			for (const task of ["Inspect the security posture", "Read-only security audit", "Read-only review. Verify release recovery; do not edit files."]) {
+			for (const task of ["Review the security posture; do not edit files.", "Read-only security audit", "Read-only review. Verify release recovery; do not edit files."]) {
 				const resolved = resolveEffectiveAcceptance({ agentName, task, mode: "single", async: true });
 				assert.equal(resolved.level, "none", `${agentName}: ${task}`);
 				assert.deepEqual(resolved.criteria, []);
 				assert.equal(formatAcceptancePrompt(resolved), "");
 			}
+		}
+	});
+
+	it("retains risk gates for unknown tasks with review names or mixed inspection and writes", async () => {
+		for (const [agentName, task] of [
+			["worker", "Inspect the security posture"],
+			["analyst", "Handle the release."],
+			["release-analyst", "Handle the security rollout."],
+			["worker", "Inspect the release, then run prettier --write files."],
+			["worker", "Inspect the migration and migrate the data."],
+		]) {
+			const resolved = resolveEffectiveAcceptance({ agentName, task, mode: "single", async: true });
+			assert.equal(resolved.level, "checked", `${agentName}: ${task}`);
+			assert.equal(resolved.review && resolved.review.required, true);
+			assert.match(formatAcceptancePrompt(resolved), /Implement the requested change/);
+			const ledger = await evaluateAcceptance({ acceptance: resolved, output: "Done", cwd: process.cwd() });
+			assert.equal(ledger.status, "rejected", `${agentName}: ${task}`);
 		}
 	});
 

--- a/test/unit/acceptance.test.ts
+++ b/test/unit/acceptance.test.ts
@@ -171,11 +171,14 @@ describe("acceptance gates", () => {
 		assert.equal(formatAcceptancePrompt(dynamicReviewer), "");
 	});
 
-	it("preserves risky keyword review inference when acceptance role metadata is omitted", () => {
-		for (const task of ["Inspect the security posture", "Read-only security audit"]) {
-			const resolved = resolveEffectiveAcceptance({ agentName: "worker", task });
-			assert.equal(resolved.level, "checked", task);
-			assert.equal(resolved.review && resolved.review !== false ? resolved.review.required : undefined, true, task);
+	it("keeps read-only tasks out of writer acceptance despite risk keywords", () => {
+		for (const agentName of ["worker", "read-only-reviewer"]) {
+			for (const task of ["Inspect the security posture", "Read-only security audit", "Read-only review. Verify release recovery; do not edit files."]) {
+				const resolved = resolveEffectiveAcceptance({ agentName, task, mode: "single", async: true });
+				assert.equal(resolved.level, "none", `${agentName}: ${task}`);
+				assert.deepEqual(resolved.criteria, []);
+				assert.equal(formatAcceptancePrompt(resolved), "");
+			}
 		}
 	});
 


### PR DESCRIPTION
Read-only reviews that mention topics such as `release` or `security` currently receive an inferred implementation acceptance contract. A reviewer can correctly report that implementation is not applicable and still end up with `acceptance.status = rejected`.

For example, `resolveEffectiveAcceptance({ agentName: "read-only-reviewer", task: "Read-only review. Verify release recovery; do not edit files.", async: true })` currently returns `checked` with the criterion “Implement the requested change without widening scope”. The same request without `release` returns `none`.

This change lets explicitly classified read-only intent take precedence over topic keywords. Unknown tasks retain their existing risk gate, including cases where the agent name suggests a reviewer or the text mixes inspection and writing. The existing role-metadata branch and caller-supplied acceptance requirements retain their behavior. Regression tests check both exemption and retained rejection of unsubstantiated results.

Validation includes the existing acceptance resolver boundary and the prompt delivered to a child session. The regression failed on the upstream behavior (`checked !== none`) before the fix.

Related prior fixes: #1789 and #1799. The keyword case remains reproducible on upstream `940406c0d48890060d1f5f5280925c8f5a5c7389`.

CI validation for current PR head `37a737f3c0886208f1b9afa9ac68d8533c00cd44`:

- [Upstream CI](https://github.com/nicobailon/pi-subagents/actions/runs/34685508935): all five jobs passed (Ubuntu, Windows, Bun workflow, Pi 0.85 clean-install, official standalone).
- Ubuntu: 3217 unit tests passed / 14 skipped; 1059 integration tests passed / 6 skipped.
- Windows: 3181 unit tests passed / 47 skipped; 1009 integration tests passed / 56 skipped.
- Local typecheck, 95 acceptance/task-intent tests, and the actual child-prompt integration case passed on implementation revision `4b407e7`. The subsequent `37a737f` commit only adds contributor/PR attribution in CHANGELOG.md; the CI linked above ran on that exact new head.

The regression covers both review-name heuristics and mixed inspection/write tasks, including rejection of a bare `Done` result when evidence is required. Independent review of frozen `4b407e7` passed with no findings, including base/head counterexample comparisons, explicit-policy preservation, and checks of the launch prompt construction. The full session execution chain is covered by the integration tests and CI above.
