### PR TITLE
fix: allow cold runners to reach resume readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Allow cold resumed runners up to 60 seconds to load and publish `ready`, while retaining the 10-second acknowledgement limit and the existing lease/token startup authorization.
+- Allow cold resumed runners up to 60 seconds to load and publish `ready`, while retaining the 10-second acknowledgement limit and the existing lease/token startup authorization. Thanks to [@qsgy-edge](https://github.com/qsgy-edge) for #2192.
 
 - Include retention-managed async, output-artifact, and structured-output retrieval paths in native completion notices. Thanks to [@peedrr](https://github.com/peedrr) for #2181.
 - Remove workflow-owned one-shot result payloads together with their child-local result indexes after successful consumption. Thanks to [@peedrr](https://github.com/peedrr) for #2182.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Allow cold resumed runners up to 60 seconds to load and publish `ready`, while retaining the 10-second acknowledgement limit and the existing lease/token startup authorization.
+
 - Include retention-managed async, output-artifact, and structured-output retrieval paths in native completion notices. Thanks to [@peedrr](https://github.com/peedrr) for #2181.
 - Remove workflow-owned one-shot result payloads together with their child-local result indexes after successful consumption. Thanks to [@peedrr](https://github.com/peedrr) for #2182.
 - Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -351,6 +351,7 @@ subagent({ action: "doctor" })
 - Completed external-job runs can use the same `resume` action as a provider follow-up when the registered provider exposes `followUp(input)`. Running external-job parents fail closed with guidance to wait for completion. Unsupported providers fail with an update/reload message.
 - Revive starts a new child session from the old session context; it does not resume the live session, and it requires the chosen child to have a persisted `.jsonl` session file.
 - Direct revival takes an exclusive cross-process lease on the canonical session file until the new child finishes. A concurrent attempt fails before Pi is spawned and identifies the owning revived run; dead-owner leases are reclaimed only when staleness can be proved.
+- Direct revival allows up to 60 seconds for cold runner loading and the initial `ready` handshake. After `ready`, the parent still allows 10 seconds for `acknowledged` before refusing startup; token validation and the final `proceed` authorization remain required.
 
 ### stop
 

--- a/src/runs/background/async-execution.ts
+++ b/src/runs/background/async-execution.ts
@@ -412,6 +412,8 @@ function closeFd(fd: number | undefined): void {
 /**
  * Spawn the async runner process
  */
+// Cold Node/Pi dependency loading precedes ready; subsequent control exchanges stay short.
+const RUNNER_READY_TIMEOUT_MS = 60_000;
 const RUNNER_STARTUP_TIMEOUT_MS = 10_000;
 const RUNNER_STARTUP_WAIT_BUFFER = typeof SharedArrayBuffer !== "undefined" ? new SharedArrayBuffer(4) : undefined;
 const RUNNER_STARTUP_WAIT_VIEW = RUNNER_STARTUP_WAIT_BUFFER ? new Int32Array(RUNNER_STARTUP_WAIT_BUFFER) : undefined;
@@ -725,7 +727,7 @@ function spawnRunner(cfg: object, suffix: string, cwd: string, initialStatus: Om
 			const persistStartupFailure = (message: string) => {
 				if (launchAsyncDir) persistPreProceedStartupFailure(launchAsyncDir, launchRunId, runnerProcessInstanceId, launchSessionId, launchCompletionOwnerId, message);
 			};
-			const ready = waitForRunnerStartup(startupPath, "ready", RUNNER_STARTUP_TIMEOUT_MS);
+			const ready = waitForRunnerStartup(startupPath, "ready", RUNNER_READY_TIMEOUT_MS);
 			if (ready.ok === false) {
 				persistStartupFailure(ready.error);
 				const terminationObserved = terminateRunnerBeforeProceed(proc.pid);

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -16,6 +16,7 @@ import { childSessionFactoryModule, setChildSessionFactoryModule } from "../../s
 import { createEventBus, createTempDir, events, makeAgent, makeMinimalCtx, removeTempDir } from "../support/helpers.ts";
 import { discoverAgents } from "../../src/agents/agents.ts";
 import { ACTIVE_ASYNC_CAPACITY_DIR, acquireActiveAsyncCapacity, activeAsyncCapacitySessionKey } from "../../src/runs/background/active-async-capacity.ts";
+import { readProcessTerminal } from "../../src/runs/background/process-terminal.ts";
 import { readPendingChainAppendRequests } from "../../src/runs/background/chain-append.ts";
 import { createRunFanoutBudget, getRunFanoutBudgetSnapshot, writeRunFanoutBudgetDescriptor } from "../../src/runs/shared/run-fanout-budget.ts";
 import { deriveForkPromptCacheKey } from "../../src/runs/shared/child-tool-plan.ts";
@@ -1710,7 +1711,7 @@ import { syncBuiltinESMExports } from "node:module";
 const rename = fs.renameSync;
 fs.renameSync = function (source, target) {
 	if (String(target).endsWith("runner-startup.json") && JSON.parse(fs.readFileSync(source, "utf8")).state === "acknowledged") {
-		fs.writeFileSync(${JSON.stringify(witnessFile)}, "true");
+		fs.writeFileSync(${JSON.stringify(witnessFile)}, String(target));
 		return;
 	}
 	return rename.call(this, source, target);
@@ -1732,8 +1733,17 @@ syncBuiltinESMExports();
 		}
 		assert.equal(failed.isError, true);
 		assert.match(failed.content[0]?.text ?? "", /Timed out after 10000ms.*'acknowledged'/);
-		assert.equal(fs.readFileSync(witnessFile, "utf-8"), "true");
+		const startupPath = fs.readFileSync(witnessFile, "utf-8");
+		assert.equal(path.basename(startupPath), "runner-startup.json");
 		assert.equal(mockPi.callCount(), 1, "the unacknowledged runner must not start a child session");
+
+		// On POSIX, the terminated runner can remain a zombie until its real close is reaped.
+		const failedDir = path.dirname(startupPath);
+		const closeDeadline = Date.now() + 10_000;
+		while (readProcessTerminal(failedDir)?.state !== "observed" && Date.now() < closeDeadline) {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		assert.equal(readProcessTerminal(failedDir, { runId: path.basename(failedDir) })?.state, "observed");
 
 		mockPi.onCall({ output: "Inspection after failed handshake" });
 		const resumed = await executor.execute(

--- a/test/integration/async-execution.part-3.test.ts
+++ b/test/integration/async-execution.part-3.test.ts
@@ -1630,6 +1630,122 @@ export default function() {
 		assert.equal(args[args.indexOf("--model") + 1], "mock/fallback");
 	});
 
+	it("resumes a retained session after runner preloading exceeds ten seconds", { timeout: 120_000, skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const sourceId = `async-revive-cold-${Date.now().toString(36)}`;
+		const sessionFile = path.join(tempDir, "cold-session.jsonl");
+		fs.writeFileSync(sessionFile, `${JSON.stringify({ type: "session", version: 1, id: "cold-session", cwd: fs.realpathSync(tempDir) })}\n`);
+		mockPi.onCall({ output: "Initial inspection" });
+		executeAsyncSingle(sourceId, {
+			agent: "worker",
+			task: "Inspect the fixture",
+			agentConfig: makeAgent("worker", { completionGuard: false }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-123" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			sessionFile,
+			maxSubagentDepth: 2,
+		});
+		// Initial creation is fixture setup; the timeout regression is on the subsequent resume.
+		const initial = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(sourceId, 60_000), "utf-8")) as AsyncResultPayload;
+		assert.equal(initial.success, true);
+
+		// Delay the real Node runner before its imports and ready handshake, not the model response.
+		const preloadFile = path.join(tempDir, "slow-runner-preload.mjs");
+		const witnessFile = path.join(tempDir, "preload-witness.json");
+		fs.writeFileSync(preloadFile, `
+import * as fs from "node:fs";
+if (process.argv.some((arg) => arg.endsWith("subagent-runner.ts"))) {
+	const startedAt = Date.now();
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 12_000);
+	fs.writeFileSync(${JSON.stringify(witnessFile)}, JSON.stringify({ elapsedMs: Date.now() - startedAt }));
+}
+`);
+		mockPi.onCall({ output: "Resumed inspection" });
+		const previousNodeOptions = process.env.NODE_OPTIONS;
+		let resumed: AsyncExecutionResult;
+		try {
+			process.env.NODE_OPTIONS = [previousNodeOptions, `--import=${pathToFileURL(preloadFile).href}`].filter(Boolean).join(" ");
+			resumed = await makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]).execute(
+				"resume-cold",
+				{ action: "resume", id: sourceId, message: "Continue inspecting" },
+				new AbortController().signal, undefined, makeMinimalCtx(tempDir),
+			) as AsyncExecutionResult;
+		} finally {
+			if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+			else process.env.NODE_OPTIONS = previousNodeOptions;
+		}
+		assert.ok(!resumed.isError, resumed.content[0]?.text);
+		assert.ok(resumed.details.asyncId);
+		assert.ok(JSON.parse(fs.readFileSync(witnessFile, "utf-8")).elapsedMs >= 12_000);
+		assert.equal((await readAsyncPayload(resumed.details.asyncId)).success, true);
+		const args = readMockPiArgs(mockPi, 1);
+		assert.equal(args[args.indexOf("--session") + 1], sessionFile);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
+	it("keeps acknowledgement failures bounded and the retained session resumable", { timeout: 120_000, skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
+		const sourceId = `async-revive-no-ack-${Date.now().toString(36)}`;
+		const sessionFile = path.join(tempDir, "no-ack-session.jsonl");
+		fs.writeFileSync(sessionFile, `${JSON.stringify({ type: "session", version: 1, id: "no-ack-session", cwd: fs.realpathSync(tempDir) })}\n`);
+		mockPi.onCall({ output: "Initial inspection" });
+		executeAsyncSingle(sourceId, {
+			agent: "worker",
+			task: "Inspect the fixture",
+			agentConfig: makeAgent("worker", { completionGuard: false }),
+			ctx: { pi: { events: { emit() {} } }, cwd: tempDir, currentSessionId: "session-123" },
+			artifactConfig: { enabled: false, includeInput: false, includeOutput: false, includeJsonl: false, includeMetadata: false, cleanupDays: 7 },
+			shareEnabled: false,
+			sessionFile,
+			maxSubagentDepth: 2,
+		});
+		const initial = JSON.parse(fs.readFileSync(await waitForAsyncResultFile(sourceId, 60_000), "utf-8")) as AsyncResultPayload;
+		assert.equal(initial.success, true);
+
+		// Suppress only the acknowledged marker at the filesystem boundary of the real runner.
+		const preloadFile = path.join(tempDir, "missing-ack-preload.mjs");
+		const witnessFile = path.join(tempDir, "missing-ack-witness.json");
+		fs.writeFileSync(preloadFile, `
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+const rename = fs.renameSync;
+fs.renameSync = function (source, target) {
+	if (String(target).endsWith("runner-startup.json") && JSON.parse(fs.readFileSync(source, "utf8")).state === "acknowledged") {
+		fs.writeFileSync(${JSON.stringify(witnessFile)}, "true");
+		return;
+	}
+	return rename.call(this, source, target);
+};
+syncBuiltinESMExports();
+`);
+		const executor = makeAsyncExecutor([makeAgent("worker", { completionGuard: false })]);
+		const previousNodeOptions = process.env.NODE_OPTIONS;
+		let failed: AsyncExecutionResult;
+		try {
+			process.env.NODE_OPTIONS = [previousNodeOptions, `--import=${pathToFileURL(preloadFile).href}`].filter(Boolean).join(" ");
+			failed = await executor.execute(
+				"resume-no-ack", { action: "resume", id: sourceId, message: "Continue inspecting" },
+				new AbortController().signal, undefined, makeMinimalCtx(tempDir),
+			) as AsyncExecutionResult;
+		} finally {
+			if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+			else process.env.NODE_OPTIONS = previousNodeOptions;
+		}
+		assert.equal(failed.isError, true);
+		assert.match(failed.content[0]?.text ?? "", /Timed out after 10000ms.*'acknowledged'/);
+		assert.equal(fs.readFileSync(witnessFile, "utf-8"), "true");
+		assert.equal(mockPi.callCount(), 1, "the unacknowledged runner must not start a child session");
+
+		mockPi.onCall({ output: "Inspection after failed handshake" });
+		const resumed = await executor.execute(
+			"resume-after-no-ack", { action: "resume", id: sourceId, message: "Continue inspecting" },
+			new AbortController().signal, undefined, makeMinimalCtx(tempDir),
+		) as AsyncExecutionResult;
+		assert.ok(!resumed.isError, resumed.content[0]?.text);
+		assert.ok(resumed.details.asyncId);
+		assert.equal((await readAsyncPayload(resumed.details.asyncId)).success, true);
+		assert.equal(mockPi.callCount(), 2);
+	});
+
 	it("revival preserves captured response aliases and their absence after config changes", { skip: !isAsyncAvailable() || !createSubagentExecutor ? "jiti or executor not available" : undefined }, async () => {
 		const route = "databricks-bedrock/ias-claude-opus-5";
 		const agents = [makeAgent("worker", { model: route, completionGuard: false })];


### PR DESCRIPTION
Direct resume currently gives a detached runner 10 seconds to publish `ready`, including loading its TypeScript/SDK dependency graph. On a Windows Node 24.18.0 host, dependency loading alone took 20.9 seconds; resume terminated the runner before it reached the handshake. Warm-cache retries succeeded.

Give the initial readiness phase a separate, bounded 60-second budget. After `ready`, the parent still requires `acknowledged` within 10 seconds and validates the token before authorizing `proceed`.

The integration regression delays a real Node runner by 12 seconds before module loading, then resumes the original session through the public executor. It reproduced the original `Timed out after 10000ms ... 'ready'` failure before the fix. A second real-process case suppresses the acknowledgement marker, verifies the 10-second failure and absence of child-session execution, waits for observed process close, then successfully resumes again. The retry waits for the parent's observed close proof, so lease checks run after termination has been processed on POSIX as well as Windows.

The readiness wait remains synchronous: a runner that never publishes readiness can take up to 60 seconds to reject. Healthy handshakes return as soon as their markers arrive. This change adds no startup configuration or protocol stage.

Validation for final revision `4e1d777`:

- [Upstream CI](https://github.com/nicobailon/pi-subagents/actions/runs/34684064145): all five jobs passed (Ubuntu, Windows, Bun workflow, Pi 0.85 clean-install, official standalone).
- Ubuntu: 3216 unit tests passed / 14 skipped; 1061 integration tests passed / 6 skipped.
- Windows: 3180 unit tests passed / 47 skipped; 1011 integration tests passed / 56 skipped.
- Both added real-process tests passed on Ubuntu and Windows; local typecheck and the updated close/retry case also passed.

The added tests give initial session creation up to 60 seconds as fixture setup; the injected delay and production readiness deadline are exercised only on the subsequent resume. Independent review of frozen `4e1d777` passed with no findings. It reran the updated close/retry test and checked the unchanged production logic against the previously executed no-ready, wrong-token, failed-proceed and lease-contention probes. Cross-platform results come from the CI above.
