### PR TITLE
fix: recognize replacement read providers during reviewer startup

### DIFF
--- a/src/runs/shared/child-tool-plan.ts
+++ b/src/runs/shared/child-tool-plan.ts
@@ -299,23 +299,30 @@ export function resolvePermissionSystemExtension(): string | undefined {
 	return undefined;
 }
 
+/** Native names remain available when an extension or SDK provider replaces them. */
+const REPLACEABLE_BUILTIN_TOOL_NAMES = new Set([
+	"read", "bash", "powershell", "edit", "write", "grep", "find", "ls",
+]);
+
 /**
- * Extract the names of builtin tools the host provides. Use this to pass
- * `hostAvailableBuiltins` to `resolvePiLaunchToolPlan` so child tool plans
- * intersect declared agent tools with what the host actually supports.
+ * Discover host builtin capabilities by name, not only provider provenance.
+ * Replacements count only for native names; arbitrary extension/MCP tools do
+ * not become builtins or gain child authorization through this discovery.
  *
- * Returns `undefined` when builtin tool discovery fails or yields nothing,
- * so callers skip the intersection (fail-safe to allowing all declared tools).
- * This handles test mocks without proper tool registration and hosts whose
- * getAllTools() throws before extensions load.
+ * Returns undefined when discovery fails or finds no builtin capabilities,
+ * preserving the existing unknown-host behavior. Child registration and
+ * capability-ceiling checks remain authoritative.
  */
 export function getHostBuiltinToolNames(pi: Pick<ExtensionAPI, "getAllTools">): string[] | undefined {
 	try {
 		const builtins = pi
 			.getAllTools()
-			.filter((tool) => (tool.sourceInfo as { source?: string } | undefined)?.source === "builtin")
+			.filter((tool) =>
+				(tool.sourceInfo as { source?: string } | undefined)?.source === "builtin" ||
+				REPLACEABLE_BUILTIN_TOOL_NAMES.has(tool.name),
+			)
 			.map((tool) => tool.name);
-		return builtins.length > 0 ? builtins : undefined;
+		return builtins.length > 0 ? [...new Set(builtins)] : undefined;
 	} catch {
 		return undefined;
 	}

--- a/test/integration/native-reviewer-read.test.ts
+++ b/test/integration/native-reviewer-read.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { test } from "node:test";
+import { Type } from "typebox";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { buildInProcessChildLaunch } from "../../src/runs/shared/child-launch.ts";
+import { createDefaultChildSessionFactory, type PiCodingAgentModule } from "../../src/runs/shared/child-session.ts";
+import { getHostBuiltinToolNames } from "../../src/runs/shared/child-tool-plan.ts";
+import { buildSkillInjection, resolveSkills } from "../../src/agents/skills.ts";
+
+// Opt in with an absolute path to a real Pi SDK entry point. The normal suite
+// uses a Pi shim, which cannot prove native tool registration or execution.
+const sdkPath = process.env.PI_NATIVE_SDK;
+
+test("given a replacement host read, when a fresh native reviewer starts, then its skill is readable", {
+	skip: !sdkPath && "Set PI_NATIVE_SDK to the real Pi SDK entry point",
+}, async () => {
+	assert.ok(sdkPath);
+	const sdk: PiCodingAgentModule = await import(pathToFileURL(sdkPath).href);
+	const cwd = mkdtempSync(join(tmpdir(), "pi-native-reviewer-read-"));
+	mkdirSync(join(cwd, "review"));
+	const skillPath = join(cwd, "review", "SKILL.md");
+	const skill = "---\nname: review\ndescription: Review fixture\n---\n# Review\nCheck correctness and capability boundaries.\n";
+	writeFileSync(skillPath, skill);
+	let hostApi: ExtensionAPI | undefined;
+	let nativeChild: Awaited<ReturnType<PiCodingAgentModule["createAgentSession"]>>["session"] | undefined;
+	const errors: unknown[] = [];
+	const settingsManager = sdk.SettingsManager.inMemory({});
+	const loader = new sdk.DefaultResourceLoader({
+		cwd,
+		agentDir: cwd,
+		settingsManager,
+		noExtensions: true,
+		noSkills: true,
+		noContextFiles: true,
+		extensionFactories: [(pi) => {
+			hostApi = pi;
+			pi.registerTool({
+				name: "read",
+				label: "Replacement read",
+				description: "Read a file",
+				parameters: Type.Object({ path: Type.String() }),
+				async execute(_id, params) {
+					return { content: [{ type: "text", text: readFileSync(params.path, "utf8") }], details: {} };
+				},
+			});
+		}],
+	});
+	await loader.reload();
+	const { session: host } = await sdk.createAgentSession({
+		cwd,
+		agentDir: cwd,
+		settingsManager,
+		resourceLoader: loader,
+		sessionManager: sdk.SessionManager.inMemory(cwd),
+		tools: ["read", "bash"],
+	});
+	const factory = createDefaultChildSessionFactory({
+		loadPiCodingAgent: async () => ({
+			...sdk,
+			async createAgentSession(options) {
+				const result = await sdk.createAgentSession(options);
+				nativeChild = result.session;
+				return result;
+			},
+		}),
+	});
+	try {
+		await host.bindExtensions({ mode: "print", onError: (error) => errors.push(error) });
+		assert.ok(hostApi);
+		const tools = hostApi.getAllTools();
+		assert.ok(tools.some((tool) => tool.name === "read" && tool.sourceInfo?.source !== "builtin"));
+		assert.ok(tools.some((tool) => tool.name === "bash" && tool.sourceInfo?.source === "builtin"));
+		const read = host.agent.state.tools.find((tool) => tool.name === "read");
+		assert.ok(read);
+		const hostResult = await read.execute("host-skill", { path: skillPath });
+		assert.ok(hostResult.content.some((part) => part.type === "text" && part.text === skill));
+
+		const skills = resolveSkills(["review"], cwd, [skillPath]);
+		assert.deepEqual(skills.missing, []);
+		const skillPrompt = buildSkillInjection(skills.resolved);
+		assert.ok(skillPrompt.includes(skillPath));
+		assert.ok(!skillPrompt.includes("Check correctness and capability boundaries."));
+		const launch = buildInProcessChildLaunch({
+			cwd,
+			host: "parent",
+			childAgentName: "delegate",
+			childIndex: 0,
+			sessionEnabled: false,
+			inheritProjectContext: false,
+			inheritGlobalContext: false,
+			inheritSkills: false,
+			requireReadTool: skills.resolved.length > 0,
+			systemPrompt: skillPrompt,
+			tools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+			hostAvailableBuiltins: getHostBuiltinToolNames(hostApi),
+		});
+		assert.ok(launch.toolPlan.requiredChildTools.includes("read"));
+		const child = await factory.create({ ...launch.session, onExtensionError: (error) => errors.push(error) });
+		assert.notEqual(child.sessionId, host.sessionId);
+		assert.ok(nativeChild);
+		const childRead = nativeChild.agent.state.tools.find((tool) => tool.name === "read");
+		assert.ok(childRead);
+		const childResult = await childRead.execute("child-skill", { path: skillPath });
+		assert.ok(childResult.content.some((part) => part.type === "text" && part.text.includes("Check correctness and capability boundaries.")));
+		assert.equal(launch.capture.toolDiagnostic(), undefined);
+		assert.deepEqual(errors, []);
+	} finally {
+		await factory.dispose();
+		host.dispose();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});

--- a/test/unit/child-tool-plan.test.ts
+++ b/test/unit/child-tool-plan.test.ts
@@ -167,6 +167,68 @@ describe("production launch path supplies hostAvailableBuiltins", () => {
 		assert.deepEqual(builtins, ["read", "bash"]);
 	});
 
+	it("given a replacement read provider, when planning a lazy reviewer, then read remains required", () => {
+		const hostAvailableBuiltins = getHostBuiltinToolNames({
+			getAllTools: () => [
+				{ name: "bash", sourceInfo: { source: "builtin" } },
+				{ name: "read", sourceInfo: { source: "extension", path: "/ext/read.ts" } },
+				{ name: "search_classes", sourceInfo: { source: "extension" } },
+			],
+		});
+		const plan = resolvePiLaunchToolPlan({
+			agentName: "delegate",
+			tools: ["read", "bash"],
+			requireReadTool: true,
+			hostAvailableBuiltins,
+		});
+		assert.deepEqual(hostAvailableBuiltins, ["bash", "read"]);
+		assert.deepEqual(plan.effectiveToolAllowlist, ["read", "bash"]);
+		assert.deepEqual(plan.requiredChildTools, ["read", "bash"]);
+		assert.deepEqual(plan.unavailableHostBuiltins, []);
+	});
+
+	for (const source of ["extension", "sdk"]) {
+		it(`given only ${source} replacements, when discovering builtins, then native capabilities are retained`, () => {
+			const names = ["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"];
+			assert.deepEqual(getHostBuiltinToolNames({
+				getAllTools: () => [...names, "read", "search_classes"].map((name) => ({ name, sourceInfo: { source } })),
+			}), names);
+		});
+	}
+
+	it("given replacement read, when a ceiling forbids reading, then lazy review still fails closed", () => {
+		const hostAvailableBuiltins = getHostBuiltinToolNames({
+			getAllTools: () => [{ name: "read", sourceInfo: { source: "extension" } }],
+		});
+		assert.throws(() => resolvePiLaunchToolPlan({
+			agentName: "delegate",
+			tools: ["read"],
+			requireReadTool: true,
+			hostAvailableBuiltins,
+			capabilityCeiling: {
+				version: 1,
+				allowedTools: ["bash"],
+				denyExtensions: false,
+				sources: ["test"],
+			},
+		}), /Capability ceiling.*excludes required tool 'read'/);
+	});
+
+	it("given no read provider, when planning lazy review, then host discovery does not invent read", () => {
+		const hostAvailableBuiltins = getHostBuiltinToolNames({
+			getAllTools: () => [
+				{ name: "bash", sourceInfo: { source: "builtin" } },
+				{ name: "read_file", sourceInfo: { source: "extension" } },
+			],
+		});
+		assert.throws(() => resolvePiLaunchToolPlan({
+			agentName: "delegate",
+			tools: ["read"],
+			requireReadTool: true,
+			hostAvailableBuiltins,
+		}), /Host runtime does not provide required tool 'read' for agent 'delegate'/);
+	});
+
 	it("getHostBuiltinToolNames returns undefined on failure or empty results", () => {
 		const throwingPi = {
 			getAllTools: () => { throw new Error("Not available"); },


### PR DESCRIPTION
## Summary

Fix reviewer startup when the host exposes `read` through a replacement extension or SDK tool provider. Previously, builtin discovery filtered solely on `sourceInfo.source === "builtin"`, so a working replacement `read` was omitted and lazy skill loading failed before child creation.

- Recognize native tool names even when their provider is a replacement.
- Keep arbitrary extension/MCP tools out of builtin discovery.
- Preserve capability ceilings, missing-read failures, and required child tool checks.
- Add unit regression coverage and an opt-in real Pi SDK test that creates a fresh child, advertises a review skill lazily, and executes its registered `read` tool against that skill fixture.

This is separate from KVG-4973's child-only `search_classes` pruning fix. No installed packages or pre-existing dirty checkouts were modified.

## Verification

- Reproduced the exact original error with both unit and real SDK regressions using the old discovery filter.
- 50 focused tests passed:
  `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/child-tool-plan.test.ts test/unit/child-launch-plan.test.ts test/unit/skills-fallback.test.ts`
- `npm run typecheck` passed.
- Full unit suite passed: 2,993 passed, 13 skipped.
- Integration rerun passed: 1,003 passed, 7 skipped.
- Real SDK regression passed with `PI_NATIVE_SDK` set to the installed Pi SDK's absolute `dist/index.js` path:
  `node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/integration/native-reviewer-read.test.ts`
- `git diff --check` passed.

The first `npm run test:all` run failed in the unrelated Orca capture-file readiness race at `test/integration/external-cli-runner.test.ts:162`. Recorded as KVG-4993; left unchanged rather than masking the failure.

## Remaining verification

The SDK test executes the registered read tool directly; it does not run an LLM reviewer conversation. A live async reviewer check remains pending in a fresh Pi host loading this source change. The currently installed extension was deliberately left untouched.

Task: KVG-4986
