### PR TITLE
Add opt-in unbounded local inference for native subagents

### DIFF
--- a/.github/workflows/local-inference.yml
+++ b/.github/workflows/local-inference.yml
@@ -1,0 +1,25 @@
+name: Local inference regression
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  local-inference:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22.22.2
+      - run: npm ci --ignore-scripts
+      - run: npm run typecheck
+      - run: npm run test:local-inference
+      - name: Install isolated real Pi runtime
+        run: npm install --prefix "$RUNNER_TEMP/pi-host" --ignore-scripts @earendil-works/pi-coding-agent@0.85.1
+      - name: Exercise real detached HTTP waits beyond five minutes and manual cancellation
+        run: node tools/check-local-inference.mjs "$RUNNER_TEMP/pi-host/node_modules/@earendil-works/pi-coding-agent" --long

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ pi install npm:pi-subagents
 
 That is the only required step. Background children use the host's SDK: npm Pi keeps its detached Node runner; the official Pi 0.85.1 Linux x64 standalone release loads the same runner through Pi's embedded SDK, without a separate SDK install. See [Standalone background execution](docs/standalone-background.md) for the supported boundary and validation gate.
 
+For local inference with long queue or prefill waits, see the opt-in [unbounded local inference policy](docs/local-inference.md).
+
 ## Try this first
 
 You do not need to create agents, write config, or learn slash commands. After installing, ask Pi in plain language:

--- a/docs/local-inference.md
+++ b/docs/local-inference.md
@@ -1,0 +1,38 @@
+# Unbounded local inference
+
+Local model requests can spend several minutes queued, prefilling a large context, or reasoning before returning response headers or the next token. Operators who deliberately allow these waits can enable an owner-level policy in `~/.pi/agent/extensions/subagent/config.json` (or the corresponding `PI_CODING_AGENT_DIR`):
+
+```json
+{ "localInference": { "enabled": true } }
+```
+
+Merge this into the existing configuration. The default remains disabled.
+
+When enabled, native foreground and detached child sessions have no automatic execution or inference deadline. The policy takes precedence over run `timeoutMs`, `maxRuntimeMs`, agent defaults and inherited execution deadlines. Each child gets a dedicated proxy-aware HTTP dispatcher with header, body and connection clocks disabled. Pi's cancellation signal still reaches the request, including during streaming. The parent process's global dispatcher is unchanged.
+
+This setting is an operator decision, not a model-controlled tool argument. Malformed policy fails explicitly. `subagent({ action: "doctor" })` reports the policy, and child session artifacts record `pi-subagents:local-inference-policy`.
+
+## Scope and tradeoffs
+
+The validated boundary is native OpenAI-compatible requests on npm Pi 0.85.1. The implementation depends on that runtime's per-request `fetch` seam. Other providers, standalone runtimes and external CLI HTTP clients require separate validation; this does not claim to disable their internal timers. Gateways and inference engines retain their own policies.
+
+Manual stop and actual transport or server errors still terminate work. No new retry loop is introduced. A permanently stalled server with a healthy connection requires operator cancellation. Tool-command timeouts, control waits, verification and usage budgets retain their meanings. Model definitions, reasoning levels, context/output capacities and concurrency are untouched.
+
+## Why both execution and transport policy are needed
+
+The native detached runner's proxy dispatcher otherwise inherits Undici's 300,000 ms header/body defaults. A large Pi idle timeout or subagent execution timeout does not override those clocks. In an observed local inference incident, four requests in each failed lane were cancelled after approximately 301–302 seconds, with retry backoffs presenting as a roughly twenty-minute failure. The gateway recorded cancellation while those requests were still queued.
+
+The child transport forwards the outer Pi cancellation signal instead of the provider SDK's separate timeout controller. This avoids substituting a large finite duration for an unlimited wait. An SDK timeout of zero is not assumed to mean unlimited; the custom transport is what removes the request clock.
+
+## Regression checks
+
+```sh
+npm ci --ignore-scripts
+npm run typecheck
+npm run test:local-inference
+node tools/check-local-inference.mjs /absolute/path/to/pi-coding-agent --long
+```
+
+The last command uses the real Pi CLI, public subagent tool, detached runner, native SDK and a local HTTP fixture. Parallel requests delay headers and streaming body for 310 seconds, while isolated Pi/run settings specify one-millisecond deadlines. Both must complete with exactly one request. It also checks foreground execution, operator stop, HTTP disconnection, observed runner exit and capacity release. Omit `--long` for a quick wiring check; it does not prove the five-minute boundary.
+
+The fixtures use separate settings, placeholder credentials, sessions and runtime storage, and never contact production model servers. The harness watchdog applies only to the test process.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "test": "npm run test:unit",
     "test:unit": "node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test test/unit/*.test.ts",
     "test:integration": "node --experimental-strip-types --import ./test/support/register-loader.mjs --test test/integration/*.test.ts",
-    "test:all": "npm run test:unit && npm run test:integration"
+    "test:all": "npm run test:unit && npm run test:integration",
+    "test:local-inference": "node --experimental-strip-types --import ./test/support/isolated-temp-root.mjs --test --test-concurrency=2 test/unit/local-inference-*.test.ts test/unit/timeout-defaults.test.ts test/unit/active-async-capacity.test.ts test/unit/child-session-queued.test.ts test/unit/child-launch-plan.test.ts"
   },
   "pi": {
     "extensions": [

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -11,6 +11,7 @@ import { validatePermissionConfig } from "../runs/shared/permissions.ts";
 import { MAX_ABANDONED_SLOT_RELEASE_AFTER_MS, MIN_ABANDONED_SLOT_RELEASE_AFTER_MS } from "../runs/background/active-async-capacity.ts";
 import { normalizeWorktreeBranchPrefix } from "../runs/shared/worktree.ts";
 import { validateModelResponseAliases } from "../shared/model-response-aliases.ts";
+import { localInferenceEnabled } from "../runs/shared/local-inference-policy.ts";
 
 const ARTIFACT_DIR_PREFERENCES = new Set<ArtifactDirPreference>(["project", "session", "temp"]);
 const FLEET_KEYBINDING_ACTION_SET = new Set<string>(FLEET_KEYBINDING_ACTIONS);
@@ -140,6 +141,7 @@ function validateMainWindowRendererConfig(value: unknown): void {
 }
 
 function validateConfig(config: Record<string, unknown>): void {
+	localInferenceEnabled(config as ExtensionConfig);
 	if (config.worktree !== undefined && typeof config.worktree !== "boolean") {
 		throw new Error("config.worktree must be a boolean");
 	}
@@ -254,7 +256,7 @@ export function loadConfig(): ExtensionConfig {
 		try {
 			const raw = JSON.parse(fs.readFileSync(configPath, "utf-8")) as unknown;
 			if (raw && typeof raw === "object" && !Array.isArray(raw)
-				&& (Object.hasOwn(raw, "worktreeProvider") || Object.hasOwn(raw, "worktreeBranchPrefix") || Object.hasOwn(raw, "modelResponseAliases") || Object.hasOwn(raw, "checkpointBeforeDeadlineMs"))) throw error;
+				&& (Object.hasOwn(raw, "localInference") || Object.hasOwn(raw, "worktreeProvider") || Object.hasOwn(raw, "worktreeBranchPrefix") || Object.hasOwn(raw, "modelResponseAliases") || Object.hasOwn(raw, "checkpointBeforeDeadlineMs"))) throw error;
 		} catch (readError) {
 			if (readError === error) throw error;
 		}

--- a/src/extension/doctor.ts
+++ b/src/extension/doctor.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { localInferenceEnabled, LOCAL_INFERENCE_POLICY_NOTICE } from "../runs/shared/local-inference-policy.ts";
 import { discoverAgentsAll, type AgentSource } from "../agents/agents.ts";
 import { isAsyncAvailable } from "../runs/background/async-execution.ts";
 import { formatSpawnBudgetSummary, getSpawnBudgetSnapshot } from "../runs/shared/spawn-budget.ts";
@@ -253,6 +254,7 @@ export function buildDoctorReport(input: DoctorReportInput): string {
 		...formatActiveAsyncCapacitySection(input),
 		"",
 		"Workflow script",
+		localInferenceEnabled(input.config) ? LOCAL_INFERENCE_POLICY_NOTICE : "Local-AI timeout policy: disabled (upstream timeout behavior).",
 		...formatWorkflowScriptSection(),
 		"",
 		"Permission system",

--- a/src/runs/background/subagent-runner.ts
+++ b/src/runs/background/subagent-runner.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import { pathToFileURL } from "node:url";
 import type { Message } from "@earendil-works/pi-ai";
 import { arbitrateCompletionGuardRescue, createTaskMutationArbiter } from "../shared/llm-intent-arbiter.ts";
+import { readLocalInferencePolicy, withoutExecutionDeadline, LOCAL_INFERENCE_POLICY_NOTICE } from "../shared/local-inference-policy.ts";
 
 // Detached runners skip Pi's CLI proxy setup. Keep fetch on the same Undici dispatcher.
 function ensureProxyAwareHttpDispatcher(): void {
@@ -2011,6 +2012,7 @@ async function runSingleStepWithTimeout(
 	ctx: SingleStepContext,
 	parentDeadlineAt?: number,
 ): Promise<SingleStepResult> {
+	if (readLocalInferencePolicy()) return runSingleStep(withoutExecutionDeadline(step), withoutExecutionDeadline(ctx));
 	if (step.timeoutMs === undefined) return runSingleStep(step, parentDeadlineAt === undefined ? ctx : {
 		...ctx,
 		deadlineAt: ctx.deadlineAt === undefined ? parentDeadlineAt : Math.min(ctx.deadlineAt, parentDeadlineAt),
@@ -2055,6 +2057,11 @@ export async function runSubagent(
 	config: SubagentRunConfig,
 	childSessions: ChildSessionFactory,
 ): Promise<void> {
+	if (readLocalInferencePolicy()) {
+		config = withoutExecutionDeadline(config);
+		config.steps = config.steps.map((step) => withoutExecutionDeadline(step));
+		console.error(LOCAL_INFERENCE_POLICY_NOTICE);
+	}
 	const { id, steps, resultPath, cwd, placeholder, taskIndex, totalTasks, maxOutput, artifactsDir, artifactConfig } =
 		config;
 	const globalSemaphore = new Semaphore(config.globalConcurrencyLimit ?? DEFAULT_GLOBAL_CONCURRENCY_LIMIT);

--- a/src/runs/foreground/execution.ts
+++ b/src/runs/foreground/execution.ts
@@ -69,6 +69,7 @@ import { applyThinkingSuffix, deriveForkPromptCacheKey } from "../shared/child-t
 import { deriveChildSessionName } from "../../shared/child-session-name.ts";
 import { assertAgentAllowedByCapabilityCeiling, intersectSubagentCapabilityCeilings, resolveCurrentSubagentCapabilityCeiling } from "../shared/capability-ceiling.ts";
 import { resolveEffectiveThinking } from "../../shared/model-info.ts";
+import { readLocalInferencePolicy, withoutExecutionDeadline } from "../shared/local-inference-policy.ts";
 import { assertThinkingWithinCeiling, intersectThinkingCeilings } from "../../shared/thinking-ceiling.ts";
 import { MISSING_STRUCTURED_ACCEPTANCE_REPORT_ERROR, MISSING_STRUCTURED_OUTPUT_CALL_ERROR } from "../shared/structured-output.ts";
 import { formatMidToolExitError, isOrdinaryToolForMidToolExit } from "../shared/process-signal.ts";
@@ -2242,6 +2243,7 @@ export async function runSync(
 	task: string,
 	options: RunSyncOptions,
 ): Promise<SingleResult> {
+	if (readLocalInferencePolicy()) options = withoutExecutionDeadline(options);
 	// Capture the strict contract before consumer-owned objects can be mutated
 	// after a detached receipt is published.
 	const strictContract = isAgentContract(options.agentContract);

--- a/src/runs/foreground/subagent-executor.ts
+++ b/src/runs/foreground/subagent-executor.ts
@@ -9,6 +9,7 @@ import { writeAtomicJson } from "../../shared/atomic-json.ts";
 import { createCapacityResilientJsonWriter } from "../../shared/capacity-resilient-json.ts";
 import { isStorageCapacityError } from "../../shared/file-system-retry.ts";
 import { resolveEffectiveThinking, toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
+import { localInferenceEnabled, withoutExecutionDeadline } from "../shared/local-inference-policy.ts";
 import {
 	beginForegroundChild,
 	finishForegroundChild,
@@ -2889,7 +2890,8 @@ export function resolveForegroundTimeout(params: SubagentParamsLike, defaultTime
  * set — even with a config default — while their runner children resolve separate
  * deadlines. Exported so the executor wiring is directly testable.
  */
-export function resolveSingleAgentLaunchTimeout(params: SubagentParamsLike, async: boolean, configDefaultTimeoutMs?: number): { timeoutMs?: number; error?: string } {
+export function resolveSingleAgentLaunchTimeout(params: SubagentParamsLike, async: boolean, configDefaultTimeoutMs?: number, localInference = false): { timeoutMs?: number; error?: string } {
+	if (localInference) return {};
 	const isComposite = (params.chain?.length ?? 0) > 0 || (params.tasks?.length ?? 0) > 0 || params.workflowScript !== undefined;
 	const foregroundDefault = configDefaultTimeoutMs ?? DEFAULT_FOREGROUND_TIMEOUT_MS;
 	const asyncSingleDefault = configDefaultTimeoutMs ?? DEFAULT_ASYNC_TIMEOUT_MS;
@@ -5021,6 +5023,8 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 		const normalizedGate = normalizeGateParams(params);
 		if (!normalizedGate.ok) return buildRequestedModeError(params, normalizedGate.error);
 		let requestParams = normalizedGate.params;
+		const localInference = localInferenceEnabled(deps.config);
+		if (localInference) requestParams = withoutExecutionDeadline(requestParams);
 		const capacityOverrideError = validateWorkflowCapacityOverrides(requestParams);
 		if (capacityOverrideError) return buildRequestedModeError(requestParams, capacityOverrideError);
 		let workflowPreflight: import("../../shared/types.ts").WorkflowPreflight | undefined;
@@ -5098,7 +5102,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 				}
 			}
 			const parentCwd = ctx.cwd;
-			const timeout = requestParams.timeoutMs ?? requestParams.maxRuntimeMs ?? (requestParams.async === false ? resolveConfigDefaultTimeoutMs(deps.config.timeoutMs) ?? DEFAULT_FOREGROUND_TIMEOUT_MS : undefined);
+			const timeout = localInference ? undefined : requestParams.timeoutMs ?? requestParams.maxRuntimeMs ?? (requestParams.async === false ? resolveConfigDefaultTimeoutMs(deps.config.timeoutMs) ?? DEFAULT_FOREGROUND_TIMEOUT_MS : undefined);
 			const workflowUsageBudget = validateUsageBudgetConfig(requestParams.usageBudget ?? deps.config.usageBudget, requestParams.usageBudget ? "usageBudget" : "config.usageBudget");
 			if (workflowUsageBudget.error) return buildRequestedModeError(requestParams, workflowUsageBudget.error);
 			const workflowCwd = resolveRequestedCwd(parentCwd, requestParams.cwd);
@@ -6937,6 +6941,7 @@ export function createSubagentExecutor(deps: ExecutorDeps): {
 			effectiveParams,
 			effectiveAsync,
 			resolveConfigDefaultTimeoutMs(deps.config.timeoutMs),
+			localInference,
 		);
 		if (foregroundTimeout.error) return buildRequestedModeError(effectiveParams, foregroundTimeout.error);
 		const controlConfig = resolveControlConfig(deps.config.control, effectiveParams.control);

--- a/src/runs/shared/child-session.ts
+++ b/src/runs/shared/child-session.ts
@@ -16,6 +16,8 @@ import { prepareReadonlySessionEvidence } from "./readonly-session-evidence.ts";
 import { toModelInfo, type ModelInfo } from "../../shared/model-info.ts";
 import type { RequiredChildExtensionSnapshot } from "../../shared/required-child-extensions.ts";
 import type { HerdrMachineReference, HerdrRemoteGitStatus } from "../../shared/types.ts";
+import { readLocalInferencePolicy, LOCAL_INFERENCE_POLICY_NOTICE } from "./local-inference-policy.ts";
+import { createLocalInferenceTransport } from "./local-inference-transport.ts";
 
 // Private runtime authority for host continuation planning; injected factories have none.
 const readonlyModels = new WeakMap<ChildSession, { current: ModelInfo; resolve(reference: string): ModelInfo | undefined; requestBytes: number }>();
@@ -231,6 +233,8 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 	};
 	return {
 		async create(launch) {
+			const localInference = readLocalInferencePolicy();
+			let localTransport: ReturnType<typeof createLocalInferenceTransport> | undefined;
 			const observeReadonly = prepareReadonlySessionEvidence(launch);
 			const pi = await loadPiCodingAgent();
 			const modelRuntime = await sharedRuntime(pi);
@@ -303,6 +307,19 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 					session.dispose();
 					throw error;
 				}
+				if (localInference) {
+					const original = session.agent.streamFunction;
+					if (typeof original !== "function") {
+						session.dispose();
+						throw new Error("Cannot enforce local inference policy: Pi streamFunction is unavailable. Check runtime compatibility before launching work.");
+					}
+					localTransport = createLocalInferenceTransport();
+					session.agent.streamFunction = localTransport.wrap(original.bind(session.agent));
+					sessionManager.appendCustomEntry("pi-subagents:local-inference-policy", {
+						version: 1, executionDeadline: "disabled", headersTimeout: 0, bodyTimeout: 0,
+						requestDeadline: "disabled", cancellation: "operator", notice: LOCAL_INFERENCE_POLICY_NOTICE,
+					});
+				}
 				return session;
 			};
 			const opened = loading.catch(() => {}).then(open);
@@ -310,7 +327,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 			const session = await opened;
 			let evidence: ReturnType<NonNullable<typeof observeReadonly>["observe"]>;
 			try { evidence = observeReadonly?.observe(pi, modelRuntime, session); }
-			catch (error) { session.dispose(); throw error; }
+			catch (error) { session.dispose(); await localTransport?.close(); throw error; }
 			let pending: Promise<void> | undefined;
 			// pi's own hosts emit `session_shutdown` before disposing a session so the
 			// extensions loaded into it (ambient extensions included) release their
@@ -328,6 +345,7 @@ export function createDefaultChildSessionFactory(options: DefaultChildSessionFac
 					launch.onExtensionError?.({ extensionPath: "<session>", event: "session_shutdown", error });
 				} finally {
 					session.dispose();
+					await localTransport?.close();
 					evidence?.finish(child);
 				}
 			};

--- a/src/runs/shared/local-inference-policy.ts
+++ b/src/runs/shared/local-inference-policy.ts
@@ -1,0 +1,38 @@
+/** Owner policy for unbounded local inference. This is deliberately not a tool argument. */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getAgentDir } from "../../shared/utils.ts";
+
+export interface LocalInferenceConfig { enabled: boolean }
+
+export function localInferenceEnabled(config: { localInference?: LocalInferenceConfig }): boolean {
+	if (config.localInference === undefined) return false;
+	if (!config.localInference || typeof config.localInference !== "object"
+		|| Array.isArray(config.localInference) || typeof config.localInference.enabled !== "boolean"
+		|| Object.keys(config.localInference).some((key) => key !== "enabled")) {
+		throw new Error("localInference must be { enabled: true | false }; refusing to silently restore timeout defaults");
+	}
+	return config.localInference.enabled;
+}
+
+/** Read at launch, including detached/resumed launches; malformed owner policy is fatal. */
+export function readLocalInferencePolicy(): boolean {
+	const configPath = path.join(getAgentDir(), "extensions", "subagent", "config.json");
+	try {
+		return localInferenceEnabled(JSON.parse(fs.readFileSync(configPath, "utf8")));
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw new Error(`Cannot enforce local-AI timeout policy from ${configPath}`, { cause: error });
+	}
+}
+
+/** Only execution clocks: do not rewrite tool, verification, or control-plane waits. */
+export function withoutExecutionDeadline<T extends object>(value: T): T {
+	const result = { ...value };
+	for (const key of ["timeoutMs", "maxRuntimeMs", "deadlineAt", "workflowParentDeadlineAt"] as const) {
+		delete (result as Record<string, unknown>)[key];
+	}
+	return result;
+}
+
+export const LOCAL_INFERENCE_POLICY_NOTICE = "Local inference: execution and inference deadlines disabled by owner policy; manual cancellation remains enabled.";

--- a/src/runs/shared/local-inference-transport.ts
+++ b/src/runs/shared/local-inference-transport.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from "node:events";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { EnvHttpProxyAgent, fetch as undiciFetch } from "undici";
+
+// Pi 0.85 carries the per-request fetch seam; upstream's development types are 0.81.
+type TransportOptions = NonNullable<Parameters<StreamFn>[2]> & { fetch?: typeof globalThis.fetch; timeoutMs?: number };
+
+/** A child-owned transport; never replaces the parent process's global dispatcher. */
+export function createLocalInferenceTransport() {
+	const dispatcher = new EnvHttpProxyAgent({
+		allowH2: false,
+		proxyTunnel: true,
+		headersTimeout: 0,
+		bodyTimeout: 0,
+		connect: { timeout: 0, autoSelectFamilyAttemptTimeout: 2_000 },
+	});
+	// Transport errors still reject fetch/body reads; prevent only EventEmitter's fatal default.
+	EventEmitter.prototype.on.call(dispatcher, "error", () => {});
+	return {
+		wrap(original: StreamFn): StreamFn {
+			return (model, context, options) => {
+				// Pi's signal is the child/operator cancellation channel. The SDK creates a
+				// DIFFERENT signal for its request clock. Never forward that clock to HTTP.
+				const cancellation = options?.signal;
+				const upstreamFetch = ((options as TransportOptions | undefined)?.fetch ?? undiciFetch) as typeof undiciFetch;
+				const fetch: typeof globalThis.fetch = async (input, init) => {
+					return await upstreamFetch(input as Parameters<typeof undiciFetch>[0], {
+						...init as Parameters<typeof undiciFetch>[1],
+						dispatcher,
+						signal: cancellation ?? null,
+					}) as unknown as Response;
+				};
+				// No giant finite deadline. SDK timeout=0 may abort its own controller;
+				// that controller is intentionally not the transport's cancellation signal.
+				const protectedOptions: TransportOptions = { ...options, timeoutMs: 0, fetch };
+				return original(model, context, protectedOptions);
+			};
+		},
+		async close(): Promise<void> { await dispatcher.close(); },
+	};
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2635,6 +2635,8 @@ export interface ExtensionConfig {
 	capacity?: ActiveAsyncCapacityConfig;
 	/** Global cap on simultaneously-running subagent tasks within a single run. Defaults to 20. */
 	globalConcurrencyLimit?: number;
+	/** Local-AI fork owner policy. Tool calls cannot override this setting. */
+	localInference?: { enabled: boolean };
 	/**
 	 * Global default runtime deadline in milliseconds. It replaces the built-in
 	 * 30-minute backstop for single, parallel, and chain launches (foreground, plus

--- a/test/smoke/local-inference-parent.ts
+++ b/test/smoke/local-inference-parent.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import registerSubagents from "../../index.ts";
+import { requestAsyncStop } from "../../src/runs/background/control-channel.ts";
+import { getActiveAsyncCapacitySnapshot } from "../../src/runs/background/active-async-capacity.ts";
+
+async function waitJson(file: string, predicate: (value: any) => boolean): Promise<any> {
+	return new Promise((resolve) => {
+		const check = () => {
+			try { const value = JSON.parse(fs.readFileSync(file, "utf8")); if (predicate(value)) { fs.unwatchFile(file, check); resolve(value); } } catch {}
+		};
+		fs.watchFile(file, { interval: 50 }, check); check();
+	});
+}
+
+export default function localInferenceRegression(pi: ExtensionAPI) {
+	let tool: Parameters<ExtensionAPI["registerTool"]>[0] | undefined;
+	const host = new Proxy(pi, {
+		get(target, key) {
+			if (key === "registerTool") return (definition: Parameters<ExtensionAPI["registerTool"]>[0]) => {
+				target.registerTool(definition); if (definition.name === "subagent") tool = definition;
+			};
+			if (key === "sendMessage") return (...args: Parameters<ExtensionAPI["sendMessage"]>) => target.sendMessage(args[0], { ...args[1], triggerTurn: false });
+			return Reflect.get(target, key);
+		},
+	});
+	registerSubagents(host);
+	pi.on("session_start", async (_event, ctx) => {
+		const root = process.env.PI_LOCAL_AI_TEST_ROOT!;
+		try {
+			assert.ok(tool);
+			const invoke = (input: unknown) => tool!.execute("local-ai-regression", input as never, new AbortController().signal, undefined, ctx);
+			const launch = await invoke({
+				workflowScript: `return await runs.all([
+					{ key: "headers", agent: "local-fixture", task: "TEST_HEADERS", timeoutMs: 1, output: false, acceptance: false },
+					{ key: "body", agent: "local-fixture", task: "TEST_BODY", timeoutMs: 1, output: false, acceptance: false }
+				]);`, async: true, timeoutMs: 1, model: "local-fixture/local-test:xhigh", context: "fresh", output: false, acceptance: false,
+			});
+			fs.writeFileSync(path.join(root, "launch.json"), JSON.stringify(launch, null, 2));
+			assert.notEqual(launch.isError, true, JSON.stringify(launch));
+			const details = launch.details as { asyncDir: string; asyncId: string };
+			assert.ok(details.asyncDir, JSON.stringify(launch));
+			const status = await waitJson(path.join(details.asyncDir, "status.json"), (s) => !["queued", "running"].includes(s.state));
+			assert.equal(status.state, "complete", JSON.stringify(status));
+			for (const step of status.steps) {
+				const dir = path.join(path.dirname(details.asyncDir), step.runId);
+				await waitJson(path.join(dir, "process-terminal.json"), (s) => s.state === "observed");
+				const child = JSON.parse(fs.readFileSync(path.join(dir, "status.json"), "utf8"));
+				assert.equal(child.state, "complete", JSON.stringify(child));
+				assert.equal(child.timeoutMs, undefined);
+				assert.equal(child.deadlineAt, undefined);
+				assert.ok(child.totalTokens.output > 0);
+				assert.match(fs.readFileSync(child.sessionFile, "utf8"), /pi-subagents:local-inference-policy/);
+			}
+			assert.equal(getActiveAsyncCapacitySnapshot(status.sessionId, 1).used, 0, "completed workflow must release capacity");
+			console.log("PASS local-AI detached workflow: delayed headers/body, short agent deadlines ignored, capacity released");
+
+			const foreground = await invoke({ agent: "local-fixture", task: "TEST_QUICK", async: false, timeoutMs: 1, context: "fresh", output: false, acceptance: false });
+			assert.notEqual(foreground.isError, true, JSON.stringify(foreground));
+			assert.match(JSON.stringify(foreground), /FIXTURE_OK/);
+			console.log("PASS local-AI foreground: short deadline ignored");
+
+			const cancel = await invoke({ agent: "local-fixture", task: "TEST_CANCEL", async: true, timeoutMs: 1, context: "fresh", output: false, acceptance: false });
+			assert.notEqual(cancel.isError, true, JSON.stringify(cancel));
+			const cancelDetails = cancel.details as { asyncDir: string };
+			await waitJson(path.join(root, "cancel-received.json"), () => true);
+			requestAsyncStop(cancelDetails.asyncDir);
+			const cancelled = await waitJson(path.join(cancelDetails.asyncDir, "status.json"), (s) => !["queued", "running"].includes(s.state));
+			assert.equal(cancelled.state, "stopped", JSON.stringify(cancelled));
+			await waitJson(path.join(cancelDetails.asyncDir, "process-terminal.json"), (s) => s.state === "observed");
+			assert.equal(getActiveAsyncCapacitySnapshot(cancelled.sessionId, 1).used, 0, "operator stop must release capacity");
+			await waitJson(path.join(root, "cancel-closed.json"), () => true);
+			console.log("PASS local-AI operator stop: HTTP disconnected, runner exited, capacity released");
+			fs.writeFileSync(path.join(root, "passed.json"), JSON.stringify({ workflow: details.asyncId, policy: "unbounded", cancelled: true, capacityReleased: true }));
+			process.exit(0);
+		} catch (error) { console.error(error); process.exit(1); }
+	});
+}

--- a/test/unit/local-inference-policy.test.ts
+++ b/test/unit/local-inference-policy.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { localInferenceEnabled, withoutExecutionDeadline } from "../../src/runs/shared/local-inference-policy.ts";
+import { resolveSingleAgentLaunchTimeout } from "../../src/runs/foreground/subagent-executor.ts";
+
+test("local-AI policy is owner opt-in and malformed values do not silently turn it off", () => {
+	assert.equal(localInferenceEnabled({}), false);
+	assert.equal(localInferenceEnabled({ localInference: { enabled: true } }), true);
+	for (const value of [null, {}, { enabled: "true" }, { enabled: true, timeout: 1 }]) {
+		assert.throws(() => localInferenceEnabled({ localInference: value } as never), /refusing/);
+	}
+});
+
+test("owner policy overrides model-supplied deadlines for foreground, async, and composites", () => {
+	for (const async of [false, true]) {
+		for (const params of [{ timeoutMs: 1 }, { maxRuntimeMs: 1 }, { timeoutMs: 1, chain: [{ agent: "worker", task: "test" }] }, { timeoutMs: 1, workflowScript: "return 1" }]) {
+			assert.deepEqual(resolveSingleAgentLaunchTimeout(params, async, 1, true), {});
+		}
+	}
+});
+
+test("deadline removal preserves cancellation, tools, limits, and the original input", () => {
+	const signal = new AbortController().signal;
+	const original = { timeoutMs: 1, maxRuntimeMs: 2, deadlineAt: 3, workflowParentDeadlineAt: 4, signal, toolTimeoutMs: 5, maxTokens: 262144, concurrency: 8 };
+	assert.deepEqual(withoutExecutionDeadline(original), { signal, toolTimeoutMs: 5, maxTokens: 262144, concurrency: 8 });
+	assert.equal(original.timeoutMs, 1);
+});

--- a/test/unit/local-inference-transport.test.ts
+++ b/test/unit/local-inference-transport.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+import OpenAI from "openai";
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { createLocalInferenceTransport } from "../../src/runs/shared/local-inference-transport.ts";
+
+// Use the real SDK and HTTP stack: a unit mock of the option object would miss
+// the regression (the SDK and Undici have independent abort controllers).
+test("local transport survives an SDK deadline, streams a delayed body, and honors operator abort", async () => {
+	const server = createServer((req, res) => {
+		if (req.url?.includes("cancel-body")) { res.writeHead(200, { "content-type": "application/json" }); res.write('{"waiting":'); return; }
+		if (req.url?.includes("cancel")) return;
+		setTimeout(() => {
+			if (res.destroyed) return;
+			res.writeHead(200, { "content-type": "application/json" });
+			res.write('{"id":"');
+			setTimeout(() => res.end('survived"}'), 80);
+		}, 80);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	assert.ok(address && typeof address !== "string");
+	const transport = createLocalInferenceTransport();
+	try {
+		const ordinary = new OpenAI({ apiKey: "fixture", baseURL: `http://127.0.0.1:${address.port}`, timeout: 1, maxRetries: 0 });
+		await assert.rejects(ordinary.get("/delayed"), /timed out/i, "negative control: the ordinary SDK must enforce the short deadline");
+		let result: Promise<unknown> | undefined;
+		const original = ((_model, _context, options) => {
+			const extended = options as typeof options & { fetch: typeof fetch; timeoutMs: number };
+			const client = new OpenAI({ apiKey: "fixture", baseURL: `http://127.0.0.1:${address.port}`, fetch: extended.fetch, timeout: extended.timeoutMs, maxRetries: 0 });
+			result = client.get("/delayed", { signal: options?.signal });
+			return undefined;
+		}) as unknown as StreamFn;
+		transport.wrap(original)({} as never, { messages: [] }, { timeoutMs: 1 } as never);
+		assert.deepEqual(await result, { id: "survived" });
+		for (const endpoint of ["/cancel", "/cancel-body"]) {
+		const controller = new AbortController();
+		const cancelling = ((_model, _context, options) => {
+			const extended = options as typeof options & { fetch: typeof fetch; timeoutMs: number };
+			const client = new OpenAI({ apiKey: "fixture", baseURL: `http://127.0.0.1:${address.port}`, fetch: extended.fetch, timeout: extended.timeoutMs, maxRetries: 0 });
+			result = client.get(endpoint, { signal: options?.signal });
+			return undefined;
+		}) as unknown as StreamFn;
+		transport.wrap(cancelling)({} as never, { messages: [] }, { signal: controller.signal });
+		setTimeout(() => controller.abort(), 50);
+		await assert.rejects(result!, /abort/i);
+		}
+	} finally {
+		server.closeAllConnections();
+		await transport.close();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+});

--- a/tools/check-local-inference.mjs
+++ b/tools/check-local-inference.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Portable, real Pi CLI -> public subagent tool -> detached runner -> real SDK -> local HTTP.
+// All config, credentials, sessions and runtime artifacts belong to an isolated test directory.
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const source = fileURLToPath(new URL("../", import.meta.url));
+const piRoot = process.argv[2];
+assert.ok(piRoot && path.isAbsolute(piRoot), "Usage: node tools/check-local-inference.mjs /absolute/pi-coding-agent/package [--long]");
+const version = JSON.parse(fs.readFileSync(path.join(piRoot, "package.json"), "utf8")).version;
+const delay = process.argv.includes("--long") ? 310_000 : 250;
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-local-ai-regression-"));
+for (const dir of ["agent/extensions/subagent", "work/.pi/agents", "tmp"]) fs.mkdirSync(path.join(root, dir), { recursive: true });
+const records = [];
+const timers = new Set();
+const later = (fn, ms) => { const timer = setTimeout(() => { timers.delete(timer); fn(); }, ms); timers.add(timer); };
+const server = createServer(async (req, res) => {
+	if (req.method !== "POST" || req.url !== "/v1/chat/completions") { res.writeHead(404); res.end(); return; }
+	let raw = ""; for await (const chunk of req) raw += chunk;
+	const body = JSON.parse(raw);
+	const task = [...body.messages].reverse().find((m) => m.role === "user")?.content;
+	const marker = JSON.stringify(task).match(/TEST_(HEADERS|BODY|CANCEL|QUICK)/)?.[0];
+	records.push({ marker, at: Date.now(), reasoning_effort: body.reasoning_effort });
+	fs.writeFileSync(path.join(root, "requests.json"), JSON.stringify(records, null, 2));
+	if (body.reasoning_effort !== "xhigh" || !marker) { res.writeHead(400); res.end(JSON.stringify({ error: { message: "fixture contract rejected" } })); return; }
+	if (marker === "TEST_CANCEL") {
+		fs.writeFileSync(path.join(root, "cancel-received.json"), "{}");
+		res.on("close", () => fs.writeFileSync(path.join(root, "cancel-closed.json"), "{}"));
+		return;
+	}
+	const send = () => {
+		if (res.destroyed) return;
+		res.write('data: ' + JSON.stringify({ id: "fixture", object: "chat.completion.chunk", model: "local-test", choices: [{ index: 0, delta: { content: "FIXTURE_OK" }, finish_reason: "stop" }], usage: { prompt_tokens: 8, completion_tokens: 2, total_tokens: 10 } }) + '\n\n');
+		res.end("data: [DONE]\n\n");
+	};
+	const headers = () => { res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" }); res.flushHeaders(); };
+	if (marker === "TEST_BODY") { headers(); res.write(": waiting for inference\n\n"); later(send, delay); }
+	else later(() => { if (!res.destroyed) { headers(); send(); } }, marker === "TEST_HEADERS" ? delay : 100);
+});
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const port = server.address().port;
+fs.writeFileSync(path.join(root, "agent/settings.json"), JSON.stringify({ defaultProvider: "local-fixture", defaultModel: "local-test", defaultThinkingLevel: "xhigh", httpIdleTimeoutMs: 1, packages: [], retry: { enabled: false } }));
+fs.writeFileSync(path.join(root, "agent/models.json"), JSON.stringify({ providers: { "local-fixture": { baseUrl: `http://127.0.0.1:${port}/v1`, api: "openai-completions", apiKey: "fixture-only", models: [{ id: "local-test", name: "Local regression fixture", reasoning: true, thinkingLevelMap: { high: "xhigh", xhigh: "xhigh" }, contextWindow: 262144, maxTokens: 262144, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } }] } } }));
+fs.writeFileSync(path.join(root, "agent/extensions/subagent/config.json"), JSON.stringify({ localInference: { enabled: true }, timeoutMs: 1, maxActiveAsyncRunsPerSession: 1, globalConcurrencyLimit: 2 }));
+fs.writeFileSync(path.join(root, "work/.pi/agents/local-fixture.md"), "---\nname: local-fixture\ndescription: Local HTTP regression fixture\nmodel: local-fixture/local-test:xhigh\nthinking: xhigh\ntools:\ncompletionGuard: false\n---\nReturn the fixture response.\n");
+console.log(`Testing Pi ${version}; ${delay}ms HTTP delay. Artifacts: ${root}`);
+const args = [path.join(piRoot, "dist/cli.js"), "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-session", "--mode", "rpc", "--extension", path.join(source, "test/smoke/local-inference-parent.ts")];
+const child = spawn(process.execPath, args, { cwd: path.join(root, "work"), env: { ...process.env, PI_CODING_AGENT_DIR: path.join(root, "agent"), PI_SUBAGENTS_TEMP_ROOT: path.join(root, "tmp"), PI_LOCAL_AI_TEST_ROOT: root, PI_OFFLINE: "1", JITI_FS_CACHE: "false", TERM: "dumb" }, stdio: ["pipe", "pipe", "pipe"] });
+const log = fs.createWriteStream(path.join(root, "parent.log"));
+child.stdout.on("data", (chunk) => { log.write(chunk); for (const line of String(chunk).split("\n")) if (line.startsWith("PASS ")) console.log(line); });
+child.stderr.on("data", (chunk) => log.write(chunk));
+// Test watchdog only; never installed as an inference setting.
+const watchdog = setTimeout(() => child.kill("SIGTERM"), delay + 120_000);
+const code = await new Promise((resolve, reject) => { child.once("error", reject); child.once("exit", resolve); });
+clearTimeout(watchdog);
+for (const timer of timers) clearTimeout(timer);
+server.closeAllConnections(); await new Promise((resolve) => server.close(resolve)); log.end();
+assert.equal(code, 0, `Regression failed. Inspect ${path.join(root, "parent.log")}`);
+assert.ok(fs.existsSync(path.join(root, "passed.json")));
+assert.equal(records.filter((r) => r.marker === "TEST_HEADERS").length, 1, "no hidden retries");
+assert.equal(records.filter((r) => r.marker === "TEST_BODY").length, 1, "no hidden retries");
+console.log(`PASS real local-AI runtime ${version}; headers/body survived ${delay}ms, foreground/background, operator cancellation, capacity release.`);


### PR DESCRIPTION
Local inference can legitimately remain queued or prefill a large context for more than five minutes. The detached runner's proxy dispatcher currently retains Undici's 300,000 ms header/body defaults, even when the operator sets much longer Pi idle and subagent execution timeouts. In an observed incident, each failed lane made four requests lasting approximately 301–302 seconds; retry backoffs made this look like one twenty-minute failure. Gateway logs showed cancellation while those requests were still queued.

This proposes an opt-in owner configuration, `localInference: { enabled: true }`, that removes automatic native child execution and inference deadlines while preserving operator cancellation. The invariant is that a model-supplied run deadline or a separate HTTP default cannot silently override that explicit owner policy. Default behavior remains unchanged.

Each native child receives its own proxy-aware dispatcher. The transport forwards Pi's cancellation signal instead of the provider SDK's separate deadline signal. Policy is visible in doctor output and child session records; invalid policy fails explicitly. Tool/control waits and usage budgets keep their existing semantics.

Validation:
- Typecheck and 53 focused tests pass on current upstream main plus this patch.
- The regression harness exercises the real Pi 0.85.1 CLI, public subagent tool, detached runner and OpenAI-compatible HTTP stack. It checks delayed headers/body, one request per lane, foreground execution, manual stop, HTTP disconnection, runner exit and capacity release.
- This upstream branch passed the full 310-second header/body regression on npm Pi 0.85.1, including foreground/background completion, manual cancellation and capacity release. The installed fork also passed the same long gate locally and in Linux CI. All fixtures used isolated configuration and a local HTTP server.

Keeping this as a draft for maintainers' review of the policy/API. The tested provider boundary is native OpenAI-compatible requests on npm Pi 0.85.1; other providers, standalone runtimes and external CLI clients need separate validation. A permanently stalled connection requires operator cancellation. No private infrastructure configuration or fork updater/branding is included.
