### PR TITLE
fix: yield headless drain for supervisor requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Let headless parent and nested coordinator sessions answer blocking child supervisor requests without deadlocking their final background-work drain. Thanks to [@ProDrifterDK](https://github.com/ProDrifterDK) for #2185.
 - Include retention-managed async, output-artifact, and structured-output retrieval paths in native completion notices. Thanks to [@peedrr](https://github.com/peedrr) for #2181.
 - Remove workflow-owned one-shot result payloads together with their child-local result indexes after successful consumption. Thanks to [@peedrr](https://github.com/peedrr) for #2182.
 - Show runtime-registered agents in `/subagents` while keeping their extension-owned definitions read-only and rejecting collisions with disabled configured agents. Thanks to [@mystery4f](https://github.com/mystery4f) for #2169.

--- a/src/extension/fanout-child.ts
+++ b/src/extension/fanout-child.ts
@@ -190,6 +190,8 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 			};
 		},
 	});
+	const hasPendingSupervisorRequest = supervisorChannel.hasPendingRequests;
+	childConfig.hasPendingSupervisorRequest = hasPendingSupervisorRequest;
 	const executor = createSubagentExecutor({
 		pi,
 		state,
@@ -245,6 +247,7 @@ export default function registerFanoutChildSubagentExtension(pi: ExtensionAPI, c
 		asyncChildren.clear();
 		foregroundChannels.clear();
 		supervisorChannel.dispose();
+		if (childConfig.hasPendingSupervisorRequest === hasPendingSupervisorRequest) childConfig.hasPendingSupervisorRequest = undefined;
 		state.supervisorOwnerSessionId = null;
 	});
 	const route = resolveNestedControlRoute(childConfig);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -824,7 +824,7 @@ export default function registerSubagentExtension(pi: ExtensionAPI): void {
 	registerWaitTool(pi, state, waitToolConfig.enabled, waitSubscriptionManager, waitToolConfig.defaultTimeoutMs);
 
 	pi.on("agent_end", async (_event, ctx) => {
-		if (!ctx.hasUI) await drainOutstandingWork({ state, events: pi.events });
+		if (!ctx.hasUI) await drainOutstandingWork({ state, events: pi.events, hasPendingSupervisorRequest: supervisorChannel.hasPendingRequests });
 		const ownerSessionId = state.currentSessionId;
 		if (!ownerSessionId) return;
 		goalTurnId += 1;

--- a/src/intercom/native-supervisor-channel.ts
+++ b/src/intercom/native-supervisor-channel.ts
@@ -612,6 +612,7 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 	start: () => void;
 	activateTransport: () => void;
 	findPendingAsks: (target: { runId: string; agent: string; childIndex: number }) => string[];
+	hasPendingRequests: () => boolean;
 	dispose: () => void;
 	pending: Map<string, PendingSupervisorRequest>;
 	getSupervisorRequestState: (event: ControlEvent) => SupervisorRequestState;
@@ -859,6 +860,11 @@ export function createNativeSupervisorChannel(pi: ExtensionAPI, state: SubagentS
 					&& request.agent === target.agent && request.childIndex === target.childIndex
 					&& requestLifecycle(request, state, now, runState(request)) === "pending" ? [request.id] : [];
 			}).sort();
+		},
+		hasPendingRequests: () => {
+			if (!started) return false;
+			poll();
+			return pending.size > 0;
 		},
 		start: () => {
 			if (started) return;

--- a/src/runs/background/auto-drain.ts
+++ b/src/runs/background/auto-drain.ts
@@ -18,6 +18,7 @@ export interface AutoDrainDeps {
 		deps: SubagentWaitDeps,
 	) => Promise<AgentToolResult<Details>>;
 	hasWork?: (sessionId: string, nowMs: number) => boolean;
+	hasPendingSupervisorRequest?: () => boolean;
 }
 
 function resultText(value: AgentToolResult<Details>): string {
@@ -40,7 +41,7 @@ function hasOutstandingWork(state: SubagentState, sessionId: string, nowMs: numb
 /** Drain all work owned by the current headless session, including work added while draining. */
 export async function drainOutstandingWork(deps: AutoDrainDeps, observation?: ReadonlyDrainObservation): Promise<void> {
 	const sessionId = deps.state.currentSessionId;
-	observation?.begin(sessionId, !deps.hasWork && !deps.wait && !deps.now);
+	observation?.begin(sessionId, !deps.hasWork && !deps.wait && !deps.now && !deps.hasPendingSupervisorRequest);
 	try {
 		if (!sessionId) throw new Error("Cannot auto-drain background work without an active session identity.");
 		const now = deps.now ?? Date.now;
@@ -51,6 +52,7 @@ export async function drainOutstandingWork(deps: AutoDrainDeps, observation?: Re
 		const wait = deps.wait ?? waitForSubagents;
 
 		while (true) {
+			if (deps.hasPendingSupervisorRequest?.()) break;
 			const work = hasWork(sessionId, now());
 			observation?.predicate(work);
 			if (!work) break;
@@ -68,11 +70,14 @@ export async function drainOutstandingWork(deps: AutoDrainDeps, observation?: Re
 					stopOnAttention: false,
 					failOnFailedRuns: true,
 					failOnAttention: true,
+					hasPendingSupervisorRequest: deps.hasPendingSupervisorRequest,
 				},
 			);
 			if (waitResult.isError) {
 				throw new Error(`Auto-drain failed for session '${sessionId}': ${resultText(waitResult) || "bg_wait returned an error without details"}.`);
 			}
+			if (waitResult.details.wait?.reason === "supervisor_request") break;
+			if (deps.hasPendingSupervisorRequest?.()) break;
 		}
 		observation?.complete();
 	} catch (error) {

--- a/src/runs/background/subagent-wait.ts
+++ b/src/runs/background/subagent-wait.ts
@@ -118,6 +118,8 @@ export interface SubagentWaitDeps {
 	failOnFailedRuns?: boolean;
 	/** Internal auto-drain mode surfaces actionable attention as an error. */
 	failOnAttention?: boolean;
+	/** Durable owned supervisor-request barrier used by headless auto-drain. */
+	hasPendingSupervisorRequest?: () => boolean;
 	/** Arm a durable exact-target wait subscription in a long-lived interactive runtime. */
 	subscribe?: (input: { targetKind: "async" | "foreground"; runId: string; requestedId: string; timeoutMs: number }) => { token: string; expiresAt: number };
 	/** Injectable provider protocol surfaces for deterministic tests. */
@@ -377,6 +379,49 @@ function windowElapsedResult(
 	};
 }
 
+function supervisorYieldResult(
+	activeRunIds: string[],
+	activeProviderItems: readonly RegisteredBackgroundWorkItem[] = [],
+): AgentToolResult<Details> {
+	return {
+		content: [{ type: "text", text: "Wait yielded for a pending supervisor request. Background work remains active and will continue after the supervisor reply." }],
+		details: {
+			mode: "management",
+			results: [],
+			wait: {
+				reason: "supervisor_request",
+				timedOut: false,
+				activeRunIds,
+				activeProviderItems: activeProviderItems.map(({ provider, id }) => ({ provider, id })),
+			},
+		},
+	};
+}
+
+interface InitialWaitScope {
+	asyncRunIds: Set<string>;
+	foregroundRuns: Array<{ runId: string; sessionId?: string; detachedIndices: Set<number> }>;
+	providerIds: Set<string>;
+}
+
+function supervisorYieldForScope(scope: InitialWaitScope, params: SubagentWaitParams, deps: SubagentWaitDeps, nowMs: number): AgentToolResult<Details> {
+	try {
+		const activeAsyncIds = new Set(activeRunsForSession(params.id ? { id: params.id } : {}, deps).map((run) => run.id));
+		const activeRunIds = new Set([...scope.asyncRunIds].filter((id) => activeAsyncIds.has(id)));
+		for (const initial of scope.foregroundRuns) {
+			const current = deps.state.foregroundRuns?.get(initial.runId);
+			if (!current || current.sessionId !== initial.sessionId) continue;
+			if (current.children.some((child) => initial.detachedIndices.has(child.index) && child.status === "detached")) activeRunIds.add(initial.runId);
+		}
+		const activeProviderItems = scope.providerIds.size > 0
+			? backgroundWorkForSession(deps, nowMs).items.filter((item) => scope.providerIds.has(backgroundWorkIdentity(item)))
+			: [];
+		return supervisorYieldResult([...activeRunIds], activeProviderItems);
+	} catch (error) {
+		return result(error instanceof Error ? error.message : String(error), true);
+	}
+}
+
 /** Build the live status shown while async work keeps bg_wait blocked. */
 function asyncWaitUpdate(runs: AsyncRunSummary[], providerCount: number, elapsedMs: number): AgentToolResult<Details> {
 	const activity = runs.flatMap((run) => {
@@ -499,6 +544,7 @@ async function waitForDetachedForegroundRun(
 	now: () => number,
 	pollIntervalMs: number,
 	timeoutMs: number,
+	supervisorYield: () => AgentToolResult<Details>,
 ): Promise<AgentToolResult<Details>> {
 	const initialDetachedIndices = new Set(run.children.filter((child) => child.status === "detached").map((child) => child.index));
 	while (true) {
@@ -509,6 +555,7 @@ async function waitForDetachedForegroundRun(
 		if (!current || current.sessionId !== run.sessionId) {
 			return result(`Remembered foreground run "${run.runId}" disappeared before a terminal child result was recorded. Completion cannot be confirmed; do not launch a replacement without checking the originating child session.`, true);
 		}
+		if (deps.hasPendingSupervisorRequest?.()) return supervisorYield();
 		const pending = current.children.filter((child) => initialDetachedIndices.has(child.index) && child.status === "detached");
 		const attention = foregroundChildrenNeedingAttention(current, initialDetachedIndices);
 		if (attention.length > 0) return formatForegroundAttention(current, attention, now() - startedAt);
@@ -541,11 +588,13 @@ async function waitForSessionDetachedForegroundRuns(
 	now: () => number,
 	pollIntervalMs: number,
 	timeoutMs: number,
+	supervisorYield: () => AgentToolResult<Details>,
 ): Promise<AgentToolResult<Details>> {
 	const texts: string[] = [];
 	for (const run of runs) {
-		const one = await waitForDetachedForegroundRun(run, signal, deps, startedAt, now, pollIntervalMs, timeoutMs);
+		const one = await waitForDetachedForegroundRun(run, signal, deps, startedAt, now, pollIntervalMs, timeoutMs, supervisorYield);
 		if (one.isError) return one;
+		if (one.details.wait?.reason === "supervisor_request") return one;
 		if (one.details.wait?.reason === "window_elapsed") {
 			const activeRunIds = runs.filter((initial) => {
 				const current = deps.state.foregroundRuns?.get(initial.runId);
@@ -608,6 +657,7 @@ export async function waitForSubagents(
 		return result(error instanceof Error ? error.message : String(error), true);
 	}
 
+	let selectedForeground: ForegroundResumeRun | undefined;
 	if (params.id) {
 		const candidates = [
 			...active.map((run) => ({ kind: "async" as const, id: run.id, run })),
@@ -630,30 +680,47 @@ export async function waitForSubagents(
 				return result(error instanceof Error ? error.message : String(error), true);
 			}
 		}
-		if (selected?.kind === "foreground") {
-			return waitForDetachedForegroundRun(selected.run, signal, deps, startedAt, now, pollIntervalMs, timeoutMs);
-		}
+		selectedForeground = selected?.kind === "foreground" ? selected.run : undefined;
 		active = selected?.kind === "async" ? [selected.run] : [];
 	}
 
 	let providerActive = providerSnapshot.items;
+	const scopedForeground = selectedForeground ? [selectedForeground] : params.id ? [] : foreground;
+	const initialAsyncIds = new Set(active.map((run) => run.id));
+	const initialProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
+	const initialScope: InitialWaitScope = {
+		asyncRunIds: initialAsyncIds,
+		foregroundRuns: scopedForeground.map((run) => ({
+			runId: run.runId,
+			sessionId: run.sessionId,
+			detachedIndices: new Set(run.children.filter((child) => child.status === "detached").map((child) => child.index)),
+		})),
+		providerIds: initialProviderIds,
+	};
+	const supervisorYield = () => supervisorYieldForScope(initialScope, params, deps, now());
+	if (selectedForeground) {
+		return waitForDetachedForegroundRun(selectedForeground, signal, deps, startedAt, now, pollIntervalMs, timeoutMs, supervisorYield);
+	}
 	if (active.length === 0 && providerActive.length === 0) {
 		if (waitForAll && !params.id && foreground.length > 0) {
-			return waitForSessionDetachedForegroundRuns(foreground, signal, deps, startedAt, now, pollIntervalMs, timeoutMs);
+			return waitForSessionDetachedForegroundRuns(foreground, signal, deps, startedAt, now, pollIntervalMs, timeoutMs, supervisorYield);
 		}
 		return result(params.id
 			? `No active run matched "${params.id}". Nothing to wait for.`
 			: "No active async runs or registered provider work in this session. Nothing to wait for.");
 	}
 	const waitParams = params.id ? { ...params, id: active[0]!.id } : params;
-	const initialAsyncIds = new Set(active.map((run) => run.id));
-	const initialProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
 	const initialProviderNames = new Set(providerActive.map((item) => item.provider));
 	const initialCount = initialAsyncIds.size + initialProviderIds.size;
 	const stopOnAttention = params.stopOnAttention ?? deps.stopOnAttention !== false;
 	let attention = active.filter((run) => needsAttention(run));
+	let supervisorBarrier = false;
 
 	const isDone = (): boolean => {
+		if (deps.hasPendingSupervisorRequest?.()) {
+			supervisorBarrier = true;
+			return true;
+		}
 		if (attention.some((run) => initialAsyncIds.has(run.id) && (stopOnAttention || hasSupervisorTool(run)))) return true;
 		const activeAsyncIds = new Set(active.map((run) => run.id));
 		const activeProviderIds = new Set(providerActive.map(backgroundWorkIdentity));
@@ -698,6 +765,9 @@ export async function waitForSubagents(
 			return result(error instanceof Error ? error.message : String(error), true);
 		}
 	}
+	if (supervisorBarrier) {
+		return supervisorYield();
+	}
 
 	let terminalSummary: string;
 	let finishedAsyncCount: number;
@@ -733,9 +803,10 @@ export async function waitForSubagents(
 
 	if (waitForAll) {
 		const foregroundResult = !params.id && foreground.length > 0 && relevantAttention.length === 0
-			? await waitForSessionDetachedForegroundRuns(foreground, signal, deps, startedAt, now, pollIntervalMs, timeoutMs)
+			? await waitForSessionDetachedForegroundRuns(foreground, signal, deps, startedAt, now, pollIntervalMs, timeoutMs, supervisorYield)
 			: undefined;
 		if (foregroundResult?.isError) return foregroundResult;
+		if (foregroundResult?.details.wait?.reason === "supervisor_request") return foregroundResult;
 		if (foregroundResult?.details.wait?.reason === "window_elapsed") return foregroundResult;
 		const foregroundNote = foregroundResult
 			? `\n${foregroundResult.content.map((part) => part.type === "text" ? part.text : "").join("\n")}`

--- a/src/runs/shared/child-runtime-config.ts
+++ b/src/runs/shared/child-runtime-config.ts
@@ -91,6 +91,8 @@ export interface ChildRuntimeConfig {
 	waitTool: ResolvedWaitToolConfig;
 	runtimeState?: SubagentState;
 	holdFinalDrain?: (held: boolean) => void;
+	/** Installation-local downward owner-channel barrier; never inherited or serialized into descendants. */
+	hasPendingSupervisorRequest?: () => boolean;
 	structuredOutput?: ChildStructuredOutput;
 	requiredTools?: string[];
 	mcpDirectTools?: string[];

--- a/src/runs/shared/subagent-prompt-runtime.ts
+++ b/src/runs/shared/subagent-prompt-runtime.ts
@@ -495,7 +495,7 @@ export default function registerSubagentPromptRuntime(pi: ExtensionAPI, config?:
 		}
 		config.holdFinalDrain?.(true);
 		try {
-			await drainOutstandingWork({ state: waitState, events: pi.events }, drainObservation);
+			await drainOutstandingWork({ state: waitState, events: pi.events, hasPendingSupervisorRequest: config.hasPendingSupervisorRequest }, drainObservation);
 		} finally {
 			config.holdFinalDrain?.(false);
 		}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1418,6 +1418,12 @@ export interface Details {
 		timedOut: true;
 		activeRunIds: string[];
 		activeProviderItems: Array<{ provider: string; id: string }>;
+	} | {
+		/** Non-terminal internal auto-drain yield; tracked work remains active. */
+		reason: "supervisor_request";
+		timedOut: false;
+		activeRunIds: string[];
+		activeProviderItems: Array<{ provider: string; id: string }>;
 	};
 	controlEvents?: ControlEvent[];
 	steering?: SteerActionResult;

--- a/test/unit/auto-drain.test.ts
+++ b/test/unit/auto-drain.test.ts
@@ -100,4 +100,53 @@ describe("headless background-work auto-drain", () => {
 		});
 		assert.equal(waits, 1);
 	});
+
+	it("yields to Pi for a pending supervisor turn and resumes draining the same work after resolution", async () => {
+		let pending = true;
+		let active = true;
+		let waits = 0;
+		const deps = {
+			state: state(),
+			hasPendingSupervisorRequest: () => pending,
+			hasWork: () => active,
+			wait: async () => {
+				waits++;
+				active = false;
+				return waitResult("done");
+			},
+		};
+
+		await drainOutstandingWork(deps);
+		assert.equal(waits, 0, "the queued supervisor triggerTurn must get control before drain blocks again");
+		assert.equal(active, true, "yielding must leave the owned workflow active");
+
+		pending = false;
+		await drainOutstandingWork(deps);
+		assert.equal(waits, 1, "the same workflow can continue and drain after the reply resolves the barrier");
+		assert.equal(active, false);
+	});
+
+	it("latches an inner supervisor yield even when the live request clears before continuation", async () => {
+		let pending = false;
+		let clock = 0;
+		let waits = 0;
+		await drainOutstandingWork({
+			state: state(),
+			timeoutMs: 50,
+			now: () => clock,
+			hasWork: () => true,
+			hasPendingSupervisorRequest: () => pending,
+			wait: async (_params, _signal, deps) => {
+				waits++;
+				assert.equal(typeof deps.hasPendingSupervisorRequest, "function");
+				clock = 100;
+				pending = false;
+				return {
+					content: [{ type: "text", text: "Wait yielded for a pending supervisor request." }],
+					details: { mode: "management", results: [], wait: { reason: "supervisor_request", timedOut: false, activeRunIds: ["run-a"], activeProviderItems: [] } },
+				};
+			},
+		});
+		assert.equal(waits, 1);
+	});
 });

--- a/test/unit/native-supervisor-channel.test.ts
+++ b/test/unit/native-supervisor-channel.test.ts
@@ -232,6 +232,7 @@ describe("native supervisor channel", () => {
 
 		assert.deepEqual(registeredTools, []);
 		channel.start();
+		assert.equal(channel.hasPendingRequests(), true, "fresh owned reply-bearing request is a drain barrier");
 		channel.dispose();
 
 		assert.deepEqual(registeredTools.map((tool) => tool.name), [NATIVE_SUPERVISOR_TOOL_NAME]);
@@ -239,6 +240,7 @@ describe("native supervisor channel", () => {
 		assert.deepEqual(sent.map(({ message }) => message.details?.id), [matchingId]);
 		assert.deepEqual(sent[0]?.options, { triggerTurn: true });
 		assert.equal(channel.pending.has(matchingId), false, "disposed channel clears pending requests");
+		assert.equal(channel.hasPendingRequests(), false, "disposed and foreign requests are not barriers");
 		assert.equal(sent.some(({ message }) => message.details?.id === otherId), false);
 	});
 
@@ -885,9 +887,13 @@ describe("native supervisor channel", () => {
 		const resolvedRunId = `run-${randomUUID()}`;
 		const expiredRunId = `run-${randomUUID()}`;
 		const inactiveRunId = `run-${randomUUID()}`;
+		const progressRunId = `run-${randomUUID()}`;
+		const foreignRunId = `run-${randomUUID()}`;
 		const resolvedId = writeRequest({ sessionId: currentSessionId, runId: resolvedRunId });
 		const expiredId = writeRequest({ sessionId: currentSessionId, runId: expiredRunId, expiresAt: Date.now() - 1 });
 		const inactiveId = writeRequest({ sessionId: currentSessionId, runId: inactiveRunId });
+		const progressId = writeRequest({ sessionId: currentSessionId, runId: progressRunId, reason: "progress_update" });
+		const foreignId = writeRequest({ sessionId: `foreign-${randomUUID()}`, runId: foreignRunId });
 		fs.writeFileSync(replyFile(resolvedRunId, resolvedId), JSON.stringify({
 			type: "subagent.supervisor.reply",
 			requestId: resolvedId,
@@ -921,12 +927,15 @@ describe("native supervisor channel", () => {
 		const channel = createNativeSupervisorChannel(pi as never, state);
 
 		channel.start();
+		assert.equal(channel.hasPendingRequests(), false, "resolved, expired, and inactive requests are not barriers");
 		channel.dispose();
 
-		assert.deepEqual(sent, []);
+		assert.deepEqual(sent.map((message) => message.details?.id), [progressId]);
 		assert.equal(fs.existsSync(requestFile(resolvedRunId, resolvedId)), false);
 		assert.equal(fs.existsSync(requestFile(expiredRunId, expiredId)), false);
 		assert.equal(fs.existsSync(requestFile(inactiveRunId, inactiveId)), false);
+		assert.equal(fs.existsSync(requestFile(progressRunId, progressId)), false);
+		assert.equal(fs.existsSync(requestFile(foreignRunId, foreignId)), true);
 	});
 
 	it("refreshes pending requests before listing or replying", async () => {

--- a/test/unit/readonly-drain-observation.test.ts
+++ b/test/unit/readonly-drain-observation.test.ts
@@ -68,7 +68,7 @@ it("observes true before wait, preserves waits/errors/deadlines and never certif
 		assert.equal(waits, mode === "false" || mode === "predicate throw" ? 0 : 1);
 		assert.equal(proof.settled(), false);
 	}
-	for (const injection of [{ hasWork: () => false }, { wait: async () => done }, { now: Date.now }]) {
+	for (const injection of [{ hasWork: () => false }, { wait: async () => done }, { now: Date.now }, { hasPendingSupervisorRequest: () => false }]) {
 		const proof = observation(); await drainOutstandingWork({ state, ...injection }, proof); assert.equal(proof.settled(), false);
 	}
 });

--- a/test/unit/subagent-prompt-runtime.test.ts
+++ b/test/unit/subagent-prompt-runtime.test.ts
@@ -58,6 +58,43 @@ it("does not skip drain for in-process child sessions when hasUI is true", async
 	assert.deepEqual(held, [true, false]);
 });
 
+it("reads a late-installed owner barrier for each final drain and balances the hold", async () => {
+	const handlers = new Map<string, Function[]>();
+	const listeners = new Map<string, Array<() => void>>();
+	const held: boolean[] = [];
+	const sessionId = "fanout-owner-session.jsonl";
+	const runtimeState = {
+		foregroundRuns: new Map([["fg", {
+			runId: "fg", mode: "single", cwd: "/tmp", sessionId, updatedAt: 1,
+			children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 1 }],
+		}]]),
+	} as SubagentState;
+	const config = childConfig({ runtimeState, holdFinalDrain: (value) => { held.push(value); } });
+	const ctx = { hasUI: true, sessionManager: { getSessionFile: () => sessionId } };
+	const emit = async (name: string) => { for (const fn of handlers.get(name) ?? []) await fn({}, ctx); };
+	registerSubagentPromptRuntime({
+		on: (name: string, fn: Function) => handlers.set(name, [...(handlers.get(name) ?? []), fn]),
+		registerTool: () => {},
+		events: { on: (channel: string, handler: () => void) => { listeners.set(channel, [...(listeners.get(channel) ?? []), handler]); return () => {}; } },
+	} as never, config);
+	await emit("session_start");
+	let pending = true;
+	config.hasPendingSupervisorRequest = () => pending;
+	await emit("agent_end");
+	assert.deepEqual(held, [true, false]);
+	assert.equal(runtimeState.foregroundRuns.get("fg")!.children[0]!.status, "detached");
+
+	pending = false;
+	let settled = false;
+	const ended = emit("agent_end").then(() => { settled = true; });
+	await new Promise((resolve) => setTimeout(resolve, 30));
+	assert.equal(settled, false);
+	runtimeState.foregroundRuns.get("fg")!.children[0]!.status = "completed";
+	for (const handler of listeners.get(SUBAGENT_FOREGROUND_COMPLETE_EVENT) ?? []) handler();
+	await ended;
+	assert.deepEqual(held, [true, false, true, false]);
+});
+
 function supervisorConfig(overrides: Partial<ChildRuntimeConfig> = {}): ChildRuntimeConfig {
 	return childConfig({
 		orchestratorTarget: "subagent-chat-parent",

--- a/test/unit/subagent-wait.test.ts
+++ b/test/unit/subagent-wait.test.ts
@@ -71,6 +71,18 @@ function textOf(result: { content: Array<{ type: string; text?: string }> }): st
 	return result.content.map((c) => c.text ?? "").join("");
 }
 
+function assertSupervisorYield(
+	result: Awaited<ReturnType<typeof waitForSubagents>>,
+	activeRunIds: string[],
+	activeProviderItems: Array<{ provider: string; id: string }> = [],
+): void {
+	assert.equal(result.isError, undefined);
+	assert.deepEqual(result.details.wait, { reason: "supervisor_request", timedOut: false, activeRunIds, activeProviderItems });
+	assert.match(textOf(result), /yielded for a pending supervisor request/i);
+	assert.doesNotMatch(textOf(result), /(?:done|complete|window elapsed)/i);
+	assert.equal(result.details.completions, undefined);
+}
+
 function baseDeps(root: string, state: SubagentState, overrides: Partial<SubagentWaitDeps> = {}): SubagentWaitDeps {
 	return {
 		state,
@@ -599,26 +611,154 @@ describe("bg_wait tool", () => {
 		}
 	});
 
-	it("returns an error for internal auto-drain on supervisor attention", async () => {
+	it("yields without an error for internal auto-drain on a durable supervisor barrier", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-drain-supervisor-"));
 		try {
 			const asyncRoot = path.join(root, "runs");
 			const state = makeState("sess-1");
 			writeStatus(asyncRoot, "run-a", "running", { sessionId: "sess-1", pid: 999999 });
 
+			let pending = false;
 			const result = await waitForSubagents({ all: true, stopOnAttention: false }, undefined, baseDeps(root, state, {
 				failOnAttention: true,
-				sleep: async () => writeStatus(asyncRoot, "run-a", "running", {
+				hasPendingSupervisorRequest: () => pending,
+				sleep: async () => {
+					pending = true;
+					writeStatus(asyncRoot, "run-a", "running", {
+						sessionId: "sess-1",
+						pid: 999999,
+						activityState: "needs_attention",
+						currentTool: "contact_supervisor",
+					});
+				},
+			}));
+
+			assertSupervisorYield(result, ["run-a"]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("yields when a durable descendant request appears during the wait before status projection", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-drain-nested-supervisor-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "workflow-a", "running", {
+				sessionId: "sess-1",
+				pid: 999999,
+				mode: "workflow",
+				steps: [{ agent: "workflow", status: "running" }],
+			});
+			let pending = false;
+			let polls = 0;
+			let clock = 0;
+			const result = await waitForSubagents({ all: true, stopOnAttention: false, timeoutMs: 50 }, undefined, baseDeps(root, state, {
+				failOnAttention: true,
+				hasPendingSupervisorRequest: () => pending,
+				now: () => clock,
+				sleep: async () => {
+					polls++;
+					pending = true;
+					clock = 100;
+				},
+			}));
+
+			assertSupervisorYield(result, ["workflow-a"]);
+			assert.equal(polls, 1, "the durable mailbox must stop an already-running wait without status projection");
+			const persisted = JSON.parse(fs.readFileSync(path.join(asyncRoot, "workflow-a", "status.json"), "utf-8")) as { state: string };
+			assert.equal(persisted.state, "running", "yielding must not mark the workflow terminal");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reports every still-active initial identity for a mixed supervisor yield", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-supervisor-mixed-scope-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "async-a", "running", { sessionId: "sess-1", pid: 999999 });
+			state.foregroundRuns = new Map(["fg-a", "fg-b"].map((runId, index) => [runId, {
+				runId, mode: "single" as const, cwd: root, sessionId: "sess-1", updatedAt: 1,
+				children: [{ agent: "worker", index, status: "detached" as const, updatedAt: 1 }],
+			}]));
+			const provider = { provider: "herdr", id: "pane-a", sessionId: "sess-1" };
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				hasPendingSupervisorRequest: () => true,
+				backgroundWork: { snapshot: () => ({ providers: ["herdr"], items: [provider] }), wakeChannels: () => [] },
+			}));
+			assertSupervisorYield(result, ["async-a", "fg-a", "fg-b"], [{ provider: "herdr", id: "pane-a" }]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("foreground aggregate yield filters terminal, new, newly detached, and foreign work from its initial scope", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-supervisor-foreground-scope-"));
+		try {
+			const state = makeState("sess-1");
+			state.foregroundRuns = new Map([
+				["fg-first", { runId: "fg-first", mode: "single", cwd: root, sessionId: "sess-1", updatedAt: 1, children: [
+					{ agent: "worker", index: 0, status: "detached", updatedAt: 1 },
+					{ agent: "worker", index: 1, status: "completed", updatedAt: 1 },
+				] }],
+				["fg-later", { runId: "fg-later", mode: "single", cwd: root, sessionId: "sess-1", updatedAt: 1, children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 1 }] }],
+				["fg-foreign", { runId: "fg-foreign", mode: "single", cwd: root, sessionId: "sess-2", updatedAt: 1, children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 1 }] }],
+			] as never);
+			let pending = false;
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, {
+				hasPendingSupervisorRequest: () => pending,
+				sleep: async () => {
+					state.foregroundRuns!.get("fg-first")!.children[0]!.status = "completed";
+					state.foregroundRuns!.get("fg-first")!.children[1]!.status = "detached";
+					state.foregroundRuns!.set("fg-new", { runId: "fg-new", mode: "single", cwd: root, sessionId: "sess-1", updatedAt: 2, children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 2 }] });
+					pending = true;
+				},
+			}));
+			assertSupervisorYield(result, ["fg-later"]);
+			assert.equal(state.foregroundRuns.get("fg-later")!.children[0]!.status, "detached");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	for (const currentTool of ["contact_supervisor", "intercom"]) {
+		it(`still errors for ${currentTool} attention without a durable owned request`, async () => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-drain-unowned-supervisor-"));
+			try {
+				const asyncRoot = path.join(root, "runs");
+				const state = makeState("sess-1");
+				writeStatus(asyncRoot, "run-a", "running", {
 					sessionId: "sess-1",
 					pid: 999999,
 					activityState: "needs_attention",
-					currentTool: "contact_supervisor",
-				}),
-			}));
+					currentTool,
+				});
+				const result = await waitForSubagents({ all: true, stopOnAttention: false }, undefined, baseDeps(root, state, {
+					failOnAttention: true,
+					hasPendingSupervisorRequest: () => false,
+				}));
+				assert.equal(result.isError, true);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		});
+	}
 
+	it("still errors for non-supervisor attention during internal auto-drain", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-drain-nonsupervisor-"));
+		try {
+			const asyncRoot = path.join(root, "runs");
+			const state = makeState("sess-1");
+			writeStatus(asyncRoot, "run-a", "running", {
+				sessionId: "sess-1",
+				pid: 999999,
+				activityState: "needs_attention",
+				currentTool: "read",
+			});
+			const result = await waitForSubagents({ all: true }, undefined, baseDeps(root, state, { failOnAttention: true }));
 			assert.equal(result.isError, true);
-			assert.match(textOf(result), /Reply to any pending supervisor request/);
-			assert.match(textOf(result), /run-a/);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}
@@ -880,6 +1020,39 @@ describe("bg_wait tool", () => {
 
 			const otherSession = await waitForSubagents({ id: "foreground-other" }, undefined, baseDeps(root, state));
 			assert.match(textOf(otherSession), /No active run matched/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("yields a foreground-only wait when a durable request appears before timeout", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-wait-foreground-supervisor-yield-"));
+		try {
+			const state = makeState("sess-1");
+			state.foregroundRuns = new Map([["foreground-live", {
+				runId: "foreground-live",
+				mode: "single",
+				cwd: root,
+				sessionId: "sess-1",
+				updatedAt: 1,
+				children: [{ agent: "worker", index: 0, status: "detached", updatedAt: 1 }],
+			}]]);
+			let pending = false;
+			let clock = 0;
+			let polls = 0;
+			const result = await waitForSubagents({ all: true, timeoutMs: 50 }, undefined, baseDeps(root, state, {
+				hasPendingSupervisorRequest: () => pending,
+				now: () => clock,
+				sleep: async () => {
+					polls++;
+					pending = true;
+					clock = 100;
+				},
+			}));
+
+			assert.equal(polls, 1);
+			assertSupervisorYield(result, ["foreground-live"]);
+			assert.equal(state.foregroundRuns.get("foreground-live")!.children[0]!.status, "detached");
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/test/unit/supervisor-ask-registration.test.ts
+++ b/test/unit/supervisor-ask-registration.test.ts
@@ -350,6 +350,7 @@ describe("supervisor ask registration", () => {
 			let cRequest: string | undefined;
 			let cReturned = false;
 			let bReturned = false;
+			let bDrainReturnedBeforeReply = false;
 			const abort = new AbortController();
 			const factory: ChildSessionFactory = {
 				async create(launch) {
@@ -375,6 +376,10 @@ describe("supervisor ask registration", () => {
 								});
 								assert.notEqual(receipt.isError, true, text(receipt));
 								workflows.push(receipt.details.asyncDir);
+								// Enter B's real prompt-runtime final drain before C writes its delayed ask.
+								await runtime.emit("agent_end");
+								bDrainReturnedBeforeReply = true;
+								assert.equal(cReturned, false, "the owner drain must yield before C is replied to");
 								// No explicit pending scan: executor activation must discover C's delayed ask.
 								await waitForCondition(() => runtime.notices.length > 0, "B to discover C's ask without a manual scan");
 								const pending = await runtime.call(NATIVE_SUPERVISOR_TOOL_NAME, { action: "pending" });
@@ -433,6 +438,7 @@ describe("supervisor ask registration", () => {
 				]);
 				assert.equal(result.exitCode, 0, result.error);
 				assert.equal(bReturned, true);
+				assert.equal(bDrainReturnedBeforeReply, true);
 				assert.equal(cReturned, true, "B's final drain must await C's real blocked contact call and workflow completion");
 				for (const dir of workflows) {
 					const status = JSON.parse(fs.readFileSync(path.join(dir, "status.json"), "utf8"));


### PR DESCRIPTION
## Summary

- yield headless final drains when the current Pi runtime owns a durable blocking supervisor request
- cover top-level and fanout coordinator owners across async, provider, foreground, and mixed wait routes
- return truthful non-terminal wait evidence while preserving unrelated attention and Herdr external CLI behavior

## Validation

- `npm run typecheck`
- 188 focused tests across auto-drain, wait, prompt runtime, readonly drain evidence, native supervisor channel, and supervisor registration
- `git diff --check`

Thanks to [@ProDrifterDK](https://github.com/ProDrifterDK) for the detailed reproduction in #2185.

Closes #2185
